### PR TITLE
adding support for seconds duration and human readable durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+**/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +468,7 @@ version = "0.0.9-dev"
 dependencies = [
  "expectorate",
  "heck",
+ "humantime",
  "log",
  "paste",
  "proc-macro2",

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 heck = "0.4.0"
+humantime = "2.1.0"
 log = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -522,7 +522,7 @@ impl TypeSpace {
             ("int64", "i64", i64::MIN as f64, i64::MAX as f64),
             ("", "std::num::NonZeroU64", 1.0, u64::MAX as f64),
             ("uint64", "u64", u64::MIN as f64, u64::MAX as f64),
-            ("seconds", "i64", i64::MIN as f64, i64::MAX as f64),
+            ("seconds", "u64", u64::MIN as f64, u64::MAX as f64),
         ];
 
         if let Some(format) = format {

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -522,6 +522,7 @@ impl TypeSpace {
             ("int64", "i64", i64::MIN as f64, i64::MAX as f64),
             ("", "std::num::NonZeroU64", 1.0, u64::MAX as f64),
             ("uint64", "u64", u64::MIN as f64, u64::MAX as f64),
+            ("seconds", "i64", i64::MIN as f64, i64::MAX as f64),
         ];
 
         if let Some(format) = format {

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -296,7 +296,7 @@ impl TypeEntry {
         let maybe_builtin = match &self.details {
             // This can only be covered by the intrinsic default
             TypeEntryDetails::Unit => unreachable!(),
-            TypeEntryDetails::Boolean => Some("super::defaults::default_bool::<false>".to_string()),
+            TypeEntryDetails::Boolean => Some("defaults::default_bool::<false>".to_string()),
             TypeEntryDetails::Integer(name) => {
                 if let Some(value) = default.as_i64() {
                     Some(format!("defaults::default_i64::<{}, {}>", name, value))

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -298,15 +298,15 @@ impl TypeEntry {
             TypeEntryDetails::Unit => unreachable!(),
             TypeEntryDetails::Boolean => Some("defaults::default_bool::<false>".to_string()),
             TypeEntryDetails::Integer(name) => {
-                if let Some(value) = default.as_i64() {
-                    Some(format!("defaults::default_i64::<{}, {}>", name, value))
-                } else if let Some(value) = default.as_u64() {
+                if let Some(value) = default.as_u64() {
                     Some(format!("defaults::default_u64::<{}, {}>", name, value))
+                } else if let Some(value) = default.as_i64() {
+                    Some(format!("defaults::default_i64::<{}, {}>", name, value))
                 } else if let Some(duration) = default.as_str() {
                     if let Ok(value) = humantime::parse_duration(duration) {
                         Some(format!("defaults::default_u64::<{}, {}>", name, value.as_secs()))
                     } else {
-                        panic!("Integer type default cannot be converted to valid integer")
+                        panic!("Seconds format default cannot be parsed as a Duration.")
                     }
                 } else {
                     panic!("Integer type default cannot be converted to valid integer")

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -296,12 +296,12 @@ impl TypeEntry {
         let maybe_builtin = match &self.details {
             // This can only be covered by the intrinsic default
             TypeEntryDetails::Unit => unreachable!(),
-            TypeEntryDetails::Boolean => Some("defaults::default_bool::<false>".to_string()),
+            TypeEntryDetails::Boolean => Some("super::defaults::default_bool::<false>".to_string()),
             TypeEntryDetails::Integer(name) => {
-                if let Some(value) = default.as_u64() {
-                    Some(format!("defaults::default_u64::<{}, {}>", name, value))
-                } else if let Some(value) = default.as_i64() {
+                if let Some(value) = default.as_i64() {
                     Some(format!("defaults::default_i64::<{}, {}>", name, value))
+                } else if let Some(value) = default.as_u64() {
+                    Some(format!("defaults::default_u64::<{}, {}>", name, value))
                 } else if let Some(duration) = default.as_str() {
                     if let Ok(value) = humantime::parse_duration(duration) {
                         Some(format!("defaults::default_u64::<{}, {}>", name, value.as_secs()))

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -302,8 +302,14 @@ impl TypeEntry {
                     Some(format!("defaults::default_u64::<{}, {}>", name, value))
                 } else if let Some(value) = default.as_i64() {
                     Some(format!("defaults::default_i64::<{}, {}>", name, value))
+                } else if let Some(duration) = default.as_str() {
+                    if let Ok(value) = humantime::parse_duration(duration) {
+                        Some(format!("defaults::default_u64::<{}, {}>", name, value.as_secs()))
+                    } else {
+                        panic!("Integer type default cannot be converted to valid integer")
+                    }
                 } else {
-                    panic!()
+                    panic!("Integer type default cannot be converted to valid integer")
                 }
             }
             _ => None,


### PR DESCRIPTION
This attempts to solve #61 in a simple way. It treats `type: integer, format: seconds` as an integer, and it also provides a default_fn implementation for human readable durations into seconds. 