### PR TITLE
restructure TypeEntry for future needs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,16 @@
 [workspace]
 members = [
 	"typify",
-	"typify-macro",
 	"typify-impl",
+	"typify-macro",
+	"typify-test",
 	"example-build",
 	"example-macro",
 ]
 
 default-members = [
 	"typify",
-	"typify-macro",
 	"typify-impl",
+	"typify-macro",
+	"typify-test",
 ]

--- a/typify-test/Cargo.toml
+++ b/typify-test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "typify-test"
+version = "0.0.6-dev"
+authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
+edition = "2018"
+
+[dependencies]
+serde = "1.0"
+
+[build-dependencies]
+schemars = "0.8"
+serde_json = "1.0"
+typify = { path = "../typify" }

--- a/typify-test/build.rs
+++ b/typify-test/build.rs
@@ -1,0 +1,55 @@
+use std::collections::HashSet;
+use std::{env, fs, path::Path};
+
+use schemars::schema::Schema;
+use schemars::JsonSchema;
+use typify::TypeSpace;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct TestStruct {
+    a: u32,
+    b: u32,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct WithSet {
+    set: HashSet<TestStruct>,
+}
+
+fn main() {
+    let mut type_space = TypeSpace::default();
+
+    WithSet::add(&mut type_space);
+
+    let content = format!(
+        "{}\n{}",
+        "use serde::{Deserialize, Serialize};",
+        type_space.to_string()
+    );
+
+    let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
+    out_file.push("codegen.rs");
+    fs::write(out_file, &content).unwrap();
+}
+
+trait AddType {
+    fn add(type_space: &mut TypeSpace);
+}
+
+impl<T> AddType for T
+where
+    T: JsonSchema,
+{
+    fn add(type_space: &mut TypeSpace) {
+        let schema = schemars::schema_for!(T);
+        type_space.add_ref_types(schema.definitions).unwrap();
+
+        let base_type = &schema.schema;
+        // Only convert the top-level type if it has a name
+        if (|| base_type.metadata.as_ref()?.title.as_ref())().is_some() {
+            let _ = type_space.add_type(&Schema::Object(schema.schema)).unwrap();
+        }
+    }
+}

--- a/typify-test/src/main.rs
+++ b/typify-test/src/main.rs
@@ -1,0 +1,6 @@
+// Copyright 2021 Oxide Computer Company
+
+// Include the generated code to make sure it compiles.
+include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
+
+fn main() {}


### PR DESCRIPTION
restructure TypeEntry for future needs and add integration testing

This is some partial work I did to improve calculation of which derive macros may be applied; I was going to do some other work and didn't want to make a big merge headache for myself later.