### PR TITLE
Add a simple example that shows how to use the generated types

### DIFF
--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -6,4 +6,13 @@ import_types!("./example.json");
 
 fn main() {
     println!("here we are");
+    let veg = Veggie {
+        veggie_name: String::from("carrots"),
+        veggie_like: true,
+    };
+    let veggies = Veggies {
+        fruits: vec![String::from("apple"), String::from("mango")],
+        vegetables: vec![veg],
+    };
+    println!("{:?}", veggies);
 }


### PR DESCRIPTION
The example-macro sub-project imports an example.json that provides a
good use case to start with. The main.rs just had `import_types!` invocation
which will generate the rust type. This PR adds on to that by showing how the
generated types can be used.

This more of a documentation PR than an actual bug. This fixes #14