### PR TITLE
Box trivial cyclic refs

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -713,7 +713,8 @@ impl TypeSpace {
         }
 
         // Rust can emit "anyOf":[{"$ref":"#/definitions/C"},{"type":"null"} for
-        // Option, so match against that here.
+        // Option, so match against that here to short circuit the check for
+        // mutual exclusivity below.
         if let Some(option_type_entry) = self.maybe_option(type_name.clone(), metadata, subschemas)
         {
             return Ok((option_type_entry, metadata));

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1043,25 +1043,21 @@ mod tests {
     }
 
     #[test]
-    fn test_enum_trivial_cycle() {
+    fn test_enum_trivial_cycles() {
         #[derive(JsonSchema, Schema)]
-        #[serde(tag = "type")]
         #[allow(dead_code)]
         enum A {
+            Variant0(u64),
             Varant1 {
                 a: u64,
                 b: Vec<A>,
                 rop: Option<Box<A>>,
             },
             Variant2 {
-                a: u64,
-                b: String,
+                a: Box<A>,
             },
-            Variant3 {
-                a: u64,
-                b: u64,
-                c: u64,
-            },
+            Variant3(u64, Box<A>),
+            Variant4(Option<Box<A>>, String),
         }
 
         validate_output::<A>();

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -714,7 +714,8 @@ impl TypeSpace {
 
         // Rust can emit "anyOf":[{"$ref":"#/definitions/C"},{"type":"null"} for
         // Option, so match against that here.
-        if let Some(option_type_entry) = self.maybe_option(type_name.clone(), metadata, subschemas) {
+        if let Some(option_type_entry) = self.maybe_option(type_name.clone(), metadata, subschemas)
+        {
             return Ok((option_type_entry, metadata));
         }
 

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1022,22 +1022,13 @@ mod tests {
 
     #[test]
     fn test_trivial_cycle() {
-        // Currently schemars will actually include the type A twice if this is
-        // made a RootSchema; it should really have a reference that it uses as
-        // the RootSchema. To workaround this, we refer to A from B below.
         #[derive(JsonSchema, Schema)]
         #[allow(dead_code)]
         struct A {
             a: Box<A>,
         }
 
-        #[derive(JsonSchema, Schema)]
-        #[allow(dead_code)]
-        struct B {
-            a: A,
-        }
-
-        validate_output::<B>();
+        validate_output::<A>();
     }
 
     #[test]
@@ -1048,17 +1039,36 @@ mod tests {
             a: Option<Box<A>>,
         }
 
-        #[derive(JsonSchema, Schema)]
-        #[allow(dead_code)]
-        struct B {
-            a: A,
-        }
-
-        validate_output::<B>();
+        validate_output::<A>();
     }
 
     #[test]
-    fn test_basic_option() {
+    fn test_enum_trivial_cycle() {
+        #[derive(JsonSchema, Schema)]
+        #[serde(tag = "type")]
+        #[allow(dead_code)]
+        enum A {
+            Varant1 {
+                a: u64,
+                b: Vec<A>,
+                rop: Option<Box<A>>,
+            },
+            Variant2 {
+                a: u64,
+                b: String,
+            },
+            Variant3 {
+                a: u64,
+                b: u64,
+                c: u64,
+            },
+        }
+
+        validate_output::<A>();
+    }
+
+    #[test]
+    fn test_basic_option_flat() {
         #[derive(JsonSchema, Schema)]
         #[allow(dead_code)]
         struct C {}
@@ -1073,24 +1083,18 @@ mod tests {
     }
 
     #[test]
-    fn test_basic_option_one_deep() {
+    fn test_unit_option() {
         #[derive(JsonSchema, Schema)]
         #[allow(dead_code)]
-        struct C {}
+        struct Foo;
 
         #[derive(JsonSchema, Schema)]
         #[allow(dead_code)]
-        struct A {
-            a: Option<C>,
+        struct Bar {
+            a: Option<Foo>,
         }
 
-        #[derive(JsonSchema, Schema)]
-        #[allow(dead_code)]
-        struct B {
-            a: A,
-        }
-
-        validate_output::<B>();
+        validate_output::<Bar>();
     }
 
     // TODO we can turn this on once we generate proper sets.

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1065,6 +1065,15 @@ mod tests {
     }
 
     #[test]
+    fn test_newtype_trivial_cycle() {
+        #[derive(JsonSchema, Schema)]
+        #[allow(dead_code)]
+        struct A(Box<A>);
+
+        validate_output::<A>();
+    }
+
+    #[test]
     fn test_basic_option_flat() {
         #[derive(JsonSchema, Schema)]
         #[allow(dead_code)]

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 impl TypeSpace {
-    pub(crate) fn maybe_option_as_enum(
+    pub(crate) fn maybe_option(
         &mut self,
         type_name: Name,
         metadata: &Option<Box<schemars::schema::Metadata>>,
@@ -1245,7 +1245,7 @@ mod tests {
     }
 
     #[test]
-    fn test_maybe_option_as_enum() {
+    fn test_maybe_option() {
         let subschemas = vec![
             SchemaObject {
                 instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
@@ -1261,7 +1261,7 @@ mod tests {
 
         let mut type_space = TypeSpace::default();
         let type_entry = type_space
-            .maybe_option_as_enum(Name::Unknown, &None, &subschemas)
+            .maybe_option(Name::Unknown, &None, &subschemas)
             .unwrap();
 
         assert_eq!(type_entry.details, TypeEntryDetails::Option(TypeId(1)))

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -319,10 +319,17 @@ impl TypeSpace {
                     }
                 }
             }
+
+            // Look for cases where a newtype refers to a parent type
+            TypeEntryDetails::Newtype(new_type_entry) => {
+                self.check_for_cyclic_ref(parent_type_id, &mut new_type_entry.type_id, box_id);
+            }
+
             // Containers that can be size 0 are *not* cyclic references for that type
             TypeEntryDetails::Array(_) => {}
             TypeEntryDetails::Set(_) => {}
             TypeEntryDetails::Map(_, _) => {}
+
             // Everything else can be ignored
             _ => {}
         }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -257,13 +257,19 @@ impl TypeSpace {
     /// certain cycles introduce a question of *where* to Box to break the
     /// cycle, and there's no one answer to this.
     ///
-    fn break_trivial_cyclic_refs(&mut self, type_id: &TypeId, type_entry: &mut TypeEntry, box_id: &mut Option<TypeId>) {
-
+    fn break_trivial_cyclic_refs(
+        &mut self,
+        type_id: &TypeId,
+        type_entry: &mut TypeEntry,
+        box_id: &mut Option<TypeId>,
+    ) {
         match &mut type_entry.details {
             // Look for the case where an option refers to the parent type
             TypeEntryDetails::Option(option_type_id) => {
                 if *option_type_id == *type_id {
-                    *option_type_id = box_id.get_or_insert_with(|| self.id_to_box(type_id)).clone();
+                    *option_type_id = box_id
+                        .get_or_insert_with(|| self.id_to_box(type_id))
+                        .clone();
                 }
             }
 
@@ -273,13 +279,17 @@ impl TypeSpace {
                 for prop in &mut s.properties {
                     if prop.type_id == *type_id {
                         // A struct property directly refers to the parent type
-                        prop.type_id = box_id.get_or_insert_with(|| self.id_to_box(type_id)).clone();
+                        prop.type_id = box_id
+                            .get_or_insert_with(|| self.id_to_box(type_id))
+                            .clone();
                     } else {
                         // A struct property optionally refers to the parent type
                         let mut prop_type_entry =
                             self.id_to_entry.get_mut(&prop.type_id).unwrap().clone();
                         self.break_trivial_cyclic_refs(&type_id, &mut prop_type_entry, box_id);
-                        let _ = self.id_to_entry.insert(prop.type_id.clone(), prop_type_entry);
+                        let _ = self
+                            .id_to_entry
+                            .insert(prop.type_id.clone(), prop_type_entry);
                     }
                 }
             }
@@ -296,13 +306,21 @@ impl TypeSpace {
                             for tuple_type_id in vec_type_id {
                                 // A tuple entry directly refers to the parent type
                                 if *tuple_type_id == *type_id {
-                                    *tuple_type_id = box_id.get_or_insert_with(|| self.id_to_box(type_id)).clone();
+                                    *tuple_type_id = box_id
+                                        .get_or_insert_with(|| self.id_to_box(type_id))
+                                        .clone();
                                 } else {
                                     // A tuple entry optionally refers to the parent type
                                     let mut tuple_type_entry =
                                         self.id_to_entry.get_mut(&tuple_type_id).unwrap().clone();
-                                    self.break_trivial_cyclic_refs(&type_id, &mut tuple_type_entry, box_id);
-                                    let _ = self.id_to_entry.insert(tuple_type_id.clone(), tuple_type_entry);
+                                    self.break_trivial_cyclic_refs(
+                                        &type_id,
+                                        &mut tuple_type_entry,
+                                        box_id,
+                                    );
+                                    let _ = self
+                                        .id_to_entry
+                                        .insert(tuple_type_id.clone(), tuple_type_entry);
                                 }
                             }
                         }
@@ -312,14 +330,22 @@ impl TypeSpace {
                                 let vec_type_id = &mut struct_property.type_id;
                                 // A struct property refers to the parent type
                                 if *vec_type_id == *type_id {
-                                    *vec_type_id = box_id.get_or_insert_with(|| self.id_to_box(type_id)).clone();
+                                    *vec_type_id = box_id
+                                        .get_or_insert_with(|| self.id_to_box(type_id))
+                                        .clone();
                                 } else {
                                     // A struct property optionally refers to
                                     // the parent type
                                     let mut prop_type_entry =
                                         self.id_to_entry.get_mut(vec_type_id).unwrap().clone();
-                                    self.break_trivial_cyclic_refs(&type_id, &mut prop_type_entry, box_id);
-                                    let _ = self.id_to_entry.insert(vec_type_id.clone(), prop_type_entry);
+                                    self.break_trivial_cyclic_refs(
+                                        &type_id,
+                                        &mut prop_type_entry,
+                                        box_id,
+                                    );
+                                    let _ = self
+                                        .id_to_entry
+                                        .insert(vec_type_id.clone(), prop_type_entry);
                                 }
                             }
                         }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -180,8 +180,11 @@ impl TypeSpace {
                 None => &ref_name,
             };
 
-            info!("converting type: {} with schema {}", type_name,
-                serde_json::to_string(&schema).unwrap());
+            info!(
+                "converting type: {} with schema {}",
+                type_name,
+                serde_json::to_string(&schema).unwrap()
+            );
 
             let (type_entry, metadata) =
                 self.convert_schema(Name::Required(type_name.to_string()), &schema)?;

--- a/typify-impl/src/test_util.rs
+++ b/typify-impl/src/test_util.rs
@@ -42,14 +42,12 @@ fn validate_output_impl<T: JsonSchema + Schema>(ignore_variant_names: bool) {
 
     // If we have converted the type already, use that, otherwise convert schema object
     let ty = if let Some(already_type_id) = type_space.ref_to_id.get(&name) {
-        info!("{} is already ref id {:?}", name, already_type_id);
         type_space
             .id_to_entry
             .get(&already_type_id)
             .unwrap()
             .clone()
     } else {
-        info!("{} needs to convert from schema.schema", name);
         let (ty, _) = type_space
             .convert_schema_object(Name::Required(name), &schema.schema)
             .unwrap();

--- a/typify-impl/src/test_util.rs
+++ b/typify-impl/src/test_util.rs
@@ -40,7 +40,13 @@ fn validate_output_impl<T: JsonSchema + Schema>(ignore_variant_names: bool) {
         .add_ref_types(schema.definitions.clone())
         .unwrap();
 
-    // If we have converted the type already, use that, otherwise convert schema object
+    // In some situations, `schema_for!(T)` may actually give us two copies of
+    // the type: one in the definitions and one in the schema. This will occur
+    // in particular for cyclic types i.e. those for which the type itself is a
+    // reference.
+    //
+    // If we have converted the type already, use that, otherwise convert schema
+    // object
     let ty = if let Some(already_type_id) = type_space.ref_to_id.get(&name) {
         type_space
             .id_to_entry

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -54,6 +54,7 @@ pub(crate) enum TypeEntryDetails {
     Newtype(TypeEntryNewtype),
 
     Option(TypeId),
+    Box(TypeId),
     Array(TypeId),
     Map(TypeId, TypeId),
     Set(TypeId),
@@ -72,8 +73,6 @@ pub(crate) enum TypeEntryDetails {
     /// reference types in particular to represent simple type aliases between
     /// types named as reference targets.
     Reference(TypeId),
-
-    Box(TypeId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -437,6 +436,17 @@ impl TypeEntry {
                 }
             }
 
+            TypeEntryDetails::Box(id) => {
+                let inner_ty = type_space
+                    .id_to_entry
+                    .get(id)
+                    .expect("unresolved type id for box");
+
+                let item = inner_ty.type_ident(type_space, external);
+
+                quote! { Box<#item> }
+            }
+
             TypeEntryDetails::Array(id) => {
                 let inner_ty = type_space
                     .id_to_entry
@@ -482,17 +492,6 @@ impl TypeEntry {
                 });
 
                 quote! { ( #(#type_streams),* ) }
-            }
-
-            TypeEntryDetails::Box(id) => {
-                let inner_ty = type_space
-                    .id_to_entry
-                    .get(id)
-                    .expect("unresolved type id for box");
-
-                let item = inner_ty.type_ident(type_space, external);
-
-                quote! { Box<#item> }
             }
 
             TypeEntryDetails::Unit => quote! { () },


### PR DESCRIPTION
If a struct A has a property that refers to type A, then insert a Box
for this. Note that this commit only checks for these trivial cyclic
refs.

Saw "anyOf" for Option, so match against that case