### PR TITLE
several type output simplifications

### DIFF
--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -20,4 +20,4 @@ syn = "1.0.76"
 serde = "1.0.125"
 schema = "0.0.1"
 rustfmt-wrapper = { path = "../rustfmt-wrapper" }
-expectorate = "1.0.3"
+expectorate = "1.0.4"

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -1,11 +1,11 @@
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use schemars::schema::{ObjectValidation, Schema};
+use schemars::schema::{Metadata, ObjectValidation, Schema};
 
 use crate::{
-    util::{metadata_description, recase},
-    Name, Result, StructProperty, StructPropertySerde, TypeSpace,
+    util::{get_type_name, metadata_description, recase},
+    Name, Result, StructProperty, StructPropertySerde, TypeDetails, TypeEntry, TypeSpace,
 };
 
 pub(crate) fn struct_members(
@@ -94,6 +94,60 @@ pub(crate) fn output_struct_property(
         #serde
         #pub_token #name: #type_name,
     }
+}
+
+/// This is used by both any-of and all-of subschema processing. This
+/// produces a struct type whose members are the subschemas (flattened).
+///
+/// ```ignore
+/// struct Name {
+///     #[serde(flatten)]
+///     schema1: Schema1Type,
+///     #[serde(flatten)]
+///     schema2: Schema2Type
+///     ...
+/// }
+/// ```
+///
+/// The only difference between any-of and all-of is that where the latter
+/// has type T_N for each member of the struct, the former has Option<T_N>.
+pub(crate) fn flattened_union_struct<'a>(
+    type_name: Name,
+    metadata: &'a Option<Box<Metadata>>,
+    subschemas: &[Schema],
+    optional: bool,
+    type_space: &mut TypeSpace,
+) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
+    let properties = subschemas
+        .iter()
+        .enumerate()
+        .map(|(idx, schema)| {
+            let type_name = match get_type_name(&type_name, metadata, Case::Pascal) {
+                Some(name) => Name::Suggested(format!("{}Subtype{}", name, idx)),
+                None => Name::Unknown,
+            };
+
+            let (mut type_id, _) = type_space.id_for_schema(type_name, schema)?;
+            if optional {
+                type_id = type_space.id_for_option(&type_id);
+            }
+
+            // TODO we need a reasonable name that could be derived
+            // from the name of the type
+            let name = format!("subtype_{}", idx);
+
+            Ok(StructProperty {
+                name,
+                serde_options: StructPropertySerde::Flatten,
+                description: None,
+                type_id,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let ty = TypeEntry::from_metadata(type_name, metadata, TypeDetails::Struct(properties));
+
+    Ok((ty, metadata))
 }
 
 #[cfg(test)]

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -380,7 +380,7 @@ pub struct CommitCommentEvent(CommitCommentCreated);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Committer {
     pub date: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub email: CommitterEmail,
+    pub email: Option<String>,
     #[doc = "The git author's name."]
     pub name: String,
     pub username: Option<String>,
@@ -481,7 +481,7 @@ pub struct DeploymentStatusEvent(DeploymentStatusCreated);
 pub struct Discussion {
     pub active_lock_reason: Option<String>,
     pub answer_chosen_at: Option<String>,
-    pub answer_chosen_by: DiscussionAnswerChosenBy,
+    pub answer_chosen_by: Option<User>,
     pub answer_html_url: Option<String>,
     pub author_association: AuthorAssociation,
     pub body: String,
@@ -746,7 +746,7 @@ pub struct Installation {
     pub single_file_name: Option<String>,
     pub single_file_paths: Option<Vec<String>>,
     pub suspended_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub suspended_by: InstallationSuspendedBy,
+    pub suspended_by: Option<User>,
     #[doc = "The ID of the user or organization this token is being scoped to."]
     pub target_id: u64,
     pub target_type: InstallationTargetType,
@@ -822,7 +822,7 @@ pub struct InstallationRepositoriesAdded {
     pub repositories_removed: Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationRepositoriesAddedRepositorySelection,
-    pub requester: InstallationRepositoriesAddedRequester,
+    pub requester: Option<User>,
     pub sender: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -835,7 +835,7 @@ pub struct InstallationRepositoriesRemoved {
     pub repositories_removed: Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationRepositoriesRemovedRepositorySelection,
-    pub requester: InstallationRepositoriesRemovedRequester,
+    pub requester: Option<User>,
     pub sender: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -847,7 +847,7 @@ pub enum InstallationRepositoriesEvent {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Issue {
     pub active_lock_reason: Option<IssueActiveLockReason>,
-    pub assignee: Option<IssueAssignee>,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
@@ -862,10 +862,10 @@ pub struct Issue {
     pub labels: Option<Vec<Label>>,
     pub labels_url: String,
     pub locked: Option<bool>,
-    pub milestone: IssueMilestone,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     pub number: u64,
-    pub performed_via_github_app: Option<IssuePerformedViaGithubApp>,
+    pub performed_via_github_app: Option<App>,
     pub pull_request: Option<IssuePullRequest>,
     pub repository_url: String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -888,7 +888,7 @@ pub struct IssueComment {
     pub id: u64,
     pub issue_url: String,
     pub node_id: String,
-    pub performed_via_github_app: IssueCommentPerformedViaGithubApp,
+    pub performed_via_github_app: Option<App>,
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     #[doc = "URL for the issue comment"]
     pub url: String,
@@ -939,7 +939,7 @@ pub enum IssueCommentEvent {
 pub struct IssuesAssigned {
     #[doc = "The action that was performed."]
     pub action: IssuesAssignedAction,
-    pub assignee: Option<IssuesAssignedAssignee>,
+    pub assignee: Option<User>,
     pub installation: Option<InstallationLite>,
     pub issue: Issue,
     pub organization: Option<Organization>,
@@ -1059,7 +1059,7 @@ pub struct IssuesTransferred {
 pub struct IssuesUnassigned {
     #[doc = "The action that was performed."]
     pub action: IssuesUnassignedAction,
-    pub assignee: Option<IssuesUnassignedAssignee>,
+    pub assignee: Option<User>,
     pub installation: Option<InstallationLite>,
     pub issue: Issue,
     pub organization: Option<Organization>,
@@ -1749,7 +1749,7 @@ pub struct PublicEvent {
 pub struct PullRequest {
     pub active_lock_reason: Option<PullRequestActiveLockReason>,
     pub additions: u64,
-    pub assignee: PullRequestAssignee,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
@@ -1781,8 +1781,8 @@ pub struct PullRequest {
     pub mergeable_state: String,
     pub merged: Option<bool>,
     pub merged_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub merged_by: PullRequestMergedBy,
-    pub milestone: PullRequestMilestone,
+    pub merged_by: Option<User>,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: u64,
@@ -2183,7 +2183,7 @@ pub struct PushEvent {
     pub created: bool,
     pub deleted: bool,
     pub forced: bool,
-    pub head_commit: PushEventHeadCommit,
+    pub head_commit: Option<Commit>,
     pub installation: Option<InstallationLite>,
     pub organization: Option<Organization>,
     pub pusher: Committer,
@@ -2383,7 +2383,7 @@ pub struct Repository {
     pub labels_url: String,
     pub language: Option<String>,
     pub languages_url: String,
-    pub license: RepositoryLicense,
+    pub license: Option<License>,
     pub master_branch: Option<String>,
     pub merges_url: String,
     pub milestones_url: String,
@@ -2675,7 +2675,7 @@ pub enum SecurityAdvisoryEvent {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SimplePullRequest {
     pub active_lock_reason: Option<SimplePullRequestActiveLockReason>,
-    pub assignee: SimplePullRequestAssignee,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
@@ -2697,7 +2697,7 @@ pub struct SimplePullRequest {
     pub locked: bool,
     pub merge_commit_sha: Option<String>,
     pub merged_at: Option<String>,
-    pub milestone: SimplePullRequestMilestone,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     pub number: u64,
     pub patch_url: String,
@@ -3037,7 +3037,7 @@ pub struct WorkflowStepInProgress {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowDispatchEvent {
-    pub inputs: WorkflowDispatchEventInputs,
+    pub inputs: Option<serde_json::Value>,
     pub installation: Option<InstallationLite>,
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -5042,12 +5042,6 @@ impl ToString for CodeScanningAlertAppearedInBranchAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum CodeScanningAlertAppearedInBranchAlertDismissedBy {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertAppearedInBranchAlertDismissedReason {
     #[serde(rename = "false positive")]
     FalsePositive,
@@ -5132,7 +5126,7 @@ pub struct CodeScanningAlertAppearedInBranchAlert {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
     #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
     pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub dismissed_by: CodeScanningAlertAppearedInBranchAlertDismissedBy,
+    pub dismissed_by: Option<User>,
     #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
     pub dismissed_reason: Option<CodeScanningAlertAppearedInBranchAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
@@ -5412,12 +5406,6 @@ impl ToString for CodeScanningAlertFixedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum CodeScanningAlertFixedAlertDismissedBy {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertFixedAlertDismissedReason {
     #[serde(rename = "false positive")]
     FalsePositive,
@@ -5520,7 +5508,7 @@ pub struct CodeScanningAlertFixedAlert {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
     #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
     pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub dismissed_by: CodeScanningAlertFixedAlertDismissedBy,
+    pub dismissed_by: Option<User>,
     #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
     pub dismissed_reason: Option<CodeScanningAlertFixedAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
@@ -5795,12 +5783,6 @@ pub struct CommitCommentCreatedComment {
     pub user: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum CommitterEmail {
-    Variant0(String),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ContentReferenceCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -5907,12 +5889,6 @@ impl ToString for DeploymentCreatedAction {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeploymentCreatedDeploymentPayload {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum DeploymentCreatedDeploymentPerformedViaGithubApp {
-    Variant0(App),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeploymentCreatedDeployment {
     pub created_at: String,
     pub creator: User,
@@ -5922,7 +5898,7 @@ pub struct DeploymentCreatedDeployment {
     pub node_id: String,
     pub original_environment: String,
     pub payload: DeploymentCreatedDeploymentPayload,
-    pub performed_via_github_app: Option<DeploymentCreatedDeploymentPerformedViaGithubApp>,
+    pub performed_via_github_app: Option<App>,
     pub repository_url: String,
     #[serde(rename = "ref")]
     pub rref: String,
@@ -5947,12 +5923,6 @@ impl ToString for DeploymentStatusCreatedAction {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeploymentStatusCreatedDeploymentPayload {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum DeploymentStatusCreatedDeploymentPerformedViaGithubApp {
-    Variant0(App),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeploymentStatusCreatedDeployment {
     pub created_at: String,
     pub creator: User,
@@ -5962,7 +5932,7 @@ pub struct DeploymentStatusCreatedDeployment {
     pub node_id: String,
     pub original_environment: String,
     pub payload: DeploymentStatusCreatedDeploymentPayload,
-    pub performed_via_github_app: DeploymentStatusCreatedDeploymentPerformedViaGithubApp,
+    pub performed_via_github_app: Option<App>,
     pub repository_url: String,
     #[serde(rename = "ref")]
     pub rref: String,
@@ -5971,12 +5941,6 @@ pub struct DeploymentStatusCreatedDeployment {
     pub task: String,
     pub updated_at: String,
     pub url: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum DeploymentStatusCreatedDeploymentStatusPerformedViaGithubApp {
-    Variant0(App),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeploymentStatusCreatedDeploymentStatus {
@@ -5988,8 +5952,7 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub environment: String,
     pub id: u64,
     pub node_id: String,
-    pub performed_via_github_app:
-        Option<DeploymentStatusCreatedDeploymentStatusPerformedViaGithubApp>,
+    pub performed_via_github_app: Option<App>,
     pub repository_url: String,
     #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
     pub state: String,
@@ -5997,12 +5960,6 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub target_url: String,
     pub updated_at: String,
     pub url: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum DiscussionAnswerChosenBy {
-    Variant0(User),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionCategory {
@@ -7245,12 +7202,6 @@ impl ToString for InstallationRepositorySelection {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum InstallationSuspendedBy {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InstallationTargetType {
     User,
     Organization,
@@ -7460,12 +7411,6 @@ impl ToString for InstallationRepositoriesAddedRepositorySelection {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum InstallationRepositoriesAddedRequester {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InstallationRepositoriesRemovedAction {
     #[serde(rename = "removed")]
     Removed,
@@ -7515,12 +7460,6 @@ impl ToString for InstallationRepositoriesRemovedRepositorySelection {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum InstallationRepositoriesRemovedRequester {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -7540,24 +7479,6 @@ impl ToString for IssueActiveLockReason {
             IssueActiveLockReason::Spam => "spam".to_string(),
         }
     }
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueMilestone {
-    Variant0(Milestone),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssuePerformedViaGithubApp {
-    Variant0(App),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuePullRequest {
@@ -7582,12 +7503,6 @@ impl ToString for IssueState {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueCommentPerformedViaGithubApp {
-    Variant0(App),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -7598,12 +7513,6 @@ impl ToString for IssueCommentCreatedAction {
             IssueCommentCreatedAction::Created => "created".to_string(),
         }
     }
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueCommentCreatedIssueVariant1Assignee {
-    Variant0(User),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentCreatedIssueVariant1PullRequest {
@@ -7629,7 +7538,7 @@ impl ToString for IssueCommentCreatedIssueVariant1State {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentCreatedIssueVariant1 {
-    pub assignee: IssueCommentCreatedIssueVariant1Assignee,
+    pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
     pub pull_request: Option<IssueCommentCreatedIssueVariant1PullRequest>,
@@ -7656,12 +7565,6 @@ impl ToString for IssueCommentDeletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueCommentDeletedIssueVariant1Assignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentDeletedIssueVariant1PullRequest {
     pub diff_url: String,
     pub html_url: String,
@@ -7685,7 +7588,7 @@ impl ToString for IssueCommentDeletedIssueVariant1State {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentDeletedIssueVariant1 {
-    pub assignee: IssueCommentDeletedIssueVariant1Assignee,
+    pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
     pub pull_request: Option<IssueCommentDeletedIssueVariant1PullRequest>,
@@ -7721,12 +7624,6 @@ pub struct IssueCommentEditedChanges {
     pub body: Option<IssueCommentEditedChangesBody>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssueCommentEditedIssueVariant1Assignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentEditedIssueVariant1PullRequest {
     pub diff_url: String,
     pub html_url: String,
@@ -7750,7 +7647,7 @@ impl ToString for IssueCommentEditedIssueVariant1State {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentEditedIssueVariant1 {
-    pub assignee: IssueCommentEditedIssueVariant1Assignee,
+    pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
     pub pull_request: Option<IssueCommentEditedIssueVariant1PullRequest>,
@@ -7775,12 +7672,6 @@ impl ToString for IssuesAssignedAction {
             IssuesAssignedAction::Assigned => "assigned".to_string(),
         }
     }
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssuesAssignedAssignee {
-    Variant0(User),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesClosedAction {
@@ -8076,12 +7967,6 @@ impl ToString for IssuesUnassignedAction {
             IssuesUnassignedAction::Unassigned => "unassigned".to_string(),
         }
     }
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum IssuesUnassignedAssignee {
-    Variant0(User),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesUnlabeledAction {
@@ -8839,16 +8724,10 @@ impl ToString for OrganizationMemberInvitedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum OrganizationMemberInvitedInvitationFailedAt {
-    Variant0(chrono::DateTime<chrono::offset::Utc>),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OrganizationMemberInvitedInvitation {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
     pub email: Option<String>,
-    pub failed_at: OrganizationMemberInvitedInvitationFailedAt,
+    pub failed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
     pub failed_reason: Option<String>,
     pub id: f64,
     pub invitation_teams_url: String,
@@ -9415,12 +9294,6 @@ impl ToString for PullRequestActiveLockReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestBase {
     pub label: String,
     pub repo: Repository,
@@ -9437,18 +9310,6 @@ pub struct PullRequestHead {
     pub rref: String,
     pub sha: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestMergedBy {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestMilestone {
-    Variant0(Milestone),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -10066,12 +9927,6 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentCreatedPullRequestAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentCreatedPullRequestBase {
     pub label: String,
     pub repo: Repository,
@@ -10088,12 +9943,6 @@ pub struct PullRequestReviewCommentCreatedPullRequestHead {
     pub rref: String,
     pub sha: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentCreatedPullRequestMilestone {
-    Variant0(Milestone),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -10119,7 +9968,7 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestState {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentCreatedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
-    pub assignee: PullRequestReviewCommentCreatedPullRequestAssignee,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: Option<()>,
@@ -10141,7 +9990,7 @@ pub struct PullRequestReviewCommentCreatedPullRequest {
     pub locked: bool,
     pub merge_commit_sha: Option<String>,
     pub merged_at: Option<String>,
-    pub milestone: PullRequestReviewCommentCreatedPullRequestMilestone,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     pub number: u64,
     pub patch_url: String,
@@ -10208,12 +10057,6 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentDeletedPullRequestAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentDeletedPullRequestBase {
     pub label: String,
     pub repo: Repository,
@@ -10230,12 +10073,6 @@ pub struct PullRequestReviewCommentDeletedPullRequestHead {
     pub rref: String,
     pub sha: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentDeletedPullRequestMilestone {
-    Variant0(Milestone),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -10261,7 +10098,7 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestState {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentDeletedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
-    pub assignee: PullRequestReviewCommentDeletedPullRequestAssignee,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: Option<()>,
@@ -10283,7 +10120,7 @@ pub struct PullRequestReviewCommentDeletedPullRequest {
     pub locked: bool,
     pub merge_commit_sha: Option<String>,
     pub merged_at: Option<String>,
-    pub milestone: PullRequestReviewCommentDeletedPullRequestMilestone,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     pub number: u64,
     pub patch_url: String,
@@ -10359,12 +10196,6 @@ impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentEditedPullRequestAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentEditedPullRequestBase {
     pub label: String,
     pub repo: Repository,
@@ -10381,12 +10212,6 @@ pub struct PullRequestReviewCommentEditedPullRequestHead {
     pub rref: String,
     pub sha: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentEditedPullRequestMilestone {
-    Variant0(Milestone),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -10412,7 +10237,7 @@ impl ToString for PullRequestReviewCommentEditedPullRequestState {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReviewCommentEditedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
-    pub assignee: PullRequestReviewCommentEditedPullRequestAssignee,
+    pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: Option<()>,
@@ -10434,7 +10259,7 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     pub locked: bool,
     pub merge_commit_sha: Option<String>,
     pub merged_at: Option<String>,
-    pub milestone: PullRequestReviewCommentEditedPullRequestMilestone,
+    pub milestone: Option<Milestone>,
     pub node_id: String,
     pub number: u64,
     pub patch_url: String,
@@ -10448,12 +10273,6 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     pub updated_at: String,
     pub url: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum PushEventHeadCommit {
-    Variant0(Commit),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleaseCreatedAction {
@@ -10605,12 +10424,6 @@ impl ToString for ReleaseAssetState {
 pub enum RepositoryCreatedAt {
     Variant0(u64),
     Variant1(chrono::DateTime<chrono::offset::Utc>),
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum RepositoryLicense {
-    Variant0(License),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryPermissions {
@@ -11309,12 +11122,6 @@ impl ToString for SimplePullRequestActiveLockReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum SimplePullRequestAssignee {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SimplePullRequestBase {
     pub label: String,
     pub repo: Repository,
@@ -11331,12 +11138,6 @@ pub struct SimplePullRequestHead {
     pub rref: String,
     pub sha: String,
     pub user: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum SimplePullRequestMilestone {
-    Variant0(Milestone),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -11550,12 +11351,6 @@ pub struct StatusEventBranchesItem {
     pub protected: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum StatusEventCommitAuthor {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitAuthorVariant1 {
     pub date: String,
 }
@@ -11660,12 +11455,6 @@ pub struct StatusEventCommitCommit {
     pub verification: StatusEventCommitCommitVerification,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum StatusEventCommitCommitter {
-    Variant0(User),
-    Variant1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitParentsItem {
     pub html_url: String,
     pub sha: String,
@@ -11673,10 +11462,10 @@ pub struct StatusEventCommitParentsItem {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommit {
-    pub author: StatusEventCommitAuthor,
+    pub author: Option<User>,
     pub comments_url: String,
     pub commit: StatusEventCommitCommit,
-    pub committer: StatusEventCommitCommitter,
+    pub committer: Option<User>,
     pub html_url: String,
     pub node_id: String,
     pub parents: Vec<StatusEventCommitParentsItem>,
@@ -12188,12 +11977,6 @@ impl ToString for WorkflowStepInProgressStatus {
             WorkflowStepInProgressStatus::InProgress => "in_progress".to_string(),
         }
     }
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum WorkflowDispatchEventInputs {
-    Variant0(serde_json::Value),
-    Variant1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowJobCompletedAction {

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -3014,8 +3014,8 @@ pub struct WorkflowRun {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum WorkflowStep {
-    Variant0(WorkflowStepInProgress),
-    Variant1(WorkflowStepCompleted),
+    InProgress(WorkflowStepInProgress),
+    Completed(WorkflowStepCompleted),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowStepCompleted {
@@ -5176,29 +5176,29 @@ impl ToString for CodeScanningAlertClosedByUserAlertDismissedReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertClosedByUserAlertInstancesItemVariant1State {
+pub enum CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State {
     #[serde(rename = "dismissed")]
     Dismissed,
 }
-impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemVariant1State {
+impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertClosedByUserAlertInstancesItemVariant1State::Dismissed => {
+            CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State::Dismissed => {
                 "dismissed".to_string()
             }
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertClosedByUserAlertInstancesItemVariant1 {
-    pub state: CodeScanningAlertClosedByUserAlertInstancesItemVariant1State,
+pub struct CodeScanningAlertClosedByUserAlertInstancesItemSubtype1 {
+    pub state: CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
     #[serde(flatten)]
-    pub variant_0: AlertInstance,
+    pub subtype_0: AlertInstance,
     #[serde(flatten)]
-    pub variant_1: CodeScanningAlertClosedByUserAlertInstancesItemVariant1,
+    pub subtype_1: CodeScanningAlertClosedByUserAlertInstancesItemSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertClosedByUserAlertRuleSeverity {
@@ -5288,32 +5288,32 @@ impl ToString for CodeScanningAlertCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertCreatedAlertInstancesItemVariant1State {
+pub enum CodeScanningAlertCreatedAlertInstancesItemSubtype1State {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
     Dismissed,
 }
-impl ToString for CodeScanningAlertCreatedAlertInstancesItemVariant1State {
+impl ToString for CodeScanningAlertCreatedAlertInstancesItemSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertCreatedAlertInstancesItemVariant1State::Open => "open".to_string(),
-            CodeScanningAlertCreatedAlertInstancesItemVariant1State::Dismissed => {
+            CodeScanningAlertCreatedAlertInstancesItemSubtype1State::Open => "open".to_string(),
+            CodeScanningAlertCreatedAlertInstancesItemSubtype1State::Dismissed => {
                 "dismissed".to_string()
             }
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertCreatedAlertInstancesItemVariant1 {
-    pub state: CodeScanningAlertCreatedAlertInstancesItemVariant1State,
+pub struct CodeScanningAlertCreatedAlertInstancesItemSubtype1 {
+    pub state: CodeScanningAlertCreatedAlertInstancesItemSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertCreatedAlertInstancesItem {
     #[serde(flatten)]
-    pub variant_0: AlertInstance,
+    pub subtype_0: AlertInstance,
     #[serde(flatten)]
-    pub variant_1: CodeScanningAlertCreatedAlertInstancesItemVariant1,
+    pub subtype_1: CodeScanningAlertCreatedAlertInstancesItemSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertCreatedAlertRuleSeverity {
@@ -5426,27 +5426,27 @@ impl ToString for CodeScanningAlertFixedAlertDismissedReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertFixedAlertInstancesItemVariant1State {
+pub enum CodeScanningAlertFixedAlertInstancesItemSubtype1State {
     #[serde(rename = "fixed")]
     Fixed,
 }
-impl ToString for CodeScanningAlertFixedAlertInstancesItemVariant1State {
+impl ToString for CodeScanningAlertFixedAlertInstancesItemSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertFixedAlertInstancesItemVariant1State::Fixed => "fixed".to_string(),
+            CodeScanningAlertFixedAlertInstancesItemSubtype1State::Fixed => "fixed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertFixedAlertInstancesItemVariant1 {
-    pub state: CodeScanningAlertFixedAlertInstancesItemVariant1State,
+pub struct CodeScanningAlertFixedAlertInstancesItemSubtype1 {
+    pub state: CodeScanningAlertFixedAlertInstancesItemSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertFixedAlertInstancesItem {
     #[serde(flatten)]
-    pub variant_0: AlertInstance,
+    pub subtype_0: AlertInstance,
     #[serde(flatten)]
-    pub variant_1: CodeScanningAlertFixedAlertInstancesItemVariant1,
+    pub subtype_1: CodeScanningAlertFixedAlertInstancesItemSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertFixedAlertRuleSeverity {
@@ -5537,27 +5537,27 @@ impl ToString for CodeScanningAlertReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertReopenedAlertInstancesItemVariant1State {
+pub enum CodeScanningAlertReopenedAlertInstancesItemSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for CodeScanningAlertReopenedAlertInstancesItemVariant1State {
+impl ToString for CodeScanningAlertReopenedAlertInstancesItemSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertReopenedAlertInstancesItemVariant1State::Open => "open".to_string(),
+            CodeScanningAlertReopenedAlertInstancesItemSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertReopenedAlertInstancesItemVariant1 {
-    pub state: CodeScanningAlertReopenedAlertInstancesItemVariant1State,
+pub struct CodeScanningAlertReopenedAlertInstancesItemSubtype1 {
+    pub state: CodeScanningAlertReopenedAlertInstancesItemSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertReopenedAlertInstancesItem {
     #[serde(flatten)]
-    pub variant_0: AlertInstance,
+    pub subtype_0: AlertInstance,
     #[serde(flatten)]
-    pub variant_1: CodeScanningAlertReopenedAlertInstancesItemVariant1,
+    pub subtype_1: CodeScanningAlertReopenedAlertInstancesItemSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertReopenedAlertRuleSeverity {
@@ -5653,29 +5653,29 @@ impl ToString for CodeScanningAlertReopenedByUserAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertReopenedByUserAlertInstancesItemVariant1State {
+pub enum CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemVariant1State {
+impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertReopenedByUserAlertInstancesItemVariant1State::Open => {
+            CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State::Open => {
                 "open".to_string()
             }
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertReopenedByUserAlertInstancesItemVariant1 {
-    pub state: CodeScanningAlertReopenedByUserAlertInstancesItemVariant1State,
+pub struct CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1 {
+    pub state: CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
     #[serde(flatten)]
-    pub variant_0: AlertInstance,
+    pub subtype_0: AlertInstance,
     #[serde(flatten)]
-    pub variant_1: CodeScanningAlertReopenedByUserAlertInstancesItemVariant1,
+    pub subtype_1: CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertReopenedByUserAlertRuleSeverity {
@@ -6019,22 +6019,22 @@ pub struct DiscussionAnsweredAnswer {
     pub user: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionAnsweredDiscussionVariant1Category {
+pub struct DiscussionAnsweredDiscussionSubtype1Category {
     pub is_answerable: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionAnsweredDiscussionVariant1 {
+pub struct DiscussionAnsweredDiscussionSubtype1 {
     pub answer_chosen_at: chrono::DateTime<chrono::offset::Utc>,
     pub answer_chosen_by: User,
     pub answer_html_url: String,
-    pub category: DiscussionAnsweredDiscussionVariant1Category,
+    pub category: DiscussionAnsweredDiscussionSubtype1Category,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionAnsweredDiscussion {
     #[serde(flatten)]
-    pub variant_0: Discussion,
+    pub subtype_0: Discussion,
     #[serde(flatten)]
-    pub variant_1: DiscussionAnsweredDiscussionVariant1,
+    pub subtype_1: DiscussionAnsweredDiscussionSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionCategoryChangedAction {
@@ -6081,34 +6081,34 @@ impl ToString for DiscussionCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionCreatedDiscussionVariant1State {
+pub enum DiscussionCreatedDiscussionSubtype1State {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "converting")]
     Converting,
 }
-impl ToString for DiscussionCreatedDiscussionVariant1State {
+impl ToString for DiscussionCreatedDiscussionSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            DiscussionCreatedDiscussionVariant1State::Open => "open".to_string(),
-            DiscussionCreatedDiscussionVariant1State::Converting => "converting".to_string(),
+            DiscussionCreatedDiscussionSubtype1State::Open => "open".to_string(),
+            DiscussionCreatedDiscussionSubtype1State::Converting => "converting".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionCreatedDiscussionVariant1 {
+pub struct DiscussionCreatedDiscussionSubtype1 {
     pub answer_chosen_at: (),
     pub answer_chosen_by: (),
     pub answer_html_url: (),
     pub locked: bool,
-    pub state: DiscussionCreatedDiscussionVariant1State,
+    pub state: DiscussionCreatedDiscussionSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionCreatedDiscussion {
     #[serde(flatten)]
-    pub variant_0: Discussion,
+    pub subtype_0: Discussion,
     #[serde(flatten)]
-    pub variant_1: DiscussionCreatedDiscussionVariant1,
+    pub subtype_1: DiscussionCreatedDiscussionSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionDeletedAction {
@@ -6172,28 +6172,28 @@ impl ToString for DiscussionLockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionLockedDiscussionVariant1State {
+pub enum DiscussionLockedDiscussionSubtype1State {
     #[serde(rename = "locked")]
     Locked,
 }
-impl ToString for DiscussionLockedDiscussionVariant1State {
+impl ToString for DiscussionLockedDiscussionSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            DiscussionLockedDiscussionVariant1State::Locked => "locked".to_string(),
+            DiscussionLockedDiscussionSubtype1State::Locked => "locked".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionLockedDiscussionVariant1 {
+pub struct DiscussionLockedDiscussionSubtype1 {
     pub locked: bool,
-    pub state: DiscussionLockedDiscussionVariant1State,
+    pub state: DiscussionLockedDiscussionSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionLockedDiscussion {
     #[serde(flatten)]
-    pub variant_0: Discussion,
+    pub subtype_0: Discussion,
     #[serde(flatten)]
-    pub variant_1: DiscussionLockedDiscussionVariant1,
+    pub subtype_1: DiscussionLockedDiscussionSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionPinnedAction {
@@ -6237,22 +6237,22 @@ impl ToString for DiscussionUnansweredAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnansweredDiscussionVariant1Category {
+pub struct DiscussionUnansweredDiscussionSubtype1Category {
     pub is_answerable: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnansweredDiscussionVariant1 {
+pub struct DiscussionUnansweredDiscussionSubtype1 {
     pub answer_chosen_at: (),
     pub answer_chosen_by: (),
     pub answer_html_url: (),
-    pub category: DiscussionUnansweredDiscussionVariant1Category,
+    pub category: DiscussionUnansweredDiscussionSubtype1Category,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnansweredDiscussion {
     #[serde(flatten)]
-    pub variant_0: Discussion,
+    pub subtype_0: Discussion,
     #[serde(flatten)]
-    pub variant_1: DiscussionUnansweredDiscussionVariant1,
+    pub subtype_1: DiscussionUnansweredDiscussionSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnansweredOldAnswer {
@@ -6294,28 +6294,28 @@ impl ToString for DiscussionUnlockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionUnlockedDiscussionVariant1State {
+pub enum DiscussionUnlockedDiscussionSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for DiscussionUnlockedDiscussionVariant1State {
+impl ToString for DiscussionUnlockedDiscussionSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            DiscussionUnlockedDiscussionVariant1State::Open => "open".to_string(),
+            DiscussionUnlockedDiscussionSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnlockedDiscussionVariant1 {
+pub struct DiscussionUnlockedDiscussionSubtype1 {
     pub locked: bool,
-    pub state: DiscussionUnlockedDiscussionVariant1State,
+    pub state: DiscussionUnlockedDiscussionSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnlockedDiscussion {
     #[serde(flatten)]
-    pub variant_0: Discussion,
+    pub subtype_0: Discussion,
     #[serde(flatten)]
-    pub variant_1: DiscussionUnlockedDiscussionVariant1,
+    pub subtype_1: DiscussionUnlockedDiscussionSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionUnpinnedAction {
@@ -6419,15 +6419,15 @@ pub struct DiscussionCommentEditedComment {
     pub user: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ForkEventForkeeVariant1 {
+pub struct ForkEventForkeeSubtype1 {
     pub fork: Option<bool>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ForkEventForkee {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: ForkEventForkeeVariant1,
+    pub subtype_1: ForkEventForkeeSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GithubAppAuthorizationRevokedAction {
@@ -7304,16 +7304,16 @@ impl ToString for InstallationSuspendAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InstallationSuspendInstallationVariant1 {
+pub struct InstallationSuspendInstallationSubtype1 {
     pub suspended_at: chrono::DateTime<chrono::offset::Utc>,
     pub suspended_by: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationSuspendInstallation {
     #[serde(flatten)]
-    pub variant_0: Installation,
+    pub subtype_0: Installation,
     #[serde(flatten)]
-    pub variant_1: InstallationSuspendInstallationVariant1,
+    pub subtype_1: InstallationSuspendInstallationSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationSuspendRepositoriesItem {
@@ -7339,16 +7339,16 @@ impl ToString for InstallationUnsuspendAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InstallationUnsuspendInstallationVariant1 {
+pub struct InstallationUnsuspendInstallationSubtype1 {
     pub suspended_at: (),
     pub suspended_by: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationUnsuspendInstallation {
     #[serde(flatten)]
-    pub variant_0: Installation,
+    pub subtype_0: Installation,
     #[serde(flatten)]
-    pub variant_1: InstallationUnsuspendInstallationVariant1,
+    pub subtype_1: InstallationUnsuspendInstallationSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationUnsuspendRepositoriesItem {
@@ -7515,42 +7515,42 @@ impl ToString for IssueCommentCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentCreatedIssueVariant1PullRequest {
+pub struct IssueCommentCreatedIssueSubtype1PullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentCreatedIssueVariant1State {
+pub enum IssueCommentCreatedIssueSubtype1State {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentCreatedIssueVariant1State {
+impl ToString for IssueCommentCreatedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentCreatedIssueVariant1State::Open => "open".to_string(),
-            IssueCommentCreatedIssueVariant1State::Closed => "closed".to_string(),
+            IssueCommentCreatedIssueSubtype1State::Open => "open".to_string(),
+            IssueCommentCreatedIssueSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentCreatedIssueVariant1 {
+pub struct IssueCommentCreatedIssueSubtype1 {
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentCreatedIssueVariant1PullRequest>,
+    pub pull_request: Option<IssueCommentCreatedIssueSubtype1PullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentCreatedIssueVariant1State,
+    pub state: IssueCommentCreatedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentCreatedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssueCommentCreatedIssueVariant1,
+    pub subtype_1: IssueCommentCreatedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueCommentDeletedAction {
@@ -7565,42 +7565,42 @@ impl ToString for IssueCommentDeletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentDeletedIssueVariant1PullRequest {
+pub struct IssueCommentDeletedIssueSubtype1PullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentDeletedIssueVariant1State {
+pub enum IssueCommentDeletedIssueSubtype1State {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentDeletedIssueVariant1State {
+impl ToString for IssueCommentDeletedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentDeletedIssueVariant1State::Open => "open".to_string(),
-            IssueCommentDeletedIssueVariant1State::Closed => "closed".to_string(),
+            IssueCommentDeletedIssueSubtype1State::Open => "open".to_string(),
+            IssueCommentDeletedIssueSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentDeletedIssueVariant1 {
+pub struct IssueCommentDeletedIssueSubtype1 {
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentDeletedIssueVariant1PullRequest>,
+    pub pull_request: Option<IssueCommentDeletedIssueSubtype1PullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentDeletedIssueVariant1State,
+    pub state: IssueCommentDeletedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentDeletedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssueCommentDeletedIssueVariant1,
+    pub subtype_1: IssueCommentDeletedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueCommentEditedAction {
@@ -7624,42 +7624,42 @@ pub struct IssueCommentEditedChanges {
     pub body: Option<IssueCommentEditedChangesBody>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentEditedIssueVariant1PullRequest {
+pub struct IssueCommentEditedIssueSubtype1PullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentEditedIssueVariant1State {
+pub enum IssueCommentEditedIssueSubtype1State {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentEditedIssueVariant1State {
+impl ToString for IssueCommentEditedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentEditedIssueVariant1State::Open => "open".to_string(),
-            IssueCommentEditedIssueVariant1State::Closed => "closed".to_string(),
+            IssueCommentEditedIssueSubtype1State::Open => "open".to_string(),
+            IssueCommentEditedIssueSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentEditedIssueVariant1 {
+pub struct IssueCommentEditedIssueSubtype1 {
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentEditedIssueVariant1PullRequest>,
+    pub pull_request: Option<IssueCommentEditedIssueSubtype1PullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentEditedIssueVariant1State,
+    pub state: IssueCommentEditedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssueCommentEditedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssueCommentEditedIssueVariant1,
+    pub subtype_1: IssueCommentEditedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesAssignedAction {
@@ -7686,28 +7686,28 @@ impl ToString for IssuesClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesClosedIssueVariant1State {
+pub enum IssuesClosedIssueSubtype1State {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssuesClosedIssueVariant1State {
+impl ToString for IssuesClosedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssuesClosedIssueVariant1State::Closed => "closed".to_string(),
+            IssuesClosedIssueSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesClosedIssueVariant1 {
+pub struct IssuesClosedIssueSubtype1 {
     pub closed_at: String,
-    pub state: IssuesClosedIssueVariant1State,
+    pub state: IssuesClosedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesClosedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesClosedIssueVariant1,
+    pub subtype_1: IssuesClosedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesDeletedAction {
@@ -7734,15 +7734,15 @@ impl ToString for IssuesDemilestonedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesDemilestonedIssueVariant1 {
+pub struct IssuesDemilestonedIssueSubtype1 {
     pub milestone: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesDemilestonedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesDemilestonedIssueVariant1,
+    pub subtype_1: IssuesDemilestonedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesEditedAction {
@@ -7796,7 +7796,7 @@ impl ToString for IssuesLockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesLockedIssueVariant1ActiveLockReason {
+pub enum IssuesLockedIssueSubtype1ActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -7806,27 +7806,27 @@ pub enum IssuesLockedIssueVariant1ActiveLockReason {
     #[serde(rename = "spam")]
     Spam,
 }
-impl ToString for IssuesLockedIssueVariant1ActiveLockReason {
+impl ToString for IssuesLockedIssueSubtype1ActiveLockReason {
     fn to_string(&self) -> String {
         match self {
-            IssuesLockedIssueVariant1ActiveLockReason::Resolved => "resolved".to_string(),
-            IssuesLockedIssueVariant1ActiveLockReason::OffTopic => "off-topic".to_string(),
-            IssuesLockedIssueVariant1ActiveLockReason::TooHeated => "too heated".to_string(),
-            IssuesLockedIssueVariant1ActiveLockReason::Spam => "spam".to_string(),
+            IssuesLockedIssueSubtype1ActiveLockReason::Resolved => "resolved".to_string(),
+            IssuesLockedIssueSubtype1ActiveLockReason::OffTopic => "off-topic".to_string(),
+            IssuesLockedIssueSubtype1ActiveLockReason::TooHeated => "too heated".to_string(),
+            IssuesLockedIssueSubtype1ActiveLockReason::Spam => "spam".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesLockedIssueVariant1 {
-    pub active_lock_reason: Option<IssuesLockedIssueVariant1ActiveLockReason>,
+pub struct IssuesLockedIssueSubtype1 {
+    pub active_lock_reason: Option<IssuesLockedIssueSubtype1ActiveLockReason>,
     pub locked: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesLockedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesLockedIssueVariant1,
+    pub subtype_1: IssuesLockedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesMilestonedAction {
@@ -7841,15 +7841,15 @@ impl ToString for IssuesMilestonedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesMilestonedIssueVariant1 {
+pub struct IssuesMilestonedIssueSubtype1 {
     pub milestone: Milestone,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesMilestonedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesMilestonedIssueVariant1,
+    pub subtype_1: IssuesMilestonedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesOpenedAction {
@@ -7869,28 +7869,28 @@ pub struct IssuesOpenedChanges {
     pub old_repository: Repository,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesOpenedIssueVariant1State {
+pub enum IssuesOpenedIssueSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for IssuesOpenedIssueVariant1State {
+impl ToString for IssuesOpenedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssuesOpenedIssueVariant1State::Open => "open".to_string(),
+            IssuesOpenedIssueSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesOpenedIssueVariant1 {
+pub struct IssuesOpenedIssueSubtype1 {
     pub closed_at: (),
-    pub state: IssuesOpenedIssueVariant1State,
+    pub state: IssuesOpenedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesOpenedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesOpenedIssueVariant1,
+    pub subtype_1: IssuesOpenedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesPinnedAction {
@@ -7917,27 +7917,27 @@ impl ToString for IssuesReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesReopenedIssueVariant1State {
+pub enum IssuesReopenedIssueSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for IssuesReopenedIssueVariant1State {
+impl ToString for IssuesReopenedIssueSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            IssuesReopenedIssueVariant1State::Open => "open".to_string(),
+            IssuesReopenedIssueSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesReopenedIssueVariant1 {
-    pub state: IssuesReopenedIssueVariant1State,
+pub struct IssuesReopenedIssueSubtype1 {
+    pub state: IssuesReopenedIssueSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesReopenedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesReopenedIssueVariant1,
+    pub subtype_1: IssuesReopenedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesTransferredAction {
@@ -7993,16 +7993,16 @@ impl ToString for IssuesUnlockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesUnlockedIssueVariant1 {
+pub struct IssuesUnlockedIssueSubtype1 {
     pub active_lock_reason: (),
     pub locked: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesUnlockedIssue {
     #[serde(flatten)]
-    pub variant_0: Issue,
+    pub subtype_0: Issue,
     #[serde(flatten)]
-    pub variant_1: IssuesUnlockedIssueVariant1,
+    pub subtype_1: IssuesUnlockedIssueSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesUnpinnedAction {
@@ -8107,15 +8107,15 @@ impl ToString for MarketplacePurchaseCancelledAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchaseCancelledMarketplacePurchaseVariant1 {
+pub struct MarketplacePurchaseCancelledMarketplacePurchaseSubtype1 {
     pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseCancelledMarketplacePurchase {
     #[serde(flatten)]
-    pub variant_0: MarketplacePurchase,
+    pub subtype_0: MarketplacePurchase,
     #[serde(flatten)]
-    pub variant_1: MarketplacePurchaseCancelledMarketplacePurchaseVariant1,
+    pub subtype_1: MarketplacePurchaseCancelledMarketplacePurchaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseCancelledSender {
@@ -8152,15 +8152,15 @@ impl ToString for MarketplacePurchaseChangedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchaseChangedMarketplacePurchaseVariant1 {
+pub struct MarketplacePurchaseChangedMarketplacePurchaseSubtype1 {
     pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseChangedMarketplacePurchase {
     #[serde(flatten)]
-    pub variant_0: MarketplacePurchase,
+    pub subtype_0: MarketplacePurchase,
     #[serde(flatten)]
-    pub variant_1: MarketplacePurchaseChangedMarketplacePurchaseVariant1,
+    pub subtype_1: MarketplacePurchaseChangedMarketplacePurchaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseChangedSender {
@@ -8197,15 +8197,15 @@ impl ToString for MarketplacePurchasePendingChangeAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePendingChangeMarketplacePurchaseVariant1 {
+pub struct MarketplacePurchasePendingChangeMarketplacePurchaseSubtype1 {
     pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeMarketplacePurchase {
     #[serde(flatten)]
-    pub variant_0: MarketplacePurchase,
+    pub subtype_0: MarketplacePurchase,
     #[serde(flatten)]
-    pub variant_1: MarketplacePurchasePendingChangeMarketplacePurchaseVariant1,
+    pub subtype_1: MarketplacePurchasePendingChangeMarketplacePurchaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeSender {
@@ -8244,15 +8244,15 @@ impl ToString for MarketplacePurchasePendingChangeCancelledAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseVariant1 {
+pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseSubtype1 {
     pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchase {
     #[serde(flatten)]
-    pub variant_0: MarketplacePurchase,
+    pub subtype_0: MarketplacePurchase,
     #[serde(flatten)]
-    pub variant_1: MarketplacePurchasePendingChangeCancelledMarketplacePurchaseVariant1,
+    pub subtype_1: MarketplacePurchasePendingChangeCancelledMarketplacePurchaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeCancelledSender {
@@ -8289,15 +8289,15 @@ impl ToString for MarketplacePurchasePurchasedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePurchasedMarketplacePurchaseVariant1 {
+pub struct MarketplacePurchasePurchasedMarketplacePurchaseSubtype1 {
     pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePurchasedMarketplacePurchase {
     #[serde(flatten)]
-    pub variant_0: MarketplacePurchase,
+    pub subtype_0: MarketplacePurchase,
     #[serde(flatten)]
-    pub variant_1: MarketplacePurchasePurchasedMarketplacePurchaseVariant1,
+    pub subtype_1: MarketplacePurchasePurchasedMarketplacePurchaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePurchasedSender {
@@ -8523,28 +8523,28 @@ impl ToString for MilestoneClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneClosedMilestoneVariant1State {
+pub enum MilestoneClosedMilestoneSubtype1State {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for MilestoneClosedMilestoneVariant1State {
+impl ToString for MilestoneClosedMilestoneSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            MilestoneClosedMilestoneVariant1State::Closed => "closed".to_string(),
+            MilestoneClosedMilestoneSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneClosedMilestoneVariant1 {
+pub struct MilestoneClosedMilestoneSubtype1 {
     pub closed_at: String,
-    pub state: MilestoneClosedMilestoneVariant1State,
+    pub state: MilestoneClosedMilestoneSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneClosedMilestone {
     #[serde(flatten)]
-    pub variant_0: Milestone,
+    pub subtype_0: Milestone,
     #[serde(flatten)]
-    pub variant_1: MilestoneClosedMilestoneVariant1,
+    pub subtype_1: MilestoneClosedMilestoneSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MilestoneCreatedAction {
@@ -8559,28 +8559,28 @@ impl ToString for MilestoneCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneCreatedMilestoneVariant1State {
+pub enum MilestoneCreatedMilestoneSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for MilestoneCreatedMilestoneVariant1State {
+impl ToString for MilestoneCreatedMilestoneSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            MilestoneCreatedMilestoneVariant1State::Open => "open".to_string(),
+            MilestoneCreatedMilestoneSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneCreatedMilestoneVariant1 {
+pub struct MilestoneCreatedMilestoneSubtype1 {
     pub closed_at: (),
-    pub state: MilestoneCreatedMilestoneVariant1State,
+    pub state: MilestoneCreatedMilestoneSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneCreatedMilestone {
     #[serde(flatten)]
-    pub variant_0: Milestone,
+    pub subtype_0: Milestone,
     #[serde(flatten)]
-    pub variant_1: MilestoneCreatedMilestoneVariant1,
+    pub subtype_1: MilestoneCreatedMilestoneSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MilestoneDeletedAction {
@@ -8640,28 +8640,28 @@ impl ToString for MilestoneOpenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneOpenedMilestoneVariant1State {
+pub enum MilestoneOpenedMilestoneSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for MilestoneOpenedMilestoneVariant1State {
+impl ToString for MilestoneOpenedMilestoneSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            MilestoneOpenedMilestoneVariant1State::Open => "open".to_string(),
+            MilestoneOpenedMilestoneSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneOpenedMilestoneVariant1 {
+pub struct MilestoneOpenedMilestoneSubtype1 {
     pub closed_at: (),
-    pub state: MilestoneOpenedMilestoneVariant1State,
+    pub state: MilestoneOpenedMilestoneSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneOpenedMilestone {
     #[serde(flatten)]
-    pub variant_0: Milestone,
+    pub subtype_0: Milestone,
     #[serde(flatten)]
-    pub variant_1: MilestoneOpenedMilestoneVariant1,
+    pub subtype_1: MilestoneOpenedMilestoneSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum OrgBlockBlockedAction {
@@ -9183,15 +9183,15 @@ pub struct ProjectCardMovedChanges {
     pub column_id: ProjectCardMovedChangesColumnId,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ProjectCardMovedProjectCardVariant1 {
+pub struct ProjectCardMovedProjectCardSubtype1 {
     pub after_id: Option<f64>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProjectCardMovedProjectCard {
     #[serde(flatten)]
-    pub variant_0: ProjectCard,
+    pub subtype_0: ProjectCard,
     #[serde(flatten)]
-    pub variant_1: ProjectCardMovedProjectCardVariant1,
+    pub subtype_1: ProjectCardMovedProjectCardSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ProjectColumnCreatedAction {
@@ -9250,15 +9250,15 @@ impl ToString for ProjectColumnMovedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PublicEventRepositoryVariant1 {
+pub struct PublicEventRepositorySubtype1 {
     pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PublicEventRepository {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: PublicEventRepositoryVariant1,
+    pub subtype_1: PublicEventRepositorySubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestLinks {
@@ -9314,8 +9314,8 @@ pub struct PullRequestHead {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum PullRequestRequestedReviewersItem {
-    Variant0(User),
-    Variant1(Team),
+    User(User),
+    Team(Team),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestState {
@@ -9420,30 +9420,30 @@ impl ToString for PullRequestClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestClosedPullRequestVariant1State {
+pub enum PullRequestClosedPullRequestSubtype1State {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for PullRequestClosedPullRequestVariant1State {
+impl ToString for PullRequestClosedPullRequestSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            PullRequestClosedPullRequestVariant1State::Closed => "closed".to_string(),
+            PullRequestClosedPullRequestSubtype1State::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestClosedPullRequestVariant1 {
+pub struct PullRequestClosedPullRequestSubtype1 {
     pub closed_at: chrono::DateTime<chrono::offset::Utc>,
     pub merged: bool,
     #[doc = "State of this Pull Request. Either `open` or `closed`."]
-    pub state: PullRequestClosedPullRequestVariant1State,
+    pub state: PullRequestClosedPullRequestSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestClosedPullRequest {
     #[serde(flatten)]
-    pub variant_0: PullRequest,
+    pub subtype_0: PullRequest,
     #[serde(flatten)]
-    pub variant_1: PullRequestClosedPullRequestVariant1,
+    pub subtype_1: PullRequestClosedPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestConvertedToDraftAction {
@@ -9458,7 +9458,7 @@ impl ToString for PullRequestConvertedToDraftAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestConvertedToDraftPullRequestVariant1 {
+pub struct PullRequestConvertedToDraftPullRequestSubtype1 {
     pub closed_at: (),
     #[doc = "Indicates whether or not the pull request is a draft."]
     pub draft: bool,
@@ -9469,9 +9469,9 @@ pub struct PullRequestConvertedToDraftPullRequestVariant1 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestConvertedToDraftPullRequest {
     #[serde(flatten)]
-    pub variant_0: PullRequest,
+    pub subtype_0: PullRequest,
     #[serde(flatten)]
-    pub variant_1: PullRequestConvertedToDraftPullRequestVariant1,
+    pub subtype_1: PullRequestConvertedToDraftPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestEditedAction {
@@ -9537,32 +9537,32 @@ impl ToString for PullRequestOpenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestOpenedPullRequestVariant1State {
+pub enum PullRequestOpenedPullRequestSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestOpenedPullRequestVariant1State {
+impl ToString for PullRequestOpenedPullRequestSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            PullRequestOpenedPullRequestVariant1State::Open => "open".to_string(),
+            PullRequestOpenedPullRequestSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestOpenedPullRequestVariant1 {
+pub struct PullRequestOpenedPullRequestSubtype1 {
     pub active_lock_reason: (),
     pub closed_at: (),
     pub merge_commit_sha: (),
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestOpenedPullRequestVariant1State,
+    pub state: PullRequestOpenedPullRequestSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestOpenedPullRequest {
     #[serde(flatten)]
-    pub variant_0: PullRequest,
+    pub subtype_0: PullRequest,
     #[serde(flatten)]
-    pub variant_1: PullRequestOpenedPullRequestVariant1,
+    pub subtype_1: PullRequestOpenedPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReadyForReviewAction {
@@ -9577,33 +9577,33 @@ impl ToString for PullRequestReadyForReviewAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestReadyForReviewPullRequestVariant1State {
+pub enum PullRequestReadyForReviewPullRequestSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestReadyForReviewPullRequestVariant1State {
+impl ToString for PullRequestReadyForReviewPullRequestSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            PullRequestReadyForReviewPullRequestVariant1State::Open => "open".to_string(),
+            PullRequestReadyForReviewPullRequestSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReadyForReviewPullRequestVariant1 {
+pub struct PullRequestReadyForReviewPullRequestSubtype1 {
     pub closed_at: (),
     #[doc = "Indicates whether or not the pull request is a draft."]
     pub draft: bool,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestReadyForReviewPullRequestVariant1State,
+    pub state: PullRequestReadyForReviewPullRequestSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReadyForReviewPullRequest {
     #[serde(flatten)]
-    pub variant_0: PullRequest,
+    pub subtype_0: PullRequest,
     #[serde(flatten)]
-    pub variant_1: PullRequestReadyForReviewPullRequestVariant1,
+    pub subtype_1: PullRequestReadyForReviewPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReopenedAction {
@@ -9618,32 +9618,32 @@ impl ToString for PullRequestReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestReopenedPullRequestVariant1State {
+pub enum PullRequestReopenedPullRequestSubtype1State {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestReopenedPullRequestVariant1State {
+impl ToString for PullRequestReopenedPullRequestSubtype1State {
     fn to_string(&self) -> String {
         match self {
-            PullRequestReopenedPullRequestVariant1State::Open => "open".to_string(),
+            PullRequestReopenedPullRequestSubtype1State::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReopenedPullRequestVariant1 {
+pub struct PullRequestReopenedPullRequestSubtype1 {
     pub closed_at: (),
     pub merge_commit_sha: (),
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestReopenedPullRequestVariant1State,
+    pub state: PullRequestReopenedPullRequestSubtype1State,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestReopenedPullRequest {
     #[serde(flatten)]
-    pub variant_0: PullRequest,
+    pub subtype_0: PullRequest,
     #[serde(flatten)]
-    pub variant_1: PullRequestReopenedPullRequestVariant1,
+    pub subtype_1: PullRequestReopenedPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReviewRequestRemovedVariant0Action {
@@ -9947,8 +9947,8 @@ pub struct PullRequestReviewCommentCreatedPullRequestHead {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
-    Variant0(User),
-    Variant1(Team),
+    User(User),
+    Team(Team),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReviewCommentCreatedPullRequestState {
@@ -10077,8 +10077,8 @@ pub struct PullRequestReviewCommentDeletedPullRequestHead {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
-    Variant0(User),
-    Variant1(Team),
+    User(User),
+    Team(Team),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReviewCommentDeletedPullRequestState {
@@ -10216,8 +10216,8 @@ pub struct PullRequestReviewCommentEditedPullRequestHead {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
-    Variant0(User),
-    Variant1(Team),
+    User(User),
+    Team(Team),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReviewCommentEditedPullRequestState {
@@ -10338,16 +10338,16 @@ impl ToString for ReleasePrereleasedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleasePrereleasedReleaseVariant1 {
+pub struct ReleasePrereleasedReleaseSubtype1 {
     #[doc = "Whether the release is identified as a prerelease or a full release."]
     pub prerelease: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleasePrereleasedRelease {
     #[serde(flatten)]
-    pub variant_0: Release,
+    pub subtype_0: Release,
     #[serde(flatten)]
-    pub variant_1: ReleasePrereleasedReleaseVariant1,
+    pub subtype_1: ReleasePrereleasedReleaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleasePublishedAction {
@@ -10362,15 +10362,15 @@ impl ToString for ReleasePublishedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleasePublishedReleaseVariant1 {
+pub struct ReleasePublishedReleaseSubtype1 {
     pub published_at: chrono::DateTime<chrono::offset::Utc>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleasePublishedRelease {
     #[serde(flatten)]
-    pub variant_0: Release,
+    pub subtype_0: Release,
     #[serde(flatten)]
-    pub variant_1: ReleasePublishedReleaseVariant1,
+    pub subtype_1: ReleasePublishedReleaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleaseReleasedAction {
@@ -10397,15 +10397,15 @@ impl ToString for ReleaseUnpublishedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleaseUnpublishedReleaseVariant1 {
+pub struct ReleaseUnpublishedReleaseSubtype1 {
     pub published_at: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleaseUnpublishedRelease {
     #[serde(flatten)]
-    pub variant_0: Release,
+    pub subtype_0: Release,
     #[serde(flatten)]
-    pub variant_1: ReleaseUnpublishedReleaseVariant1,
+    pub subtype_1: ReleaseUnpublishedReleaseSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleaseAssetState {
@@ -10453,16 +10453,16 @@ impl ToString for RepositoryArchivedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryArchivedRepositoryVariant1 {
+pub struct RepositoryArchivedRepositorySubtype1 {
     #[doc = "Whether the repository is archived."]
     pub archived: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryArchivedRepository {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: RepositoryArchivedRepositoryVariant1,
+    pub subtype_1: RepositoryArchivedRepositorySubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryCreatedAction {
@@ -10531,16 +10531,16 @@ impl ToString for RepositoryPrivatizedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryPrivatizedRepositoryVariant1 {
+pub struct RepositoryPrivatizedRepositorySubtype1 {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryPrivatizedRepository {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: RepositoryPrivatizedRepositoryVariant1,
+    pub subtype_1: RepositoryPrivatizedRepositorySubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryPublicizedAction {
@@ -10555,16 +10555,16 @@ impl ToString for RepositoryPublicizedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryPublicizedRepositoryVariant1 {
+pub struct RepositoryPublicizedRepositorySubtype1 {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryPublicizedRepository {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: RepositoryPublicizedRepositoryVariant1,
+    pub subtype_1: RepositoryPublicizedRepositorySubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryRenamedAction {
@@ -10627,16 +10627,16 @@ impl ToString for RepositoryUnarchivedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryUnarchivedRepositoryVariant1 {
+pub struct RepositoryUnarchivedRepositorySubtype1 {
     #[doc = "Whether the repository is archived."]
     pub archived: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryUnarchivedRepository {
     #[serde(flatten)]
-    pub variant_0: Repository,
+    pub subtype_0: Repository,
     #[serde(flatten)]
-    pub variant_1: RepositoryUnarchivedRepositoryVariant1,
+    pub subtype_1: RepositoryUnarchivedRepositorySubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryDispatchOnDemandTestAction {
@@ -11142,8 +11142,8 @@ pub struct SimplePullRequestHead {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum SimplePullRequestRequestedReviewersItem {
-    Variant0(User),
-    Variant1(Team),
+    User(User),
+    Team(Team),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum SimplePullRequestState {
@@ -11351,26 +11351,26 @@ pub struct StatusEventBranchesItem {
     pub protected: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct StatusEventCommitCommitAuthorVariant1 {
+pub struct StatusEventCommitCommitAuthorSubtype1 {
     pub date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitAuthor {
     #[serde(flatten)]
-    pub variant_0: Committer,
+    pub subtype_0: Committer,
     #[serde(flatten)]
-    pub variant_1: StatusEventCommitCommitAuthorVariant1,
+    pub subtype_1: StatusEventCommitCommitAuthorSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct StatusEventCommitCommitCommitterVariant1 {
+pub struct StatusEventCommitCommitCommitterSubtype1 {
     pub date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitCommitter {
     #[serde(flatten)]
-    pub variant_0: Committer,
+    pub subtype_0: Committer,
     #[serde(flatten)]
-    pub variant_1: StatusEventCommitCommitCommitterVariant1,
+    pub subtype_1: StatusEventCommitCommitCommitterSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitTree {
@@ -11991,30 +11991,30 @@ impl ToString for WorkflowJobCompletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum WorkflowJobCompletedWorkflowJobVariant1Conclusion {
+pub enum WorkflowJobCompletedWorkflowJobSubtype1Conclusion {
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
     Failure,
 }
-impl ToString for WorkflowJobCompletedWorkflowJobVariant1Conclusion {
+impl ToString for WorkflowJobCompletedWorkflowJobSubtype1Conclusion {
     fn to_string(&self) -> String {
         match self {
-            WorkflowJobCompletedWorkflowJobVariant1Conclusion::Success => "success".to_string(),
-            WorkflowJobCompletedWorkflowJobVariant1Conclusion::Failure => "failure".to_string(),
+            WorkflowJobCompletedWorkflowJobSubtype1Conclusion::Success => "success".to_string(),
+            WorkflowJobCompletedWorkflowJobSubtype1Conclusion::Failure => "failure".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowJobCompletedWorkflowJobVariant1 {
-    pub conclusion: WorkflowJobCompletedWorkflowJobVariant1Conclusion,
+pub struct WorkflowJobCompletedWorkflowJobSubtype1 {
+    pub conclusion: WorkflowJobCompletedWorkflowJobSubtype1Conclusion,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowJobCompletedWorkflowJob {
     #[serde(flatten)]
-    pub variant_0: WorkflowJob,
+    pub subtype_0: WorkflowJob,
     #[serde(flatten)]
-    pub variant_1: WorkflowJobCompletedWorkflowJobVariant1,
+    pub subtype_1: WorkflowJobCompletedWorkflowJobSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowJobQueuedAction {
@@ -12071,7 +12071,7 @@ impl ToString for WorkflowJobStartedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowJobStartedWorkflowJobVariant1 {
+pub struct WorkflowJobStartedWorkflowJobSubtype1 {
     pub completed_at: (),
     pub conclusion: (),
     pub steps: Vec<WorkflowStepInProgress>,
@@ -12079,9 +12079,9 @@ pub struct WorkflowJobStartedWorkflowJobVariant1 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowJobStartedWorkflowJob {
     #[serde(flatten)]
-    pub variant_0: WorkflowJob,
+    pub subtype_0: WorkflowJob,
     #[serde(flatten)]
-    pub variant_1: WorkflowJobStartedWorkflowJobVariant1,
+    pub subtype_1: WorkflowJobStartedWorkflowJobSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowRunCompletedAction {
@@ -12096,7 +12096,7 @@ impl ToString for WorkflowRunCompletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum WorkflowRunCompletedWorkflowRunVariant1Conclusion {
+pub enum WorkflowRunCompletedWorkflowRunSubtype1Conclusion {
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -12112,31 +12112,31 @@ pub enum WorkflowRunCompletedWorkflowRunVariant1Conclusion {
     #[serde(rename = "stale")]
     Stale,
 }
-impl ToString for WorkflowRunCompletedWorkflowRunVariant1Conclusion {
+impl ToString for WorkflowRunCompletedWorkflowRunSubtype1Conclusion {
     fn to_string(&self) -> String {
         match self {
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::Success => "success".to_string(),
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::Failure => "failure".to_string(),
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::Neutral => "neutral".to_string(),
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::Cancelled => "cancelled".to_string(),
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::TimedOut => "timed_out".to_string(),
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::ActionRequired => {
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Success => "success".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Failure => "failure".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Neutral => "neutral".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Cancelled => "cancelled".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::TimedOut => "timed_out".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::ActionRequired => {
                 "action_required".to_string()
             }
-            WorkflowRunCompletedWorkflowRunVariant1Conclusion::Stale => "stale".to_string(),
+            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Stale => "stale".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowRunCompletedWorkflowRunVariant1 {
-    pub conclusion: WorkflowRunCompletedWorkflowRunVariant1Conclusion,
+pub struct WorkflowRunCompletedWorkflowRunSubtype1 {
+    pub conclusion: WorkflowRunCompletedWorkflowRunSubtype1Conclusion,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowRunCompletedWorkflowRun {
     #[serde(flatten)]
-    pub variant_0: WorkflowRun,
+    pub subtype_0: WorkflowRun,
     #[serde(flatten)]
-    pub variant_1: WorkflowRunCompletedWorkflowRunVariant1,
+    pub subtype_1: WorkflowRunCompletedWorkflowRunSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowRunRequestedAction {

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -380,6 +380,7 @@ pub struct CommitCommentEvent(CommitCommentCreated);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Committer {
     pub date: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "The git author's email address."]
     pub email: Option<String>,
     #[doc = "The git author's name."]
     pub name: String,
@@ -939,6 +940,7 @@ pub enum IssueCommentEvent {
 pub struct IssuesAssigned {
     #[doc = "The action that was performed."]
     pub action: IssuesAssignedAction,
+    #[doc = "The optional user who was assigned or unassigned from the issue."]
     pub assignee: Option<User>,
     pub installation: Option<InstallationLite>,
     pub issue: Issue,
@@ -1059,6 +1061,7 @@ pub struct IssuesTransferred {
 pub struct IssuesUnassigned {
     #[doc = "The action that was performed."]
     pub action: IssuesUnassignedAction,
+    #[doc = "The optional user who was assigned or unassigned from the issue."]
     pub assignee: Option<User>,
     pub installation: Option<InstallationLite>,
     pub issue: Issue,
@@ -1304,6 +1307,7 @@ pub struct MembershipRemoved {
     #[doc = "The scope of the membership. Currently, can only be `team`."]
     pub scope: MembershipRemovedScope,
     pub sender: User,
+    #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
     pub team: MembershipRemovedTeam,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -5176,29 +5180,24 @@ impl ToString for CodeScanningAlertClosedByUserAlertDismissedReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State {
+pub enum CodeScanningAlertClosedByUserAlertInstancesItemState {
     #[serde(rename = "dismissed")]
     Dismissed,
 }
-impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State {
+impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemState {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State::Dismissed => {
+            CodeScanningAlertClosedByUserAlertInstancesItemState::Dismissed => {
                 "dismissed".to_string()
             }
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertClosedByUserAlertInstancesItemSubtype1 {
-    pub state: CodeScanningAlertClosedByUserAlertInstancesItemSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
     #[serde(flatten)]
-    pub subtype_0: AlertInstance,
-    #[serde(flatten)]
-    pub subtype_1: CodeScanningAlertClosedByUserAlertInstancesItemSubtype1,
+    pub alert_instance: AlertInstance,
+    pub state: CodeScanningAlertClosedByUserAlertInstancesItemState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertClosedByUserAlertRuleSeverity {
@@ -5288,32 +5287,25 @@ impl ToString for CodeScanningAlertCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertCreatedAlertInstancesItemSubtype1State {
+pub enum CodeScanningAlertCreatedAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
     Dismissed,
 }
-impl ToString for CodeScanningAlertCreatedAlertInstancesItemSubtype1State {
+impl ToString for CodeScanningAlertCreatedAlertInstancesItemState {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertCreatedAlertInstancesItemSubtype1State::Open => "open".to_string(),
-            CodeScanningAlertCreatedAlertInstancesItemSubtype1State::Dismissed => {
-                "dismissed".to_string()
-            }
+            CodeScanningAlertCreatedAlertInstancesItemState::Open => "open".to_string(),
+            CodeScanningAlertCreatedAlertInstancesItemState::Dismissed => "dismissed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertCreatedAlertInstancesItemSubtype1 {
-    pub state: CodeScanningAlertCreatedAlertInstancesItemSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertCreatedAlertInstancesItem {
     #[serde(flatten)]
-    pub subtype_0: AlertInstance,
-    #[serde(flatten)]
-    pub subtype_1: CodeScanningAlertCreatedAlertInstancesItemSubtype1,
+    pub alert_instance: AlertInstance,
+    pub state: CodeScanningAlertCreatedAlertInstancesItemState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertCreatedAlertRuleSeverity {
@@ -5426,27 +5418,22 @@ impl ToString for CodeScanningAlertFixedAlertDismissedReason {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertFixedAlertInstancesItemSubtype1State {
+pub enum CodeScanningAlertFixedAlertInstancesItemState {
     #[serde(rename = "fixed")]
     Fixed,
 }
-impl ToString for CodeScanningAlertFixedAlertInstancesItemSubtype1State {
+impl ToString for CodeScanningAlertFixedAlertInstancesItemState {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertFixedAlertInstancesItemSubtype1State::Fixed => "fixed".to_string(),
+            CodeScanningAlertFixedAlertInstancesItemState::Fixed => "fixed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertFixedAlertInstancesItemSubtype1 {
-    pub state: CodeScanningAlertFixedAlertInstancesItemSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertFixedAlertInstancesItem {
     #[serde(flatten)]
-    pub subtype_0: AlertInstance,
-    #[serde(flatten)]
-    pub subtype_1: CodeScanningAlertFixedAlertInstancesItemSubtype1,
+    pub alert_instance: AlertInstance,
+    pub state: CodeScanningAlertFixedAlertInstancesItemState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertFixedAlertRuleSeverity {
@@ -5537,27 +5524,22 @@ impl ToString for CodeScanningAlertReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertReopenedAlertInstancesItemSubtype1State {
+pub enum CodeScanningAlertReopenedAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for CodeScanningAlertReopenedAlertInstancesItemSubtype1State {
+impl ToString for CodeScanningAlertReopenedAlertInstancesItemState {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertReopenedAlertInstancesItemSubtype1State::Open => "open".to_string(),
+            CodeScanningAlertReopenedAlertInstancesItemState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertReopenedAlertInstancesItemSubtype1 {
-    pub state: CodeScanningAlertReopenedAlertInstancesItemSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertReopenedAlertInstancesItem {
     #[serde(flatten)]
-    pub subtype_0: AlertInstance,
-    #[serde(flatten)]
-    pub subtype_1: CodeScanningAlertReopenedAlertInstancesItemSubtype1,
+    pub alert_instance: AlertInstance,
+    pub state: CodeScanningAlertReopenedAlertInstancesItemState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertReopenedAlertRuleSeverity {
@@ -5653,29 +5635,22 @@ impl ToString for CodeScanningAlertReopenedByUserAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State {
+pub enum CodeScanningAlertReopenedByUserAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State {
+impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemState {
     fn to_string(&self) -> String {
         match self {
-            CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State::Open => {
-                "open".to_string()
-            }
+            CodeScanningAlertReopenedByUserAlertInstancesItemState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1 {
-    pub state: CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
     #[serde(flatten)]
-    pub subtype_0: AlertInstance,
-    #[serde(flatten)]
-    pub subtype_1: CodeScanningAlertReopenedByUserAlertInstancesItemSubtype1,
+    pub alert_instance: AlertInstance,
+    pub state: CodeScanningAlertReopenedByUserAlertInstancesItemState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CodeScanningAlertReopenedByUserAlertRuleSeverity {
@@ -6019,22 +5994,17 @@ pub struct DiscussionAnsweredAnswer {
     pub user: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionAnsweredDiscussionSubtype1Category {
+pub struct DiscussionAnsweredDiscussionCategory {
     pub is_answerable: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionAnsweredDiscussionSubtype1 {
-    pub answer_chosen_at: chrono::DateTime<chrono::offset::Utc>,
-    pub answer_chosen_by: User,
-    pub answer_html_url: String,
-    pub category: DiscussionAnsweredDiscussionSubtype1Category,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionAnsweredDiscussion {
     #[serde(flatten)]
-    pub subtype_0: Discussion,
-    #[serde(flatten)]
-    pub subtype_1: DiscussionAnsweredDiscussionSubtype1,
+    pub discussion: Discussion,
+    pub answer_chosen_at: chrono::DateTime<chrono::offset::Utc>,
+    pub answer_chosen_by: User,
+    pub answer_html_url: String,
+    pub category: DiscussionAnsweredDiscussionCategory,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionCategoryChangedAction {
@@ -6081,34 +6051,29 @@ impl ToString for DiscussionCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionCreatedDiscussionSubtype1State {
+pub enum DiscussionCreatedDiscussionState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "converting")]
     Converting,
 }
-impl ToString for DiscussionCreatedDiscussionSubtype1State {
+impl ToString for DiscussionCreatedDiscussionState {
     fn to_string(&self) -> String {
         match self {
-            DiscussionCreatedDiscussionSubtype1State::Open => "open".to_string(),
-            DiscussionCreatedDiscussionSubtype1State::Converting => "converting".to_string(),
+            DiscussionCreatedDiscussionState::Open => "open".to_string(),
+            DiscussionCreatedDiscussionState::Converting => "converting".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionCreatedDiscussionSubtype1 {
+pub struct DiscussionCreatedDiscussion {
+    #[serde(flatten)]
+    pub discussion: Discussion,
     pub answer_chosen_at: (),
     pub answer_chosen_by: (),
     pub answer_html_url: (),
     pub locked: bool,
-    pub state: DiscussionCreatedDiscussionSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionCreatedDiscussion {
-    #[serde(flatten)]
-    pub subtype_0: Discussion,
-    #[serde(flatten)]
-    pub subtype_1: DiscussionCreatedDiscussionSubtype1,
+    pub state: DiscussionCreatedDiscussionState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionDeletedAction {
@@ -6172,28 +6137,23 @@ impl ToString for DiscussionLockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionLockedDiscussionSubtype1State {
+pub enum DiscussionLockedDiscussionState {
     #[serde(rename = "locked")]
     Locked,
 }
-impl ToString for DiscussionLockedDiscussionSubtype1State {
+impl ToString for DiscussionLockedDiscussionState {
     fn to_string(&self) -> String {
         match self {
-            DiscussionLockedDiscussionSubtype1State::Locked => "locked".to_string(),
+            DiscussionLockedDiscussionState::Locked => "locked".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionLockedDiscussionSubtype1 {
-    pub locked: bool,
-    pub state: DiscussionLockedDiscussionSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionLockedDiscussion {
     #[serde(flatten)]
-    pub subtype_0: Discussion,
-    #[serde(flatten)]
-    pub subtype_1: DiscussionLockedDiscussionSubtype1,
+    pub discussion: Discussion,
+    pub locked: bool,
+    pub state: DiscussionLockedDiscussionState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionPinnedAction {
@@ -6237,22 +6197,17 @@ impl ToString for DiscussionUnansweredAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnansweredDiscussionSubtype1Category {
+pub struct DiscussionUnansweredDiscussionCategory {
     pub is_answerable: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnansweredDiscussionSubtype1 {
-    pub answer_chosen_at: (),
-    pub answer_chosen_by: (),
-    pub answer_html_url: (),
-    pub category: DiscussionUnansweredDiscussionSubtype1Category,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnansweredDiscussion {
     #[serde(flatten)]
-    pub subtype_0: Discussion,
-    #[serde(flatten)]
-    pub subtype_1: DiscussionUnansweredDiscussionSubtype1,
+    pub discussion: Discussion,
+    pub answer_chosen_at: (),
+    pub answer_chosen_by: (),
+    pub answer_html_url: (),
+    pub category: DiscussionUnansweredDiscussionCategory,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnansweredOldAnswer {
@@ -6294,28 +6249,23 @@ impl ToString for DiscussionUnlockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DiscussionUnlockedDiscussionSubtype1State {
+pub enum DiscussionUnlockedDiscussionState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for DiscussionUnlockedDiscussionSubtype1State {
+impl ToString for DiscussionUnlockedDiscussionState {
     fn to_string(&self) -> String {
         match self {
-            DiscussionUnlockedDiscussionSubtype1State::Open => "open".to_string(),
+            DiscussionUnlockedDiscussionState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscussionUnlockedDiscussionSubtype1 {
-    pub locked: bool,
-    pub state: DiscussionUnlockedDiscussionSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscussionUnlockedDiscussion {
     #[serde(flatten)]
-    pub subtype_0: Discussion,
-    #[serde(flatten)]
-    pub subtype_1: DiscussionUnlockedDiscussionSubtype1,
+    pub discussion: Discussion,
+    pub locked: bool,
+    pub state: DiscussionUnlockedDiscussionState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DiscussionUnpinnedAction {
@@ -6419,15 +6369,10 @@ pub struct DiscussionCommentEditedComment {
     pub user: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ForkEventForkeeSubtype1 {
-    pub fork: Option<bool>,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ForkEventForkee {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: ForkEventForkeeSubtype1,
+    pub repository: Repository,
+    pub fork: Option<bool>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GithubAppAuthorizationRevokedAction {
@@ -7304,16 +7249,11 @@ impl ToString for InstallationSuspendAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InstallationSuspendInstallationSubtype1 {
-    pub suspended_at: chrono::DateTime<chrono::offset::Utc>,
-    pub suspended_by: User,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationSuspendInstallation {
     #[serde(flatten)]
-    pub subtype_0: Installation,
-    #[serde(flatten)]
-    pub subtype_1: InstallationSuspendInstallationSubtype1,
+    pub installation: Installation,
+    pub suspended_at: chrono::DateTime<chrono::offset::Utc>,
+    pub suspended_by: User,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationSuspendRepositoriesItem {
@@ -7339,16 +7279,11 @@ impl ToString for InstallationUnsuspendAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InstallationUnsuspendInstallationSubtype1 {
-    pub suspended_at: (),
-    pub suspended_by: (),
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationUnsuspendInstallation {
     #[serde(flatten)]
-    pub subtype_0: Installation,
-    #[serde(flatten)]
-    pub subtype_1: InstallationUnsuspendInstallationSubtype1,
+    pub installation: Installation,
+    pub suspended_at: (),
+    pub suspended_by: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InstallationUnsuspendRepositoriesItem {
@@ -7515,42 +7450,37 @@ impl ToString for IssueCommentCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentCreatedIssueSubtype1PullRequest {
+pub struct IssueCommentCreatedIssuePullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentCreatedIssueSubtype1State {
+pub enum IssueCommentCreatedIssueState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentCreatedIssueSubtype1State {
+impl ToString for IssueCommentCreatedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentCreatedIssueSubtype1State::Open => "open".to_string(),
-            IssueCommentCreatedIssueSubtype1State::Closed => "closed".to_string(),
+            IssueCommentCreatedIssueState::Open => "open".to_string(),
+            IssueCommentCreatedIssueState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentCreatedIssueSubtype1 {
+pub struct IssueCommentCreatedIssue {
+    #[serde(flatten)]
+    pub issue: Issue,
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentCreatedIssueSubtype1PullRequest>,
+    pub pull_request: Option<IssueCommentCreatedIssuePullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentCreatedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentCreatedIssue {
-    #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssueCommentCreatedIssueSubtype1,
+    pub state: IssueCommentCreatedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueCommentDeletedAction {
@@ -7565,42 +7495,37 @@ impl ToString for IssueCommentDeletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentDeletedIssueSubtype1PullRequest {
+pub struct IssueCommentDeletedIssuePullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentDeletedIssueSubtype1State {
+pub enum IssueCommentDeletedIssueState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentDeletedIssueSubtype1State {
+impl ToString for IssueCommentDeletedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentDeletedIssueSubtype1State::Open => "open".to_string(),
-            IssueCommentDeletedIssueSubtype1State::Closed => "closed".to_string(),
+            IssueCommentDeletedIssueState::Open => "open".to_string(),
+            IssueCommentDeletedIssueState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentDeletedIssueSubtype1 {
+pub struct IssueCommentDeletedIssue {
+    #[serde(flatten)]
+    pub issue: Issue,
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentDeletedIssueSubtype1PullRequest>,
+    pub pull_request: Option<IssueCommentDeletedIssuePullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentDeletedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentDeletedIssue {
-    #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssueCommentDeletedIssueSubtype1,
+    pub state: IssueCommentDeletedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssueCommentEditedAction {
@@ -7624,42 +7549,37 @@ pub struct IssueCommentEditedChanges {
     pub body: Option<IssueCommentEditedChangesBody>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentEditedIssueSubtype1PullRequest {
+pub struct IssueCommentEditedIssuePullRequest {
     pub diff_url: String,
     pub html_url: String,
     pub patch_url: String,
     pub url: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssueCommentEditedIssueSubtype1State {
+pub enum IssueCommentEditedIssueState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssueCommentEditedIssueSubtype1State {
+impl ToString for IssueCommentEditedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssueCommentEditedIssueSubtype1State::Open => "open".to_string(),
-            IssueCommentEditedIssueSubtype1State::Closed => "closed".to_string(),
+            IssueCommentEditedIssueState::Open => "open".to_string(),
+            IssueCommentEditedIssueState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentEditedIssueSubtype1 {
+pub struct IssueCommentEditedIssue {
+    #[serde(flatten)]
+    pub issue: Issue,
     pub assignee: Option<User>,
     pub labels: Vec<Label>,
     pub locked: bool,
-    pub pull_request: Option<IssueCommentEditedIssueSubtype1PullRequest>,
+    pub pull_request: Option<IssueCommentEditedIssuePullRequest>,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    pub state: IssueCommentEditedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssueCommentEditedIssue {
-    #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssueCommentEditedIssueSubtype1,
+    pub state: IssueCommentEditedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesAssignedAction {
@@ -7686,28 +7606,23 @@ impl ToString for IssuesClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesClosedIssueSubtype1State {
+pub enum IssuesClosedIssueState {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for IssuesClosedIssueSubtype1State {
+impl ToString for IssuesClosedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssuesClosedIssueSubtype1State::Closed => "closed".to_string(),
+            IssuesClosedIssueState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesClosedIssueSubtype1 {
-    pub closed_at: String,
-    pub state: IssuesClosedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesClosedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesClosedIssueSubtype1,
+    pub issue: Issue,
+    pub closed_at: String,
+    pub state: IssuesClosedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesDeletedAction {
@@ -7734,15 +7649,10 @@ impl ToString for IssuesDemilestonedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesDemilestonedIssueSubtype1 {
-    pub milestone: (),
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesDemilestonedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesDemilestonedIssueSubtype1,
+    pub issue: Issue,
+    pub milestone: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesEditedAction {
@@ -7796,7 +7706,7 @@ impl ToString for IssuesLockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesLockedIssueSubtype1ActiveLockReason {
+pub enum IssuesLockedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -7806,27 +7716,22 @@ pub enum IssuesLockedIssueSubtype1ActiveLockReason {
     #[serde(rename = "spam")]
     Spam,
 }
-impl ToString for IssuesLockedIssueSubtype1ActiveLockReason {
+impl ToString for IssuesLockedIssueActiveLockReason {
     fn to_string(&self) -> String {
         match self {
-            IssuesLockedIssueSubtype1ActiveLockReason::Resolved => "resolved".to_string(),
-            IssuesLockedIssueSubtype1ActiveLockReason::OffTopic => "off-topic".to_string(),
-            IssuesLockedIssueSubtype1ActiveLockReason::TooHeated => "too heated".to_string(),
-            IssuesLockedIssueSubtype1ActiveLockReason::Spam => "spam".to_string(),
+            IssuesLockedIssueActiveLockReason::Resolved => "resolved".to_string(),
+            IssuesLockedIssueActiveLockReason::OffTopic => "off-topic".to_string(),
+            IssuesLockedIssueActiveLockReason::TooHeated => "too heated".to_string(),
+            IssuesLockedIssueActiveLockReason::Spam => "spam".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesLockedIssueSubtype1 {
-    pub active_lock_reason: Option<IssuesLockedIssueSubtype1ActiveLockReason>,
-    pub locked: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesLockedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesLockedIssueSubtype1,
+    pub issue: Issue,
+    pub active_lock_reason: Option<IssuesLockedIssueActiveLockReason>,
+    pub locked: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesMilestonedAction {
@@ -7841,15 +7746,10 @@ impl ToString for IssuesMilestonedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesMilestonedIssueSubtype1 {
-    pub milestone: Milestone,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesMilestonedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesMilestonedIssueSubtype1,
+    pub issue: Issue,
+    pub milestone: Milestone,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesOpenedAction {
@@ -7869,28 +7769,23 @@ pub struct IssuesOpenedChanges {
     pub old_repository: Repository,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesOpenedIssueSubtype1State {
+pub enum IssuesOpenedIssueState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for IssuesOpenedIssueSubtype1State {
+impl ToString for IssuesOpenedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssuesOpenedIssueSubtype1State::Open => "open".to_string(),
+            IssuesOpenedIssueState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesOpenedIssueSubtype1 {
-    pub closed_at: (),
-    pub state: IssuesOpenedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesOpenedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesOpenedIssueSubtype1,
+    pub issue: Issue,
+    pub closed_at: (),
+    pub state: IssuesOpenedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesPinnedAction {
@@ -7917,27 +7812,22 @@ impl ToString for IssuesReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum IssuesReopenedIssueSubtype1State {
+pub enum IssuesReopenedIssueState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for IssuesReopenedIssueSubtype1State {
+impl ToString for IssuesReopenedIssueState {
     fn to_string(&self) -> String {
         match self {
-            IssuesReopenedIssueSubtype1State::Open => "open".to_string(),
+            IssuesReopenedIssueState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesReopenedIssueSubtype1 {
-    pub state: IssuesReopenedIssueSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesReopenedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesReopenedIssueSubtype1,
+    pub issue: Issue,
+    pub state: IssuesReopenedIssueState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesTransferredAction {
@@ -7993,16 +7883,11 @@ impl ToString for IssuesUnlockedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IssuesUnlockedIssueSubtype1 {
-    pub active_lock_reason: (),
-    pub locked: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IssuesUnlockedIssue {
     #[serde(flatten)]
-    pub subtype_0: Issue,
-    #[serde(flatten)]
-    pub subtype_1: IssuesUnlockedIssueSubtype1,
+    pub issue: Issue,
+    pub active_lock_reason: (),
+    pub locked: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuesUnpinnedAction {
@@ -8107,15 +7992,10 @@ impl ToString for MarketplacePurchaseCancelledAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchaseCancelledMarketplacePurchaseSubtype1 {
-    pub next_billing_date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseCancelledMarketplacePurchase {
     #[serde(flatten)]
-    pub subtype_0: MarketplacePurchase,
-    #[serde(flatten)]
-    pub subtype_1: MarketplacePurchaseCancelledMarketplacePurchaseSubtype1,
+    pub marketplace_purchase: MarketplacePurchase,
+    pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseCancelledSender {
@@ -8152,15 +8032,10 @@ impl ToString for MarketplacePurchaseChangedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchaseChangedMarketplacePurchaseSubtype1 {
-    pub next_billing_date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseChangedMarketplacePurchase {
     #[serde(flatten)]
-    pub subtype_0: MarketplacePurchase,
-    #[serde(flatten)]
-    pub subtype_1: MarketplacePurchaseChangedMarketplacePurchaseSubtype1,
+    pub marketplace_purchase: MarketplacePurchase,
+    pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchaseChangedSender {
@@ -8197,15 +8072,10 @@ impl ToString for MarketplacePurchasePendingChangeAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePendingChangeMarketplacePurchaseSubtype1 {
-    pub next_billing_date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeMarketplacePurchase {
     #[serde(flatten)]
-    pub subtype_0: MarketplacePurchase,
-    #[serde(flatten)]
-    pub subtype_1: MarketplacePurchasePendingChangeMarketplacePurchaseSubtype1,
+    pub marketplace_purchase: MarketplacePurchase,
+    pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeSender {
@@ -8244,15 +8114,10 @@ impl ToString for MarketplacePurchasePendingChangeCancelledAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseSubtype1 {
-    pub next_billing_date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchase {
     #[serde(flatten)]
-    pub subtype_0: MarketplacePurchase,
-    #[serde(flatten)]
-    pub subtype_1: MarketplacePurchasePendingChangeCancelledMarketplacePurchaseSubtype1,
+    pub marketplace_purchase: MarketplacePurchase,
+    pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePendingChangeCancelledSender {
@@ -8289,15 +8154,10 @@ impl ToString for MarketplacePurchasePurchasedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MarketplacePurchasePurchasedMarketplacePurchaseSubtype1 {
-    pub next_billing_date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePurchasedMarketplacePurchase {
     #[serde(flatten)]
-    pub subtype_0: MarketplacePurchase,
-    #[serde(flatten)]
-    pub subtype_1: MarketplacePurchasePurchasedMarketplacePurchaseSubtype1,
+    pub marketplace_purchase: MarketplacePurchase,
+    pub next_billing_date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketplacePurchasePurchasedSender {
@@ -8523,28 +8383,23 @@ impl ToString for MilestoneClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneClosedMilestoneSubtype1State {
+pub enum MilestoneClosedMilestoneState {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for MilestoneClosedMilestoneSubtype1State {
+impl ToString for MilestoneClosedMilestoneState {
     fn to_string(&self) -> String {
         match self {
-            MilestoneClosedMilestoneSubtype1State::Closed => "closed".to_string(),
+            MilestoneClosedMilestoneState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneClosedMilestoneSubtype1 {
-    pub closed_at: String,
-    pub state: MilestoneClosedMilestoneSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneClosedMilestone {
     #[serde(flatten)]
-    pub subtype_0: Milestone,
-    #[serde(flatten)]
-    pub subtype_1: MilestoneClosedMilestoneSubtype1,
+    pub milestone: Milestone,
+    pub closed_at: String,
+    pub state: MilestoneClosedMilestoneState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MilestoneCreatedAction {
@@ -8559,28 +8414,23 @@ impl ToString for MilestoneCreatedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneCreatedMilestoneSubtype1State {
+pub enum MilestoneCreatedMilestoneState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for MilestoneCreatedMilestoneSubtype1State {
+impl ToString for MilestoneCreatedMilestoneState {
     fn to_string(&self) -> String {
         match self {
-            MilestoneCreatedMilestoneSubtype1State::Open => "open".to_string(),
+            MilestoneCreatedMilestoneState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneCreatedMilestoneSubtype1 {
-    pub closed_at: (),
-    pub state: MilestoneCreatedMilestoneSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneCreatedMilestone {
     #[serde(flatten)]
-    pub subtype_0: Milestone,
-    #[serde(flatten)]
-    pub subtype_1: MilestoneCreatedMilestoneSubtype1,
+    pub milestone: Milestone,
+    pub closed_at: (),
+    pub state: MilestoneCreatedMilestoneState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MilestoneDeletedAction {
@@ -8640,28 +8490,23 @@ impl ToString for MilestoneOpenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum MilestoneOpenedMilestoneSubtype1State {
+pub enum MilestoneOpenedMilestoneState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for MilestoneOpenedMilestoneSubtype1State {
+impl ToString for MilestoneOpenedMilestoneState {
     fn to_string(&self) -> String {
         match self {
-            MilestoneOpenedMilestoneSubtype1State::Open => "open".to_string(),
+            MilestoneOpenedMilestoneState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MilestoneOpenedMilestoneSubtype1 {
-    pub closed_at: (),
-    pub state: MilestoneOpenedMilestoneSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MilestoneOpenedMilestone {
     #[serde(flatten)]
-    pub subtype_0: Milestone,
-    #[serde(flatten)]
-    pub subtype_1: MilestoneOpenedMilestoneSubtype1,
+    pub milestone: Milestone,
+    pub closed_at: (),
+    pub state: MilestoneOpenedMilestoneState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum OrgBlockBlockedAction {
@@ -9183,15 +9028,10 @@ pub struct ProjectCardMovedChanges {
     pub column_id: ProjectCardMovedChangesColumnId,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ProjectCardMovedProjectCardSubtype1 {
-    pub after_id: Option<f64>,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProjectCardMovedProjectCard {
     #[serde(flatten)]
-    pub subtype_0: ProjectCard,
-    #[serde(flatten)]
-    pub subtype_1: ProjectCardMovedProjectCardSubtype1,
+    pub project_card: ProjectCard,
+    pub after_id: Option<f64>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ProjectColumnCreatedAction {
@@ -9250,15 +9090,10 @@ impl ToString for ProjectColumnMovedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PublicEventRepositorySubtype1 {
-    pub private: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PublicEventRepository {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: PublicEventRepositorySubtype1,
+    pub repository: Repository,
+    pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PullRequestLinks {
@@ -9420,30 +9255,25 @@ impl ToString for PullRequestClosedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestClosedPullRequestSubtype1State {
+pub enum PullRequestClosedPullRequestState {
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for PullRequestClosedPullRequestSubtype1State {
+impl ToString for PullRequestClosedPullRequestState {
     fn to_string(&self) -> String {
         match self {
-            PullRequestClosedPullRequestSubtype1State::Closed => "closed".to_string(),
+            PullRequestClosedPullRequestState::Closed => "closed".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestClosedPullRequestSubtype1 {
+pub struct PullRequestClosedPullRequest {
+    #[serde(flatten)]
+    pub pull_request: PullRequest,
     pub closed_at: chrono::DateTime<chrono::offset::Utc>,
     pub merged: bool,
     #[doc = "State of this Pull Request. Either `open` or `closed`."]
-    pub state: PullRequestClosedPullRequestSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestClosedPullRequest {
-    #[serde(flatten)]
-    pub subtype_0: PullRequest,
-    #[serde(flatten)]
-    pub subtype_1: PullRequestClosedPullRequestSubtype1,
+    pub state: PullRequestClosedPullRequestState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestConvertedToDraftAction {
@@ -9458,20 +9288,15 @@ impl ToString for PullRequestConvertedToDraftAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestConvertedToDraftPullRequestSubtype1 {
+pub struct PullRequestConvertedToDraftPullRequest {
+    #[serde(flatten)]
+    pub pull_request: PullRequest,
     pub closed_at: (),
     #[doc = "Indicates whether or not the pull request is a draft."]
     pub draft: bool,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestConvertedToDraftPullRequest {
-    #[serde(flatten)]
-    pub subtype_0: PullRequest,
-    #[serde(flatten)]
-    pub subtype_1: PullRequestConvertedToDraftPullRequestSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestEditedAction {
@@ -9537,32 +9362,27 @@ impl ToString for PullRequestOpenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestOpenedPullRequestSubtype1State {
+pub enum PullRequestOpenedPullRequestState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestOpenedPullRequestSubtype1State {
+impl ToString for PullRequestOpenedPullRequestState {
     fn to_string(&self) -> String {
         match self {
-            PullRequestOpenedPullRequestSubtype1State::Open => "open".to_string(),
+            PullRequestOpenedPullRequestState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestOpenedPullRequestSubtype1 {
+pub struct PullRequestOpenedPullRequest {
+    #[serde(flatten)]
+    pub pull_request: PullRequest,
     pub active_lock_reason: (),
     pub closed_at: (),
     pub merge_commit_sha: (),
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestOpenedPullRequestSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestOpenedPullRequest {
-    #[serde(flatten)]
-    pub subtype_0: PullRequest,
-    #[serde(flatten)]
-    pub subtype_1: PullRequestOpenedPullRequestSubtype1,
+    pub state: PullRequestOpenedPullRequestState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReadyForReviewAction {
@@ -9577,33 +9397,28 @@ impl ToString for PullRequestReadyForReviewAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestReadyForReviewPullRequestSubtype1State {
+pub enum PullRequestReadyForReviewPullRequestState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestReadyForReviewPullRequestSubtype1State {
+impl ToString for PullRequestReadyForReviewPullRequestState {
     fn to_string(&self) -> String {
         match self {
-            PullRequestReadyForReviewPullRequestSubtype1State::Open => "open".to_string(),
+            PullRequestReadyForReviewPullRequestState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReadyForReviewPullRequestSubtype1 {
+pub struct PullRequestReadyForReviewPullRequest {
+    #[serde(flatten)]
+    pub pull_request: PullRequest,
     pub closed_at: (),
     #[doc = "Indicates whether or not the pull request is a draft."]
     pub draft: bool,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestReadyForReviewPullRequestSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReadyForReviewPullRequest {
-    #[serde(flatten)]
-    pub subtype_0: PullRequest,
-    #[serde(flatten)]
-    pub subtype_1: PullRequestReadyForReviewPullRequestSubtype1,
+    pub state: PullRequestReadyForReviewPullRequestState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReopenedAction {
@@ -9618,32 +9433,27 @@ impl ToString for PullRequestReopenedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PullRequestReopenedPullRequestSubtype1State {
+pub enum PullRequestReopenedPullRequestState {
     #[serde(rename = "open")]
     Open,
 }
-impl ToString for PullRequestReopenedPullRequestSubtype1State {
+impl ToString for PullRequestReopenedPullRequestState {
     fn to_string(&self) -> String {
         match self {
-            PullRequestReopenedPullRequestSubtype1State::Open => "open".to_string(),
+            PullRequestReopenedPullRequestState::Open => "open".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReopenedPullRequestSubtype1 {
+pub struct PullRequestReopenedPullRequest {
+    #[serde(flatten)]
+    pub pull_request: PullRequest,
     pub closed_at: (),
     pub merge_commit_sha: (),
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
-    pub state: PullRequestReopenedPullRequestSubtype1State,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PullRequestReopenedPullRequest {
-    #[serde(flatten)]
-    pub subtype_0: PullRequest,
-    #[serde(flatten)]
-    pub subtype_1: PullRequestReopenedPullRequestSubtype1,
+    pub state: PullRequestReopenedPullRequestState,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PullRequestReviewRequestRemovedVariant0Action {
@@ -10338,16 +10148,11 @@ impl ToString for ReleasePrereleasedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleasePrereleasedReleaseSubtype1 {
-    #[doc = "Whether the release is identified as a prerelease or a full release."]
-    pub prerelease: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleasePrereleasedRelease {
     #[serde(flatten)]
-    pub subtype_0: Release,
-    #[serde(flatten)]
-    pub subtype_1: ReleasePrereleasedReleaseSubtype1,
+    pub release: Release,
+    #[doc = "Whether the release is identified as a prerelease or a full release."]
+    pub prerelease: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleasePublishedAction {
@@ -10362,15 +10167,10 @@ impl ToString for ReleasePublishedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleasePublishedReleaseSubtype1 {
-    pub published_at: chrono::DateTime<chrono::offset::Utc>,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleasePublishedRelease {
     #[serde(flatten)]
-    pub subtype_0: Release,
-    #[serde(flatten)]
-    pub subtype_1: ReleasePublishedReleaseSubtype1,
+    pub release: Release,
+    pub published_at: chrono::DateTime<chrono::offset::Utc>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleaseReleasedAction {
@@ -10397,15 +10197,10 @@ impl ToString for ReleaseUnpublishedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReleaseUnpublishedReleaseSubtype1 {
-    pub published_at: (),
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReleaseUnpublishedRelease {
     #[serde(flatten)]
-    pub subtype_0: Release,
-    #[serde(flatten)]
-    pub subtype_1: ReleaseUnpublishedReleaseSubtype1,
+    pub release: Release,
+    pub published_at: (),
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ReleaseAssetState {
@@ -10453,16 +10248,11 @@ impl ToString for RepositoryArchivedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryArchivedRepositorySubtype1 {
-    #[doc = "Whether the repository is archived."]
-    pub archived: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryArchivedRepository {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: RepositoryArchivedRepositorySubtype1,
+    pub repository: Repository,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryCreatedAction {
@@ -10531,16 +10321,11 @@ impl ToString for RepositoryPrivatizedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryPrivatizedRepositorySubtype1 {
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryPrivatizedRepository {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: RepositoryPrivatizedRepositorySubtype1,
+    pub repository: Repository,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryPublicizedAction {
@@ -10555,16 +10340,11 @@ impl ToString for RepositoryPublicizedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryPublicizedRepositorySubtype1 {
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryPublicizedRepository {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: RepositoryPublicizedRepositorySubtype1,
+    pub repository: Repository,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryRenamedAction {
@@ -10627,16 +10407,11 @@ impl ToString for RepositoryUnarchivedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RepositoryUnarchivedRepositorySubtype1 {
-    #[doc = "Whether the repository is archived."]
-    pub archived: bool,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryUnarchivedRepository {
     #[serde(flatten)]
-    pub subtype_0: Repository,
-    #[serde(flatten)]
-    pub subtype_1: RepositoryUnarchivedRepositorySubtype1,
+    pub repository: Repository,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RepositoryDispatchOnDemandTestAction {
@@ -11351,26 +11126,16 @@ pub struct StatusEventBranchesItem {
     pub protected: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct StatusEventCommitCommitAuthorSubtype1 {
-    pub date: String,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitAuthor {
     #[serde(flatten)]
-    pub subtype_0: Committer,
-    #[serde(flatten)]
-    pub subtype_1: StatusEventCommitCommitAuthorSubtype1,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct StatusEventCommitCommitCommitterSubtype1 {
+    pub committer: Committer,
     pub date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitCommitter {
     #[serde(flatten)]
-    pub subtype_0: Committer,
-    #[serde(flatten)]
-    pub subtype_1: StatusEventCommitCommitCommitterSubtype1,
+    pub committer: Committer,
+    pub date: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusEventCommitCommitTree {
@@ -11991,30 +11756,25 @@ impl ToString for WorkflowJobCompletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum WorkflowJobCompletedWorkflowJobSubtype1Conclusion {
+pub enum WorkflowJobCompletedWorkflowJobConclusion {
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
     Failure,
 }
-impl ToString for WorkflowJobCompletedWorkflowJobSubtype1Conclusion {
+impl ToString for WorkflowJobCompletedWorkflowJobConclusion {
     fn to_string(&self) -> String {
         match self {
-            WorkflowJobCompletedWorkflowJobSubtype1Conclusion::Success => "success".to_string(),
-            WorkflowJobCompletedWorkflowJobSubtype1Conclusion::Failure => "failure".to_string(),
+            WorkflowJobCompletedWorkflowJobConclusion::Success => "success".to_string(),
+            WorkflowJobCompletedWorkflowJobConclusion::Failure => "failure".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowJobCompletedWorkflowJobSubtype1 {
-    pub conclusion: WorkflowJobCompletedWorkflowJobSubtype1Conclusion,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowJobCompletedWorkflowJob {
     #[serde(flatten)]
-    pub subtype_0: WorkflowJob,
-    #[serde(flatten)]
-    pub subtype_1: WorkflowJobCompletedWorkflowJobSubtype1,
+    pub workflow_job: WorkflowJob,
+    pub conclusion: WorkflowJobCompletedWorkflowJobConclusion,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowJobQueuedAction {
@@ -12071,17 +11831,12 @@ impl ToString for WorkflowJobStartedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowJobStartedWorkflowJobSubtype1 {
+pub struct WorkflowJobStartedWorkflowJob {
+    #[serde(flatten)]
+    pub workflow_job: WorkflowJob,
     pub completed_at: (),
     pub conclusion: (),
     pub steps: Vec<WorkflowStepInProgress>,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowJobStartedWorkflowJob {
-    #[serde(flatten)]
-    pub subtype_0: WorkflowJob,
-    #[serde(flatten)]
-    pub subtype_1: WorkflowJobStartedWorkflowJobSubtype1,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowRunCompletedAction {
@@ -12096,7 +11851,7 @@ impl ToString for WorkflowRunCompletedAction {
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum WorkflowRunCompletedWorkflowRunSubtype1Conclusion {
+pub enum WorkflowRunCompletedWorkflowRunConclusion {
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -12112,31 +11867,26 @@ pub enum WorkflowRunCompletedWorkflowRunSubtype1Conclusion {
     #[serde(rename = "stale")]
     Stale,
 }
-impl ToString for WorkflowRunCompletedWorkflowRunSubtype1Conclusion {
+impl ToString for WorkflowRunCompletedWorkflowRunConclusion {
     fn to_string(&self) -> String {
         match self {
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Success => "success".to_string(),
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Failure => "failure".to_string(),
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Neutral => "neutral".to_string(),
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Cancelled => "cancelled".to_string(),
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::TimedOut => "timed_out".to_string(),
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::ActionRequired => {
+            WorkflowRunCompletedWorkflowRunConclusion::Success => "success".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::Failure => "failure".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::Neutral => "neutral".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::Cancelled => "cancelled".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::TimedOut => "timed_out".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::ActionRequired => {
                 "action_required".to_string()
             }
-            WorkflowRunCompletedWorkflowRunSubtype1Conclusion::Stale => "stale".to_string(),
+            WorkflowRunCompletedWorkflowRunConclusion::Stale => "stale".to_string(),
         }
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct WorkflowRunCompletedWorkflowRunSubtype1 {
-    pub conclusion: WorkflowRunCompletedWorkflowRunSubtype1Conclusion,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkflowRunCompletedWorkflowRun {
     #[serde(flatten)]
-    pub subtype_0: WorkflowRun,
-    #[serde(flatten)]
-    pub subtype_1: WorkflowRunCompletedWorkflowRunSubtype1,
+    pub workflow_run: WorkflowRun,
+    pub conclusion: WorkflowRunCompletedWorkflowRunConclusion,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkflowRunRequestedAction {

--- a/typify-impl/tests/test_github.rs
+++ b/typify-impl/tests/test_github.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufReader, path::Path};
 
 use quote::quote;
-use schemars::schema::{Metadata, RootSchema, Schema};
+use schemars::schema::{RootSchema, Schema};
 use typify_impl::TypeSpace;
 
 #[test]
@@ -14,12 +14,7 @@ fn test_github() {
 
     // Read the JSON contents of the file as an instance of `User`.
     let mut schema: RootSchema = serde_json::from_reader(reader).unwrap();
-    schema
-        .schema
-        .metadata
-        .get_or_insert_with(|| Box::new(Metadata::default()))
-        .as_mut()
-        .title = Some("Everything".to_string());
+    schema.schema.metadata().title = Some("Everything".to_string());
 
     type_space.add_ref_types(schema.definitions).unwrap();
     type_space.add_type(&Schema::Object(schema.schema)).unwrap();


### PR DESCRIPTION
* Make Option-like `oneOf`s into Options
* Improve rendering of the `allOf` subclassing idiom

The only remaining lousy names for github variants/properties are for actually weird constructions.