### PR TITLE
Add support for rust_decimal

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -407,6 +407,11 @@ impl TypeSpace {
                 ))
             }
 
+            Some("decimal") => {
+                self.uses_rust_decimal = true;
+                Ok((TypeEntry::new_builtin("rust_decimal::Decimal"), metadata))
+            }
+
             Some("ipv6") => Ok((TypeEntry::new_builtin("std::net::Ipv6Addr"), metadata)),
 
             // TODO random types I'm not sure what to do with

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -116,6 +116,7 @@ pub struct TypeSpace {
     ref_to_id: BTreeMap<String, TypeId>,
 
     uses_chrono: bool,
+    uses_rust_decimal: bool,
     uses_uuid: bool,
     uses_serde_json: bool,
 
@@ -143,6 +144,7 @@ impl Default for TypeSpace {
             ref_to_id: BTreeMap::new(),
             type_to_id: BTreeMap::new(),
             uses_chrono: false,
+            uses_rust_decimal: false,
             uses_uuid: false,
             uses_serde_json: false,
             type_mod: None,
@@ -427,6 +429,10 @@ impl TypeSpace {
 
     pub fn uses_chrono(&self) -> bool {
         self.uses_chrono
+    }
+
+    pub fn uses_rust_decimal(&self) -> bool {
+        self.uses_rust_decimal
     }
 
     pub fn uses_uuid(&self) -> bool {


### PR DESCRIPTION
Hey everyone, I encountered an openapi spec with a `decimal` format (primarily for currency type amounts) and figured this would be a reasonable addition to the library. This change adds support for `rust_decimal` to typify, inspired by the `chrono` support. Let me know if you have any objections/feedback to this and I'd be happy to address.

By the way, great work on `progenitor` and this library. I'm really liking the direction these are heading and hoping I can make use of these in the future.

This is the openapi spec in question: https://raw.githubusercontent.com/alpacahq/alpaca-docs/master/oas/broker/openapi.yaml