### PR TITLE
move to heck for case conversion since it seems to be closer to what serde does wrt case conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +88,12 @@ checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "home"
@@ -459,8 +459,8 @@ dependencies = [
 name = "typify-impl"
 version = "0.0.6-dev"
 dependencies = [
- "convert_case",
  "expectorate",
+ "heck",
  "log",
  "paste",
  "proc-macro2",

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
 
 [dependencies]
-convert_case = "0.4"
+heck = "0.4.0"
 log = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -4,8 +4,7 @@ use crate::type_entry::{
     EnumTagType, TypeEntry, TypeEntryDetails, TypeEntryEnum, TypeEntryStruct, Variant,
     VariantDetails,
 };
-use crate::util::{all_mutually_exclusive, recase};
-use convert_case::Case;
+use crate::util::{all_mutually_exclusive, recase, Case};
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
     SubschemaValidation,
@@ -447,7 +446,7 @@ impl TypeSpace {
                     None
                 }
                 serde_json::Value::String(value) => {
-                    let (name, rename) = recase(value.clone(), Case::Pascal);
+                    let (name, rename) = recase(value, Case::Pascal);
                     Some(Ok(Variant {
                         name,
                         rename,
@@ -632,7 +631,7 @@ impl TypeSpace {
 
             // The typical case
             Some(validation) => {
-                let tmp_type_name = get_type_name(&type_name, metadata, Case::Pascal);
+                let tmp_type_name = get_type_name(&type_name, metadata);
                 let (properties, deny_unknown_fields) =
                     self.struct_members(tmp_type_name, validation)?;
 
@@ -845,7 +844,7 @@ impl TypeSpace {
                 unique_items,
                 contains: None,
             } => {
-                let tmp_type_name = match get_type_name(&type_name, metadata, Case::Pascal) {
+                let tmp_type_name = match get_type_name(&type_name, metadata) {
                     Some(s) => Name::Suggested(format!("{}Item", s)),
                     None => Name::Unknown,
                 };

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -2,7 +2,6 @@
 
 use std::collections::BTreeSet;
 
-use convert_case::Case;
 use proc_macro2::{Punct, Spacing, TokenStream, TokenTree};
 use quote::{format_ident, quote, ToTokens};
 use schemars::schema::Metadata;
@@ -128,7 +127,7 @@ impl TypeEntryEnum {
         variants: Vec<Variant>,
         deny_unknown_fields: bool,
     ) -> TypeEntryDetails {
-        let name = get_type_name(&type_name, metadata, Case::Pascal).unwrap();
+        let name = get_type_name(&type_name, metadata).unwrap();
         let rename = None;
         let description = metadata_description(metadata);
 
@@ -150,7 +149,7 @@ impl TypeEntryStruct {
         properties: Vec<StructProperty>,
         deny_unknown_fields: bool,
     ) -> TypeEntryDetails {
-        let name = get_type_name(&type_name, metadata, Case::Pascal).unwrap();
+        let name = get_type_name(&type_name, metadata).unwrap();
         let rename = None;
         let description = metadata_description(metadata);
 
@@ -170,7 +169,7 @@ impl TypeEntryNewtype {
         metadata: &Option<Box<Metadata>>,
         type_id: TypeId,
     ) -> TypeEntryDetails {
-        let name = get_type_name(&type_name, metadata, Case::Pascal).unwrap();
+        let name = get_type_name(&type_name, metadata).unwrap();
         let rename = None;
         let description = metadata_description(metadata);
 

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashSet;
 
-use convert_case::{Case, Casing};
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
     SubschemaValidation,
@@ -327,7 +326,7 @@ fn array_schemas_mutually_exclusive(
 
 /// If this schema represents a constant-value string, return that string,
 /// otherwise return None.
-pub(crate) fn constant_string_value(schema: &Schema) -> Option<String> {
+pub(crate) fn constant_string_value(schema: &Schema) -> Option<&str> {
     match schema {
         // Strings must be simple enumerations.
         Schema::Object(SchemaObject {
@@ -345,9 +344,7 @@ pub(crate) fn constant_string_value(schema: &Schema) -> Option<String> {
             extensions: _,
         }) if single.as_ref() == &InstanceType::String => {
             if values.len() == 1 {
-                values
-                    .get(0)
-                    .and_then(|value| value.as_str().map(ToString::to_string))
+                values.get(0).and_then(|value| value.as_str())
             } else {
                 None
             }
@@ -463,19 +460,30 @@ pub(crate) fn schema_is_named(schema: &Schema) -> Option<String> {
     Some(sanitize(&raw_name, Case::Pascal))
 }
 
+pub(crate) enum Case {
+    Pascal,
+    Snake,
+}
+
 fn sanitize(input: &str, case: Case) -> String {
+    use heck::{ToPascalCase, ToSnakeCase};
+    let to_case = match case {
+        Case::Pascal => str::to_pascal_case,
+        Case::Snake => str::to_snake_case,
+    };
     // If every case was special then none of them would be.
     let out = match input {
         "+1" => "plus1".to_string(),
         "-1" => "minus1".to_string(),
-        _ => input
-            .replace("'", "")
-            .replace(|c: char| !c.is_xid_continue(), "-")
-            .to_case(case),
+        _ => to_case(
+            &input
+                .replace("'", "")
+                .replace(|c: char| !c.is_xid_continue(), "-"),
+        ),
     };
 
     let out = match out.chars().next() {
-        None => "x".to_case(case),
+        None => to_case("x"),
         Some(c) if c.is_xid_start() => out,
         Some(_) => format!("_{}", out),
     };
@@ -488,17 +496,17 @@ fn sanitize(input: &str, case: Case) -> String {
     }
 }
 
-pub(crate) fn recase(input: String, case: Case) -> (String, Option<String>) {
+pub(crate) fn recase(input: &str, case: Case) -> (String, Option<String>) {
     let new = sanitize(&input, case);
-    let rename = if new == input { None } else { Some(input) };
+    let rename = if new == input {
+        None
+    } else {
+        Some(input.to_string())
+    };
     (new, rename)
 }
 
-pub(crate) fn get_type_name(
-    type_name: &Name,
-    metadata: &Option<Box<Metadata>>,
-    case: Case,
-) -> Option<String> {
+pub(crate) fn get_type_name(type_name: &Name, metadata: &Option<Box<Metadata>>) -> Option<String> {
     let name = match (type_name, metadata_title(metadata)) {
         (Name::Required(name), _) => name.clone(),
         (Name::Suggested(name), None) => name.clone(),
@@ -506,15 +514,14 @@ pub(crate) fn get_type_name(
         (Name::Unknown, None) => None?,
     };
 
-    Some(sanitize(&name, case))
+    Some(sanitize(&name, Case::Pascal))
 }
 
 #[cfg(test)]
 mod tests {
-    use convert_case::Case;
     use schemars::{schema_for, JsonSchema};
 
-    use crate::util::{sanitize, schemas_mutually_exclusive};
+    use crate::util::{sanitize, schemas_mutually_exclusive, Case};
 
     #[test]
     fn test_non_exclusive_structs() {
@@ -629,9 +636,11 @@ mod tests {
         assert_eq!(
             sanitize(
                 "urn:ietf:params:scim:schemas:extension:gluu:2.0:user_",
-                Case::Camel
+                Case::Pascal
             ),
-            "urnIetfParamsScimSchemasExtensionGluu20User"
+            "UrnIetfParamsScimSchemasExtensionGluu20User"
         );
+        assert_eq!(sanitize("Ipv6Net", Case::Snake), "ipv6_net");
+        assert_eq!(sanitize("V6", Case::Pascal), "V6");
     }
 }

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,10 +1,8 @@
 mod types {
     #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
     pub struct CompoundType {
-        #[serde(rename = "value1")]
-        pub value_1: String,
-        #[serde(rename = "value2")]
-        pub value_2: u64,
+        pub value1: String,
+        pub value2: u64,
     }
     #[derive(
         Serialize, Deserialize, Debug, Clone, JsonSchema, Copy, PartialOrd, Ord, PartialEq, Eq, Hash,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -9663,13 +9663,10 @@ pub struct PackagePublishedPackagePackageVersionPackageFilesItem {
     pub created_at: String,
     pub download_url: String,
     pub id: i64,
-    #[serde(rename = "md5")]
-    pub md_5: String,
+    pub md5: String,
     pub name: String,
-    #[serde(rename = "sha1")]
-    pub sha_1: String,
-    #[serde(rename = "sha256")]
-    pub sha_256: String,
+    pub sha1: String,
+    pub sha256: String,
     pub size: i64,
     pub state: String,
     pub updated_at: String,
@@ -9762,13 +9759,10 @@ pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub created_at: String,
     pub download_url: String,
     pub id: i64,
-    #[serde(rename = "md5")]
-    pub md_5: String,
+    pub md5: String,
     pub name: String,
-    #[serde(rename = "sha1")]
-    pub sha_1: String,
-    #[serde(rename = "sha256")]
-    pub sha_256: String,
+    pub sha1: String,
+    pub sha256: String,
     pub size: i64,
     pub state: String,
     pub updated_at: String,


### PR DESCRIPTION
This is particularly imporatnt for dealing with variants e.g. "V4" and "V6" since we don't want to use common component elimination to wind up with "4" and "6"

Note some obvious improvements in the github output such as:

```diff
@@ -9762,13 +9759,10 @@ pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub created_at: String,
     pub download_url: String,
     pub id: i64,
-    #[serde(rename = "md5")]
-    pub md_5: String,
+    pub md5: String,
     pub name: String,
-    #[serde(rename = "sha1")]
-    pub sha_1: String,
-    #[serde(rename = "sha256")]
-    pub sha_256: String,
+    pub sha1: String,
+    pub sha256: String,
     pub size: i64,
     pub state: String,
     pub updated_at: String,
```