### PR TITLE
Add support for simple types with enumerated values

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,13 +15,7 @@
 
 https://github.com/oxidecomputer/typify/compare/v0.0.7\...HEAD[Full list of commits]
 
-== 0.0.7 (released 2022-05-18)
-
-https://github.com/oxidecomputer/typify/compare/v0.0.7\...v0.0.7[Full list of commits]
-
-== 0.0.7 (released 2022-05-18)
-
-https://github.com/oxidecomputer/typify/compare/v0.0.7\...v0.0.7[Full list of commits]
+* Support for integer schemas with `enum_values` populated (breaking change) (#57)
 
 == 0.0.7 (released 2022-05-18)
 

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -9,8 +9,8 @@ use schemars::schema::{
 
 use crate::{
     type_entry::{
-        DefaultValue, StructProperty, StructPropertyRename, StructPropertyState, TypeEntry,
-        TypeEntryStruct,
+        StructProperty, StructPropertyRename, StructPropertyState, TypeEntry, TypeEntryStruct,
+        WrappedValue,
     },
     util::{get_type_name, metadata_description, recase, schema_is_named, Case},
     Name, Result, TypeEntryDetails, TypeId, TypeSpace,
@@ -420,7 +420,7 @@ fn generate_serde_attr(
             None
         }
         (StructPropertyState::Required, _) => None,
-        (StructPropertyState::Default(DefaultValue(value)), _) => {
+        (StructPropertyState::Default(WrappedValue(value)), _) => {
             let (fn_name, default_fn) =
                 prop_type.default_fn(value, type_space, type_name, prop_name);
             serde_options.push(quote! { default = #fn_name });
@@ -499,10 +499,10 @@ fn has_default(
         }
 
         // This is a reference that will resolve to this type id later.
-        (None, Some(default)) => StructPropertyState::Default(DefaultValue(default.clone())),
+        (None, Some(default)) => StructPropertyState::Default(WrappedValue(default.clone())),
         // All other types as well as types with intrinsic defaults that have
         // been explicitly overridden.
-        (Some(_), Some(default)) => StructPropertyState::Default(DefaultValue(default.clone())),
+        (Some(_), Some(default)) => StructPropertyState::Default(WrappedValue(default.clone())),
     }
 }
 

--- a/typify-impl/src/test_util.rs
+++ b/typify-impl/src/test_util.rs
@@ -40,7 +40,9 @@ pub(crate) fn get_type<T: JsonSchema>() -> (TypeSpace, TypeId) {
     let type_id = if let Some(already_type_id) = type_space.ref_to_id.get(&name) {
         already_type_id.clone()
     } else {
-        type_space.add_type(&schema.schema.into()).unwrap()
+        type_space
+            .add_type_with_name(&schema.schema.into(), Some(name.to_string()))
+            .unwrap()
     };
 
     (type_space, type_id)


### PR DESCRIPTION
Previously a schema such as this one would result in a `typify` panic:

```json
      "BlockSize": {
        "title": "disk block size in bytes",
        "type": "integer",
        "enum": [
          512,
          2048,
          4096
        ]
      }
```

This PR turns that schema into this code:

```rust
    #[derive(Serialize, Deserialize, Debug, Clone)]
    pub struct BlockSize(i64);
    impl std::ops::Deref for BlockSize {
        type Target = i64;
        fn deref(&self) -> &Self::Target {
            &self.0
        }
    }

    impl std::convert::TryFrom<i64> for BlockSize {
        type Error = &'static str;
        fn try_from(value: i64) -> Result<Self, Self::Error> {
            if ![512_i64, 2048_i64, 4096_i64].contains(&value) {
                Err("invalid value")
            } else {
                Ok(Self(value))
            }
        }
    }
```

Note that unlike the non-enumerated type version, the newtype struct does not mark its inner type as `pub`. The only way to construct this is with `BlockSize::try_from(512).unwrap()`.