### PR TITLE
Add an optional builder for struct types

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,8 @@ https://github.com/oxidecomputer/typify/compare/v0.0.9\...HEAD[Full list of comm
 * Added `regress` dependency for ECMA 262 style regexes (#81)
 * Dropshot produces a complex `Null` type (by necessity); now rendered as `()` (#83)
 * Fixed rendering of enums with a single variant (#87)
+* Updated public interface (breaking for consumers) (#98)
+* Optional builder interface for generated structs (#98)
 
 == 0.0.9 (released 2022-06-20)
 

--- a/example-build/build.rs
+++ b/example-build/build.rs
@@ -1,13 +1,13 @@
 use std::{env, fs, path::Path};
 
 use schemars::schema::Schema;
-use typify::TypeSpace;
+use typify::{TypeSpace, TypeSpaceSettings};
 
 fn main() {
     let content = std::fs::read_to_string("../example.json").unwrap();
     let schema = serde_json::from_str::<schemars::schema::RootSchema>(&content).unwrap();
 
-    let mut type_space = TypeSpace::default();
+    let mut type_space = TypeSpace::new(TypeSpaceSettings::default().with_struct_builder(true));
     type_space.add_ref_types(schema.definitions).unwrap();
     let base_type = &schema.schema;
     // Only convert the top-level type if it has a name

--- a/example-build/src/main.rs
+++ b/example-build/src/main.rs
@@ -1,13 +1,20 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 // Include the generated code.
 include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
+#[test]
+fn test_main() {
+    main()
+}
+
 fn main() {
-    let veg = Veggie {
-        veggie_name: String::from("carrots"),
-        veggie_like: true,
-    };
+    let veg = Veggie::builder()
+        .veggie_name("carrots")
+        .veggie_like(true)
+        .try_into()
+        .unwrap();
+
     let veggies = Veggies {
         fruits: vec![String::from("apple"), String::from("mango")],
         vegetables: vec![veg],

--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -1,10 +1,15 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 use typify::import_types;
 
 use serde::{Deserialize, Serialize};
 
 import_types!("../example.json");
+
+#[test]
+fn test_main() {
+    main()
+}
 
 fn main() {
     let veg = Veggie {

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1116,6 +1116,7 @@ mod tests {
     use serde_json::json;
 
     use crate::{
+        output::OutputSpace,
         test_util::{get_type, validate_output},
         validate_builtin, Error, Name, TypeSpace,
     };
@@ -1368,7 +1369,9 @@ mod tests {
         let (type_space, type_id) = get_type::<Sub10Primes>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        let actual = type_entry.output(&type_space);
+        let mut output = OutputSpace::default();
+        type_entry.output(&type_space, &mut output);
+        let actual = output.into_stream();
         let expected = quote! {
             #[derive(Clone, Debug, Deserialize, Serialize)]
             pub struct Sub10Primes(u32);

--- a/typify-impl/src/output.rs
+++ b/typify-impl/src/output.rs
@@ -1,0 +1,112 @@
+// Copyright 2022 Oxide Computer Company
+
+use std::collections::BTreeMap;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+#[derive(Debug, Default)]
+pub struct OutputSpace {
+    items: BTreeMap<(OutputSpaceMod, String), TokenStream>,
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OutputSpaceMod {
+    Crate,
+    Builder,
+    Defaults,
+}
+
+impl OutputSpace {
+    pub fn add_item(
+        &mut self,
+        location: OutputSpaceMod,
+        order_hint: impl ToString,
+        stream: TokenStream,
+    ) {
+        self.items
+            .entry((location, order_hint.to_string()))
+            .or_insert_with(TokenStream::new)
+            .extend(stream);
+    }
+
+    pub fn into_stream(self) -> TokenStream {
+        let mods = self
+            .items
+            .into_iter()
+            .map(|((location, _), item)| (location, item))
+            .fold(BTreeMap::new(), |mut map, (location, item)| {
+                map.entry(location)
+                    .or_insert_with(TokenStream::new)
+                    .extend(item);
+                map
+            });
+
+        let mod_streams = mods.into_iter().map(|(location, items)| match location {
+            OutputSpaceMod::Crate => quote! {
+                #items
+            },
+            OutputSpaceMod::Builder => quote! {
+                mod builder {
+                    #items
+                }
+            },
+            OutputSpaceMod::Defaults => quote! {
+                mod defaults {
+                    #items
+                }
+            },
+        });
+
+        quote! {
+            #(#mod_streams)*
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OutputSpace, OutputSpaceMod};
+
+    use quote::quote;
+
+    #[test]
+    fn test_order() {
+        let mut output = OutputSpace::default();
+        output.add_item(
+            OutputSpaceMod::Crate,
+            "a",
+            quote! {
+                struct A;
+            },
+        );
+        output.add_item(
+            OutputSpaceMod::Crate,
+            "b",
+            quote! {
+                struct B;
+            },
+        );
+        output.add_item(
+            OutputSpaceMod::Crate,
+            "a",
+            quote! {
+                impl A {
+                    fn new() -> Self { Self }
+                }
+            },
+        );
+
+        assert_eq!(
+            output.into_stream().to_string(),
+            quote! {
+                struct A;
+                impl A {
+                    fn new() -> Self { Self }
+                }
+                struct B;
+            }
+            .to_string()
+        );
+    }
+}

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -4,6 +4,23 @@ mod types {
         pub value1: String,
         pub value2: u64,
     }
+    impl CompoundType {
+        pub fn builder() -> builder::CompoundType {
+            builder::CompoundType::default()
+        }
+    }
+    #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+    pub struct Pair {
+        #[serde(default = "defaults::pair_a")]
+        pub a: StringEnum,
+        #[serde(default = "defaults::pair_b")]
+        pub b: StringEnum,
+    }
+    impl Pair {
+        pub fn builder() -> builder::Pair {
+            builder::Pair::default()
+        }
+    }
     #[derive(
         Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, JsonSchema,
     )]
@@ -32,18 +49,101 @@ mod types {
             }
         }
     }
-    #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-    pub struct Pair {
-        #[serde(default = "pair_a")]
-        pub a: String,
-        #[serde(default = "pair_b")]
-        pub b: String,
+    mod builder {
+        pub struct CompoundType {
+            value1: Result<String, String>,
+            value2: Result<u64, String>,
+        }
+        impl Default for CompoundType {
+            fn default() -> Self {
+                Self {
+                    value1: Err("no value supplied for value1".to_string()),
+                    value2: Err("no value supplied for value2".to_string()),
+                }
+            }
+        }
+        impl CompoundType {
+            pub fn value1<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<String>,
+                T::Error: std::fmt::Display,
+            {
+                self.value1 = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for value1: {}", e));
+                self
+            }
+            pub fn value2<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<u64>,
+                T::Error: std::fmt::Display,
+            {
+                self.value2 = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for value2: {}", e));
+                self
+            }
+        }
+        impl std::convert::TryFrom<CompoundType> for super::CompoundType {
+            type Error = String;
+            fn try_from(value: CompoundType) -> Result<Self, Self::Error> {
+                Ok(Self {
+                    value1: value.value1?,
+                    value2: value.value2?,
+                })
+            }
+        }
+        pub struct Pair {
+            a: Result<super::StringEnum, String>,
+            b: Result<super::StringEnum, String>,
+        }
+        impl Default for Pair {
+            fn default() -> Self {
+                Self {
+                    a: Ok(super::defaults::pair_a()),
+                    b: Ok(super::defaults::pair_b()),
+                }
+            }
+        }
+        impl Pair {
+            pub fn a<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::StringEnum>,
+                T::Error: std::fmt::Display,
+            {
+                self.a = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for a: {}", e));
+                self
+            }
+            pub fn b<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<super::StringEnum>,
+                T::Error: std::fmt::Display,
+            {
+                self.b = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for b: {}", e));
+                self
+            }
+        }
+        impl std::convert::TryFrom<Pair> for super::Pair {
+            type Error = String;
+            fn try_from(value: Pair) -> Result<Self, Self::Error> {
+                Ok(Self {
+                    a: value.a?,
+                    b: value.b?,
+                })
+            }
+        }
     }
-    fn pair_a() -> String {
-        "A".to_string()
-    }
-    fn pair_b() -> String {
-        "B".to_string()
+    mod defaults {
+        pub(super) fn pair_a() -> super::StringEnum {
+            super::StringEnum::One
+        }
+        pub(super) fn pair_b() -> super::StringEnum {
+            super::StringEnum::Two
+        }
     }
 }
 pub fn do_stuff(

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -1,8 +1,3 @@
-mod defaults {
-    pub(super) fn default_bool<const V: bool>() -> bool {
-        V
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstance {
@@ -23,5392 +18,6 @@ pub struct AlertInstance {
     pub ref_: String,
     #[doc = "State of a code scanning alert."]
     pub state: AlertInstanceState,
-}
-#[doc = "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct App {
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub description: Option<String>,
-    #[doc = "The list of events for the GitHub app"]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<AppEventsItem>,
-    pub external_url: String,
-    pub html_url: String,
-    #[doc = "Unique identifier of the GitHub app"]
-    pub id: i64,
-    #[doc = "The name of the GitHub app"]
-    pub name: String,
-    pub node_id: String,
-    pub owner: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub permissions: Option<AppPermissions>,
-    #[doc = "The slug name of the GitHub app"]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub slug: Option<String>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-}
-#[doc = "How the author is associated with the repository."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum AuthorAssociation {
-    #[serde(rename = "COLLABORATOR")]
-    Collaborator,
-    #[serde(rename = "CONTRIBUTOR")]
-    Contributor,
-    #[serde(rename = "FIRST_TIMER")]
-    FirstTimer,
-    #[serde(rename = "FIRST_TIME_CONTRIBUTOR")]
-    FirstTimeContributor,
-    #[serde(rename = "MANNEQUIN")]
-    Mannequin,
-    #[serde(rename = "MEMBER")]
-    Member,
-    #[serde(rename = "NONE")]
-    None,
-    #[serde(rename = "OWNER")]
-    Owner,
-}
-impl ToString for AuthorAssociation {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Collaborator => "COLLABORATOR".to_string(),
-            Self::Contributor => "CONTRIBUTOR".to_string(),
-            Self::FirstTimer => "FIRST_TIMER".to_string(),
-            Self::FirstTimeContributor => "FIRST_TIME_CONTRIBUTOR".to_string(),
-            Self::Mannequin => "MANNEQUIN".to_string(),
-            Self::Member => "MEMBER".to_string(),
-            Self::None => "NONE".to_string(),
-            Self::Owner => "OWNER".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for AuthorAssociation {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "COLLABORATOR" => Ok(Self::Collaborator),
-            "CONTRIBUTOR" => Ok(Self::Contributor),
-            "FIRST_TIMER" => Ok(Self::FirstTimer),
-            "FIRST_TIME_CONTRIBUTOR" => Ok(Self::FirstTimeContributor),
-            "MANNEQUIN" => Ok(Self::Mannequin),
-            "MEMBER" => Ok(Self::Member),
-            "NONE" => Ok(Self::None),
-            "OWNER" => Ok(Self::Owner),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[doc = "The branch protection rule. Includes a `name` and all the [branch protection settings](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-settings) applied to branches that match the name. Binary settings are boolean. Multi-level configurations are one of `off`, `non_admins`, or `everyone`. Actor and build lists are arrays of strings."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRule {
-    pub admin_enforced: bool,
-    pub allow_deletions_enforcement_level: BranchProtectionRuleAllowDeletionsEnforcementLevel,
-    pub allow_force_pushes_enforcement_level: BranchProtectionRuleAllowForcePushesEnforcementLevel,
-    pub authorized_actor_names: Vec<String>,
-    pub authorized_actors_only: bool,
-    pub authorized_dismissal_actors_only: bool,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub dismiss_stale_reviews_on_push: bool,
-    pub id: i64,
-    pub ignore_approvals_from_contributors: bool,
-    pub linear_history_requirement_enforcement_level:
-        BranchProtectionRuleLinearHistoryRequirementEnforcementLevel,
-    pub merge_queue_enforcement_level: BranchProtectionRuleMergeQueueEnforcementLevel,
-    pub name: String,
-    pub pull_request_reviews_enforcement_level:
-        BranchProtectionRulePullRequestReviewsEnforcementLevel,
-    pub repository_id: i64,
-    pub require_code_owner_review: bool,
-    pub required_approving_review_count: i64,
-    pub required_conversation_resolution_level:
-        BranchProtectionRuleRequiredConversationResolutionLevel,
-    pub required_deployments_enforcement_level:
-        BranchProtectionRuleRequiredDeploymentsEnforcementLevel,
-    pub required_status_checks: Vec<String>,
-    pub required_status_checks_enforcement_level:
-        BranchProtectionRuleRequiredStatusChecksEnforcementLevel,
-    pub signature_requirement_enforcement_level:
-        BranchProtectionRuleSignatureRequirementEnforcementLevel,
-    pub strict_required_status_checks_policy: bool,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-}
-#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleCreated {
-    pub action: BranchProtectionRuleCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub rule: BranchProtectionRule,
-    pub sender: User,
-}
-#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleDeleted {
-    pub action: BranchProtectionRuleDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub rule: BranchProtectionRule,
-    pub sender: User,
-}
-#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleEdited {
-    pub action: BranchProtectionRuleEditedAction,
-    pub changes: BranchProtectionRuleEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub rule: BranchProtectionRule,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum BranchProtectionRuleEvent {
-    #[doc = "branch protection rule created event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        rule: BranchProtectionRule,
-        sender: User,
-    },
-    #[doc = "branch protection rule deleted event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        rule: BranchProtectionRule,
-        sender: User,
-    },
-    #[doc = "branch protection rule edited event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: BranchProtectionRuleEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        rule: BranchProtectionRule,
-        sender: User,
-    },
-}
-#[doc = "A deployment to a repository environment. This will only be populated if the check run was created by a GitHub Actions workflow job that references an environment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunDeployment {
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub description: Option<String>,
-    pub environment: String,
-    pub id: i64,
-    pub node_id: String,
-    pub original_environment: String,
-    pub repository_url: String,
-    pub statuses_url: String,
-    pub task: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunPullRequest {
-    pub base: CheckRunPullRequestBase,
-    pub head: CheckRunPullRequestHead,
-    pub id: i64,
-    pub number: i64,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCompleted {
-    pub action: CheckRunCompletedAction,
-    pub check_run: CheckRunCompletedCheckRun,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_action: Option<CheckRunCompletedRequestedAction>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCreated {
-    pub action: CheckRunCreatedAction,
-    pub check_run: CheckRunCreatedCheckRun,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_action: Option<CheckRunCreatedRequestedAction>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRequestedAction {
-    pub action: CheckRunRequestedActionAction,
-    pub check_run: CheckRunRequestedActionCheckRun,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub requested_action: CheckRunRequestedActionRequestedAction,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRerequested {
-    pub action: CheckRunRerequestedAction,
-    pub check_run: CheckRunRerequestedCheckRun,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_action: Option<CheckRunRerequestedRequestedAction>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum CheckRunEvent {
-    #[doc = "check_run completed event"]
-    #[serde(rename = "completed")]
-    Completed {
-        check_run: CheckRunCompletedCheckRun,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        #[doc = "The action requested by the user."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        requested_action: Option<CheckRunCompletedRequestedAction>,
-        sender: User,
-    },
-    #[doc = "check_run created event"]
-    #[serde(rename = "created")]
-    Created {
-        check_run: CheckRunCreatedCheckRun,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        #[doc = "The action requested by the user."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        requested_action: Option<CheckRunCreatedRequestedAction>,
-        sender: User,
-    },
-    #[doc = "check_run requested_action event"]
-    #[serde(rename = "requested_action")]
-    RequestedAction {
-        check_run: CheckRunRequestedActionCheckRun,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        requested_action: CheckRunRequestedActionRequestedAction,
-        sender: User,
-    },
-    #[doc = "check_run rerequested event"]
-    #[serde(rename = "rerequested")]
-    Rerequested {
-        check_run: CheckRunRerequestedCheckRun,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        #[doc = "The action requested by the user."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        requested_action: Option<CheckRunRerequestedRequestedAction>,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckSuiteCompleted {
-    pub action: CheckSuiteCompletedAction,
-    pub check_suite: CheckSuiteCompletedCheckSuite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckSuiteRequested {
-    pub action: CheckSuiteRequestedAction,
-    pub check_suite: CheckSuiteRequestedCheckSuite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckSuiteRerequested {
-    pub action: CheckSuiteRerequestedAction,
-    pub check_suite: CheckSuiteRerequestedCheckSuite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum CheckSuiteEvent {
-    #[doc = "check_suite completed event"]
-    #[serde(rename = "completed")]
-    Completed {
-        check_suite: CheckSuiteCompletedCheckSuite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "check_suite requested event"]
-    #[serde(rename = "requested")]
-    Requested {
-        check_suite: CheckSuiteRequestedCheckSuite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "check_suite rerequested event"]
-    #[serde(rename = "rerequested")]
-    Rerequested {
-        check_suite: CheckSuiteRerequestedCheckSuite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertAppearedInBranch {
-    pub action: CodeScanningAlertAppearedInBranchAction,
-    pub alert: CodeScanningAlertAppearedInBranchAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: GithubOrg,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertClosedByUser {
-    pub action: CodeScanningAlertClosedByUserAction,
-    pub alert: CodeScanningAlertClosedByUserAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertCreated {
-    pub action: CodeScanningAlertCreatedAction,
-    pub alert: CodeScanningAlertCreatedAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: GithubOrg,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertFixed {
-    pub action: CodeScanningAlertFixedAction,
-    pub alert: CodeScanningAlertFixedAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: GithubOrg,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopened {
-    pub action: CodeScanningAlertReopenedAction,
-    pub alert: CodeScanningAlertReopenedAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: GithubOrg,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopenedByUser {
-    pub action: CodeScanningAlertReopenedByUserAction,
-    pub alert: CodeScanningAlertReopenedByUserAlert,
-    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    pub commit_oid: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum CodeScanningAlertEvent {
-    #[doc = "code_scanning_alert appeared_in_branch event"]
-    #[serde(rename = "appeared_in_branch")]
-    AppearedInBranch {
-        alert: CodeScanningAlertAppearedInBranchAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: GithubOrg,
-    },
-    #[doc = "code_scanning_alert closed_by_user event"]
-    #[serde(rename = "closed_by_user")]
-    ClosedByUser {
-        alert: CodeScanningAlertClosedByUserAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "code_scanning_alert created event"]
-    #[serde(rename = "created")]
-    Created {
-        alert: CodeScanningAlertCreatedAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: GithubOrg,
-    },
-    #[doc = "code_scanning_alert fixed event"]
-    #[serde(rename = "fixed")]
-    Fixed {
-        alert: CodeScanningAlertFixedAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: GithubOrg,
-    },
-    #[doc = "code_scanning_alert reopened event"]
-    #[serde(rename = "reopened")]
-    Reopened {
-        alert: CodeScanningAlertReopenedAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: GithubOrg,
-    },
-    #[doc = "code_scanning_alert reopened_by_user event"]
-    #[serde(rename = "reopened_by_user")]
-    ReopenedByUser {
-        alert: CodeScanningAlertReopenedByUserAlert,
-        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        commit_oid: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
-        #[serde(rename = "ref")]
-        ref_: String,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Commit {
-    #[doc = "An array of files added in the commit."]
-    pub added: Vec<String>,
-    pub author: Committer,
-    pub committer: Committer,
-    #[doc = "Whether this commit is distinct from any that have been pushed before."]
-    pub distinct: bool,
-    pub id: String,
-    #[doc = "The commit message."]
-    pub message: String,
-    #[doc = "An array of files modified by the commit."]
-    pub modified: Vec<String>,
-    #[doc = "An array of files removed in the commit."]
-    pub removed: Vec<String>,
-    #[doc = "The ISO 8601 timestamp of the commit."]
-    pub timestamp: String,
-    pub tree_id: String,
-    #[doc = "URL that points to the commit API resource."]
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CommitSimple {
-    pub author: Committer,
-    pub committer: Committer,
-    pub id: String,
-    pub message: String,
-    pub timestamp: String,
-    pub tree_id: String,
-}
-#[doc = "A commit comment is created. The type of activity is specified in the `action` property. "]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CommitCommentCreated {
-    #[doc = "The action performed. Can be `created`."]
-    pub action: CommitCommentCreatedAction,
-    pub comment: CommitCommentCreatedComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum CommitCommentEvent {
-    #[doc = "commit_comment created event\n\nA commit comment is created. The type of activity is specified in the `action` property. "]
-    #[serde(rename = "created")]
-    Created {
-        comment: CommitCommentCreatedComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "Metaproperties for Git author/committer information."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Committer {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub date: Option<chrono::DateTime<chrono::offset::Utc>>,
-    #[doc = "The git author's email address."]
-    pub email: Option<String>,
-    #[doc = "The git author's name."]
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub username: Option<String>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ContentReferenceCreated {
-    pub action: ContentReferenceCreatedAction,
-    pub content_reference: ContentReferenceCreatedContentReference,
-    pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum ContentReferenceEvent {
-    #[doc = "content_reference created event"]
-    #[serde(rename = "created")]
-    Created {
-        content_reference: ContentReferenceCreatedContentReference,
-        installation: InstallationLite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "A Git branch or tag is created."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CreateEvent {
-    #[doc = "The repository's current description."]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The name of the repository's default branch (usually `main`)."]
-    pub master_branch: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
-    pub pusher_type: String,
-    #[doc = "The [`git ref`](https://docs.github.com/en/rest/reference/git#get-a-reference) resource."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    #[doc = "The type of Git ref object created in the repository. Can be either `branch` or `tag`."]
-    pub ref_type: CreateEventRefType,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[doc = "A Git branch or tag is deleted."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeleteEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
-    pub pusher_type: String,
-    #[doc = "The [`git ref`](https://docs.github.com/en/rest/reference/git#get-a-reference) resource."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    #[doc = "The type of Git ref object deleted in the repository. Can be either `branch` or `tag`."]
-    pub ref_type: DeleteEventRefType,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeployKeyCreated {
-    pub action: DeployKeyCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub key: DeployKeyCreatedKey,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeployKeyDeleted {
-    pub action: DeployKeyDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub key: DeployKeyDeletedKey,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum DeployKeyEvent {
-    #[doc = "deploy_key created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        key: DeployKeyCreatedKey,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "deploy_key deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        key: DeployKeyDeletedKey,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeploymentCreated {
-    pub action: DeploymentCreatedAction,
-    pub deployment: DeploymentCreatedDeployment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow: (),
-    pub workflow_run: (),
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum DeploymentEvent {
-    #[doc = "deployment created event"]
-    #[serde(rename = "created")]
-    Created {
-        deployment: DeploymentCreatedDeployment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow: (),
-        workflow_run: (),
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeploymentStatusCreated {
-    pub action: DeploymentStatusCreatedAction,
-    pub deployment: DeploymentStatusCreatedDeployment,
-    pub deployment_status: DeploymentStatusCreatedDeploymentStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum DeploymentStatusEvent {
-    #[doc = "deployment_status created event"]
-    #[serde(rename = "created")]
-    Created {
-        deployment: DeploymentStatusCreatedDeployment,
-        deployment_status: DeploymentStatusCreatedDeploymentStatus,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Discussion {
-    pub active_lock_reason: Option<String>,
-    pub answer_chosen_at: Option<String>,
-    pub answer_chosen_by: Option<User>,
-    pub answer_html_url: Option<String>,
-    pub author_association: AuthorAssociation,
-    pub body: String,
-    pub category: DiscussionCategory,
-    pub comments: i64,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub html_url: String,
-    pub id: i64,
-    pub locked: bool,
-    pub node_id: String,
-    pub number: i64,
-    pub repository_url: String,
-    pub state: DiscussionState,
-    pub title: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionAnswered {
-    pub action: DiscussionAnsweredAction,
-    pub answer: DiscussionAnsweredAnswer,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCategoryChanged {
-    pub action: DiscussionCategoryChangedAction,
-    pub changes: DiscussionCategoryChangedChanges,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCreated {
-    pub action: DiscussionCreatedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionDeleted {
-    pub action: DiscussionDeletedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionEdited {
-    pub action: DiscussionEditedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changes: Option<DiscussionEditedChanges>,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionLabeled {
-    pub action: DiscussionLabeledAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub label: Label,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionLocked {
-    pub action: DiscussionLockedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionPinned {
-    pub action: DiscussionPinnedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionTransferred {
-    pub action: DiscussionTransferredAction,
-    pub changes: DiscussionTransferredChanges,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionUnanswered {
-    pub action: DiscussionUnansweredAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub old_answer: DiscussionUnansweredOldAnswer,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionUnlabeled {
-    pub action: DiscussionUnlabeledAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub label: Label,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionUnlocked {
-    pub action: DiscussionUnlockedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionUnpinned {
-    pub action: DiscussionUnpinnedAction,
-    pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCommentCreated {
-    pub action: DiscussionCommentCreatedAction,
-    pub comment: DiscussionCommentCreatedComment,
-    pub discussion: Discussion,
-    pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCommentDeleted {
-    pub action: DiscussionCommentDeletedAction,
-    pub comment: DiscussionCommentDeletedComment,
-    pub discussion: Discussion,
-    pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCommentEdited {
-    pub action: DiscussionCommentEditedAction,
-    pub changes: DiscussionCommentEditedChanges,
-    pub comment: DiscussionCommentEditedComment,
-    pub discussion: Discussion,
-    pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum DiscussionCommentEvent {
-    #[doc = "discussion_comment created event"]
-    #[serde(rename = "created")]
-    Created {
-        comment: DiscussionCommentCreatedComment,
-        discussion: Discussion,
-        installation: InstallationLite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion_comment deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        comment: DiscussionCommentDeletedComment,
-        discussion: Discussion,
-        installation: InstallationLite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion_comment edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: DiscussionCommentEditedChanges,
-        comment: DiscussionCommentEditedComment,
-        discussion: Discussion,
-        installation: InstallationLite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum DiscussionEvent {
-    #[doc = "discussion answered event"]
-    #[serde(rename = "answered")]
-    Answered {
-        answer: DiscussionAnsweredAnswer,
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion category changed event"]
-    #[serde(rename = "category_changed")]
-    CategoryChanged {
-        changes: DiscussionCategoryChangedChanges,
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion created event"]
-    #[serde(rename = "created")]
-    Created {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        changes: Option<DiscussionEditedChanges>,
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion labeled event"]
-    #[serde(rename = "labeled")]
-    Labeled {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        label: Label,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion locked event"]
-    #[serde(rename = "locked")]
-    Locked {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion pinned event"]
-    #[serde(rename = "pinned")]
-    Pinned {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion transferred event"]
-    #[serde(rename = "transferred")]
-    Transferred {
-        changes: DiscussionTransferredChanges,
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion unanswered event"]
-    #[serde(rename = "unanswered")]
-    Unanswered {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        old_answer: DiscussionUnansweredOldAnswer,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion unlabeled event"]
-    #[serde(rename = "unlabeled")]
-    Unlabeled {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        label: Label,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion unlocked event"]
-    #[serde(rename = "unlocked")]
-    Unlocked {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "discussion unpinned event"]
-    #[serde(rename = "unpinned")]
-    Unpinned {
-        discussion: Discussion,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "A user forks a repository."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ForkEvent {
-    #[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
-    pub forkee: Repository,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GithubOrg {
-    pub avatar_url: String,
-    #[serde(default)]
-    pub email: (),
-    pub events_url: String,
-    pub followers_url: String,
-    pub following_url: String,
-    pub gists_url: String,
-    pub gravatar_id: String,
-    pub html_url: String,
-    pub id: i64,
-    pub login: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    pub node_id: String,
-    pub organizations_url: String,
-    pub received_events_url: String,
-    pub repos_url: String,
-    pub site_admin: bool,
-    pub starred_url: String,
-    pub subscriptions_url: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GithubAppAuthorizationRevoked {
-    pub action: GithubAppAuthorizationRevokedAction,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", content = "sender")]
-pub enum GithubAppAuthorizationEvent {
-    #[doc = "github_app_authorization revoked event"]
-    #[serde(rename = "revoked")]
-    Revoked(User),
-}
-#[doc = "A wiki page is created or updated."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GollumEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[doc = "The pages that were updated."]
-    pub pages: Vec<GollumEventPagesItem>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[doc = "The GitHub App installation."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Installation {
-    pub access_tokens_url: String,
-    pub account: User,
-    pub app_id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub app_slug: Option<String>,
-    pub created_at: InstallationCreatedAt,
-    pub events: Vec<InstallationEventsItem>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub has_multiple_single_files: Option<bool>,
-    pub html_url: String,
-    #[doc = "The ID of the installation."]
-    pub id: i64,
-    pub permissions: InstallationPermissions,
-    pub repositories_url: String,
-    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-    pub repository_selection: InstallationRepositorySelection,
-    pub single_file_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub single_file_paths: Vec<String>,
-    pub suspended_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub suspended_by: Option<User>,
-    #[doc = "The ID of the user or organization this token is being scoped to."]
-    pub target_id: i64,
-    pub target_type: InstallationTargetType,
-    pub updated_at: InstallationUpdatedAt,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationCreated {
-    pub action: InstallationCreatedAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects that the installation can access."]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repositories: Vec<InstallationCreatedRepositoriesItem>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requester: Option<User>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationDeleted {
-    pub action: InstallationDeletedAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects that the installation can access."]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repositories: Vec<InstallationDeletedRepositoriesItem>,
-    #[serde(default)]
-    pub requester: (),
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationNewPermissionsAccepted {
-    pub action: InstallationNewPermissionsAcceptedAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects that the installation can access."]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repositories: Vec<InstallationNewPermissionsAcceptedRepositoriesItem>,
-    #[serde(default)]
-    pub requester: (),
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationSuspend {
-    pub action: InstallationSuspendAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects that the installation can access."]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repositories: Vec<InstallationSuspendRepositoriesItem>,
-    #[serde(default)]
-    pub requester: (),
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationUnsuspend {
-    pub action: InstallationUnsuspendAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects that the installation can access."]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub repositories: Vec<InstallationUnsuspendRepositoriesItem>,
-    #[serde(default)]
-    pub requester: (),
-    pub sender: User,
-}
-#[doc = "Installation"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationLite {
-    #[doc = "The ID of the installation."]
-    pub id: i64,
-    pub node_id: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum InstallationEvent {
-    #[doc = "installation created event"]
-    #[serde(rename = "created")]
-    Created {
-        installation: Installation,
-        #[doc = "An array of repository objects that the installation can access."]
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        repositories: Vec<InstallationCreatedRepositoriesItem>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        requester: Option<User>,
-        sender: User,
-    },
-    #[doc = "installation deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        installation: Installation,
-        #[doc = "An array of repository objects that the installation can access."]
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        repositories: Vec<InstallationDeletedRepositoriesItem>,
-        #[serde(default)]
-        requester: (),
-        sender: User,
-    },
-    #[doc = "installation new_permissions_accepted event"]
-    #[serde(rename = "new_permissions_accepted")]
-    NewPermissionsAccepted {
-        installation: Installation,
-        #[doc = "An array of repository objects that the installation can access."]
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        repositories: Vec<InstallationNewPermissionsAcceptedRepositoriesItem>,
-        #[serde(default)]
-        requester: (),
-        sender: User,
-    },
-    #[doc = "installation suspend event"]
-    #[serde(rename = "suspend")]
-    Suspend {
-        installation: Installation,
-        #[doc = "An array of repository objects that the installation can access."]
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        repositories: Vec<InstallationSuspendRepositoriesItem>,
-        #[serde(default)]
-        requester: (),
-        sender: User,
-    },
-    #[doc = "installation unsuspend event"]
-    #[serde(rename = "unsuspend")]
-    Unsuspend {
-        installation: Installation,
-        #[doc = "An array of repository objects that the installation can access."]
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        repositories: Vec<InstallationUnsuspendRepositoriesItem>,
-        #[serde(default)]
-        requester: (),
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationRepositoriesAdded {
-    pub action: InstallationRepositoriesAddedAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects, which were added to the installation."]
-    pub repositories_added: Vec<InstallationRepositoriesAddedRepositoriesAddedItem>,
-    #[doc = "An array of repository objects, which were removed from the installation."]
-    pub repositories_removed: Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
-    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-    pub repository_selection: InstallationRepositoriesAddedRepositorySelection,
-    pub requester: Option<User>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationRepositoriesRemoved {
-    pub action: InstallationRepositoriesRemovedAction,
-    pub installation: Installation,
-    #[doc = "An array of repository objects, which were added to the installation."]
-    pub repositories_added: Vec<InstallationRepositoriesRemovedRepositoriesAddedItem>,
-    #[doc = "An array of repository objects, which were removed from the installation."]
-    pub repositories_removed: Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
-    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-    pub repository_selection: InstallationRepositoriesRemovedRepositorySelection,
-    pub requester: Option<User>,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum InstallationRepositoriesEvent {
-    #[doc = "installation_repositories added event"]
-    #[serde(rename = "added")]
-    Added {
-        installation: Installation,
-        #[doc = "An array of repository objects, which were added to the installation."]
-        repositories_added: Vec<InstallationRepositoriesAddedRepositoriesAddedItem>,
-        #[doc = "An array of repository objects, which were removed from the installation."]
-        repositories_removed: Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
-        #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-        repository_selection: InstallationRepositoriesAddedRepositorySelection,
-        requester: Option<User>,
-        sender: User,
-    },
-    #[doc = "installation_repositories removed event"]
-    #[serde(rename = "removed")]
-    Removed {
-        installation: Installation,
-        #[doc = "An array of repository objects, which were added to the installation."]
-        repositories_added: Vec<InstallationRepositoriesRemovedRepositoriesAddedItem>,
-        #[doc = "An array of repository objects, which were removed from the installation."]
-        repositories_removed: Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
-        #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-        repository_selection: InstallationRepositoriesRemovedRepositorySelection,
-        requester: Option<User>,
-        sender: User,
-    },
-}
-#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Issue {
-    pub active_lock_reason: Option<IssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    #[doc = "Contents of the issue"]
-    pub body: Option<String>,
-    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub comments: i64,
-    pub comments_url: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub events_url: String,
-    pub html_url: String,
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub labels: Vec<Label>,
-    pub labels_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub locked: Option<bool>,
-    pub milestone: Option<Milestone>,
-    pub node_id: String,
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub performed_via_github_app: Option<App>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pull_request: Option<IssuePullRequest>,
-    pub repository_url: String,
-    #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<IssueState>,
-    #[doc = "Title of the issue"]
-    pub title: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL for the issue"]
-    pub url: String,
-    pub user: User,
-}
-#[doc = "The [comment](https://docs.github.com/en/rest/reference/issues#comments) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssueComment {
-    pub author_association: AuthorAssociation,
-    #[doc = "Contents of the issue comment"]
-    pub body: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub html_url: String,
-    #[doc = "Unique identifier of the issue comment"]
-    pub id: i64,
-    pub issue_url: String,
-    pub node_id: String,
-    pub performed_via_github_app: Option<App>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL for the issue comment"]
-    pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssueCommentCreated {
-    pub action: IssueCommentCreatedAction,
-    pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssueCommentDeleted {
-    pub action: IssueCommentDeletedAction,
-    pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssueCommentEdited {
-    pub action: IssueCommentEditedAction,
-    pub changes: IssueCommentEditedChanges,
-    pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum IssueCommentEvent {
-    #[doc = "issue_comment created event"]
-    #[serde(rename = "created")]
-    Created {
-        comment: IssueComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issue_comment deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        comment: IssueComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issue_comment edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: IssueCommentEditedChanges,
-        comment: IssueComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "Activity related to an issue. The type of activity is specified in the action property."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesAssigned {
-    #[doc = "The action that was performed."]
-    pub action: IssuesAssignedAction,
-    #[doc = "The optional user who was assigned or unassigned from the issue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub assignee: Option<User>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesClosed {
-    #[doc = "The action that was performed."]
-    pub action: IssuesClosedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesDeleted {
-    pub action: IssuesDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesDemilestoned {
-    pub action: IssuesDemilestonedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesEdited {
-    pub action: IssuesEditedAction,
-    pub changes: IssuesEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<Label>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesLabeled {
-    pub action: IssuesLabeledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[doc = "The label that was added to the issue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<Label>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesLocked {
-    pub action: IssuesLockedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesMilestoned {
-    pub action: IssuesMilestonedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesOpened {
-    pub action: IssuesOpenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changes: Option<IssuesOpenedChanges>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesPinned {
-    pub action: IssuesPinnedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesReopened {
-    pub action: IssuesReopenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesTransferred {
-    pub action: IssuesTransferredAction,
-    pub changes: IssuesTransferredChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesUnassigned {
-    #[doc = "The action that was performed."]
-    pub action: IssuesUnassignedAction,
-    #[doc = "The optional user who was assigned or unassigned from the issue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub assignee: Option<User>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesUnlabeled {
-    pub action: IssuesUnlabeledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[doc = "The label that was removed from the issue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<Label>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesUnlocked {
-    pub action: IssuesUnlockedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssuesUnpinned {
-    pub action: IssuesUnpinnedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub issue: Issue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum IssuesEvent {
-    #[doc = "issues assigned event\n\nActivity related to an issue. The type of activity is specified in the action property."]
-    #[serde(rename = "assigned")]
-    Assigned {
-        #[doc = "The optional user who was assigned or unassigned from the issue."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        assignee: Option<User>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues closed event"]
-    #[serde(rename = "closed")]
-    Closed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues demilestoned event"]
-    #[serde(rename = "demilestoned")]
-    Demilestoned {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: IssuesEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        label: Option<Label>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues labeled event"]
-    #[serde(rename = "labeled")]
-    Labeled {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[doc = "The label that was added to the issue."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        label: Option<Label>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues locked event"]
-    #[serde(rename = "locked")]
-    Locked {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues milestoned event"]
-    #[serde(rename = "milestoned")]
-    Milestoned {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues opened event"]
-    #[serde(rename = "opened")]
-    Opened {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        changes: Option<IssuesOpenedChanges>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues pinned event"]
-    #[serde(rename = "pinned")]
-    Pinned {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues reopened event"]
-    #[serde(rename = "reopened")]
-    Reopened {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues transferred event"]
-    #[serde(rename = "transferred")]
-    Transferred {
-        changes: IssuesTransferredChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues unassigned event"]
-    #[serde(rename = "unassigned")]
-    Unassigned {
-        #[doc = "The optional user who was assigned or unassigned from the issue."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        assignee: Option<User>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues unlabeled event"]
-    #[serde(rename = "unlabeled")]
-    Unlabeled {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[doc = "The label that was removed from the issue."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        label: Option<Label>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues unlocked event"]
-    #[serde(rename = "unlocked")]
-    Unlocked {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "issues unpinned event"]
-    #[serde(rename = "unpinned")]
-    Unpinned {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        issue: Issue,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Label {
-    #[doc = "6-character hex code, without the leading #, identifying the color"]
-    pub color: String,
-    pub default: bool,
-    pub description: Option<String>,
-    pub id: i64,
-    #[doc = "The name of the label."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "URL for the label"]
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct LabelCreated {
-    pub action: LabelCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The label that was added."]
-    pub label: Label,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct LabelDeleted {
-    pub action: LabelDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The label that was removed."]
-    pub label: Label,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct LabelEdited {
-    pub action: LabelEditedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changes: Option<LabelEditedChanges>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The label that was edited."]
-    pub label: Label,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum LabelEvent {
-    #[doc = "label created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The label that was added."]
-        label: Label,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "label deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The label that was removed."]
-        label: Label,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "label edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        changes: Option<LabelEditedChanges>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The label that was edited."]
-        label: Label,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct License {
-    pub key: String,
-    pub name: String,
-    pub node_id: String,
-    pub spdx_id: String,
-    pub url: Option<String>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Link {
-    pub href: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchase {
-    pub account: MarketplacePurchaseAccount,
-    pub billing_cycle: String,
-    pub free_trial_ends_on: (),
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_billing_date: Option<String>,
-    pub on_free_trial: bool,
-    pub plan: MarketplacePurchasePlan,
-    pub unit_count: i64,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchaseCancelled {
-    pub action: MarketplacePurchaseCancelledAction,
-    pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
-    pub sender: MarketplacePurchaseCancelledSender,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchaseChanged {
-    pub action: MarketplacePurchaseChangedAction,
-    pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
-    pub sender: MarketplacePurchaseChangedSender,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchasePendingChange {
-    pub action: MarketplacePurchasePendingChangeAction,
-    pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
-    pub sender: MarketplacePurchasePendingChangeSender,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchasePendingChangeCancelled {
-    pub action: MarketplacePurchasePendingChangeCancelledAction,
-    pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
-    pub sender: MarketplacePurchasePendingChangeCancelledSender,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarketplacePurchasePurchased {
-    pub action: MarketplacePurchasePurchasedAction,
-    pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
-    pub sender: MarketplacePurchasePurchasedSender,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum MarketplacePurchaseEvent {
-    #[doc = "marketplace_purchase cancelled event"]
-    #[serde(rename = "cancelled")]
-    Cancelled {
-        effective_date: String,
-        marketplace_purchase: MarketplacePurchase,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        previous_marketplace_purchase: Option<MarketplacePurchase>,
-        sender: MarketplacePurchaseCancelledSender,
-    },
-    #[doc = "marketplace_purchase changed event"]
-    #[serde(rename = "changed")]
-    Changed {
-        effective_date: String,
-        marketplace_purchase: MarketplacePurchase,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        previous_marketplace_purchase: Option<MarketplacePurchase>,
-        sender: MarketplacePurchaseChangedSender,
-    },
-    #[doc = "marketplace_purchase pending_change event"]
-    #[serde(rename = "pending_change")]
-    PendingChange {
-        effective_date: String,
-        marketplace_purchase: MarketplacePurchase,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        previous_marketplace_purchase: Option<MarketplacePurchase>,
-        sender: MarketplacePurchasePendingChangeSender,
-    },
-    #[doc = "marketplace_purchase pending_change_cancelled event"]
-    #[serde(rename = "pending_change_cancelled")]
-    PendingChangeCancelled {
-        effective_date: String,
-        marketplace_purchase: MarketplacePurchase,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        previous_marketplace_purchase: Option<MarketplacePurchase>,
-        sender: MarketplacePurchasePendingChangeCancelledSender,
-    },
-    #[doc = "marketplace_purchase purchased event"]
-    #[serde(rename = "purchased")]
-    Purchased {
-        effective_date: String,
-        marketplace_purchase: MarketplacePurchase,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        previous_marketplace_purchase: Option<MarketplacePurchase>,
-        sender: MarketplacePurchasePurchasedSender,
-    },
-}
-#[doc = "Activity related to repository collaborators. The type of activity is specified in the action property."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MemberAdded {
-    pub action: MemberAddedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub changes: Option<MemberAddedChanges>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The user that was added."]
-    pub member: User,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MemberEdited {
-    pub action: MemberEditedAction,
-    pub changes: MemberEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The user who's permissions are changed."]
-    pub member: User,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MemberRemoved {
-    pub action: MemberRemovedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The user that was removed."]
-    pub member: User,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum MemberEvent {
-    #[doc = "member added event\n\nActivity related to repository collaborators. The type of activity is specified in the action property."]
-    #[serde(rename = "added")]
-    Added {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        changes: Option<MemberAddedChanges>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The user that was added."]
-        member: User,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "member edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: MemberEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The user who's permissions are changed."]
-        member: User,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "member removed event"]
-    #[serde(rename = "removed")]
-    Removed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The user that was removed."]
-        member: User,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "The membership between the user and the organization. Not present when the action is `member_invited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Membership {
-    pub organization_url: String,
-    pub role: String,
-    pub state: String,
-    pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MembershipAdded {
-    pub action: MembershipAddedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
-    pub member: User,
-    pub organization: Organization,
-    #[doc = "The scope of the membership. Currently, can only be `team`."]
-    pub scope: MembershipAddedScope,
-    pub sender: User,
-    #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MembershipRemoved {
-    pub action: MembershipRemovedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
-    pub member: User,
-    pub organization: Organization,
-    #[doc = "The scope of the membership. Currently, can only be `team`."]
-    pub scope: MembershipRemovedScope,
-    pub sender: User,
-    #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
-    pub team: MembershipRemovedTeam,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum MembershipEvent {
-    #[doc = "membership added event"]
-    #[serde(rename = "added")]
-    Added {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
-        member: User,
-        organization: Organization,
-        #[doc = "The scope of the membership. Currently, can only be `team`."]
-        scope: MembershipAddedScope,
-        sender: User,
-        #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
-        team: Team,
-    },
-    #[doc = "membership removed event"]
-    #[serde(rename = "removed")]
-    Removed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
-        member: User,
-        organization: Organization,
-        #[doc = "The scope of the membership. Currently, can only be `team`."]
-        scope: MembershipRemovedScope,
-        sender: User,
-        #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
-        team: MembershipRemovedTeam,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MetaDeleted {
-    pub action: MetaDeletedAction,
-    pub hook: MetaDeletedHook,
-    #[doc = "The id of the modified webhook."]
-    pub hook_id: i64,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum MetaEvent {
-    #[doc = "meta deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        hook: MetaDeletedHook,
-        #[doc = "The id of the modified webhook."]
-        hook_id: i64,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "A collection of related issues and pull requests."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Milestone {
-    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub closed_issues: i64,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub creator: User,
-    pub description: Option<String>,
-    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub html_url: String,
-    pub id: i64,
-    pub labels_url: String,
-    pub node_id: String,
-    #[doc = "The number of the milestone."]
-    pub number: i64,
-    pub open_issues: i64,
-    #[doc = "The state of the milestone."]
-    pub state: MilestoneState,
-    #[doc = "The title of the milestone."]
-    pub title: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneClosed {
-    pub action: MilestoneClosedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneCreated {
-    pub action: MilestoneCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneDeleted {
-    pub action: MilestoneDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneEdited {
-    pub action: MilestoneEditedAction,
-    pub changes: MilestoneEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneOpened {
-    pub action: MilestoneOpenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum MilestoneEvent {
-    #[doc = "milestone closed event"]
-    #[serde(rename = "closed")]
-    Closed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "milestone created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "milestone deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "milestone edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: MilestoneEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "milestone opened event"]
-    #[serde(rename = "opened")]
-    Opened {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        milestone: Milestone,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrgBlockBlocked {
-    pub action: OrgBlockBlockedAction,
-    #[doc = "Information about the user that was blocked or unblocked."]
-    pub blocked_user: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrgBlockUnblocked {
-    pub action: OrgBlockUnblockedAction,
-    #[doc = "Information about the user that was blocked or unblocked."]
-    pub blocked_user: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum OrgBlockEvent {
-    #[doc = "org_block blocked event"]
-    #[serde(rename = "blocked")]
-    Blocked {
-        #[doc = "Information about the user that was blocked or unblocked."]
-        blocked_user: User,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        sender: User,
-    },
-    #[doc = "org_block unblocked event"]
-    #[serde(rename = "unblocked")]
-    Unblocked {
-        #[doc = "Information about the user that was blocked or unblocked."]
-        blocked_user: User,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Organization {
-    pub avatar_url: String,
-    pub description: Option<String>,
-    pub events_url: String,
-    pub hooks_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub html_url: Option<String>,
-    pub id: i64,
-    pub issues_url: String,
-    pub login: String,
-    pub members_url: String,
-    pub node_id: String,
-    pub public_members_url: String,
-    pub repos_url: String,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrganizationDeleted {
-    pub action: OrganizationDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub membership: Membership,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrganizationMemberAdded {
-    pub action: OrganizationMemberAddedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub membership: Membership,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrganizationMemberInvited {
-    pub action: OrganizationMemberInvitedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub invitation: OrganizationMemberInvitedInvitation,
-    pub organization: Organization,
-    pub sender: User,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrganizationMemberRemoved {
-    pub action: OrganizationMemberRemovedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub membership: Membership,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct OrganizationRenamed {
-    pub action: OrganizationRenamedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub membership: Membership,
-    pub organization: Organization,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum OrganizationEvent {
-    #[doc = "organization deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        membership: Membership,
-        organization: Organization,
-        sender: User,
-    },
-    #[doc = "organization member_added event"]
-    #[serde(rename = "member_added")]
-    MemberAdded {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        membership: Membership,
-        organization: Organization,
-        sender: User,
-    },
-    #[doc = "organization member_invited event"]
-    #[serde(rename = "member_invited")]
-    MemberInvited {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        invitation: OrganizationMemberInvitedInvitation,
-        organization: Organization,
-        sender: User,
-        user: User,
-    },
-    #[doc = "organization member_removed event"]
-    #[serde(rename = "member_removed")]
-    MemberRemoved {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        membership: Membership,
-        organization: Organization,
-        sender: User,
-    },
-    #[doc = "organization renamed event"]
-    #[serde(rename = "renamed")]
-    Renamed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        membership: Membership,
-        organization: Organization,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PackagePublished {
-    pub action: PackagePublishedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub package: PackagePublishedPackage,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PackageUpdated {
-    pub action: PackageUpdatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub package: PackageUpdatedPackage,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum PackageEvent {
-    #[doc = "package published event"]
-    #[serde(rename = "published")]
-    Published {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        package: PackagePublishedPackage,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "package updated event"]
-    #[serde(rename = "updated")]
-    Updated {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        package: PackageUpdatedPackage,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "Page Build"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PageBuildEvent {
-    pub build: PageBuildEventBuild,
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PingEvent {
-    pub hook: PingEventHook,
-    #[doc = "The ID of the webhook that triggered the ping."]
-    pub hook_id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sender: Option<User>,
-    pub zen: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Project {
-    #[doc = "Body of the project"]
-    pub body: Option<String>,
-    pub columns_url: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub creator: User,
-    pub html_url: String,
-    pub id: i64,
-    #[doc = "Name of the project"]
-    pub name: String,
-    pub node_id: String,
-    pub number: i64,
-    pub owner_url: String,
-    #[doc = "State of the project; either 'open' or 'closed'"]
-    pub state: ProjectState,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectClosed {
-    pub action: ProjectClosedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project: Project,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCreated {
-    pub action: ProjectCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project: Project,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectDeleted {
-    pub action: ProjectDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project: Project,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectEdited {
-    pub action: ProjectEditedAction,
-    pub changes: ProjectEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project: Project,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectReopened {
-    pub action: ProjectReopenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project: Project,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCard {
-    #[serde(default)]
-    pub after_id: (),
-    #[doc = "Whether or not the card is archived"]
-    pub archived: bool,
-    pub column_id: i64,
-    pub column_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content_url: Option<String>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub creator: User,
-    #[doc = "The project card's ID"]
-    pub id: i64,
-    pub node_id: String,
-    pub note: Option<String>,
-    pub project_url: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumn {
-    pub cards_url: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The unique identifier of the project column"]
-    pub id: i64,
-    #[doc = "Name of the project column"]
-    pub name: String,
-    pub node_id: String,
-    pub project_url: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardConverted {
-    pub action: ProjectCardConvertedAction,
-    pub changes: ProjectCardConvertedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardCreated {
-    pub action: ProjectCardCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardDeleted {
-    pub action: ProjectCardDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardEdited {
-    pub action: ProjectCardEditedAction,
-    pub changes: ProjectCardEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardMoved {
-    pub action: ProjectCardMovedAction,
-    pub changes: ProjectCardMovedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum ProjectCardEvent {
-    #[doc = "project_card converted event"]
-    #[serde(rename = "converted")]
-    Converted {
-        changes: ProjectCardConvertedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_card: ProjectCard,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_card created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_card: ProjectCard,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_card deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_card: ProjectCard,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_card edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: ProjectCardEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_card: ProjectCard,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_card moved event"]
-    #[serde(rename = "moved")]
-    Moved {
-        changes: ProjectCardMovedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_card: ProjectCard,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnCreated {
-    pub action: ProjectColumnCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_column: ProjectColumn,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnDeleted {
-    pub action: ProjectColumnDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_column: ProjectColumn,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnEdited {
-    pub action: ProjectColumnEditedAction,
-    pub changes: ProjectColumnEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_column: ProjectColumn,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnMoved {
-    pub action: ProjectColumnMovedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub project_column: ProjectColumn,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum ProjectColumnEvent {
-    #[doc = "project_column created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_column: ProjectColumn,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_column deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_column: ProjectColumn,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_column edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: ProjectColumnEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_column: ProjectColumn,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project_column moved event"]
-    #[serde(rename = "moved")]
-    Moved {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project_column: ProjectColumn,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum ProjectEvent {
-    #[doc = "project closed event"]
-    #[serde(rename = "closed")]
-    Closed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project: Project,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project: Project,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project: Project,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: ProjectEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project: Project,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "project reopened event"]
-    #[serde(rename = "reopened")]
-    Reopened {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        project: Project,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[doc = "When a private repository is made public."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PublicEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequest {
-    pub active_lock_reason: Option<PullRequestActiveLockReason>,
-    pub additions: i64,
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    pub auto_merge: (),
-    pub base: PullRequestBase,
-    pub body: Option<String>,
-    pub changed_files: i64,
-    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub comments: i64,
-    pub comments_url: String,
-    pub commits: i64,
-    pub commits_url: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub deletions: i64,
-    pub diff_url: String,
-    #[doc = "Indicates whether or not the pull request is a draft."]
-    pub draft: bool,
-    pub head: PullRequestHead,
-    pub html_url: String,
-    pub id: i64,
-    pub issue_url: String,
-    pub labels: Vec<Label>,
-    #[serde(rename = "_links")]
-    pub links: PullRequestLinks,
-    pub locked: bool,
-    #[doc = "Indicates whether maintainers can modify the pull request."]
-    pub maintainer_can_modify: bool,
-    pub merge_commit_sha: Option<String>,
-    pub mergeable: Option<bool>,
-    pub mergeable_state: String,
-    pub merged: Option<bool>,
-    pub merged_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub merged_by: Option<User>,
-    pub milestone: Option<Milestone>,
-    pub node_id: String,
-    #[doc = "Number uniquely identifying the pull request within its repository."]
-    pub number: i64,
-    pub patch_url: String,
-    pub rebaseable: Option<bool>,
-    pub requested_reviewers: Vec<PullRequestRequestedReviewersItem>,
-    pub requested_teams: Vec<Team>,
-    pub review_comment_url: String,
-    pub review_comments: i64,
-    pub review_comments_url: String,
-    #[doc = "State of this Pull Request. Either `open` or `closed`."]
-    pub state: PullRequestState,
-    pub statuses_url: String,
-    #[doc = "The title of the pull request."]
-    pub title: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-    pub user: User,
-}
-#[doc = "The [comment](https://docs.github.com/en/rest/reference/pulls#comments) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewComment {
-    pub author_association: AuthorAssociation,
-    #[doc = "The text of the comment."]
-    pub body: String,
-    #[doc = "The SHA of the commit to which the comment applies."]
-    pub commit_id: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The diff of the line that the comment refers to."]
-    pub diff_hunk: String,
-    #[doc = "HTML URL for the pull request review comment."]
-    pub html_url: String,
-    #[doc = "The ID of the pull request review comment."]
-    pub id: i64,
-    #[doc = "The comment ID to reply to."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub in_reply_to_id: Option<i64>,
-    #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
-    pub line: Option<i64>,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewCommentLinks,
-    #[doc = "The node ID of the pull request review comment."]
-    pub node_id: String,
-    #[doc = "The SHA of the original commit to which the comment applies."]
-    pub original_commit_id: String,
-    #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
-    pub original_line: i64,
-    #[doc = "The index of the original line in the diff to which the comment applies."]
-    pub original_position: i64,
-    #[doc = "The first line of the range for a multi-line comment."]
-    pub original_start_line: Option<i64>,
-    #[doc = "The relative path of the file to which the comment applies."]
-    pub path: String,
-    #[doc = "The line index in the diff to which the comment applies."]
-    pub position: Option<i64>,
-    #[doc = "The ID of the pull request review to which the comment belongs."]
-    pub pull_request_review_id: i64,
-    #[doc = "URL for the pull request that the review comment belongs to."]
-    pub pull_request_url: String,
-    #[doc = "The side of the first line of the range for a multi-line comment."]
-    pub side: PullRequestReviewCommentSide,
-    #[doc = "The first line of the range for a multi-line comment."]
-    pub start_line: Option<i64>,
-    #[doc = "The side of the first line of the range for a multi-line comment."]
-    pub start_side: Option<PullRequestReviewCommentStartSide>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL for the pull request review comment"]
-    pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestAssigned {
-    pub action: PullRequestAssignedAction,
-    pub assignee: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestAutoMergeDisabled {
-    pub action: PullRequestAutoMergeDisabledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestAutoMergeEnabled {
-    pub action: PullRequestAutoMergeEnabledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestClosed {
-    pub action: PullRequestClosedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestConvertedToDraft {
-    pub action: PullRequestConvertedToDraftAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestEdited {
-    pub action: PullRequestEditedAction,
-    pub changes: PullRequestEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestLabeled {
-    pub action: PullRequestLabeledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub label: Label,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestLocked {
-    pub action: PullRequestLockedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestOpened {
-    pub action: PullRequestOpenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReadyForReview {
-    pub action: PullRequestReadyForReviewAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReopened {
-    pub action: PullRequestReopenedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum PullRequestReviewRequestRemoved {
-    Variant0 {
-        action: PullRequestReviewRequestRemovedVariant0Action,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The pull request number."]
-        number: i64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequest,
-        repository: Repository,
-        requested_reviewer: User,
-        sender: User,
-    },
-    Variant1 {
-        action: PullRequestReviewRequestRemovedVariant1Action,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The pull request number."]
-        number: i64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequest,
-        repository: Repository,
-        requested_team: Team,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum PullRequestReviewRequested {
-    Variant0 {
-        action: PullRequestReviewRequestedVariant0Action,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The pull request number."]
-        number: i64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequest,
-        repository: Repository,
-        requested_reviewer: User,
-        sender: User,
-    },
-    Variant1 {
-        action: PullRequestReviewRequestedVariant1Action,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[doc = "The pull request number."]
-        number: i64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequest,
-        repository: Repository,
-        requested_team: Team,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestSynchronize {
-    pub action: PullRequestSynchronizeAction,
-    pub after: String,
-    pub before: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestUnassigned {
-    pub action: PullRequestUnassignedAction,
-    pub assignee: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestUnlabeled {
-    pub action: PullRequestUnlabeledAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub label: Label,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestUnlocked {
-    pub action: PullRequestUnlockedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[doc = "The pull request number."]
-    pub number: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum PullRequestEvent {
-    Assigned(PullRequestAssigned),
-    AutoMergeDisabled(PullRequestAutoMergeDisabled),
-    AutoMergeEnabled(PullRequestAutoMergeEnabled),
-    Closed(PullRequestClosed),
-    ConvertedToDraft(PullRequestConvertedToDraft),
-    Edited(PullRequestEdited),
-    Labeled(PullRequestLabeled),
-    Locked(PullRequestLocked),
-    Opened(PullRequestOpened),
-    ReadyForReview(PullRequestReadyForReview),
-    Reopened(PullRequestReopened),
-    ReviewRequestRemoved(PullRequestReviewRequestRemoved),
-    ReviewRequested(PullRequestReviewRequested),
-    Synchronize(PullRequestSynchronize),
-    Unassigned(PullRequestUnassigned),
-    Unlabeled(PullRequestUnlabeled),
-    Unlocked(PullRequestUnlocked),
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewDismissed {
-    pub action: PullRequestReviewDismissedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: SimplePullRequest,
-    pub repository: Repository,
-    pub review: PullRequestReviewDismissedReview,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewEdited {
-    pub action: PullRequestReviewEditedAction,
-    pub changes: PullRequestReviewEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: SimplePullRequest,
-    pub repository: Repository,
-    pub review: PullRequestReviewEditedReview,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewSubmitted {
-    pub action: PullRequestReviewSubmittedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: SimplePullRequest,
-    pub repository: Repository,
-    pub review: PullRequestReviewSubmittedReview,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentCreated {
-    pub action: PullRequestReviewCommentCreatedAction,
-    pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequestReviewCommentCreatedPullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentDeleted {
-    pub action: PullRequestReviewCommentDeletedAction,
-    pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequestReviewCommentDeletedPullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEdited {
-    pub action: PullRequestReviewCommentEditedAction,
-    pub changes: PullRequestReviewCommentEditedChanges,
-    pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pull_request: PullRequestReviewCommentEditedPullRequest,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum PullRequestReviewCommentEvent {
-    #[doc = "pull_request_review_comment created event"]
-    #[serde(rename = "created")]
-    Created {
-        comment: PullRequestReviewComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequestReviewCommentCreatedPullRequest,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "pull_request_review_comment deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        comment: PullRequestReviewComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequestReviewCommentDeletedPullRequest,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "pull_request_review_comment edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: PullRequestReviewCommentEditedChanges,
-        comment: PullRequestReviewComment,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: PullRequestReviewCommentEditedPullRequest,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum PullRequestReviewEvent {
-    #[doc = "pull_request_review dismissed event"]
-    #[serde(rename = "dismissed")]
-    Dismissed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: SimplePullRequest,
-        repository: Repository,
-        review: PullRequestReviewDismissedReview,
-        sender: User,
-    },
-    #[doc = "pull_request_review edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: PullRequestReviewEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: SimplePullRequest,
-        repository: Repository,
-        review: PullRequestReviewEditedReview,
-        sender: User,
-    },
-    #[doc = "pull_request_review submitted event"]
-    #[serde(rename = "submitted")]
-    Submitted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        pull_request: SimplePullRequest,
-        repository: Repository,
-        review: PullRequestReviewSubmittedReview,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PushEvent {
-    #[doc = "The SHA of the most recent commit on `ref` after the push."]
-    pub after: String,
-    pub base_ref: Option<String>,
-    #[doc = "The SHA of the most recent commit on `ref` before the push."]
-    pub before: String,
-    #[doc = "An array of commit objects describing the pushed commits."]
-    pub commits: Vec<Commit>,
-    pub compare: String,
-    pub created: bool,
-    pub deleted: bool,
-    pub forced: bool,
-    pub head_commit: Option<Commit>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub pusher: Committer,
-    #[doc = "The full git ref that was pushed. Example: `refs/heads/main`."]
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[doc = "The [release](https://docs.github.com/en/rest/reference/repos/#get-a-release) object."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Release {
-    pub assets: Vec<ReleaseAsset>,
-    pub assets_url: String,
-    pub author: User,
-    pub body: String,
-    pub created_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    #[doc = "Wether the release is a draft or published"]
-    pub draft: bool,
-    pub html_url: String,
-    pub id: i64,
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the release is identified as a prerelease or a full release."]
-    pub prerelease: bool,
-    pub published_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    #[doc = "The name of the tag."]
-    pub tag_name: String,
-    pub tarball_url: Option<String>,
-    #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
-    pub target_commitish: String,
-    pub upload_url: String,
-    pub url: String,
-    pub zipball_url: Option<String>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseCreated {
-    pub action: ReleaseCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseDeleted {
-    pub action: ReleaseDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseEdited {
-    pub action: ReleaseEditedAction,
-    pub changes: ReleaseEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleasePrereleased {
-    pub action: ReleasePrereleasedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleasePublished {
-    pub action: ReleasePublishedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseReleased {
-    pub action: ReleaseReleasedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseUnpublished {
-    pub action: ReleaseUnpublishedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub release: Release,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[doc = "Data related to a release."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseAsset {
-    pub browser_download_url: String,
-    pub content_type: String,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub download_count: i64,
-    pub id: i64,
-    pub label: Option<String>,
-    #[doc = "The file name of the asset."]
-    pub name: String,
-    pub node_id: String,
-    pub size: i64,
-    #[doc = "State of the release asset."]
-    pub state: ReleaseAssetState,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub uploader: Option<User>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum ReleaseEvent {
-    #[doc = "release created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: ReleaseEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release prereleased event"]
-    #[serde(rename = "prereleased")]
-    Prereleased {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release published event"]
-    #[serde(rename = "published")]
-    Published {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release released event"]
-    #[serde(rename = "released")]
-    Released {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "release unpublished event"]
-    #[serde(rename = "unpublished")]
-    Unpublished {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        release: Release,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepoRef {
-    pub id: i64,
-    pub name: String,
-    pub url: String,
-}
-#[doc = "A git repository"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Repository {
-    #[doc = "Whether to allow auto-merge for pull requests."]
-    #[serde(default)]
-    pub allow_auto_merge: bool,
-    #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allow_forking: Option<bool>,
-    #[doc = "Whether to allow merge commits for pull requests."]
-    #[serde(default = "defaults::default_bool::<false>")]
-    pub allow_merge_commit: bool,
-    #[doc = "Whether to allow rebase merges for pull requests."]
-    #[serde(default = "defaults::default_bool::<false>")]
-    pub allow_rebase_merge: bool,
-    #[doc = "Whether to allow squash merges for pull requests."]
-    #[serde(default = "defaults::default_bool::<false>")]
-    pub allow_squash_merge: bool,
-    pub archive_url: String,
-    #[doc = "Whether the repository is archived."]
-    pub archived: bool,
-    pub assignees_url: String,
-    pub blobs_url: String,
-    pub branches_url: String,
-    pub clone_url: String,
-    pub collaborators_url: String,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub compare_url: String,
-    pub contents_url: String,
-    pub contributors_url: String,
-    pub created_at: RepositoryCreatedAt,
-    #[doc = "The default branch of the repository."]
-    pub default_branch: String,
-    #[doc = "Whether to delete head branches when pull requests are merged"]
-    #[serde(default)]
-    pub delete_branch_on_merge: bool,
-    pub deployments_url: String,
-    pub description: Option<String>,
-    #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub disabled: Option<bool>,
-    pub downloads_url: String,
-    pub events_url: String,
-    pub fork: bool,
-    pub forks: i64,
-    pub forks_count: i64,
-    pub forks_url: String,
-    pub full_name: String,
-    pub git_commits_url: String,
-    pub git_refs_url: String,
-    pub git_tags_url: String,
-    pub git_url: String,
-    #[doc = "Whether downloads are enabled."]
-    pub has_downloads: bool,
-    #[doc = "Whether issues are enabled."]
-    pub has_issues: bool,
-    pub has_pages: bool,
-    #[doc = "Whether projects are enabled."]
-    pub has_projects: bool,
-    #[doc = "Whether the wiki is enabled."]
-    pub has_wiki: bool,
-    pub homepage: Option<String>,
-    pub hooks_url: String,
-    pub html_url: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    pub issue_comment_url: String,
-    pub issue_events_url: String,
-    pub issues_url: String,
-    pub keys_url: String,
-    pub labels_url: String,
-    pub language: Option<String>,
-    pub languages_url: String,
-    pub license: Option<License>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub master_branch: Option<String>,
-    pub merges_url: String,
-    pub milestones_url: String,
-    pub mirror_url: Option<String>,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    pub notifications_url: String,
-    pub open_issues: i64,
-    pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<String>,
-    pub owner: User,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub permissions: Option<RepositoryPermissions>,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public: Option<bool>,
-    pub pulls_url: String,
-    pub pushed_at: RepositoryPushedAt,
-    pub releases_url: String,
-    pub size: i64,
-    pub ssh_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stargazers: Option<i64>,
-    pub stargazers_count: i64,
-    pub stargazers_url: String,
-    pub statuses_url: String,
-    pub subscribers_url: String,
-    pub subscription_url: String,
-    pub svn_url: String,
-    pub tags_url: String,
-    pub teams_url: String,
-    pub trees_url: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-    pub watchers: i64,
-    pub watchers_count: i64,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryArchived {
-    pub action: RepositoryArchivedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryCreated {
-    pub action: RepositoryCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryDeleted {
-    pub action: RepositoryDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryEdited {
-    pub action: RepositoryEditedAction,
-    pub changes: RepositoryEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryPrivatized {
-    pub action: RepositoryPrivatizedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryPublicized {
-    pub action: RepositoryPublicizedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryRenamed {
-    pub action: RepositoryRenamedAction,
-    pub changes: RepositoryRenamedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryTransferred {
-    pub action: RepositoryTransferredAction,
-    pub changes: RepositoryTransferredChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryUnarchived {
-    pub action: RepositoryUnarchivedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryLite {
-    pub archive_url: String,
-    pub assignees_url: String,
-    pub blobs_url: String,
-    pub branches_url: String,
-    pub collaborators_url: String,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub compare_url: String,
-    pub contents_url: String,
-    pub contributors_url: String,
-    pub deployments_url: String,
-    pub description: Option<String>,
-    pub downloads_url: String,
-    pub events_url: String,
-    pub fork: bool,
-    pub forks_url: String,
-    pub full_name: String,
-    pub git_commits_url: String,
-    pub git_refs_url: String,
-    pub git_tags_url: String,
-    pub hooks_url: String,
-    pub html_url: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    pub issue_comment_url: String,
-    pub issue_events_url: String,
-    pub issues_url: String,
-    pub keys_url: String,
-    pub labels_url: String,
-    pub languages_url: String,
-    pub merges_url: String,
-    pub milestones_url: String,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    pub notifications_url: String,
-    pub owner: User,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-    pub pulls_url: String,
-    pub releases_url: String,
-    pub stargazers_url: String,
-    pub statuses_url: String,
-    pub subscribers_url: String,
-    pub subscription_url: String,
-    pub tags_url: String,
-    pub teams_url: String,
-    pub trees_url: String,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryDispatchOnDemandTest {
-    pub action: RepositoryDispatchOnDemandTestAction,
-    pub branch: String,
-    pub client_payload: std::collections::HashMap<String, serde_json::Value>,
-    pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum RepositoryDispatchEvent {
-    #[doc = "repository_dispatch on-demand-test event"]
-    #[serde(rename = "on-demand-test")]
-    OnDemandTest {
-        branch: String,
-        client_payload: std::collections::HashMap<String, serde_json::Value>,
-        installation: InstallationLite,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum RepositoryEvent {
-    #[doc = "repository archived event"]
-    #[serde(rename = "archived")]
-    Archived {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: RepositoryEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository privatized event"]
-    #[serde(rename = "privatized")]
-    Privatized {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository publicized event"]
-    #[serde(rename = "publicized")]
-    Publicized {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository renamed event"]
-    #[serde(rename = "renamed")]
-    Renamed {
-        changes: RepositoryRenamedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository transferred event"]
-    #[serde(rename = "transferred")]
-    Transferred {
-        changes: RepositoryTransferredChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository unarchived event"]
-    #[serde(rename = "unarchived")]
-    Unarchived {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryImportEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub status: RepositoryImportEventStatus,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryVulnerabilityAlertCreate {
-    pub action: RepositoryVulnerabilityAlertCreateAction,
-    pub alert: RepositoryVulnerabilityAlertCreateAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryVulnerabilityAlertDismiss {
-    pub action: RepositoryVulnerabilityAlertDismissAction,
-    pub alert: RepositoryVulnerabilityAlertDismissAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryVulnerabilityAlertResolve {
-    pub action: RepositoryVulnerabilityAlertResolveAction,
-    pub alert: RepositoryVulnerabilityAlertResolveAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum RepositoryVulnerabilityAlertEvent {
-    #[doc = "repository_vulnerability_alert create event"]
-    #[serde(rename = "create")]
-    Create {
-        alert: RepositoryVulnerabilityAlertCreateAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository_vulnerability_alert dismiss event"]
-    #[serde(rename = "dismiss")]
-    Dismiss {
-        alert: RepositoryVulnerabilityAlertDismissAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "repository_vulnerability_alert resolve event"]
-    #[serde(rename = "resolve")]
-    Resolve {
-        alert: RepositoryVulnerabilityAlertResolveAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecretScanningAlertCreated {
-    pub action: SecretScanningAlertCreatedAction,
-    pub alert: SecretScanningAlertCreatedAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecretScanningAlertReopened {
-    pub action: SecretScanningAlertReopenedAction,
-    pub alert: SecretScanningAlertReopenedAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecretScanningAlertResolved {
-    pub action: SecretScanningAlertResolvedAction,
-    pub alert: SecretScanningAlertResolvedAlert,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum SecretScanningAlertEvent {
-    #[doc = "secret_scanning_alert created event"]
-    #[serde(rename = "created")]
-    Created {
-        alert: SecretScanningAlertCreatedAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-    },
-    #[doc = "secret_scanning_alert reopened event"]
-    #[serde(rename = "reopened")]
-    Reopened {
-        alert: SecretScanningAlertReopenedAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-    #[doc = "secret_scanning_alert resolved event"]
-    #[serde(rename = "resolved")]
-    Resolved {
-        alert: SecretScanningAlertResolvedAlert,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPerformed {
-    pub action: SecurityAdvisoryPerformedAction,
-    pub security_advisory: SecurityAdvisoryPerformedSecurityAdvisory,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPublished {
-    pub action: SecurityAdvisoryPublishedAction,
-    pub security_advisory: SecurityAdvisoryPublishedSecurityAdvisory,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryUpdated {
-    pub action: SecurityAdvisoryUpdatedAction,
-    pub security_advisory: SecurityAdvisoryUpdatedSecurityAdvisory,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryWithdrawn {
-    pub action: SecurityAdvisoryWithdrawnAction,
-    pub security_advisory: SecurityAdvisoryWithdrawnSecurityAdvisory,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", content = "security_advisory")]
-pub enum SecurityAdvisoryEvent {
-    #[doc = "security_advisory performed event"]
-    #[serde(rename = "performed")]
-    Performed(SecurityAdvisoryPerformedSecurityAdvisory),
-    #[doc = "security_advisory published event"]
-    #[serde(rename = "published")]
-    Published(SecurityAdvisoryPublishedSecurityAdvisory),
-    #[doc = "security_advisory updated event"]
-    #[serde(rename = "updated")]
-    Updated(SecurityAdvisoryUpdatedSecurityAdvisory),
-    #[doc = "security_advisory withdrawn event"]
-    #[serde(rename = "withdrawn")]
-    Withdrawn(SecurityAdvisoryWithdrawnSecurityAdvisory),
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SimplePullRequest {
-    pub active_lock_reason: Option<SimplePullRequestActiveLockReason>,
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    pub auto_merge: (),
-    pub base: SimplePullRequestBase,
-    pub body: String,
-    pub closed_at: Option<String>,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub created_at: String,
-    pub diff_url: String,
-    pub draft: bool,
-    pub head: SimplePullRequestHead,
-    pub html_url: String,
-    pub id: i64,
-    pub issue_url: String,
-    pub labels: Vec<Label>,
-    #[serde(rename = "_links")]
-    pub links: SimplePullRequestLinks,
-    pub locked: bool,
-    pub merge_commit_sha: Option<String>,
-    pub merged_at: Option<String>,
-    pub milestone: Option<Milestone>,
-    pub node_id: String,
-    pub number: i64,
-    pub patch_url: String,
-    pub requested_reviewers: Vec<SimplePullRequestRequestedReviewersItem>,
-    pub requested_teams: Vec<Team>,
-    pub review_comment_url: String,
-    pub review_comments_url: String,
-    pub state: SimplePullRequestState,
-    pub statuses_url: String,
-    pub title: String,
-    pub updated_at: String,
-    pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipCancelled {
-    pub action: SponsorshipCancelledAction,
-    pub sender: User,
-    pub sponsorship: SponsorshipCancelledSponsorship,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipCreated {
-    pub action: SponsorshipCreatedAction,
-    pub sender: User,
-    pub sponsorship: SponsorshipCreatedSponsorship,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipEdited {
-    pub action: SponsorshipEditedAction,
-    pub changes: SponsorshipEditedChanges,
-    pub sender: User,
-    pub sponsorship: SponsorshipEditedSponsorship,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipPendingCancellation {
-    pub action: SponsorshipPendingCancellationAction,
-    #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effective_date: Option<String>,
-    pub sender: User,
-    pub sponsorship: SponsorshipPendingCancellationSponsorship,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipPendingTierChange {
-    pub action: SponsorshipPendingTierChangeAction,
-    pub changes: SponsorshipPendingTierChangeChanges,
-    #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effective_date: Option<String>,
-    pub sender: User,
-    pub sponsorship: SponsorshipPendingTierChangeSponsorship,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipTierChanged {
-    pub action: SponsorshipTierChangedAction,
-    pub changes: SponsorshipTierChangedChanges,
-    pub sender: User,
-    pub sponsorship: SponsorshipTierChangedSponsorship,
-}
-#[doc = "The `tier_changed` and `pending_tier_change` will include the original tier before the change or pending change. For more information, see the pending tier change payload."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SponsorshipTier {
-    pub created_at: String,
-    pub description: String,
-    pub is_custom_ammount: bool,
-    pub is_one_time: bool,
-    pub monthly_price_in_cents: i64,
-    pub monthly_price_in_dollars: i64,
-    pub name: String,
-    pub node_id: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum SponsorshipEvent {
-    #[doc = "sponsorship cancelled event"]
-    #[serde(rename = "cancelled")]
-    Cancelled {
-        sender: User,
-        sponsorship: SponsorshipCancelledSponsorship,
-    },
-    #[doc = "sponsorship created event"]
-    #[serde(rename = "created")]
-    Created {
-        sender: User,
-        sponsorship: SponsorshipCreatedSponsorship,
-    },
-    #[doc = "sponsorship edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: SponsorshipEditedChanges,
-        sender: User,
-        sponsorship: SponsorshipEditedSponsorship,
-    },
-    #[doc = "sponsorship pending_cancellation event"]
-    #[serde(rename = "pending_cancellation")]
-    PendingCancellation {
-        #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        effective_date: Option<String>,
-        sender: User,
-        sponsorship: SponsorshipPendingCancellationSponsorship,
-    },
-    #[doc = "sponsorship pending_tier_change event"]
-    #[serde(rename = "pending_tier_change")]
-    PendingTierChange {
-        changes: SponsorshipPendingTierChangeChanges,
-        #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        effective_date: Option<String>,
-        sender: User,
-        sponsorship: SponsorshipPendingTierChangeSponsorship,
-    },
-    #[doc = "sponsorship tier_changed event"]
-    #[serde(rename = "tier_changed")]
-    TierChanged {
-        changes: SponsorshipTierChangedChanges,
-        sender: User,
-        sponsorship: SponsorshipTierChangedSponsorship,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct StarCreated {
-    pub action: StarCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
-    pub starred_at: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct StarDeleted {
-    pub action: StarDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
-    pub starred_at: (),
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum StarEvent {
-    #[doc = "star created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
-        starred_at: String,
-    },
-    #[doc = "star deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
-        starred_at: (),
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct StatusEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub avatar_url: Option<String>,
-    #[doc = "An array of branch objects containing the status' SHA. Each branch contains the given SHA, but the SHA may or may not be the head of the branch. The array includes a maximum of 10 branches."]
-    pub branches: Vec<StatusEventBranchesItem>,
-    pub commit: StatusEventCommit,
-    pub context: String,
-    pub created_at: String,
-    #[doc = "The optional human-readable description added to the status."]
-    pub description: Option<String>,
-    #[doc = "The unique identifier of the status."]
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    #[doc = "The Commit SHA."]
-    pub sha: String,
-    #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
-    pub state: StatusEventState,
-    #[doc = "The optional link added to the status."]
-    pub target_url: Option<String>,
-    pub updated_at: String,
-}
-#[doc = "Groups of organization members that gives permissions on specified repositories."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Team {
-    #[doc = "Description of the team"]
-    pub description: Option<String>,
-    pub html_url: String,
-    #[doc = "Unique identifier of the team"]
-    pub id: i64,
-    pub members_url: String,
-    #[doc = "Name of the team"]
-    pub name: String,
-    pub node_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent: Option<TeamParent>,
-    #[doc = "Permission that the team will have for its repositories"]
-    pub permission: String,
-    pub privacy: TeamPrivacy,
-    pub repositories_url: String,
-    pub slug: String,
-    #[doc = "URL for the team"]
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamAddedToRepository {
-    pub action: TeamAddedToRepositoryAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamCreated {
-    pub action: TeamCreatedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamDeleted {
-    pub action: TeamDeletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEdited {
-    pub action: TeamEditedAction,
-    pub changes: TeamEditedChanges,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamRemovedFromRepository {
-    pub action: TeamRemovedFromRepositoryAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<Repository>,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamAddEvent {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    pub organization: Organization,
-    pub repository: Repository,
-    pub sender: User,
-    pub team: Team,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum TeamEvent {
-    #[doc = "team added_to_repository event"]
-    #[serde(rename = "added_to_repository")]
-    AddedToRepository {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository: Option<Repository>,
-        sender: User,
-        team: Team,
-    },
-    #[doc = "team created event"]
-    #[serde(rename = "created")]
-    Created {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository: Option<Repository>,
-        sender: User,
-        team: Team,
-    },
-    #[doc = "team deleted event"]
-    #[serde(rename = "deleted")]
-    Deleted {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository: Option<Repository>,
-        sender: User,
-        team: Team,
-    },
-    #[doc = "team edited event"]
-    #[serde(rename = "edited")]
-    Edited {
-        changes: TeamEditedChanges,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository: Option<Repository>,
-        sender: User,
-        team: Team,
-    },
-    #[doc = "team removed_from_repository event"]
-    #[serde(rename = "removed_from_repository")]
-    RemovedFromRepository {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        organization: Organization,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository: Option<Repository>,
-        sender: User,
-        team: Team,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct User {
-    pub avatar_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
-    pub events_url: String,
-    pub followers_url: String,
-    pub following_url: String,
-    pub gists_url: String,
-    pub gravatar_id: String,
-    pub html_url: String,
-    pub id: i64,
-    pub login: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    pub node_id: String,
-    pub organizations_url: String,
-    pub received_events_url: String,
-    pub repos_url: String,
-    pub site_admin: bool,
-    pub starred_url: String,
-    pub subscriptions_url: String,
-    #[serde(rename = "type")]
-    pub type_: UserType,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WatchStarted {
-    pub action: WatchStartedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum WatchEvent {
-    #[doc = "watch started event"]
-    #[serde(rename = "started")]
-    Started {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum WebhookEvents {
-    Variant0(Vec<WebhookEventsVariant0Item>),
-    Variant1(Vec<String>),
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Workflow {
-    pub badge_url: String,
-    pub created_at: String,
-    pub html_url: String,
-    pub id: i64,
-    pub name: String,
-    pub node_id: String,
-    pub path: String,
-    pub state: String,
-    pub updated_at: String,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowJob {
-    pub check_run_url: String,
-    pub completed_at: Option<String>,
-    pub conclusion: Option<WorkflowJobConclusion>,
-    pub head_sha: String,
-    pub html_url: String,
-    pub id: i64,
-    pub labels: Vec<String>,
-    pub name: String,
-    pub node_id: String,
-    pub run_id: f64,
-    pub run_url: String,
-    pub started_at: String,
-    pub status: WorkflowJobStatus,
-    pub steps: Vec<WorkflowStep>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowRun {
-    pub artifacts_url: String,
-    pub cancel_url: String,
-    pub check_suite_id: i64,
-    pub check_suite_node_id: String,
-    pub check_suite_url: String,
-    pub conclusion: Option<WorkflowRunConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub event: String,
-    pub head_branch: String,
-    pub head_commit: CommitSimple,
-    pub head_repository: RepositoryLite,
-    pub head_sha: String,
-    pub html_url: String,
-    pub id: i64,
-    pub jobs_url: String,
-    pub logs_url: String,
-    pub name: String,
-    pub node_id: String,
-    pub pull_requests: Vec<WorkflowRunPullRequestsItem>,
-    pub repository: RepositoryLite,
-    pub rerun_url: String,
-    pub run_number: i64,
-    pub status: WorkflowRunStatus,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
-    pub workflow_id: i64,
-    pub workflow_url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "status", deny_unknown_fields)]
-pub enum WorkflowStep {
-    #[doc = "Workflow Step (In Progress)"]
-    #[serde(rename = "in_progress")]
-    InProgress {
-        completed_at: (),
-        conclusion: (),
-        name: String,
-        number: i64,
-        started_at: String,
-    },
-    #[doc = "Workflow Step (Completed)"]
-    #[serde(rename = "completed")]
-    Completed {
-        completed_at: String,
-        conclusion: WorkflowStepCompletedConclusion,
-        name: String,
-        number: i64,
-        started_at: String,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowStepCompleted {
-    pub completed_at: String,
-    pub conclusion: WorkflowStepCompletedConclusion,
-    pub name: String,
-    pub number: i64,
-    pub started_at: String,
-    pub status: WorkflowStepCompletedStatus,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowStepInProgress {
-    pub completed_at: (),
-    pub conclusion: (),
-    pub name: String,
-    pub number: i64,
-    pub started_at: String,
-    pub status: WorkflowStepInProgressStatus,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowDispatchEvent {
-    pub inputs: Option<std::collections::HashMap<String, serde_json::Value>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowJobCompleted {
-    pub action: WorkflowJobCompletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow_job: WorkflowJob,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowJobQueued {
-    pub action: WorkflowJobQueuedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow_job: WorkflowJobQueuedWorkflowJob,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowJobStarted {
-    pub action: WorkflowJobStartedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow_job: WorkflowJob,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum WorkflowJobEvent {
-    #[doc = "workflow_job completed event"]
-    #[serde(rename = "completed")]
-    Completed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow_job: WorkflowJob,
-    },
-    #[doc = "workflow_job queued event"]
-    #[serde(rename = "queued")]
-    Queued {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow_job: WorkflowJobQueuedWorkflowJob,
-    },
-    #[doc = "workflow_job started event"]
-    #[serde(rename = "started")]
-    Started {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow_job: WorkflowJob,
-    },
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowRunCompleted {
-    pub action: WorkflowRunCompletedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow: Workflow,
-    pub workflow_run: WorkflowRun,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowRunRequested {
-    pub action: WorkflowRunRequestedAction,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installation: Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: User,
-    pub workflow: Workflow,
-    pub workflow_run: WorkflowRun,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "action", deny_unknown_fields)]
-pub enum WorkflowRunEvent {
-    #[doc = "workflow_run completed event"]
-    #[serde(rename = "completed")]
-    Completed {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow: Workflow,
-        workflow_run: WorkflowRun,
-    },
-    #[doc = "workflow_run requested event"]
-    #[serde(rename = "requested")]
-    Requested {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        installation: Option<InstallationLite>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        organization: Option<Organization>,
-        repository: Repository,
-        sender: User,
-        workflow: Workflow,
-        workflow_run: WorkflowRun,
-    },
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -5459,6 +68,30 @@ impl std::str::FromStr for AlertInstanceState {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct App {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: Option<String>,
+    #[doc = "The list of events for the GitHub app"]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<AppEventsItem>,
+    pub external_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the GitHub app"]
+    pub id: i64,
+    #[doc = "The name of the GitHub app"]
+    pub name: String,
+    pub node_id: String,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<AppPermissions>,
+    #[doc = "The slug name of the GitHub app"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppEventsItem {
@@ -5652,6 +285,79 @@ impl std::str::FromStr for AppEventsItem {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The set of permissions for the GitHub app"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppPermissions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions: Option<AppPermissionsActions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub administration: Option<AppPermissionsAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checks: Option<AppPermissionsChecks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_references: Option<AppPermissionsContentReferences>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contents: Option<AppPermissionsContents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployments: Option<AppPermissionsDeployments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discussions: Option<AppPermissionsDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emails: Option<AppPermissionsEmails>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environments: Option<AppPermissionsEnvironments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issues: Option<AppPermissionsIssues>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub members: Option<AppPermissionsMembers>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<AppPermissionsMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_administration: Option<AppPermissionsOrganizationAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_hooks: Option<AppPermissionsOrganizationHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_packages: Option<AppPermissionsOrganizationPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_plan: Option<AppPermissionsOrganizationPlan>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_projects: Option<AppPermissionsOrganizationProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_secrets: Option<AppPermissionsOrganizationSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_self_hosted_runners: Option<AppPermissionsOrganizationSelfHostedRunners>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_user_blocking: Option<AppPermissionsOrganizationUserBlocking>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packages: Option<AppPermissionsPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pages: Option<AppPermissionsPages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_requests: Option<AppPermissionsPullRequests>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_hooks: Option<AppPermissionsRepositoryHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_projects: Option<AppPermissionsRepositoryProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_scanning_alerts: Option<AppPermissionsSecretScanningAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<AppPermissionsSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_events: Option<AppPermissionsSecurityEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_scanning_alert: Option<AppPermissionsSecurityScanningAlert>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub single_file: Option<AppPermissionsSingleFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub statuses: Option<AppPermissionsStatuses>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_discussions: Option<AppPermissionsTeamDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerability_alerts: Option<AppPermissionsVulnerabilityAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflows: Option<AppPermissionsWorkflows>,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsActions {
@@ -6503,78 +1209,90 @@ impl std::str::FromStr for AppPermissionsWorkflows {
         }
     }
 }
-#[doc = "The set of permissions for the GitHub app"]
+#[doc = "How the author is associated with the repository."]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum AuthorAssociation {
+    #[serde(rename = "COLLABORATOR")]
+    Collaborator,
+    #[serde(rename = "CONTRIBUTOR")]
+    Contributor,
+    #[serde(rename = "FIRST_TIMER")]
+    FirstTimer,
+    #[serde(rename = "FIRST_TIME_CONTRIBUTOR")]
+    FirstTimeContributor,
+    #[serde(rename = "MANNEQUIN")]
+    Mannequin,
+    #[serde(rename = "MEMBER")]
+    Member,
+    #[serde(rename = "NONE")]
+    None,
+    #[serde(rename = "OWNER")]
+    Owner,
+}
+impl ToString for AuthorAssociation {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Collaborator => "COLLABORATOR".to_string(),
+            Self::Contributor => "CONTRIBUTOR".to_string(),
+            Self::FirstTimer => "FIRST_TIMER".to_string(),
+            Self::FirstTimeContributor => "FIRST_TIME_CONTRIBUTOR".to_string(),
+            Self::Mannequin => "MANNEQUIN".to_string(),
+            Self::Member => "MEMBER".to_string(),
+            Self::None => "NONE".to_string(),
+            Self::Owner => "OWNER".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for AuthorAssociation {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "COLLABORATOR" => Ok(Self::Collaborator),
+            "CONTRIBUTOR" => Ok(Self::Contributor),
+            "FIRST_TIMER" => Ok(Self::FirstTimer),
+            "FIRST_TIME_CONTRIBUTOR" => Ok(Self::FirstTimeContributor),
+            "MANNEQUIN" => Ok(Self::Mannequin),
+            "MEMBER" => Ok(Self::Member),
+            "NONE" => Ok(Self::None),
+            "OWNER" => Ok(Self::Owner),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The branch protection rule. Includes a `name` and all the [branch protection settings](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-settings) applied to branches that match the name. Binary settings are boolean. Multi-level configurations are one of `off`, `non_admins`, or `everyone`. Actor and build lists are arrays of strings."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct AppPermissions {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub actions: Option<AppPermissionsActions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub administration: Option<AppPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checks: Option<AppPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content_references: Option<AppPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contents: Option<AppPermissionsContents>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployments: Option<AppPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub discussions: Option<AppPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub emails: Option<AppPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub environments: Option<AppPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issues: Option<AppPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub members: Option<AppPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<AppPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_administration: Option<AppPermissionsOrganizationAdministration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_hooks: Option<AppPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_packages: Option<AppPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_plan: Option<AppPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_projects: Option<AppPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_secrets: Option<AppPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_self_hosted_runners: Option<AppPermissionsOrganizationSelfHostedRunners>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_user_blocking: Option<AppPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub packages: Option<AppPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pages: Option<AppPermissionsPages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pull_requests: Option<AppPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository_hooks: Option<AppPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository_projects: Option<AppPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secret_scanning_alerts: Option<AppPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secrets: Option<AppPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_events: Option<AppPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_scanning_alert: Option<AppPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub single_file: Option<AppPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub statuses: Option<AppPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub team_discussions: Option<AppPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vulnerability_alerts: Option<AppPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflows: Option<AppPermissionsWorkflows>,
+pub struct BranchProtectionRule {
+    pub admin_enforced: bool,
+    pub allow_deletions_enforcement_level: BranchProtectionRuleAllowDeletionsEnforcementLevel,
+    pub allow_force_pushes_enforcement_level: BranchProtectionRuleAllowForcePushesEnforcementLevel,
+    pub authorized_actor_names: Vec<String>,
+    pub authorized_actors_only: bool,
+    pub authorized_dismissal_actors_only: bool,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub dismiss_stale_reviews_on_push: bool,
+    pub id: i64,
+    pub ignore_approvals_from_contributors: bool,
+    pub linear_history_requirement_enforcement_level:
+        BranchProtectionRuleLinearHistoryRequirementEnforcementLevel,
+    pub merge_queue_enforcement_level: BranchProtectionRuleMergeQueueEnforcementLevel,
+    pub name: String,
+    pub pull_request_reviews_enforcement_level:
+        BranchProtectionRulePullRequestReviewsEnforcementLevel,
+    pub repository_id: i64,
+    pub require_code_owner_review: bool,
+    pub required_approving_review_count: i64,
+    pub required_conversation_resolution_level:
+        BranchProtectionRuleRequiredConversationResolutionLevel,
+    pub required_deployments_enforcement_level:
+        BranchProtectionRuleRequiredDeploymentsEnforcementLevel,
+    pub required_status_checks: Vec<String>,
+    pub required_status_checks_enforcement_level:
+        BranchProtectionRuleRequiredStatusChecksEnforcementLevel,
+    pub signature_requirement_enforcement_level:
+        BranchProtectionRuleSignatureRequirementEnforcementLevel,
+    pub strict_required_status_checks_policy: bool,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleAllowDeletionsEnforcementLevel {
@@ -6633,6 +1351,166 @@ impl std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLevel 
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleCreated {
+    pub action: BranchProtectionRuleCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub rule: BranchProtectionRule,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum BranchProtectionRuleCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for BranchProtectionRuleCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for BranchProtectionRuleCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleDeleted {
+    pub action: BranchProtectionRuleDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub rule: BranchProtectionRule,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum BranchProtectionRuleDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for BranchProtectionRuleDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for BranchProtectionRuleDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleEdited {
+    pub action: BranchProtectionRuleEditedAction,
+    pub changes: BranchProtectionRuleEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub rule: BranchProtectionRule,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum BranchProtectionRuleEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for BranchProtectionRuleEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for BranchProtectionRuleEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "If the action was `edited`, the changes to the rule."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorized_actor_names: Option<BranchProtectionRuleEditedChangesAuthorizedActorNames>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorized_actors_only: Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleEditedChangesAuthorizedActorNames {
+    pub from: Vec<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BranchProtectionRuleEditedChangesAuthorizedActorsOnly {
+    pub from: bool,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum BranchProtectionRuleEvent {
+    #[doc = "branch protection rule created event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        rule: BranchProtectionRule,
+        sender: User,
+    },
+    #[doc = "branch protection rule deleted event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        rule: BranchProtectionRule,
+        sender: User,
+    },
+    #[doc = "branch protection rule edited event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: BranchProtectionRuleEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        rule: BranchProtectionRule,
+        sender: User,
+    },
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
@@ -6837,103 +1715,20 @@ impl std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcementLe
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BranchProtectionRuleCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for BranchProtectionRuleCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for BranchProtectionRuleCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BranchProtectionRuleDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for BranchProtectionRuleDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for BranchProtectionRuleDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BranchProtectionRuleEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for BranchProtectionRuleEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for BranchProtectionRuleEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleEditedChangesAuthorizedActorNames {
-    pub from: Vec<String>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleEditedChangesAuthorizedActorsOnly {
-    pub from: bool,
-}
-#[doc = "If the action was `edited`, the changes to the rule."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BranchProtectionRuleEditedChanges {
+pub struct CheckRunCompleted {
+    pub action: CheckRunCompletedAction,
+    pub check_run: CheckRunCompletedCheckRun,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub authorized_actor_names: Option<BranchProtectionRuleEditedChangesAuthorizedActorNames>,
+    pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub authorized_actors_only: Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunPullRequestBase {
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: RepoRef,
-    pub sha: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunPullRequestHead {
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: RepoRef,
-    pub sha: String,
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    #[doc = "The action requested by the user."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_action: Option<CheckRunCompletedRequestedAction>,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCompletedAction {
@@ -6955,6 +1750,59 @@ impl std::str::FromStr for CheckRunCompletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunCompletedCheckRun {
+    pub app: App,
+    pub check_suite: CheckRunCompletedCheckRunCheckSuite,
+    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub completed_at: String,
+    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    pub conclusion: Option<CheckRunCompletedCheckRunConclusion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details_url: Option<String>,
+    pub external_id: String,
+    #[doc = "The SHA of the commit that is being checked."]
+    pub head_sha: String,
+    pub html_url: String,
+    #[doc = "The id of the check."]
+    pub id: i64,
+    #[doc = "The name of the check run."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub output: CheckRunCompletedCheckRunOutput,
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub started_at: String,
+    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
+    pub status: CheckRunCompletedCheckRunStatus,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunCompletedCheckRunCheckSuite {
+    pub after: Option<String>,
+    pub app: App,
+    pub before: Option<String>,
+    pub conclusion: Option<CheckRunCompletedCheckRunCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<CheckRunDeployment>,
+    pub head_branch: Option<String>,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    #[doc = "The id of the check suite that this check run is part of."]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    pub status: CheckRunCompletedCheckRunCheckSuiteStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCompletedCheckRunCheckSuiteConclusion {
@@ -7029,29 +1877,6 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCompletedCheckRunCheckSuite {
-    pub after: Option<String>,
-    pub app: App,
-    pub before: Option<String>,
-    pub conclusion: Option<CheckRunCompletedCheckRunCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployment: Option<CheckRunDeployment>,
-    pub head_branch: Option<String>,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    #[doc = "The id of the check suite that this check run is part of."]
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    pub status: CheckRunCompletedCheckRunCheckSuiteStatus,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7135,36 +1960,6 @@ impl std::str::FromStr for CheckRunCompletedCheckRunStatus {
         }
     }
 }
-#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCompletedCheckRun {
-    pub app: App,
-    pub check_suite: CheckRunCompletedCheckRunCheckSuite,
-    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub completed_at: String,
-    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-    pub conclusion: Option<CheckRunCompletedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub details_url: Option<String>,
-    pub external_id: String,
-    #[doc = "The SHA of the commit that is being checked."]
-    pub head_sha: String,
-    pub html_url: String,
-    #[doc = "The id of the check."]
-    pub id: i64,
-    #[doc = "The name of the check run."]
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    pub output: CheckRunCompletedCheckRunOutput,
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub started_at: String,
-    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-    pub status: CheckRunCompletedCheckRunStatus,
-    pub url: String,
-}
 #[doc = "The action requested by the user."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -7172,6 +1967,21 @@ pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunCreated {
+    pub action: CheckRunCreatedAction,
+    pub check_run: CheckRunCreatedCheckRun,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    #[doc = "The action requested by the user."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_action: Option<CheckRunCreatedRequestedAction>,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCreatedAction {
@@ -7193,6 +2003,59 @@ impl std::str::FromStr for CheckRunCreatedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunCreatedCheckRun {
+    pub app: App,
+    pub check_suite: CheckRunCreatedCheckRunCheckSuite,
+    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub completed_at: Option<String>,
+    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    pub conclusion: Option<CheckRunCreatedCheckRunConclusion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details_url: Option<String>,
+    pub external_id: String,
+    #[doc = "The SHA of the commit that is being checked."]
+    pub head_sha: String,
+    pub html_url: String,
+    #[doc = "The id of the check."]
+    pub id: i64,
+    #[doc = "The name of the check run."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub output: CheckRunCreatedCheckRunOutput,
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub started_at: String,
+    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
+    pub status: CheckRunCreatedCheckRunStatus,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunCreatedCheckRunCheckSuite {
+    pub after: Option<String>,
+    pub app: App,
+    pub before: Option<String>,
+    pub conclusion: Option<CheckRunCreatedCheckRunCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<CheckRunDeployment>,
+    pub head_branch: Option<String>,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    #[doc = "The id of the check suite that this check run is part of."]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    pub status: CheckRunCreatedCheckRunCheckSuiteStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCreatedCheckRunCheckSuiteConclusion {
@@ -7267,29 +2130,6 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCreatedCheckRunCheckSuite {
-    pub after: Option<String>,
-    pub app: App,
-    pub before: Option<String>,
-    pub conclusion: Option<CheckRunCreatedCheckRunCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployment: Option<CheckRunDeployment>,
-    pub head_branch: Option<String>,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    #[doc = "The id of the check suite that this check run is part of."]
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    pub status: CheckRunCreatedCheckRunCheckSuiteStatus,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7381,36 +2221,6 @@ impl std::str::FromStr for CheckRunCreatedCheckRunStatus {
         }
     }
 }
-#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunCreatedCheckRun {
-    pub app: App,
-    pub check_suite: CheckRunCreatedCheckRunCheckSuite,
-    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub completed_at: Option<String>,
-    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-    pub conclusion: Option<CheckRunCreatedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub details_url: Option<String>,
-    pub external_id: String,
-    #[doc = "The SHA of the commit that is being checked."]
-    pub head_sha: String,
-    pub html_url: String,
-    #[doc = "The id of the check."]
-    pub id: i64,
-    #[doc = "The name of the check run."]
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    pub output: CheckRunCreatedCheckRunOutput,
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub started_at: String,
-    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-    pub status: CheckRunCreatedCheckRunStatus,
-    pub url: String,
-}
 #[doc = "The action requested by the user."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -7418,6 +2228,118 @@ pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+#[doc = "A deployment to a repository environment. This will only be populated if the check run was created by a GitHub Actions workflow job that references an environment."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunDeployment {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: Option<String>,
+    pub environment: String,
+    pub id: i64,
+    pub node_id: String,
+    pub original_environment: String,
+    pub repository_url: String,
+    pub statuses_url: String,
+    pub task: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum CheckRunEvent {
+    #[doc = "check_run completed event"]
+    #[serde(rename = "completed")]
+    Completed {
+        check_run: CheckRunCompletedCheckRun,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        #[doc = "The action requested by the user."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requested_action: Option<CheckRunCompletedRequestedAction>,
+        sender: User,
+    },
+    #[doc = "check_run created event"]
+    #[serde(rename = "created")]
+    Created {
+        check_run: CheckRunCreatedCheckRun,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        #[doc = "The action requested by the user."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requested_action: Option<CheckRunCreatedRequestedAction>,
+        sender: User,
+    },
+    #[doc = "check_run requested_action event"]
+    #[serde(rename = "requested_action")]
+    RequestedAction {
+        check_run: CheckRunRequestedActionCheckRun,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        requested_action: CheckRunRequestedActionRequestedAction,
+        sender: User,
+    },
+    #[doc = "check_run rerequested event"]
+    #[serde(rename = "rerequested")]
+    Rerequested {
+        check_run: CheckRunRerequestedCheckRun,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        #[doc = "The action requested by the user."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requested_action: Option<CheckRunRerequestedRequestedAction>,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunPullRequest {
+    pub base: CheckRunPullRequestBase,
+    pub head: CheckRunPullRequestHead,
+    pub id: i64,
+    pub number: i64,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunPullRequestBase {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: RepoRef,
+    pub sha: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunPullRequestHead {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: RepoRef,
+    pub sha: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRequestedAction {
+    pub action: CheckRunRequestedActionAction,
+    pub check_run: CheckRunRequestedActionCheckRun,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub requested_action: CheckRunRequestedActionRequestedAction,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRequestedActionAction {
@@ -7439,6 +2361,59 @@ impl std::str::FromStr for CheckRunRequestedActionAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRequestedActionCheckRun {
+    pub app: App,
+    pub check_suite: CheckRunRequestedActionCheckRunCheckSuite,
+    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub completed_at: Option<String>,
+    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    pub conclusion: Option<CheckRunRequestedActionCheckRunConclusion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details_url: Option<String>,
+    pub external_id: String,
+    #[doc = "The SHA of the commit that is being checked."]
+    pub head_sha: String,
+    pub html_url: String,
+    #[doc = "The id of the check."]
+    pub id: i64,
+    #[doc = "The name of the check run."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub output: CheckRunRequestedActionCheckRunOutput,
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub started_at: String,
+    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
+    pub status: CheckRunRequestedActionCheckRunStatus,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRequestedActionCheckRunCheckSuite {
+    pub after: Option<String>,
+    pub app: App,
+    pub before: Option<String>,
+    pub conclusion: Option<CheckRunRequestedActionCheckRunCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<CheckRunDeployment>,
+    pub head_branch: Option<String>,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    #[doc = "The id of the check suite that this check run is part of."]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    pub status: CheckRunRequestedActionCheckRunCheckSuiteStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteConclusion {
@@ -7513,29 +2488,6 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRequestedActionCheckRunCheckSuite {
-    pub after: Option<String>,
-    pub app: App,
-    pub before: Option<String>,
-    pub conclusion: Option<CheckRunRequestedActionCheckRunCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployment: Option<CheckRunDeployment>,
-    pub head_branch: Option<String>,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    #[doc = "The id of the check suite that this check run is part of."]
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    pub status: CheckRunRequestedActionCheckRunCheckSuiteStatus,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7627,36 +2579,6 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
         }
     }
 }
-#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRequestedActionCheckRun {
-    pub app: App,
-    pub check_suite: CheckRunRequestedActionCheckRunCheckSuite,
-    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub completed_at: Option<String>,
-    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-    pub conclusion: Option<CheckRunRequestedActionCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub details_url: Option<String>,
-    pub external_id: String,
-    #[doc = "The SHA of the commit that is being checked."]
-    pub head_sha: String,
-    pub html_url: String,
-    #[doc = "The id of the check."]
-    pub id: i64,
-    #[doc = "The name of the check run."]
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    pub output: CheckRunRequestedActionCheckRunOutput,
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub started_at: String,
-    #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-    pub status: CheckRunRequestedActionCheckRunStatus,
-    pub url: String,
-}
 #[doc = "The action requested by the user."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -7664,6 +2586,21 @@ pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRerequested {
+    pub action: CheckRunRerequestedAction,
+    pub check_run: CheckRunRerequestedCheckRun,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    #[doc = "The action requested by the user."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_action: Option<CheckRunRerequestedRequestedAction>,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRerequestedAction {
@@ -7685,6 +2622,59 @@ impl std::str::FromStr for CheckRunRerequestedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRerequestedCheckRun {
+    pub app: App,
+    pub check_suite: CheckRunRerequestedCheckRunCheckSuite,
+    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub completed_at: String,
+    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
+    pub conclusion: Option<CheckRunRerequestedCheckRunConclusion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details_url: Option<String>,
+    pub external_id: String,
+    #[doc = "The SHA of the commit that is being checked."]
+    pub head_sha: String,
+    pub html_url: String,
+    #[doc = "The id of the check."]
+    pub id: i64,
+    #[doc = "The name of the check."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub output: CheckRunRerequestedCheckRunOutput,
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub started_at: String,
+    #[doc = "The phase of the lifecycle that the check is currently in."]
+    pub status: CheckRunRerequestedCheckRunStatus,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRunRerequestedCheckRunCheckSuite {
+    pub after: Option<String>,
+    pub app: App,
+    pub before: Option<String>,
+    pub conclusion: CheckRunRerequestedCheckRunCheckSuiteConclusion,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<CheckRunDeployment>,
+    pub head_branch: Option<String>,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    #[doc = "The id of the check suite that this check run is part of."]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    pub status: CheckRunRerequestedCheckRunCheckSuiteStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteConclusion {
@@ -7751,29 +2741,6 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRerequestedCheckRunCheckSuite {
-    pub after: Option<String>,
-    pub app: App,
-    pub before: Option<String>,
-    pub conclusion: CheckRunRerequestedCheckRunCheckSuiteConclusion,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployment: Option<CheckRunDeployment>,
-    pub head_branch: Option<String>,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    #[doc = "The id of the check suite that this check run is part of."]
-    pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    pub status: CheckRunRerequestedCheckRunCheckSuiteStatus,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub url: String,
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7857,36 +2824,6 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunStatus {
         }
     }
 }
-#[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CheckRunRerequestedCheckRun {
-    pub app: App,
-    pub check_suite: CheckRunRerequestedCheckRunCheckSuite,
-    #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub completed_at: String,
-    #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
-    pub conclusion: Option<CheckRunRerequestedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub details_url: Option<String>,
-    pub external_id: String,
-    #[doc = "The SHA of the commit that is being checked."]
-    pub head_sha: String,
-    pub html_url: String,
-    #[doc = "The id of the check."]
-    pub id: i64,
-    #[doc = "The name of the check."]
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-    pub output: CheckRunRerequestedCheckRunOutput,
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub started_at: String,
-    #[doc = "The phase of the lifecycle that the check is currently in."]
-    pub status: CheckRunRerequestedCheckRunStatus,
-    pub url: String,
-}
 #[doc = "The action requested by the user."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -7894,6 +2831,18 @@ pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckSuiteCompleted {
+    pub action: CheckSuiteCompletedAction,
+    pub check_suite: CheckSuiteCompletedCheckSuite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteCompletedAction {
@@ -7915,6 +2864,33 @@ impl std::str::FromStr for CheckSuiteCompletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckSuiteCompletedCheckSuite {
+    pub after: String,
+    pub app: App,
+    pub before: Option<String>,
+    pub check_runs_url: String,
+    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
+    pub conclusion: Option<CheckSuiteCompletedCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The head branch name the changes are on."]
+    pub head_branch: Option<String>,
+    pub head_commit: CommitSimple,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    pub id: i64,
+    pub latest_check_runs_count: i64,
+    pub node_id: String,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    pub status: Option<CheckSuiteCompletedCheckSuiteStatus>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL that points to the check suite API resource."]
+    pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7996,32 +2972,54 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
         }
     }
 }
-#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum CheckSuiteEvent {
+    #[doc = "check_suite completed event"]
+    #[serde(rename = "completed")]
+    Completed {
+        check_suite: CheckSuiteCompletedCheckSuite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "check_suite requested event"]
+    #[serde(rename = "requested")]
+    Requested {
+        check_suite: CheckSuiteRequestedCheckSuite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "check_suite rerequested event"]
+    #[serde(rename = "rerequested")]
+    Rerequested {
+        check_suite: CheckSuiteRerequestedCheckSuite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CheckSuiteCompletedCheckSuite {
-    pub after: String,
-    pub app: App,
-    pub before: Option<String>,
-    pub check_runs_url: String,
-    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
-    pub conclusion: Option<CheckSuiteCompletedCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The head branch name the changes are on."]
-    pub head_branch: Option<String>,
-    pub head_commit: CommitSimple,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    pub id: i64,
-    pub latest_check_runs_count: i64,
-    pub node_id: String,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-    pub status: Option<CheckSuiteCompletedCheckSuiteStatus>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL that points to the check suite API resource."]
-    pub url: String,
+pub struct CheckSuiteRequested {
+    pub action: CheckSuiteRequestedAction,
+    pub check_suite: CheckSuiteRequestedCheckSuite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteRequestedAction {
@@ -8043,6 +3041,33 @@ impl std::str::FromStr for CheckSuiteRequestedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckSuiteRequestedCheckSuite {
+    pub after: String,
+    pub app: App,
+    pub before: Option<String>,
+    pub check_runs_url: String,
+    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    pub conclusion: Option<CheckSuiteRequestedCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The head branch name the changes are on."]
+    pub head_branch: Option<String>,
+    pub head_commit: CommitSimple,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    pub id: i64,
+    pub latest_check_runs_count: i64,
+    pub node_id: String,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    pub status: Option<CheckSuiteRequestedCheckSuiteStatus>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL that points to the check suite API resource."]
+    pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8124,32 +3149,17 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
         }
     }
 }
-#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CheckSuiteRequestedCheckSuite {
-    pub after: String,
-    pub app: App,
-    pub before: Option<String>,
-    pub check_runs_url: String,
-    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-    pub conclusion: Option<CheckSuiteRequestedCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The head branch name the changes are on."]
-    pub head_branch: Option<String>,
-    pub head_commit: CommitSimple,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    pub id: i64,
-    pub latest_check_runs_count: i64,
-    pub node_id: String,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-    pub status: Option<CheckSuiteRequestedCheckSuiteStatus>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL that points to the check suite API resource."]
-    pub url: String,
+pub struct CheckSuiteRerequested {
+    pub action: CheckSuiteRerequestedAction,
+    pub check_suite: CheckSuiteRerequestedCheckSuite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteRerequestedAction {
@@ -8171,6 +3181,33 @@ impl std::str::FromStr for CheckSuiteRerequestedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckSuiteRerequestedCheckSuite {
+    pub after: String,
+    pub app: App,
+    pub before: Option<String>,
+    pub check_runs_url: String,
+    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    pub conclusion: Option<CheckSuiteRerequestedCheckSuiteConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The head branch name the changes are on."]
+    pub head_branch: Option<String>,
+    pub head_commit: CommitSimple,
+    #[doc = "The SHA of the head commit that is being checked."]
+    pub head_sha: String,
+    pub id: i64,
+    pub latest_check_runs_count: i64,
+    pub node_id: String,
+    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
+    pub pull_requests: Vec<CheckRunPullRequest>,
+    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    pub status: Option<CheckSuiteRerequestedCheckSuiteStatus>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL that points to the check suite API resource."]
+    pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8252,32 +3289,22 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
         }
     }
 }
-#[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CheckSuiteRerequestedCheckSuite {
-    pub after: String,
-    pub app: App,
-    pub before: Option<String>,
-    pub check_runs_url: String,
-    #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-    pub conclusion: Option<CheckSuiteRerequestedCheckSuiteConclusion>,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The head branch name the changes are on."]
-    pub head_branch: Option<String>,
-    pub head_commit: CommitSimple,
-    #[doc = "The SHA of the head commit that is being checked."]
-    pub head_sha: String,
-    pub id: i64,
-    pub latest_check_runs_count: i64,
-    pub node_id: String,
-    #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
-    pub pull_requests: Vec<CheckRunPullRequest>,
-    #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-    pub status: Option<CheckSuiteRerequestedCheckSuiteStatus>,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "URL that points to the check suite API resource."]
-    pub url: String,
+pub struct CodeScanningAlertAppearedInBranch {
+    pub action: CodeScanningAlertAppearedInBranchAction,
+    pub alert: CodeScanningAlertAppearedInBranchAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: GithubOrg,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertAppearedInBranchAction {
@@ -8299,6 +3326,30 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertAppearedInBranchAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub dismissed_by: Option<User>,
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: Option<CodeScanningAlertAppearedInBranchAlertDismissedReason>,
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertAppearedInBranchAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertAppearedInBranchAlertState,
+    pub tool: CodeScanningAlertAppearedInBranchAlertTool,
+    pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8329,6 +3380,16 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertDismissedReason
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertAppearedInBranchAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertAppearedInBranchAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8363,16 +3424,6 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertAppearedInBranchAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertAppearedInBranchAlertRuleSeverity>,
 }
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8412,29 +3463,22 @@ pub struct CodeScanningAlertAppearedInBranchAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertAppearedInBranchAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub dismissed_by: Option<User>,
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: Option<CodeScanningAlertAppearedInBranchAlertDismissedReason>,
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+pub struct CodeScanningAlertClosedByUser {
+    pub action: CodeScanningAlertClosedByUserAction,
+    pub alert: CodeScanningAlertClosedByUserAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertAppearedInBranchAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertAppearedInBranchAlertState,
-    pub tool: CodeScanningAlertAppearedInBranchAlertTool,
-    pub url: String,
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertClosedByUserAction {
@@ -8456,6 +3500,30 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertClosedByUserAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: chrono::DateTime<chrono::offset::Utc>,
+    pub dismissed_by: User,
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: Option<CodeScanningAlertClosedByUserAlertDismissedReason>,
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertClosedByUserAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertClosedByUserAlertState,
+    pub tool: CodeScanningAlertClosedByUserAlertTool,
+    pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8486,6 +3554,24 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertDismissedReason {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertClosedByUserAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<String>,
+    #[serde(default)]
+    pub help: (),
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertClosedByUserAlertRuleSeverity>,
+    #[serde(default)]
+    pub tags: (),
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8521,24 +3607,6 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertRuleSeverity {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertClosedByUserAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_description: Option<String>,
-    #[serde(default)]
-    pub help: (),
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertClosedByUserAlertRuleSeverity>,
-    #[serde(default)]
-    pub tags: (),
-}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertClosedByUserAlertState {
@@ -8571,29 +3639,22 @@ pub struct CodeScanningAlertClosedByUserAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertClosedByUserAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: chrono::DateTime<chrono::offset::Utc>,
-    pub dismissed_by: User,
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: Option<CodeScanningAlertClosedByUserAlertDismissedReason>,
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+pub struct CodeScanningAlertCreated {
+    pub action: CodeScanningAlertCreatedAction,
+    pub alert: CodeScanningAlertCreatedAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertClosedByUserAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertClosedByUserAlertState,
-    pub tool: CodeScanningAlertClosedByUserAlertTool,
-    pub url: String,
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: GithubOrg,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertCreatedAction {
@@ -8615,6 +3676,48 @@ impl std::str::FromStr for CodeScanningAlertCreatedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertCreatedAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: (),
+    pub dismissed_by: (),
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: (),
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertCreatedAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertCreatedAlertState,
+    pub tool: CodeScanningAlertCreatedAlertTool,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertCreatedAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<String>,
+    #[serde(default)]
+    pub help: (),
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertCreatedAlertRuleSeverity>,
+    #[serde(default)]
+    pub tags: (),
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8649,24 +3752,6 @@ impl std::str::FromStr for CodeScanningAlertCreatedAlertRuleSeverity {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertCreatedAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_description: Option<String>,
-    #[serde(default)]
-    pub help: (),
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertCreatedAlertRuleSeverity>,
-    #[serde(default)]
-    pub tags: (),
 }
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8704,29 +3789,122 @@ pub struct CodeScanningAlertCreatedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum CodeScanningAlertEvent {
+    #[doc = "code_scanning_alert appeared_in_branch event"]
+    #[serde(rename = "appeared_in_branch")]
+    AppearedInBranch {
+        alert: CodeScanningAlertAppearedInBranchAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: GithubOrg,
+    },
+    #[doc = "code_scanning_alert closed_by_user event"]
+    #[serde(rename = "closed_by_user")]
+    ClosedByUser {
+        alert: CodeScanningAlertClosedByUserAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "code_scanning_alert created event"]
+    #[serde(rename = "created")]
+    Created {
+        alert: CodeScanningAlertCreatedAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: GithubOrg,
+    },
+    #[doc = "code_scanning_alert fixed event"]
+    #[serde(rename = "fixed")]
+    Fixed {
+        alert: CodeScanningAlertFixedAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: GithubOrg,
+    },
+    #[doc = "code_scanning_alert reopened event"]
+    #[serde(rename = "reopened")]
+    Reopened {
+        alert: CodeScanningAlertReopenedAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: GithubOrg,
+    },
+    #[doc = "code_scanning_alert reopened_by_user event"]
+    #[serde(rename = "reopened_by_user")]
+    ReopenedByUser {
+        alert: CodeScanningAlertReopenedByUserAlert,
+        #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        commit_oid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+        #[serde(rename = "ref")]
+        ref_: String,
+        repository: Repository,
+        sender: User,
+    },
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertCreatedAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: (),
-    pub dismissed_by: (),
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: (),
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+pub struct CodeScanningAlertFixed {
+    pub action: CodeScanningAlertFixedAction,
+    pub alert: CodeScanningAlertFixedAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertCreatedAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertCreatedAlertState,
-    pub tool: CodeScanningAlertCreatedAlertTool,
-    pub url: String,
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: GithubOrg,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertFixedAction {
@@ -8748,6 +3926,32 @@ impl std::str::FromStr for CodeScanningAlertFixedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertFixedAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub dismissed_by: Option<User>,
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: Option<CodeScanningAlertFixedAlertDismissedReason>,
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instances_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertFixedAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertFixedAlertState,
+    pub tool: CodeScanningAlertFixedAlertTool,
+    pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8778,6 +3982,24 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertDismissedReason {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertFixedAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<String>,
+    #[serde(default)]
+    pub help: (),
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertFixedAlertRuleSeverity>,
+    #[serde(default)]
+    pub tags: (),
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8813,24 +4035,6 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertRuleSeverity {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertFixedAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_description: Option<String>,
-    #[serde(default)]
-    pub help: (),
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertFixedAlertRuleSeverity>,
-    #[serde(default)]
-    pub tags: (),
-}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertFixedAlertState {
@@ -8863,31 +4067,22 @@ pub struct CodeScanningAlertFixedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertFixedAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
-    pub dismissed_by: Option<User>,
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: Option<CodeScanningAlertFixedAlertDismissedReason>,
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+pub struct CodeScanningAlertReopened {
+    pub action: CodeScanningAlertReopenedAction,
+    pub alert: CodeScanningAlertReopenedAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instances_url: Option<String>,
+    pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertFixedAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertFixedAlertState,
-    pub tool: CodeScanningAlertFixedAlertTool,
-    pub url: String,
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: GithubOrg,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertReopenedAction {
@@ -8909,6 +4104,48 @@ impl std::str::FromStr for CodeScanningAlertReopenedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: (),
+    pub dismissed_by: (),
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: (),
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertReopenedAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertReopenedAlertState,
+    pub tool: CodeScanningAlertReopenedAlertTool,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<String>,
+    #[serde(default)]
+    pub help: (),
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertReopenedAlertRuleSeverity>,
+    #[serde(default)]
+    pub tags: (),
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8943,24 +4180,6 @@ impl std::str::FromStr for CodeScanningAlertReopenedAlertRuleSeverity {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopenedAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_description: Option<String>,
-    #[serde(default)]
-    pub help: (),
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertReopenedAlertRuleSeverity>,
-    #[serde(default)]
-    pub tags: (),
 }
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9002,29 +4221,22 @@ pub struct CodeScanningAlertReopenedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopenedAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: (),
-    pub dismissed_by: (),
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: (),
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+pub struct CodeScanningAlertReopenedByUser {
+    pub action: CodeScanningAlertReopenedByUserAction,
+    pub alert: CodeScanningAlertReopenedByUserAlert,
+    #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    pub commit_oid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertReopenedAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertReopenedAlertState,
-    pub tool: CodeScanningAlertReopenedAlertTool,
-    pub url: String,
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertReopenedByUserAction {
@@ -9046,6 +4258,40 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The code scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedByUserAlert {
+    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    pub dismissed_at: (),
+    pub dismissed_by: (),
+    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    pub dismissed_reason: (),
+    #[doc = "The GitHub URL of the alert resource."]
+    pub html_url: String,
+    pub instances: Vec<AlertInstance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_instance: Option<AlertInstance>,
+    #[doc = "The code scanning alert number."]
+    pub number: i64,
+    pub rule: CodeScanningAlertReopenedByUserAlertRule,
+    #[doc = "State of a code scanning alert."]
+    pub state: CodeScanningAlertReopenedByUserAlertState,
+    pub tool: CodeScanningAlertReopenedByUserAlertTool,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedByUserAlertRule {
+    #[doc = "A short description of the rule used to detect the alert."]
+    pub description: String,
+    #[doc = "A unique identifier for the rule used to detect the alert."]
+    pub id: String,
+    #[doc = "The severity of the alert."]
+    pub severity: Option<CodeScanningAlertReopenedByUserAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9081,16 +4327,6 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertRuleSeverity {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopenedByUserAlertRule {
-    #[doc = "A short description of the rule used to detect the alert."]
-    pub description: String,
-    #[doc = "A unique identifier for the rule used to detect the alert."]
-    pub id: String,
-    #[doc = "The severity of the alert."]
-    pub severity: Option<CodeScanningAlertReopenedByUserAlertRuleSeverity>,
-}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertReopenedByUserAlertState {
@@ -9121,29 +4357,41 @@ pub struct CodeScanningAlertReopenedByUserAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeScanningAlertReopenedByUserAlert {
-    #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
-    pub dismissed_at: (),
-    pub dismissed_by: (),
-    #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-    pub dismissed_reason: (),
-    #[doc = "The GitHub URL of the alert resource."]
-    pub html_url: String,
-    pub instances: Vec<AlertInstance>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub most_recent_instance: Option<AlertInstance>,
-    #[doc = "The code scanning alert number."]
-    pub number: i64,
-    pub rule: CodeScanningAlertReopenedByUserAlertRule,
-    #[doc = "State of a code scanning alert."]
-    pub state: CodeScanningAlertReopenedByUserAlertState,
-    pub tool: CodeScanningAlertReopenedByUserAlertTool,
+pub struct Commit {
+    #[doc = "An array of files added in the commit."]
+    pub added: Vec<String>,
+    pub author: Committer,
+    pub committer: Committer,
+    #[doc = "Whether this commit is distinct from any that have been pushed before."]
+    pub distinct: bool,
+    pub id: String,
+    #[doc = "The commit message."]
+    pub message: String,
+    #[doc = "An array of files modified by the commit."]
+    pub modified: Vec<String>,
+    #[doc = "An array of files removed in the commit."]
+    pub removed: Vec<String>,
+    #[doc = "The ISO 8601 timestamp of the commit."]
+    pub timestamp: String,
+    pub tree_id: String,
+    #[doc = "URL that points to the commit API resource."]
     pub url: String,
+}
+#[doc = "A commit comment is created. The type of activity is specified in the `action` property. "]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommitCommentCreated {
+    #[doc = "The action performed. Can be `created`."]
+    pub action: CommitCommentCreatedAction,
+    pub comment: CommitCommentCreatedComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[doc = "The action performed. Can be `created`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9192,6 +4440,55 @@ pub struct CommitCommentCreatedComment {
     pub url: String,
     pub user: User,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum CommitCommentEvent {
+    #[doc = "commit_comment created event\n\nA commit comment is created. The type of activity is specified in the `action` property. "]
+    #[serde(rename = "created")]
+    Created {
+        comment: CommitCommentCreatedComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommitSimple {
+    pub author: Committer,
+    pub committer: Committer,
+    pub id: String,
+    pub message: String,
+    pub timestamp: String,
+    pub tree_id: String,
+}
+#[doc = "Metaproperties for Git author/committer information."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Committer {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub date: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "The git author's email address."]
+    pub email: Option<String>,
+    #[doc = "The git author's name."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContentReferenceCreated {
+    pub action: ContentReferenceCreatedAction,
+    pub content_reference: ContentReferenceCreatedContentReference,
+    pub installation: InstallationLite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ContentReferenceCreatedAction {
     #[serde(rename = "created")]
@@ -9220,6 +4517,42 @@ pub struct ContentReferenceCreatedContentReference {
     pub node_id: String,
     pub reference: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum ContentReferenceEvent {
+    #[doc = "content_reference created event"]
+    #[serde(rename = "created")]
+    Created {
+        content_reference: ContentReferenceCreatedContentReference,
+        installation: InstallationLite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[doc = "A Git branch or tag is created."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateEvent {
+    #[doc = "The repository's current description."]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The name of the repository's default branch (usually `main`)."]
+    pub master_branch: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
+    pub pusher_type: String,
+    #[doc = "The [`git ref`](https://docs.github.com/en/rest/reference/git#get-a-reference) resource."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    #[doc = "The type of Git ref object created in the repository. Can be either `branch` or `tag`."]
+    pub ref_type: CreateEventRefType,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[doc = "The type of Git ref object created in the repository. Can be either `branch` or `tag`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CreateEventRefType {
@@ -9246,6 +4579,24 @@ impl std::str::FromStr for CreateEventRefType {
         }
     }
 }
+#[doc = "A Git branch or tag is deleted."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
+    pub pusher_type: String,
+    #[doc = "The [`git ref`](https://docs.github.com/en/rest/reference/git#get-a-reference) resource."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    #[doc = "The type of Git ref object deleted in the repository. Can be either `branch` or `tag`."]
+    pub ref_type: DeleteEventRefType,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[doc = "The type of Git ref object deleted in the repository. Can be either `branch` or `tag`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DeleteEventRefType {
@@ -9271,6 +4622,18 @@ impl std::str::FromStr for DeleteEventRefType {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeployKeyCreated {
+    pub action: DeployKeyCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub key: DeployKeyCreatedKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DeployKeyCreatedAction {
@@ -9305,6 +4668,18 @@ pub struct DeployKeyCreatedKey {
     pub url: String,
     pub verified: bool,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeployKeyDeleted {
+    pub action: DeployKeyDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub key: DeployKeyDeletedKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DeployKeyDeletedAction {
     #[serde(rename = "deleted")]
@@ -9338,6 +4713,46 @@ pub struct DeployKeyDeletedKey {
     pub url: String,
     pub verified: bool,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum DeployKeyEvent {
+    #[doc = "deploy_key created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        key: DeployKeyCreatedKey,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "deploy_key deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        key: DeployKeyDeletedKey,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentCreated {
+    pub action: DeploymentCreatedAction,
+    pub deployment: DeploymentCreatedDeployment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow: (),
+    pub workflow_run: (),
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DeploymentCreatedAction {
     #[serde(rename = "created")]
@@ -9359,9 +4774,6 @@ impl std::str::FromStr for DeploymentCreatedAction {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeploymentCreatedDeploymentPayload {}
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9385,6 +4797,39 @@ pub struct DeploymentCreatedDeployment {
     pub updated_at: String,
     pub url: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentCreatedDeploymentPayload {}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum DeploymentEvent {
+    #[doc = "deployment created event"]
+    #[serde(rename = "created")]
+    Created {
+        deployment: DeploymentCreatedDeployment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow: (),
+        workflow_run: (),
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentStatusCreated {
+    pub action: DeploymentStatusCreatedAction,
+    pub deployment: DeploymentStatusCreatedDeployment,
+    pub deployment_status: DeploymentStatusCreatedDeploymentStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DeploymentStatusCreatedAction {
     #[serde(rename = "created")]
@@ -9406,9 +4851,6 @@ impl std::str::FromStr for DeploymentStatusCreatedAction {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeploymentStatusCreatedDeploymentPayload {}
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments) that this status is associated with."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9431,6 +4873,9 @@ pub struct DeploymentStatusCreatedDeployment {
     pub updated_at: String,
     pub url: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentStatusCreatedDeploymentPayload {}
 #[doc = "The [deployment status](https://docs.github.com/en/rest/reference/repos#list-deployment-statuses)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9454,46 +4899,56 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub url: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum DeploymentStatusEvent {
+    #[doc = "deployment_status created event"]
+    #[serde(rename = "created")]
+    Created {
+        deployment: DeploymentStatusCreatedDeployment,
+        deployment_status: DeploymentStatusCreatedDeploymentStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct DiscussionCategory {
+pub struct Discussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: Option<String>,
+    pub answer_chosen_by: Option<User>,
+    pub answer_html_url: Option<String>,
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionCategory,
+    pub comments: i64,
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub description: String,
-    pub emoji: String,
+    pub html_url: String,
     pub id: i64,
-    pub is_answerable: bool,
-    pub name: String,
-    pub repository_id: i64,
-    pub slug: String,
-    pub updated_at: String,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionState {
-    #[serde(rename = "open")]
-    Open,
-    #[serde(rename = "locked")]
-    Locked,
-    #[serde(rename = "converting")]
-    Converting,
-}
-impl ToString for DiscussionState {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Open => "open".to_string(),
-            Self::Locked => "locked".to_string(),
-            Self::Converting => "converting".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "open" => Ok(Self::Open),
-            "locked" => Ok(Self::Locked),
-            "converting" => Ok(Self::Converting),
-            _ => Err("invalid value"),
-        }
-    }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionAnswered {
+    pub action: DiscussionAnsweredAction,
+    pub answer: DiscussionAnsweredAnswer,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionAnsweredAction {
@@ -9532,6 +4987,32 @@ pub struct DiscussionAnsweredAnswer {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCategoryChanged {
+    pub action: DiscussionCategoryChangedAction,
+    pub changes: DiscussionCategoryChangedChanges,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionCategoryChangedAction {
     #[serde(rename = "category_changed")]
@@ -9555,6 +5036,16 @@ impl std::str::FromStr for DiscussionCategoryChangedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct DiscussionCategoryChangedChanges {
+    pub category: DiscussionCategoryChangedChangesCategory,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCategoryChangedChangesCategory {
+    pub from: DiscussionCategoryChangedChangesCategoryFrom,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChangesCategoryFrom {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
     pub description: String,
@@ -9568,284 +5059,15 @@ pub struct DiscussionCategoryChangedChangesCategoryFrom {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct DiscussionCategoryChangedChangesCategory {
-    pub from: DiscussionCategoryChangedChangesCategoryFrom,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionCategoryChangedChanges {
-    pub category: DiscussionCategoryChangedChangesCategory,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for DiscussionCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for DiscussionDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for DiscussionEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionEditedChangesBody {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionEditedChangesTitle {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionEditedChanges {
+pub struct DiscussionCommentCreated {
+    pub action: DiscussionCommentCreatedAction,
+    pub comment: DiscussionCommentCreatedComment,
+    pub discussion: Discussion,
+    pub installation: InstallationLite,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<DiscussionEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<DiscussionEditedChangesTitle>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionLabeledAction {
-    #[serde(rename = "labeled")]
-    Labeled,
-}
-impl ToString for DiscussionLabeledAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Labeled => "labeled".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionLabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "labeled" => Ok(Self::Labeled),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionLockedAction {
-    #[serde(rename = "locked")]
-    Locked,
-}
-impl ToString for DiscussionLockedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Locked => "locked".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionLockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionPinnedAction {
-    #[serde(rename = "pinned")]
-    Pinned,
-}
-impl ToString for DiscussionPinnedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Pinned => "pinned".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionPinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "pinned" => Ok(Self::Pinned),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionTransferredAction {
-    #[serde(rename = "transferred")]
-    Transferred,
-}
-impl ToString for DiscussionTransferredAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Transferred => "transferred".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionTransferredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "transferred" => Ok(Self::Transferred),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionTransferredChanges {
-    pub new_discussion: Discussion,
-    pub new_repository: Repository,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionUnansweredAction {
-    #[serde(rename = "unanswered")]
-    Unanswered,
-}
-impl ToString for DiscussionUnansweredAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unanswered => "unanswered".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionUnansweredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unanswered" => Ok(Self::Unanswered),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DiscussionUnansweredOldAnswer {
-    pub author_association: AuthorAssociation,
-    pub body: String,
-    pub child_comment_count: i64,
-    pub created_at: chrono::DateTime<chrono::offset::Utc>,
-    pub discussion_id: i64,
-    pub html_url: String,
-    pub id: i64,
-    pub node_id: String,
-    pub parent_id: (),
-    pub repository_url: String,
-    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
-    pub user: User,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionUnlabeledAction {
-    #[serde(rename = "unlabeled")]
-    Unlabeled,
-}
-impl ToString for DiscussionUnlabeledAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unlabeled => "unlabeled".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionUnlabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unlabeled" => Ok(Self::Unlabeled),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionUnlockedAction {
-    #[serde(rename = "unlocked")]
-    Unlocked,
-}
-impl ToString for DiscussionUnlockedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unlocked => "unlocked".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionUnlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unlocked" => Ok(Self::Unlocked),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DiscussionUnpinnedAction {
-    #[serde(rename = "unpinned")]
-    Unpinned,
-}
-impl ToString for DiscussionUnpinnedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unpinned => "unpinned".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DiscussionUnpinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unpinned" => Ok(Self::Unpinned),
-            _ => Err("invalid value"),
-        }
-    }
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionCommentCreatedAction {
@@ -9884,6 +5106,18 @@ pub struct DiscussionCommentCreatedComment {
     pub updated_at: String,
     pub user: User,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCommentDeleted {
+    pub action: DiscussionCommentDeletedAction,
+    pub comment: DiscussionCommentDeletedComment,
+    pub discussion: Discussion,
+    pub installation: InstallationLite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionCommentDeletedAction {
     #[serde(rename = "deleted")]
@@ -9921,6 +5155,19 @@ pub struct DiscussionCommentDeletedComment {
     pub updated_at: String,
     pub user: User,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCommentEdited {
+    pub action: DiscussionCommentEditedAction,
+    pub changes: DiscussionCommentEditedChanges,
+    pub comment: DiscussionCommentEditedComment,
+    pub discussion: Discussion,
+    pub installation: InstallationLite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionCommentEditedAction {
     #[serde(rename = "edited")]
@@ -9944,13 +5191,13 @@ impl std::str::FromStr for DiscussionCommentEditedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct DiscussionCommentEditedChangesBody {
-    pub from: String,
+pub struct DiscussionCommentEditedChanges {
+    pub body: DiscussionCommentEditedChangesBody,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct DiscussionCommentEditedChanges {
-    pub body: DiscussionCommentEditedChangesBody,
+pub struct DiscussionCommentEditedChangesBody {
+    pub from: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9967,6 +5214,722 @@ pub struct DiscussionCommentEditedComment {
     pub repository_url: String,
     pub updated_at: String,
     pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum DiscussionCommentEvent {
+    #[doc = "discussion_comment created event"]
+    #[serde(rename = "created")]
+    Created {
+        comment: DiscussionCommentCreatedComment,
+        discussion: Discussion,
+        installation: InstallationLite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion_comment deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        comment: DiscussionCommentDeletedComment,
+        discussion: Discussion,
+        installation: InstallationLite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion_comment edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: DiscussionCommentEditedChanges,
+        comment: DiscussionCommentEditedComment,
+        discussion: Discussion,
+        installation: InstallationLite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCreated {
+    pub action: DiscussionCreatedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for DiscussionCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionDeleted {
+    pub action: DiscussionDeletedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for DiscussionDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionEdited {
+    pub action: DiscussionEditedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<DiscussionEditedChanges>,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for DiscussionEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<DiscussionEditedChangesBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<DiscussionEditedChangesTitle>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionEditedChangesBody {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionEditedChangesTitle {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum DiscussionEvent {
+    #[doc = "discussion answered event"]
+    #[serde(rename = "answered")]
+    Answered {
+        answer: DiscussionAnsweredAnswer,
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion category changed event"]
+    #[serde(rename = "category_changed")]
+    CategoryChanged {
+        changes: DiscussionCategoryChangedChanges,
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion created event"]
+    #[serde(rename = "created")]
+    Created {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        changes: Option<DiscussionEditedChanges>,
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion labeled event"]
+    #[serde(rename = "labeled")]
+    Labeled {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        label: Label,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion locked event"]
+    #[serde(rename = "locked")]
+    Locked {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion pinned event"]
+    #[serde(rename = "pinned")]
+    Pinned {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion transferred event"]
+    #[serde(rename = "transferred")]
+    Transferred {
+        changes: DiscussionTransferredChanges,
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion unanswered event"]
+    #[serde(rename = "unanswered")]
+    Unanswered {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        old_answer: DiscussionUnansweredOldAnswer,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion unlabeled event"]
+    #[serde(rename = "unlabeled")]
+    Unlabeled {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        label: Label,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion unlocked event"]
+    #[serde(rename = "unlocked")]
+    Unlocked {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "discussion unpinned event"]
+    #[serde(rename = "unpinned")]
+    Unpinned {
+        discussion: Discussion,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionLabeled {
+    pub action: DiscussionLabeledAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub label: Label,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionLabeledAction {
+    #[serde(rename = "labeled")]
+    Labeled,
+}
+impl ToString for DiscussionLabeledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Labeled => "labeled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionLabeledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "labeled" => Ok(Self::Labeled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionLocked {
+    pub action: DiscussionLockedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionLockedAction {
+    #[serde(rename = "locked")]
+    Locked,
+}
+impl ToString for DiscussionLockedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Locked => "locked".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionLockedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "locked" => Ok(Self::Locked),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionPinned {
+    pub action: DiscussionPinnedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionPinnedAction {
+    #[serde(rename = "pinned")]
+    Pinned,
+}
+impl ToString for DiscussionPinnedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Pinned => "pinned".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionPinnedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "pinned" => Ok(Self::Pinned),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "locked")]
+    Locked,
+    #[serde(rename = "converting")]
+    Converting,
+}
+impl ToString for DiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Locked => "locked".to_string(),
+            Self::Converting => "converting".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "open" => Ok(Self::Open),
+            "locked" => Ok(Self::Locked),
+            "converting" => Ok(Self::Converting),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionTransferred {
+    pub action: DiscussionTransferredAction,
+    pub changes: DiscussionTransferredChanges,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionTransferredAction {
+    #[serde(rename = "transferred")]
+    Transferred,
+}
+impl ToString for DiscussionTransferredAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Transferred => "transferred".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionTransferredAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "transferred" => Ok(Self::Transferred),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionTransferredChanges {
+    pub new_discussion: Discussion,
+    pub new_repository: Repository,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnanswered {
+    pub action: DiscussionUnansweredAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub old_answer: DiscussionUnansweredOldAnswer,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnansweredAction {
+    #[serde(rename = "unanswered")]
+    Unanswered,
+}
+impl ToString for DiscussionUnansweredAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unanswered => "unanswered".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnansweredAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unanswered" => Ok(Self::Unanswered),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnansweredOldAnswer {
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub child_comment_count: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub discussion_id: i64,
+    pub html_url: String,
+    pub id: i64,
+    pub node_id: String,
+    pub parent_id: (),
+    pub repository_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnlabeled {
+    pub action: DiscussionUnlabeledAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub label: Label,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnlabeledAction {
+    #[serde(rename = "unlabeled")]
+    Unlabeled,
+}
+impl ToString for DiscussionUnlabeledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unlabeled => "unlabeled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnlabeledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unlabeled" => Ok(Self::Unlabeled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnlocked {
+    pub action: DiscussionUnlockedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnlockedAction {
+    #[serde(rename = "unlocked")]
+    Unlocked,
+}
+impl ToString for DiscussionUnlockedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unlocked => "unlocked".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnlockedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unlocked" => Ok(Self::Unlocked),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnpinned {
+    pub action: DiscussionUnpinnedAction,
+    pub discussion: Discussion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnpinnedAction {
+    #[serde(rename = "unpinned")]
+    Unpinned,
+}
+impl ToString for DiscussionUnpinnedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unpinned => "unpinned".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnpinnedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unpinned" => Ok(Self::Unpinned),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Everything {
+    BranchProtectionRuleEvent(BranchProtectionRuleEvent),
+    CheckRunEvent(CheckRunEvent),
+    CheckSuiteEvent(CheckSuiteEvent),
+    CodeScanningAlertEvent(CodeScanningAlertEvent),
+    CommitCommentEvent(CommitCommentEvent),
+    ContentReferenceEvent(ContentReferenceEvent),
+    CreateEvent(CreateEvent),
+    DeleteEvent(DeleteEvent),
+    DeployKeyEvent(DeployKeyEvent),
+    DeploymentEvent(DeploymentEvent),
+    DeploymentStatusEvent(DeploymentStatusEvent),
+    DiscussionEvent(DiscussionEvent),
+    DiscussionCommentEvent(DiscussionCommentEvent),
+    ForkEvent(ForkEvent),
+    GithubAppAuthorizationEvent(GithubAppAuthorizationEvent),
+    GollumEvent(GollumEvent),
+    InstallationEvent(InstallationEvent),
+    InstallationRepositoriesEvent(InstallationRepositoriesEvent),
+    IssueCommentEvent(IssueCommentEvent),
+    IssuesEvent(IssuesEvent),
+    LabelEvent(LabelEvent),
+    MarketplacePurchaseEvent(MarketplacePurchaseEvent),
+    MemberEvent(MemberEvent),
+    MembershipEvent(MembershipEvent),
+    MetaEvent(MetaEvent),
+    MilestoneEvent(MilestoneEvent),
+    OrgBlockEvent(OrgBlockEvent),
+    OrganizationEvent(OrganizationEvent),
+    PackageEvent(PackageEvent),
+    PageBuildEvent(PageBuildEvent),
+    PingEvent(PingEvent),
+    ProjectEvent(ProjectEvent),
+    ProjectCardEvent(ProjectCardEvent),
+    ProjectColumnEvent(ProjectColumnEvent),
+    PublicEvent(PublicEvent),
+    PullRequestEvent(PullRequestEvent),
+    PullRequestReviewEvent(PullRequestReviewEvent),
+    PullRequestReviewCommentEvent(PullRequestReviewCommentEvent),
+    PushEvent(PushEvent),
+    ReleaseEvent(ReleaseEvent),
+    RepositoryEvent(RepositoryEvent),
+    RepositoryDispatchEvent(RepositoryDispatchEvent),
+    RepositoryImportEvent(RepositoryImportEvent),
+    RepositoryVulnerabilityAlertEvent(RepositoryVulnerabilityAlertEvent),
+    SecretScanningAlertEvent(SecretScanningAlertEvent),
+    SecurityAdvisoryEvent(SecurityAdvisoryEvent),
+    SponsorshipEvent(SponsorshipEvent),
+    StarEvent(StarEvent),
+    StatusEvent(StatusEvent),
+    TeamEvent(TeamEvent),
+    TeamAddEvent(TeamAddEvent),
+    WatchEvent(WatchEvent),
+    WorkflowDispatchEvent(WorkflowDispatchEvent),
+    WorkflowJobEvent(WorkflowJobEvent),
+    WorkflowRunEvent(WorkflowRunEvent),
+}
+#[doc = "A user forks a repository."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForkEvent {
+    #[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
+    pub forkee: Repository,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", content = "sender")]
+pub enum GithubAppAuthorizationEvent {
+    #[doc = "github_app_authorization revoked event"]
+    #[serde(rename = "revoked")]
+    Revoked(User),
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GithubAppAuthorizationRevoked {
+    pub action: GithubAppAuthorizationRevokedAction,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum GithubAppAuthorizationRevokedAction {
@@ -9988,6 +5951,61 @@ impl std::str::FromStr for GithubAppAuthorizationRevokedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GithubOrg {
+    pub avatar_url: String,
+    #[serde(default)]
+    pub email: (),
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub node_id: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub url: String,
+}
+#[doc = "A wiki page is created or updated."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GollumEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[doc = "The pages that were updated."]
+    pub pages: Vec<GollumEventPagesItem>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GollumEventPagesItem {
+    #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
+    pub action: GollumEventPagesItemAction,
+    #[doc = "Points to the HTML wiki page."]
+    pub html_url: String,
+    #[doc = "The name of the page."]
+    pub page_name: String,
+    #[doc = "The latest commit SHA of the page."]
+    pub sha: String,
+    pub summary: (),
+    #[doc = "The current page title."]
+    pub title: String,
 }
 #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -10015,26 +6033,190 @@ impl std::str::FromStr for GollumEventPagesItemAction {
         }
     }
 }
+#[doc = "The GitHub App installation."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct GollumEventPagesItem {
-    #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
-    pub action: GollumEventPagesItemAction,
-    #[doc = "Points to the HTML wiki page."]
+pub struct Installation {
+    pub access_tokens_url: String,
+    pub account: User,
+    pub app_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_slug: Option<String>,
+    pub created_at: InstallationCreatedAt,
+    pub events: Vec<InstallationEventsItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_multiple_single_files: Option<bool>,
     pub html_url: String,
-    #[doc = "The name of the page."]
-    pub page_name: String,
-    #[doc = "The latest commit SHA of the page."]
-    pub sha: String,
-    pub summary: (),
-    #[doc = "The current page title."]
-    pub title: String,
+    #[doc = "The ID of the installation."]
+    pub id: i64,
+    pub permissions: InstallationPermissions,
+    pub repositories_url: String,
+    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+    pub repository_selection: InstallationRepositorySelection,
+    pub single_file_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub single_file_paths: Vec<String>,
+    pub suspended_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub suspended_by: Option<User>,
+    #[doc = "The ID of the user or organization this token is being scoped to."]
+    pub target_id: i64,
+    pub target_type: InstallationTargetType,
+    pub updated_at: InstallationUpdatedAt,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationCreated {
+    pub action: InstallationCreatedAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects that the installation can access."]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<InstallationCreatedRepositoriesItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester: Option<User>,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for InstallationCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum InstallationCreatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
     Variant1(i64),
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationCreatedRepositoriesItem {
+    pub full_name: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationDeleted {
+    pub action: InstallationDeletedAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects that the installation can access."]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<InstallationDeletedRepositoriesItem>,
+    #[serde(default)]
+    pub requester: (),
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for InstallationDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationDeletedRepositoriesItem {
+    pub full_name: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum InstallationEvent {
+    #[doc = "installation created event"]
+    #[serde(rename = "created")]
+    Created {
+        installation: Installation,
+        #[doc = "An array of repository objects that the installation can access."]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        repositories: Vec<InstallationCreatedRepositoriesItem>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requester: Option<User>,
+        sender: User,
+    },
+    #[doc = "installation deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        installation: Installation,
+        #[doc = "An array of repository objects that the installation can access."]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        repositories: Vec<InstallationDeletedRepositoriesItem>,
+        #[serde(default)]
+        requester: (),
+        sender: User,
+    },
+    #[doc = "installation new_permissions_accepted event"]
+    #[serde(rename = "new_permissions_accepted")]
+    NewPermissionsAccepted {
+        installation: Installation,
+        #[doc = "An array of repository objects that the installation can access."]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        repositories: Vec<InstallationNewPermissionsAcceptedRepositoriesItem>,
+        #[serde(default)]
+        requester: (),
+        sender: User,
+    },
+    #[doc = "installation suspend event"]
+    #[serde(rename = "suspend")]
+    Suspend {
+        installation: Installation,
+        #[doc = "An array of repository objects that the installation can access."]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        repositories: Vec<InstallationSuspendRepositoriesItem>,
+        #[serde(default)]
+        requester: (),
+        sender: User,
+    },
+    #[doc = "installation unsuspend event"]
+    #[serde(rename = "unsuspend")]
+    Unsuspend {
+        installation: Installation,
+        #[doc = "An array of repository objects that the installation can access."]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        repositories: Vec<InstallationUnsuspendRepositoriesItem>,
+        #[serde(default)]
+        requester: (),
+        sender: User,
+    },
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationEventsItem {
@@ -10232,6 +6414,134 @@ impl std::str::FromStr for InstallationEventsItem {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "Installation"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationLite {
+    #[doc = "The ID of the installation."]
+    pub id: i64,
+    pub node_id: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationNewPermissionsAccepted {
+    pub action: InstallationNewPermissionsAcceptedAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects that the installation can access."]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<InstallationNewPermissionsAcceptedRepositoriesItem>,
+    #[serde(default)]
+    pub requester: (),
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationNewPermissionsAcceptedAction {
+    #[serde(rename = "new_permissions_accepted")]
+    NewPermissionsAccepted,
+}
+impl ToString for InstallationNewPermissionsAcceptedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::NewPermissionsAccepted => "new_permissions_accepted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "new_permissions_accepted" => Ok(Self::NewPermissionsAccepted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
+    pub full_name: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationPermissions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions: Option<InstallationPermissionsActions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub administration: Option<InstallationPermissionsAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checks: Option<InstallationPermissionsChecks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_references: Option<InstallationPermissionsContentReferences>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contents: Option<InstallationPermissionsContents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployments: Option<InstallationPermissionsDeployments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discussions: Option<InstallationPermissionsDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emails: Option<InstallationPermissionsEmails>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environments: Option<InstallationPermissionsEnvironments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issues: Option<InstallationPermissionsIssues>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub members: Option<InstallationPermissionsMembers>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<InstallationPermissionsMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_administration: Option<InstallationPermissionsOrganizationAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_events: Option<InstallationPermissionsOrganizationEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_hooks: Option<InstallationPermissionsOrganizationHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_packages: Option<InstallationPermissionsOrganizationPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_plan: Option<InstallationPermissionsOrganizationPlan>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_projects: Option<InstallationPermissionsOrganizationProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_secrets: Option<InstallationPermissionsOrganizationSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_self_hosted_runners:
+        Option<InstallationPermissionsOrganizationSelfHostedRunners>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_user_blocking: Option<InstallationPermissionsOrganizationUserBlocking>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packages: Option<InstallationPermissionsPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pages: Option<InstallationPermissionsPages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_requests: Option<InstallationPermissionsPullRequests>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_hooks: Option<InstallationPermissionsRepositoryHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_projects: Option<InstallationPermissionsRepositoryProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_scanning_alerts: Option<InstallationPermissionsSecretScanningAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<InstallationPermissionsSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_events: Option<InstallationPermissionsSecurityEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_scanning_alert: Option<InstallationPermissionsSecurityScanningAlert>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub single_file: Option<InstallationPermissionsSingleFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub statuses: Option<InstallationPermissionsStatuses>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_discussions: Option<InstallationPermissionsTeamDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerability_alerts: Option<InstallationPermissionsVulnerabilityAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflows: Option<InstallationPermissionsWorkflows>,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsActions {
@@ -11110,298 +7420,17 @@ impl std::str::FromStr for InstallationPermissionsWorkflows {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct InstallationPermissions {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub actions: Option<InstallationPermissionsActions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub administration: Option<InstallationPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checks: Option<InstallationPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content_references: Option<InstallationPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contents: Option<InstallationPermissionsContents>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deployments: Option<InstallationPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub discussions: Option<InstallationPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub emails: Option<InstallationPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub environments: Option<InstallationPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issues: Option<InstallationPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub members: Option<InstallationPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<InstallationPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_administration: Option<InstallationPermissionsOrganizationAdministration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_events: Option<InstallationPermissionsOrganizationEvents>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_hooks: Option<InstallationPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_packages: Option<InstallationPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_plan: Option<InstallationPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_projects: Option<InstallationPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_secrets: Option<InstallationPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_self_hosted_runners:
-        Option<InstallationPermissionsOrganizationSelfHostedRunners>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub organization_user_blocking: Option<InstallationPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub packages: Option<InstallationPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pages: Option<InstallationPermissionsPages>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pull_requests: Option<InstallationPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository_hooks: Option<InstallationPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository_projects: Option<InstallationPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secret_scanning_alerts: Option<InstallationPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secrets: Option<InstallationPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_events: Option<InstallationPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_scanning_alert: Option<InstallationPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub single_file: Option<InstallationPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub statuses: Option<InstallationPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub team_discussions: Option<InstallationPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vulnerability_alerts: Option<InstallationPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflows: Option<InstallationPermissionsWorkflows>,
-}
-#[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationRepositorySelection {
-    #[serde(rename = "all")]
-    All,
-    #[serde(rename = "selected")]
-    Selected,
-}
-impl ToString for InstallationRepositorySelection {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "all" => Ok(Self::All),
-            "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationTargetType {
-    User,
-    Organization,
-}
-impl ToString for InstallationTargetType {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationTargetType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "User" => Ok(Self::User),
-            "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum InstallationUpdatedAt {
-    Variant0(chrono::DateTime<chrono::offset::Utc>),
-    Variant1(i64),
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for InstallationCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationCreatedRepositoriesItem {
-    pub full_name: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for InstallationDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationDeletedRepositoriesItem {
-    pub full_name: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationNewPermissionsAcceptedAction {
-    #[serde(rename = "new_permissions_accepted")]
-    NewPermissionsAccepted,
-}
-impl ToString for InstallationNewPermissionsAcceptedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::NewPermissionsAccepted => "new_permissions_accepted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "new_permissions_accepted" => Ok(Self::NewPermissionsAccepted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
-    pub full_name: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationSuspendAction {
-    #[serde(rename = "suspend")]
-    Suspend,
-}
-impl ToString for InstallationSuspendAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Suspend => "suspend".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationSuspendAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "suspend" => Ok(Self::Suspend),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationSuspendRepositoriesItem {
-    pub full_name: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum InstallationUnsuspendAction {
-    #[serde(rename = "unsuspend")]
-    Unsuspend,
-}
-impl ToString for InstallationUnsuspendAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unsuspend => "unsuspend".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for InstallationUnsuspendAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unsuspend" => Ok(Self::Unsuspend),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct InstallationUnsuspendRepositoriesItem {
-    pub full_name: String,
-    #[doc = "Unique identifier of the repository"]
-    pub id: i64,
-    #[doc = "The name of the repository."]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Whether the repository is private or public."]
-    pub private: bool,
+pub struct InstallationRepositoriesAdded {
+    pub action: InstallationRepositoriesAddedAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects, which were added to the installation."]
+    pub repositories_added: Vec<InstallationRepositoriesAddedRepositoriesAddedItem>,
+    #[doc = "An array of repository objects, which were removed from the installation."]
+    pub repositories_removed: Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
+    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+    pub repository_selection: InstallationRepositoriesAddedRepositorySelection,
+    pub requester: Option<User>,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationRepositoriesAddedAction {
@@ -11479,6 +7508,50 @@ impl std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum InstallationRepositoriesEvent {
+    #[doc = "installation_repositories added event"]
+    #[serde(rename = "added")]
+    Added {
+        installation: Installation,
+        #[doc = "An array of repository objects, which were added to the installation."]
+        repositories_added: Vec<InstallationRepositoriesAddedRepositoriesAddedItem>,
+        #[doc = "An array of repository objects, which were removed from the installation."]
+        repositories_removed: Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
+        #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+        repository_selection: InstallationRepositoriesAddedRepositorySelection,
+        requester: Option<User>,
+        sender: User,
+    },
+    #[doc = "installation_repositories removed event"]
+    #[serde(rename = "removed")]
+    Removed {
+        installation: Installation,
+        #[doc = "An array of repository objects, which were added to the installation."]
+        repositories_added: Vec<InstallationRepositoriesRemovedRepositoriesAddedItem>,
+        #[doc = "An array of repository objects, which were removed from the installation."]
+        repositories_removed: Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
+        #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+        repository_selection: InstallationRepositoriesRemovedRepositorySelection,
+        requester: Option<User>,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationRepositoriesRemoved {
+    pub action: InstallationRepositoriesRemovedAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects, which were added to the installation."]
+    pub repositories_added: Vec<InstallationRepositoriesRemovedRepositoriesAddedItem>,
+    #[doc = "An array of repository objects, which were removed from the installation."]
+    pub repositories_removed: Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
+    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+    pub repository_selection: InstallationRepositoriesRemovedRepositorySelection,
+    pub requester: Option<User>,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationRepositoriesRemovedAction {
     #[serde(rename = "removed")]
@@ -11550,6 +7623,192 @@ impl std::str::FromStr for InstallationRepositoriesRemovedRepositorySelection {
         }
     }
 }
+#[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationRepositorySelection {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "selected")]
+    Selected,
+}
+impl ToString for InstallationRepositorySelection {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Selected => "selected".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationRepositorySelection {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "all" => Ok(Self::All),
+            "selected" => Ok(Self::Selected),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationSuspend {
+    pub action: InstallationSuspendAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects that the installation can access."]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<InstallationSuspendRepositoriesItem>,
+    #[serde(default)]
+    pub requester: (),
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendAction {
+    #[serde(rename = "suspend")]
+    Suspend,
+}
+impl ToString for InstallationSuspendAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Suspend => "suspend".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "suspend" => Ok(Self::Suspend),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationSuspendRepositoriesItem {
+    pub full_name: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationTargetType {
+    User,
+    Organization,
+}
+impl ToString for InstallationTargetType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationTargetType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationUnsuspend {
+    pub action: InstallationUnsuspendAction,
+    pub installation: Installation,
+    #[doc = "An array of repository objects that the installation can access."]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<InstallationUnsuspendRepositoriesItem>,
+    #[serde(default)]
+    pub requester: (),
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendAction {
+    #[serde(rename = "unsuspend")]
+    Unsuspend,
+}
+impl ToString for InstallationUnsuspendAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unsuspend => "unsuspend".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unsuspend" => Ok(Self::Unsuspend),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationUnsuspendRepositoriesItem {
+    pub full_name: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InstallationUpdatedAt {
+    Variant0(chrono::DateTime<chrono::offset::Utc>),
+    Variant1(i64),
+}
+#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Issue {
+    pub active_lock_reason: Option<IssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuePullRequest>,
+    pub repository_url: String,
+    #[doc = "State of the issue; either 'open' or 'closed'"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssueState>,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssueActiveLockReason {
     #[serde(rename = "resolved")]
@@ -11582,6 +7841,188 @@ impl std::str::FromStr for IssueActiveLockReason {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The [comment](https://docs.github.com/en/rest/reference/issues#comments) itself."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueComment {
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue comment"]
+    pub body: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    #[doc = "Unique identifier of the issue comment"]
+    pub id: i64,
+    pub issue_url: String,
+    pub node_id: String,
+    pub performed_via_github_app: Option<App>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue comment"]
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentCreated {
+    pub action: IssueCommentCreatedAction,
+    pub comment: IssueComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for IssueCommentCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentDeleted {
+    pub action: IssueCommentDeletedAction,
+    pub comment: IssueComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for IssueCommentDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentEdited {
+    pub action: IssueCommentEditedAction,
+    pub changes: IssueCommentEditedChanges,
+    pub comment: IssueComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for IssueCommentEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the comment."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<IssueCommentEditedChangesBody>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentEditedChangesBody {
+    #[doc = "The previous version of the body."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum IssueCommentEvent {
+    #[doc = "issue_comment created event"]
+    #[serde(rename = "created")]
+    Created {
+        comment: IssueComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issue_comment deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        comment: IssueComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issue_comment edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: IssueCommentEditedChanges,
+        comment: IssueComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -11621,81 +8062,22 @@ impl std::str::FromStr for IssueState {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum IssueCommentCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for IssueCommentCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for IssueCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum IssueCommentDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for IssueCommentDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for IssueCommentDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum IssueCommentEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for IssueCommentEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for IssueCommentEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
+#[doc = "Activity related to an issue. The type of activity is specified in the action property."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct IssueCommentEditedChangesBody {
-    #[doc = "The previous version of the body."]
-    pub from: String,
-}
-#[doc = "The changes to the comment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct IssueCommentEditedChanges {
+pub struct IssuesAssigned {
+    #[doc = "The action that was performed."]
+    pub action: IssuesAssignedAction,
+    #[doc = "The optional user who was assigned or unassigned from the issue."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<IssueCommentEditedChangesBody>,
+    pub assignee: Option<User>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[doc = "The action that was performed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11719,6 +8101,20 @@ impl std::str::FromStr for IssuesAssignedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesClosed {
+    #[doc = "The action that was performed."]
+    pub action: IssuesClosedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[doc = "The action that was performed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesClosedAction {
@@ -11741,6 +8137,18 @@ impl std::str::FromStr for IssuesClosedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesDeleted {
+    pub action: IssuesDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesDeletedAction {
     #[serde(rename = "deleted")]
@@ -11761,6 +8169,19 @@ impl std::str::FromStr for IssuesDeletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesDemilestoned {
+    pub action: IssuesDemilestonedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesDemilestonedAction {
@@ -11783,6 +8204,21 @@ impl std::str::FromStr for IssuesDemilestonedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesEdited {
+    pub action: IssuesEditedAction,
+    pub changes: IssuesEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<Label>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesEditedAction {
     #[serde(rename = "edited")]
@@ -11804,6 +8240,15 @@ impl std::str::FromStr for IssuesEditedAction {
         }
     }
 }
+#[doc = "The changes to the issue."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<IssuesEditedChangesBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<IssuesEditedChangesTitle>,
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChangesBody {
@@ -11816,14 +8261,221 @@ pub struct IssuesEditedChangesTitle {
     #[doc = "The previous version of the title."]
     pub from: String,
 }
-#[doc = "The changes to the issue."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum IssuesEvent {
+    #[doc = "issues assigned event\n\nActivity related to an issue. The type of activity is specified in the action property."]
+    #[serde(rename = "assigned")]
+    Assigned {
+        #[doc = "The optional user who was assigned or unassigned from the issue."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        assignee: Option<User>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues closed event"]
+    #[serde(rename = "closed")]
+    Closed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues demilestoned event"]
+    #[serde(rename = "demilestoned")]
+    Demilestoned {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: IssuesEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<Label>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues labeled event"]
+    #[serde(rename = "labeled")]
+    Labeled {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[doc = "The label that was added to the issue."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<Label>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues locked event"]
+    #[serde(rename = "locked")]
+    Locked {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues milestoned event"]
+    #[serde(rename = "milestoned")]
+    Milestoned {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues opened event"]
+    #[serde(rename = "opened")]
+    Opened {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        changes: Option<IssuesOpenedChanges>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues pinned event"]
+    #[serde(rename = "pinned")]
+    Pinned {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues reopened event"]
+    #[serde(rename = "reopened")]
+    Reopened {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues transferred event"]
+    #[serde(rename = "transferred")]
+    Transferred {
+        changes: IssuesTransferredChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues unassigned event"]
+    #[serde(rename = "unassigned")]
+    Unassigned {
+        #[doc = "The optional user who was assigned or unassigned from the issue."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        assignee: Option<User>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues unlabeled event"]
+    #[serde(rename = "unlabeled")]
+    Unlabeled {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[doc = "The label that was removed from the issue."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<Label>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues unlocked event"]
+    #[serde(rename = "unlocked")]
+    Unlocked {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "issues unpinned event"]
+    #[serde(rename = "unpinned")]
+    Unpinned {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        issue: Issue,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct IssuesEditedChanges {
+pub struct IssuesLabeled {
+    pub action: IssuesLabeledAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<IssuesEditedChangesBody>,
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[doc = "The label that was added to the issue."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<IssuesEditedChangesTitle>,
+    pub label: Option<Label>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesLabeledAction {
@@ -11846,6 +8498,18 @@ impl std::str::FromStr for IssuesLabeledAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesLocked {
+    pub action: IssuesLockedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesLockedAction {
     #[serde(rename = "locked")]
@@ -11867,6 +8531,19 @@ impl std::str::FromStr for IssuesLockedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesMilestoned {
+    pub action: IssuesMilestonedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesMilestonedAction {
     #[serde(rename = "milestoned")]
@@ -11887,6 +8564,20 @@ impl std::str::FromStr for IssuesMilestonedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesOpened {
+    pub action: IssuesOpenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<IssuesOpenedChanges>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesOpenedAction {
@@ -11915,6 +8606,18 @@ pub struct IssuesOpenedChanges {
     pub old_issue: Issue,
     pub old_repository: Repository,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesPinned {
+    pub action: IssuesPinnedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesPinnedAction {
     #[serde(rename = "pinned")]
@@ -11936,6 +8639,18 @@ impl std::str::FromStr for IssuesPinnedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesReopened {
+    pub action: IssuesReopenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesReopenedAction {
     #[serde(rename = "reopened")]
@@ -11956,6 +8671,19 @@ impl std::str::FromStr for IssuesReopenedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesTransferred {
+    pub action: IssuesTransferredAction,
+    pub changes: IssuesTransferredChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesTransferredAction {
@@ -11984,6 +8712,22 @@ pub struct IssuesTransferredChanges {
     pub new_issue: Issue,
     pub new_repository: Repository,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnassigned {
+    #[doc = "The action that was performed."]
+    pub action: IssuesUnassignedAction,
+    #[doc = "The optional user who was assigned or unassigned from the issue."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[doc = "The action that was performed."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesUnassignedAction {
@@ -12006,6 +8750,21 @@ impl std::str::FromStr for IssuesUnassignedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnlabeled {
+    pub action: IssuesUnlabeledAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[doc = "The label that was removed from the issue."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<Label>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesUnlabeledAction {
     #[serde(rename = "unlabeled")]
@@ -12026,6 +8785,18 @@ impl std::str::FromStr for IssuesUnlabeledAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnlocked {
+    pub action: IssuesUnlockedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesUnlockedAction {
@@ -12048,6 +8819,18 @@ impl std::str::FromStr for IssuesUnlockedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnpinned {
+    pub action: IssuesUnpinnedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub issue: Issue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IssuesUnpinnedAction {
     #[serde(rename = "unpinned")]
@@ -12068,6 +8851,33 @@ impl std::str::FromStr for IssuesUnpinnedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Label {
+    #[doc = "6-character hex code, without the leading #, identifying the color"]
+    pub color: String,
+    pub default: bool,
+    pub description: Option<String>,
+    pub id: i64,
+    #[doc = "The name of the label."]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "URL for the label"]
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabelCreated {
+    pub action: LabelCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The label that was added."]
+    pub label: Label,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LabelCreatedAction {
@@ -12090,6 +8900,19 @@ impl std::str::FromStr for LabelCreatedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabelDeleted {
+    pub action: LabelDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The label that was removed."]
+    pub label: Label,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LabelDeletedAction {
     #[serde(rename = "deleted")]
@@ -12110,6 +8933,21 @@ impl std::str::FromStr for LabelDeletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabelEdited {
+    pub action: LabelEditedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<LabelEditedChanges>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The label that was edited."]
+    pub label: Label,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LabelEditedAction {
@@ -12132,6 +8970,17 @@ impl std::str::FromStr for LabelEditedAction {
         }
     }
 }
+#[doc = "The changes to the label if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabelEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<LabelEditedChangesColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<LabelEditedChangesDescription>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<LabelEditedChangesName>,
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesColor {
@@ -12150,16 +8999,73 @@ pub struct LabelEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: String,
 }
-#[doc = "The changes to the label if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum LabelEvent {
+    #[doc = "label created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The label that was added."]
+        label: Label,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "label deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The label that was removed."]
+        label: Label,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "label edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        changes: Option<LabelEditedChanges>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The label that was edited."]
+        label: Label,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct LabelEditedChanges {
+pub struct License {
+    pub key: String,
+    pub name: String,
+    pub node_id: String,
+    pub spdx_id: String,
+    pub url: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Link {
+    pub href: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchase {
+    pub account: MarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub color: Option<LabelEditedChangesColor>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<LabelEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<LabelEditedChangesName>,
+    pub next_billing_date: Option<String>,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchasePlan,
+    pub unit_count: i64,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -12173,16 +9079,13 @@ pub struct MarketplacePurchaseAccount {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MarketplacePurchasePlan {
-    pub bullets: Vec<String>,
-    pub description: String,
-    pub has_free_trial: bool,
-    pub id: i64,
-    pub monthly_price_in_cents: i64,
-    pub name: String,
-    pub price_model: String,
-    pub unit_name: Option<String>,
-    pub yearly_price_in_cents: i64,
+pub struct MarketplacePurchaseCancelled {
+    pub action: MarketplacePurchaseCancelledAction,
+    pub effective_date: String,
+    pub marketplace_purchase: MarketplacePurchase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
+    pub sender: MarketplacePurchaseCancelledSender,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MarketplacePurchaseCancelledAction {
@@ -12228,6 +9131,16 @@ pub struct MarketplacePurchaseCancelledSender {
     pub type_: String,
     pub url: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseChanged {
+    pub action: MarketplacePurchaseChangedAction,
+    pub effective_date: String,
+    pub marketplace_purchase: MarketplacePurchase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
+    pub sender: MarketplacePurchaseChangedSender,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MarketplacePurchaseChangedAction {
     #[serde(rename = "changed")]
@@ -12272,6 +9185,65 @@ pub struct MarketplacePurchaseChangedSender {
     pub type_: String,
     pub url: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum MarketplacePurchaseEvent {
+    #[doc = "marketplace_purchase cancelled event"]
+    #[serde(rename = "cancelled")]
+    Cancelled {
+        effective_date: String,
+        marketplace_purchase: MarketplacePurchase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_marketplace_purchase: Option<MarketplacePurchase>,
+        sender: MarketplacePurchaseCancelledSender,
+    },
+    #[doc = "marketplace_purchase changed event"]
+    #[serde(rename = "changed")]
+    Changed {
+        effective_date: String,
+        marketplace_purchase: MarketplacePurchase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_marketplace_purchase: Option<MarketplacePurchase>,
+        sender: MarketplacePurchaseChangedSender,
+    },
+    #[doc = "marketplace_purchase pending_change event"]
+    #[serde(rename = "pending_change")]
+    PendingChange {
+        effective_date: String,
+        marketplace_purchase: MarketplacePurchase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_marketplace_purchase: Option<MarketplacePurchase>,
+        sender: MarketplacePurchasePendingChangeSender,
+    },
+    #[doc = "marketplace_purchase pending_change_cancelled event"]
+    #[serde(rename = "pending_change_cancelled")]
+    PendingChangeCancelled {
+        effective_date: String,
+        marketplace_purchase: MarketplacePurchase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_marketplace_purchase: Option<MarketplacePurchase>,
+        sender: MarketplacePurchasePendingChangeCancelledSender,
+    },
+    #[doc = "marketplace_purchase purchased event"]
+    #[serde(rename = "purchased")]
+    Purchased {
+        effective_date: String,
+        marketplace_purchase: MarketplacePurchase,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_marketplace_purchase: Option<MarketplacePurchase>,
+        sender: MarketplacePurchasePurchasedSender,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChange {
+    pub action: MarketplacePurchasePendingChangeAction,
+    pub effective_date: String,
+    pub marketplace_purchase: MarketplacePurchase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
+    pub sender: MarketplacePurchasePendingChangeSender,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MarketplacePurchasePendingChangeAction {
     #[serde(rename = "pending_change")]
@@ -12295,26 +9267,13 @@ impl std::str::FromStr for MarketplacePurchasePendingChangeAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MarketplacePurchasePendingChangeSender {
-    pub avatar_url: String,
-    pub email: String,
-    pub events_url: String,
-    pub followers_url: String,
-    pub following_url: String,
-    pub gists_url: String,
-    pub gravatar_id: String,
-    pub html_url: String,
-    pub id: i64,
-    pub login: String,
-    pub organizations_url: String,
-    pub received_events_url: String,
-    pub repos_url: String,
-    pub site_admin: bool,
-    pub starred_url: String,
-    pub subscriptions_url: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub url: String,
+pub struct MarketplacePurchasePendingChangeCancelled {
+    pub action: MarketplacePurchasePendingChangeCancelledAction,
+    pub effective_date: String,
+    pub marketplace_purchase: MarketplacePurchase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
+    pub sender: MarketplacePurchasePendingChangeCancelledSender,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MarketplacePurchasePendingChangeCancelledAction {
@@ -12360,6 +9319,52 @@ pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub type_: String,
     pub url: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeSender {
+    pub avatar_url: String,
+    pub email: String,
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePurchased {
+    pub action: MarketplacePurchasePurchasedAction,
+    pub effective_date: String,
+    pub marketplace_purchase: MarketplacePurchase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_marketplace_purchase: Option<MarketplacePurchase>,
+    pub sender: MarketplacePurchasePurchasedSender,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MarketplacePurchasePurchasedAction {
     #[serde(rename = "purchased")]
@@ -12404,6 +9409,20 @@ pub struct MarketplacePurchasePurchasedSender {
     pub type_: String,
     pub url: String,
 }
+#[doc = "Activity related to repository collaborators. The type of activity is specified in the action property."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemberAdded {
+    pub action: MemberAddedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes: Option<MemberAddedChanges>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The user that was added."]
+    pub member: User,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MemberAddedAction {
     #[serde(rename = "added")]
@@ -12424,6 +9443,17 @@ impl std::str::FromStr for MemberAddedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemberAddedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<MemberAddedChangesPermission>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemberAddedChangesPermission {
+    pub to: MemberAddedChangesPermissionTo,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MemberAddedChangesPermissionTo {
@@ -12452,14 +9482,15 @@ impl std::str::FromStr for MemberAddedChangesPermissionTo {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MemberAddedChangesPermission {
-    pub to: MemberAddedChangesPermissionTo,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MemberAddedChanges {
+pub struct MemberEdited {
+    pub action: MemberEditedAction,
+    pub changes: MemberEditedChanges,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub permission: Option<MemberAddedChangesPermission>,
+    pub installation: Option<InstallationLite>,
+    #[doc = "The user who's permissions are changed."]
+    pub member: User,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MemberEditedAction {
@@ -12482,17 +9513,65 @@ impl std::str::FromStr for MemberEditedAction {
         }
     }
 }
+#[doc = "The changes to the collaborator permissions"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemberEditedChanges {
+    pub old_permission: MemberEditedChangesOldPermission,
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEditedChangesOldPermission {
     #[doc = "The previous permissions of the collaborator if the action was edited."]
     pub from: String,
 }
-#[doc = "The changes to the collaborator permissions"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum MemberEvent {
+    #[doc = "member added event\n\nActivity related to repository collaborators. The type of activity is specified in the action property."]
+    #[serde(rename = "added")]
+    Added {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        changes: Option<MemberAddedChanges>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The user that was added."]
+        member: User,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "member edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: MemberEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The user who's permissions are changed."]
+        member: User,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "member removed event"]
+    #[serde(rename = "removed")]
+    Removed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The user that was removed."]
+        member: User,
+        repository: Repository,
+        sender: User,
+    },
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MemberEditedChanges {
-    pub old_permission: MemberEditedChangesOldPermission,
+pub struct MemberRemoved {
+    pub action: MemberRemovedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The user that was removed."]
+    pub member: User,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MemberRemovedAction {
@@ -12514,6 +9593,31 @@ impl std::str::FromStr for MemberRemovedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The membership between the user and the organization. Not present when the action is `member_invited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Membership {
+    pub organization_url: String,
+    pub role: String,
+    pub state: String,
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MembershipAdded {
+    pub action: MembershipAddedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
+    pub member: User,
+    pub organization: Organization,
+    #[doc = "The scope of the membership. Currently, can only be `team`."]
+    pub scope: MembershipAddedScope,
+    pub sender: User,
+    #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
+    pub team: Team,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MembershipAddedAction {
@@ -12557,6 +9661,53 @@ impl std::str::FromStr for MembershipAddedScope {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum MembershipEvent {
+    #[doc = "membership added event"]
+    #[serde(rename = "added")]
+    Added {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
+        member: User,
+        organization: Organization,
+        #[doc = "The scope of the membership. Currently, can only be `team`."]
+        scope: MembershipAddedScope,
+        sender: User,
+        #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
+        team: Team,
+    },
+    #[doc = "membership removed event"]
+    #[serde(rename = "removed")]
+    Removed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
+        member: User,
+        organization: Organization,
+        #[doc = "The scope of the membership. Currently, can only be `team`."]
+        scope: MembershipRemovedScope,
+        sender: User,
+        #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
+        team: MembershipRemovedTeam,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MembershipRemoved {
+    pub action: MembershipRemovedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
+    pub member: User,
+    pub organization: Organization,
+    #[doc = "The scope of the membership. Currently, can only be `team`."]
+    pub scope: MembershipRemovedScope,
+    pub sender: User,
+    #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
+    pub team: MembershipRemovedTeam,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MembershipRemovedAction {
@@ -12617,6 +9768,16 @@ pub enum MembershipRemovedTeam {
         name: String,
     },
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetaDeleted {
+    pub action: MetaDeletedAction,
+    pub hook: MetaDeletedHook,
+    #[doc = "The id of the modified webhook."]
+    pub hook_id: i64,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MetaDeletedAction {
     #[serde(rename = "deleted")]
@@ -12637,6 +9798,27 @@ impl std::str::FromStr for MetaDeletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The modified webhook. This will contain different keys based on the type of webhook it is: repository, organization, business, app, or GitHub Marketplace."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetaDeletedHook {
+    pub active: bool,
+    pub config: MetaDeletedHookConfig,
+    pub created_at: String,
+    pub events: WebhookEvents,
+    pub id: i64,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub updated_at: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetaDeletedHookConfig {
+    pub content_type: MetaDeletedHookConfigContentType,
+    pub insecure_ssl: String,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MetaDeletedHookConfigContentType {
@@ -12664,25 +9846,296 @@ impl std::str::FromStr for MetaDeletedHookConfigContentType {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MetaDeletedHookConfig {
-    pub content_type: MetaDeletedHookConfigContentType,
-    pub insecure_ssl: String,
-    pub url: String,
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum MetaEvent {
+    #[doc = "meta deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        hook: MetaDeletedHook,
+        #[doc = "The id of the modified webhook."]
+        hook_id: i64,
+        repository: Repository,
+        sender: User,
+    },
 }
-#[doc = "The modified webhook. This will contain different keys based on the type of webhook it is: repository, organization, business, app, or GitHub Marketplace."]
+#[doc = "A collection of related issues and pull requests."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MetaDeletedHook {
-    pub active: bool,
-    pub config: MetaDeletedHookConfig,
-    pub created_at: String,
-    pub events: WebhookEvents,
+pub struct Milestone {
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub closed_issues: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    pub description: Option<String>,
+    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub html_url: String,
     pub id: i64,
-    pub name: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub updated_at: String,
+    pub labels_url: String,
+    pub node_id: String,
+    #[doc = "The number of the milestone."]
+    pub number: i64,
+    pub open_issues: i64,
+    #[doc = "The state of the milestone."]
+    pub state: MilestoneState,
+    #[doc = "The title of the milestone."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneClosed {
+    pub action: MilestoneClosedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneClosedAction {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl ToString for MilestoneClosedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneClosedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneCreated {
+    pub action: MilestoneCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for MilestoneCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneDeleted {
+    pub action: MilestoneDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for MilestoneDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneEdited {
+    pub action: MilestoneEditedAction,
+    pub changes: MilestoneEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for MilestoneEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the milestone if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<MilestoneEditedChangesDescription>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub due_on: Option<MilestoneEditedChangesDueOn>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<MilestoneEditedChangesTitle>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneEditedChangesDescription {
+    #[doc = "The previous version of the description if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneEditedChangesDueOn {
+    #[doc = "The previous version of the due date if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneEditedChangesTitle {
+    #[doc = "The previous version of the title if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum MilestoneEvent {
+    #[doc = "milestone closed event"]
+    #[serde(rename = "closed")]
+    Closed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "milestone created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "milestone deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "milestone edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: MilestoneEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "milestone opened event"]
+    #[serde(rename = "opened")]
+    Opened {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        milestone: Milestone,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneOpened {
+    pub action: MilestoneOpenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub milestone: Milestone,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneOpenedAction {
+    #[serde(rename = "opened")]
+    Opened,
+}
+impl ToString for MilestoneOpenedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Opened => "opened".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneOpenedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "opened" => Ok(Self::Opened),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[doc = "The state of the milestone."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12710,139 +10163,16 @@ impl std::str::FromStr for MilestoneState {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MilestoneClosedAction {
-    #[serde(rename = "closed")]
-    Closed,
-}
-impl ToString for MilestoneClosedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Closed => "closed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for MilestoneClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MilestoneCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for MilestoneCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for MilestoneCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MilestoneDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for MilestoneDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for MilestoneDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MilestoneEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for MilestoneEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for MilestoneEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MilestoneEditedChangesDescription {
-    #[doc = "The previous version of the description if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneEditedChangesDueOn {
-    #[doc = "The previous version of the due date if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneEditedChangesTitle {
-    #[doc = "The previous version of the title if the action was `edited`."]
-    pub from: String,
-}
-#[doc = "The changes to the milestone if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct MilestoneEditedChanges {
+pub struct OrgBlockBlocked {
+    pub action: OrgBlockBlockedAction,
+    #[doc = "Information about the user that was blocked or unblocked."]
+    pub blocked_user: User,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<MilestoneEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub due_on: Option<MilestoneEditedChangesDueOn>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<MilestoneEditedChangesTitle>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MilestoneOpenedAction {
-    #[serde(rename = "opened")]
-    Opened,
-}
-impl ToString for MilestoneOpenedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Opened => "opened".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for MilestoneOpenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "opened" => Ok(Self::Opened),
-            _ => Err("invalid value"),
-        }
-    }
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrgBlockBlockedAction {
@@ -12865,6 +10195,41 @@ impl std::str::FromStr for OrgBlockBlockedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum OrgBlockEvent {
+    #[doc = "org_block blocked event"]
+    #[serde(rename = "blocked")]
+    Blocked {
+        #[doc = "Information about the user that was blocked or unblocked."]
+        blocked_user: User,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        sender: User,
+    },
+    #[doc = "org_block unblocked event"]
+    #[serde(rename = "unblocked")]
+    Unblocked {
+        #[doc = "Information about the user that was blocked or unblocked."]
+        blocked_user: User,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrgBlockUnblocked {
+    pub action: OrgBlockUnblockedAction,
+    #[doc = "Information about the user that was blocked or unblocked."]
+    pub blocked_user: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrgBlockUnblockedAction {
     #[serde(rename = "unblocked")]
@@ -12885,6 +10250,34 @@ impl std::str::FromStr for OrgBlockUnblockedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Organization {
+    pub avatar_url: String,
+    pub description: Option<String>,
+    pub events_url: String,
+    pub hooks_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    pub id: i64,
+    pub issues_url: String,
+    pub login: String,
+    pub members_url: String,
+    pub node_id: String,
+    pub public_members_url: String,
+    pub repos_url: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationDeleted {
+    pub action: OrganizationDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub membership: Membership,
+    pub organization: Organization,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrganizationDeletedAction {
@@ -12907,6 +10300,66 @@ impl std::str::FromStr for OrganizationDeletedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum OrganizationEvent {
+    #[doc = "organization deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        membership: Membership,
+        organization: Organization,
+        sender: User,
+    },
+    #[doc = "organization member_added event"]
+    #[serde(rename = "member_added")]
+    MemberAdded {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        membership: Membership,
+        organization: Organization,
+        sender: User,
+    },
+    #[doc = "organization member_invited event"]
+    #[serde(rename = "member_invited")]
+    MemberInvited {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        invitation: OrganizationMemberInvitedInvitation,
+        organization: Organization,
+        sender: User,
+        user: User,
+    },
+    #[doc = "organization member_removed event"]
+    #[serde(rename = "member_removed")]
+    MemberRemoved {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        membership: Membership,
+        organization: Organization,
+        sender: User,
+    },
+    #[doc = "organization renamed event"]
+    #[serde(rename = "renamed")]
+    Renamed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        membership: Membership,
+        organization: Organization,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationMemberAdded {
+    pub action: OrganizationMemberAddedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub membership: Membership,
+    pub organization: Organization,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrganizationMemberAddedAction {
     #[serde(rename = "member_added")]
@@ -12927,6 +10380,17 @@ impl std::str::FromStr for OrganizationMemberAddedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationMemberInvited {
+    pub action: OrganizationMemberInvitedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub invitation: OrganizationMemberInvitedInvitation,
+    pub organization: Organization,
+    pub sender: User,
+    pub user: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrganizationMemberInvitedAction {
@@ -12965,6 +10429,16 @@ pub struct OrganizationMemberInvitedInvitation {
     pub role: String,
     pub team_count: f64,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationMemberRemoved {
+    pub action: OrganizationMemberRemovedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub membership: Membership,
+    pub organization: Organization,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrganizationMemberRemovedAction {
     #[serde(rename = "member_removed")]
@@ -12985,6 +10459,16 @@ impl std::str::FromStr for OrganizationMemberRemovedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationRenamed {
+    pub action: OrganizationRenamedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub membership: Membership,
+    pub organization: Organization,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OrganizationRenamedAction {
@@ -13007,6 +10491,38 @@ impl std::str::FromStr for OrganizationRenamedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum PackageEvent {
+    #[doc = "package published event"]
+    #[serde(rename = "published")]
+    Published {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        package: PackagePublishedPackage,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "package updated event"]
+    #[serde(rename = "updated")]
+    Updated {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        package: PackageUpdatedPackage,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackagePublished {
+    pub action: PackagePublishedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub package: PackagePublishedPackage,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PackagePublishedAction {
     #[serde(rename = "published")]
@@ -13027,6 +10543,50 @@ impl std::str::FromStr for PackagePublishedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "Information about the package."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackagePublishedPackage {
+    pub created_at: String,
+    pub description: Option<String>,
+    pub ecosystem: String,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub namespace: String,
+    pub owner: User,
+    pub package_type: String,
+    pub package_version: PackagePublishedPackagePackageVersion,
+    pub registry: PackagePublishedPackageRegistry,
+    pub updated_at: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackagePublishedPackagePackageVersion {
+    pub author: User,
+    pub body: String,
+    pub body_html: String,
+    pub created_at: String,
+    pub description: String,
+    pub docker_metadata: Vec<serde_json::Value>,
+    pub draft: bool,
+    pub html_url: String,
+    pub id: i64,
+    pub installation_command: String,
+    pub manifest: String,
+    pub metadata: Vec<serde_json::Value>,
+    pub name: String,
+    pub package_files: Vec<PackagePublishedPackagePackageVersionPackageFilesItem>,
+    pub prerelease: bool,
+    pub release: PackagePublishedPackagePackageVersionRelease,
+    pub source_url: String,
+    pub summary: String,
+    pub tag_name: String,
+    pub target_commitish: String,
+    pub target_oid: String,
+    pub updated_at: String,
+    pub version: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -13060,33 +10620,6 @@ pub struct PackagePublishedPackagePackageVersionRelease {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PackagePublishedPackagePackageVersion {
-    pub author: User,
-    pub body: String,
-    pub body_html: String,
-    pub created_at: String,
-    pub description: String,
-    pub docker_metadata: Vec<serde_json::Value>,
-    pub draft: bool,
-    pub html_url: String,
-    pub id: i64,
-    pub installation_command: String,
-    pub manifest: String,
-    pub metadata: Vec<serde_json::Value>,
-    pub name: String,
-    pub package_files: Vec<PackagePublishedPackagePackageVersionPackageFilesItem>,
-    pub prerelease: bool,
-    pub release: PackagePublishedPackagePackageVersionRelease,
-    pub source_url: String,
-    pub summary: String,
-    pub tag_name: String,
-    pub target_commitish: String,
-    pub target_oid: String,
-    pub updated_at: String,
-    pub version: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackageRegistry {
     pub about_url: String,
     pub name: String,
@@ -13095,22 +10628,15 @@ pub struct PackagePublishedPackageRegistry {
     pub url: String,
     pub vendor: String,
 }
-#[doc = "Information about the package."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PackagePublishedPackage {
-    pub created_at: String,
-    pub description: Option<String>,
-    pub ecosystem: String,
-    pub html_url: String,
-    pub id: i64,
-    pub name: String,
-    pub namespace: String,
-    pub owner: User,
-    pub package_type: String,
-    pub package_version: PackagePublishedPackagePackageVersion,
-    pub registry: PackagePublishedPackageRegistry,
-    pub updated_at: String,
+pub struct PackageUpdated {
+    pub action: PackageUpdatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub package: PackageUpdatedPackage,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PackageUpdatedAction {
@@ -13132,6 +10658,50 @@ impl std::str::FromStr for PackageUpdatedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "Information about the package."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageUpdatedPackage {
+    pub created_at: String,
+    pub description: Option<String>,
+    pub ecosystem: String,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub namespace: String,
+    pub owner: User,
+    pub package_type: String,
+    pub package_version: PackageUpdatedPackagePackageVersion,
+    pub registry: PackageUpdatedPackageRegistry,
+    pub updated_at: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageUpdatedPackagePackageVersion {
+    pub author: User,
+    pub body: String,
+    pub body_html: String,
+    pub created_at: String,
+    pub description: String,
+    pub docker_metadata: Vec<serde_json::Value>,
+    pub draft: bool,
+    pub html_url: String,
+    pub id: i64,
+    pub installation_command: String,
+    pub manifest: String,
+    pub metadata: Vec<serde_json::Value>,
+    pub name: String,
+    pub package_files: Vec<PackageUpdatedPackagePackageVersionPackageFilesItem>,
+    pub prerelease: bool,
+    pub release: PackageUpdatedPackagePackageVersionRelease,
+    pub source_url: String,
+    pub summary: String,
+    pub tag_name: String,
+    pub target_commitish: String,
+    pub target_oid: String,
+    pub updated_at: String,
+    pub version: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -13165,33 +10735,6 @@ pub struct PackageUpdatedPackagePackageVersionRelease {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PackageUpdatedPackagePackageVersion {
-    pub author: User,
-    pub body: String,
-    pub body_html: String,
-    pub created_at: String,
-    pub description: String,
-    pub docker_metadata: Vec<serde_json::Value>,
-    pub draft: bool,
-    pub html_url: String,
-    pub id: i64,
-    pub installation_command: String,
-    pub manifest: String,
-    pub metadata: Vec<serde_json::Value>,
-    pub name: String,
-    pub package_files: Vec<PackageUpdatedPackagePackageVersionPackageFilesItem>,
-    pub prerelease: bool,
-    pub release: PackageUpdatedPackagePackageVersionRelease,
-    pub source_url: String,
-    pub summary: String,
-    pub tag_name: String,
-    pub target_commitish: String,
-    pub target_oid: String,
-    pub updated_at: String,
-    pub version: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackageRegistry {
     pub about_url: String,
     pub name: String,
@@ -13200,27 +10743,18 @@ pub struct PackageUpdatedPackageRegistry {
     pub url: String,
     pub vendor: String,
 }
-#[doc = "Information about the package."]
+#[doc = "Page Build"]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PackageUpdatedPackage {
-    pub created_at: String,
-    pub description: Option<String>,
-    pub ecosystem: String,
-    pub html_url: String,
+pub struct PageBuildEvent {
+    pub build: PageBuildEventBuild,
     pub id: i64,
-    pub name: String,
-    pub namespace: String,
-    pub owner: User,
-    pub package_type: String,
-    pub package_version: PackageUpdatedPackagePackageVersion,
-    pub registry: PackageUpdatedPackageRegistry,
-    pub updated_at: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PageBuildEventBuildError {
-    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[doc = "The [List GitHub Pages builds](https://docs.github.com/en/rest/reference/repos#list-github-pages-builds) itself."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13233,6 +10767,57 @@ pub struct PageBuildEventBuild {
     pub pusher: User,
     pub status: String,
     pub updated_at: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PageBuildEventBuildError {
+    pub message: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PingEvent {
+    pub hook: PingEventHook,
+    #[doc = "The ID of the webhook that triggered the ping."]
+    pub hook_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<User>,
+    pub zen: String,
+}
+#[doc = "The [webhook configuration](https://docs.github.com/en/rest/reference/repos#get-a-repository-webhook)."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PingEventHook {
+    pub active: bool,
+    #[doc = "When you register a new GitHub App, GitHub sends a ping event to the **webhook URL** you specified during registration. The event contains the `app_id`, which is required for [authenticating](https://docs.github.com/en/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps) an app."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<i64>,
+    pub config: PingEventHookConfig,
+    pub created_at: String,
+    pub events: WebhookEvents,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_response: Option<PingEventHookLastResponse>,
+    pub name: String,
+    pub ping_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_url: Option<String>,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub updated_at: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PingEventHookConfig {
+    pub content_type: PingEventHookConfigContentType,
+    pub insecure_ssl: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
     pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13262,42 +10847,765 @@ impl std::str::FromStr for PingEventHookConfigContentType {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PingEventHookConfig {
-    pub content_type: PingEventHookConfigContentType,
-    pub insecure_ssl: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secret: Option<String>,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct PingEventHookLastResponse {
     pub code: (),
     pub message: (),
     pub status: String,
 }
-#[doc = "The [webhook configuration](https://docs.github.com/en/rest/reference/repos#get-a-repository-webhook)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PingEventHook {
-    pub active: bool,
-    #[doc = "When you register a new GitHub App, GitHub sends a ping event to the **webhook URL** you specified during registration. The event contains the `app_id`, which is required for [authenticating](https://docs.github.com/en/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps) an app."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<i64>,
-    pub config: PingEventHookConfig,
-    pub created_at: String,
-    pub events: WebhookEvents,
+pub struct Project {
+    #[doc = "Body of the project"]
+    pub body: Option<String>,
+    pub columns_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    pub html_url: String,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_response: Option<PingEventHookLastResponse>,
+    #[doc = "Name of the project"]
     pub name: String,
-    pub ping_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub test_url: Option<String>,
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub updated_at: String,
+    pub node_id: String,
+    pub number: i64,
+    pub owner_url: String,
+    #[doc = "State of the project; either 'open' or 'closed'"]
+    pub state: ProjectState,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCard {
+    #[serde(default)]
+    pub after_id: (),
+    #[doc = "Whether or not the card is archived"]
+    pub archived: bool,
+    pub column_id: i64,
+    pub column_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_url: Option<String>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    #[doc = "The project card's ID"]
+    pub id: i64,
+    pub node_id: String,
+    pub note: Option<String>,
+    pub project_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardConverted {
+    pub action: ProjectCardConvertedAction,
+    pub changes: ProjectCardConvertedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_card: ProjectCard,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCardConvertedAction {
+    #[serde(rename = "converted")]
+    Converted,
+}
+impl ToString for ProjectCardConvertedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Converted => "converted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCardConvertedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "converted" => Ok(Self::Converted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardConvertedChanges {
+    pub note: ProjectCardConvertedChangesNote,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardConvertedChangesNote {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardCreated {
+    pub action: ProjectCardCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_card: ProjectCard,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCardCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for ProjectCardCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCardCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardDeleted {
+    pub action: ProjectCardDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_card: ProjectCard,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCardDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for ProjectCardDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCardDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardEdited {
+    pub action: ProjectCardEditedAction,
+    pub changes: ProjectCardEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_card: ProjectCard,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCardEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for ProjectCardEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCardEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardEditedChanges {
+    pub note: ProjectCardEditedChangesNote,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardEditedChangesNote {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum ProjectCardEvent {
+    #[doc = "project_card converted event"]
+    #[serde(rename = "converted")]
+    Converted {
+        changes: ProjectCardConvertedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_card: ProjectCard,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_card created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_card: ProjectCard,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_card deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_card: ProjectCard,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_card edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: ProjectCardEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_card: ProjectCard,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_card moved event"]
+    #[serde(rename = "moved")]
+    Moved {
+        changes: ProjectCardMovedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_card: ProjectCard,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardMoved {
+    pub action: ProjectCardMovedAction,
+    pub changes: ProjectCardMovedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_card: ProjectCard,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCardMovedAction {
+    #[serde(rename = "moved")]
+    Moved,
+}
+impl ToString for ProjectCardMovedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Moved => "moved".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCardMovedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "moved" => Ok(Self::Moved),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardMovedChanges {
+    pub column_id: ProjectCardMovedChangesColumnId,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardMovedChangesColumnId {
+    pub from: i64,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectClosed {
+    pub action: ProjectClosedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project: Project,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectClosedAction {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl ToString for ProjectClosedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectClosedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumn {
+    pub cards_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The unique identifier of the project column"]
+    pub id: i64,
+    #[doc = "Name of the project column"]
+    pub name: String,
+    pub node_id: String,
+    pub project_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnCreated {
+    pub action: ProjectColumnCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_column: ProjectColumn,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectColumnCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for ProjectColumnCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectColumnCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnDeleted {
+    pub action: ProjectColumnDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_column: ProjectColumn,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectColumnDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for ProjectColumnDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectColumnDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnEdited {
+    pub action: ProjectColumnEditedAction,
+    pub changes: ProjectColumnEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_column: ProjectColumn,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectColumnEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for ProjectColumnEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectColumnEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<ProjectColumnEditedChangesName>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnEditedChangesName {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum ProjectColumnEvent {
+    #[doc = "project_column created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_column: ProjectColumn,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_column deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_column: ProjectColumn,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_column edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: ProjectColumnEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_column: ProjectColumn,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project_column moved event"]
+    #[serde(rename = "moved")]
+    Moved {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project_column: ProjectColumn,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectColumnMoved {
+    pub action: ProjectColumnMovedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project_column: ProjectColumn,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectColumnMovedAction {
+    #[serde(rename = "moved")]
+    Moved,
+}
+impl ToString for ProjectColumnMovedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Moved => "moved".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectColumnMovedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "moved" => Ok(Self::Moved),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCreated {
+    pub action: ProjectCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project: Project,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for ProjectCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectDeleted {
+    pub action: ProjectDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project: Project,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for ProjectDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectEdited {
+    pub action: ProjectEditedAction,
+    pub changes: ProjectEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project: Project,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for ProjectEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the project if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<ProjectEditedChangesBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<ProjectEditedChangesName>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectEditedChangesBody {
+    #[doc = "The previous version of the body if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectEditedChangesName {
+    #[doc = "The changes to the project if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum ProjectEvent {
+    #[doc = "project closed event"]
+    #[serde(rename = "closed")]
+    Closed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project: Project,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project: Project,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project: Project,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: ProjectEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project: Project,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "project reopened event"]
+    #[serde(rename = "reopened")]
+    Reopened {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        project: Project,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectReopened {
+    pub action: ProjectReopenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub project: Project,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ProjectReopenedAction {
+    #[serde(rename = "reopened")]
+    Reopened,
+}
+impl ToString for ProjectReopenedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Reopened => "reopened".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ProjectReopenedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "reopened" => Ok(Self::Reopened),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[doc = "State of the project; either 'open' or 'closed'"]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13325,374 +11633,74 @@ impl std::str::FromStr for ProjectState {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectClosedAction {
-    #[serde(rename = "closed")]
-    Closed,
-}
-impl ToString for ProjectClosedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Closed => "closed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for ProjectCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for ProjectDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for ProjectEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
+#[doc = "When a private repository is made public."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct ProjectEditedChangesBody {
-    #[doc = "The previous version of the body if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectEditedChangesName {
-    #[doc = "The changes to the project if the action was `edited`."]
-    pub from: String,
-}
-#[doc = "The changes to the project if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectEditedChanges {
+pub struct PublicEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<ProjectEditedChangesBody>,
+    pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<ProjectEditedChangesName>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectReopenedAction {
-    #[serde(rename = "reopened")]
-    Reopened,
-}
-impl ToString for ProjectReopenedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Reopened => "reopened".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCardConvertedAction {
-    #[serde(rename = "converted")]
-    Converted,
-}
-impl ToString for ProjectCardConvertedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Converted => "converted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCardConvertedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "converted" => Ok(Self::Converted),
-            _ => Err("invalid value"),
-        }
-    }
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct ProjectCardConvertedChangesNote {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardConvertedChanges {
-    pub note: ProjectCardConvertedChangesNote,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCardCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for ProjectCardCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCardCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCardDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for ProjectCardDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCardDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCardEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for ProjectCardEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCardEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardEditedChangesNote {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardEditedChanges {
-    pub note: ProjectCardEditedChangesNote,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectCardMovedAction {
-    #[serde(rename = "moved")]
-    Moved,
-}
-impl ToString for ProjectCardMovedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Moved => "moved".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectCardMovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "moved" => Ok(Self::Moved),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardMovedChangesColumnId {
-    pub from: i64,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectCardMovedChanges {
-    pub column_id: ProjectCardMovedChangesColumnId,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectColumnCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for ProjectColumnCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectColumnCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectColumnDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for ProjectColumnDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectColumnDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectColumnEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for ProjectColumnEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectColumnEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnEditedChangesName {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ProjectColumnEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<ProjectColumnEditedChangesName>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ProjectColumnMovedAction {
-    #[serde(rename = "moved")]
-    Moved,
-}
-impl ToString for ProjectColumnMovedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Moved => "moved".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ProjectColumnMovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "moved" => Ok(Self::Moved),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestLinks {
-    pub comments: Link,
-    pub commits: Link,
-    pub html: Link,
-    pub issue: Link,
-    pub review_comment: Link,
-    pub review_comments: Link,
-    #[serde(rename = "self")]
-    pub self_: Link,
-    pub statuses: Link,
+pub struct PullRequest {
+    pub active_lock_reason: Option<PullRequestActiveLockReason>,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    #[doc = "Indicates whether or not the pull request is a draft."]
+    pub draft: bool,
+    pub head: PullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: Option<String>,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: Option<bool>,
+    pub merged_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub merged_by: Option<User>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    #[doc = "State of this Pull Request. Either `open` or `closed`."]
+    pub state: PullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestActiveLockReason {
@@ -13729,6 +11737,110 @@ impl std::str::FromStr for PullRequestActiveLockReason {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct PullRequestAssigned {
+    pub action: PullRequestAssignedAction,
+    pub assignee: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestAssignedAction {
+    #[serde(rename = "assigned")]
+    Assigned,
+}
+impl ToString for PullRequestAssignedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Assigned => "assigned".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestAssignedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "assigned" => Ok(Self::Assigned),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestAutoMergeDisabled {
+    pub action: PullRequestAutoMergeDisabledAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestAutoMergeDisabledAction {
+    #[serde(rename = "auto_merge_disabled")]
+    AutoMergeDisabled,
+}
+impl ToString for PullRequestAutoMergeDisabledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::AutoMergeDisabled => "auto_merge_disabled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto_merge_disabled" => Ok(Self::AutoMergeDisabled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestAutoMergeEnabled {
+    pub action: PullRequestAutoMergeEnabledAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestAutoMergeEnabledAction {
+    #[serde(rename = "auto_merge_enabled")]
+    AutoMergeEnabled,
+}
+impl ToString for PullRequestAutoMergeEnabledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::AutoMergeEnabled => "auto_merge_enabled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto_merge_enabled" => Ok(Self::AutoMergeEnabled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PullRequestBase {
     pub label: String,
     #[serde(rename = "ref")]
@@ -13736,6 +11848,154 @@ pub struct PullRequestBase {
     pub repo: Repository,
     pub sha: String,
     pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestClosed {
+    pub action: PullRequestClosedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestClosedAction {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl ToString for PullRequestClosedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestClosedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestConvertedToDraft {
+    pub action: PullRequestConvertedToDraftAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestConvertedToDraftAction {
+    #[serde(rename = "converted_to_draft")]
+    ConvertedToDraft,
+}
+impl ToString for PullRequestConvertedToDraftAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::ConvertedToDraft => "converted_to_draft".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestConvertedToDraftAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "converted_to_draft" => Ok(Self::ConvertedToDraft),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestEdited {
+    pub action: PullRequestEditedAction,
+    pub changes: PullRequestEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for PullRequestEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the comment if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<PullRequestEditedChangesBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<PullRequestEditedChangesTitle>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestEditedChangesBody {
+    #[doc = "The previous version of the body if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestEditedChangesTitle {
+    #[doc = "The previous version of the title if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestEvent {
+    Assigned(PullRequestAssigned),
+    AutoMergeDisabled(PullRequestAutoMergeDisabled),
+    AutoMergeEnabled(PullRequestAutoMergeEnabled),
+    Closed(PullRequestClosed),
+    ConvertedToDraft(PullRequestConvertedToDraft),
+    Edited(PullRequestEdited),
+    Labeled(PullRequestLabeled),
+    Locked(PullRequestLocked),
+    Opened(PullRequestOpened),
+    ReadyForReview(PullRequestReadyForReview),
+    Reopened(PullRequestReopened),
+    ReviewRequestRemoved(PullRequestReviewRequestRemoved),
+    ReviewRequested(PullRequestReviewRequested),
+    Synchronize(PullRequestSynchronize),
+    Unassigned(PullRequestUnassigned),
+    Unlabeled(PullRequestUnlabeled),
+    Unlocked(PullRequestUnlocked),
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -13748,20 +12008,409 @@ pub struct PullRequestHead {
     pub user: User,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestLabeled {
+    pub action: PullRequestLabeledAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub label: Label,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestLabeledAction {
+    #[serde(rename = "labeled")]
+    Labeled,
+}
+impl ToString for PullRequestLabeledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Labeled => "labeled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestLabeledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "labeled" => Ok(Self::Labeled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestLocked {
+    pub action: PullRequestLockedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestLockedAction {
+    #[serde(rename = "locked")]
+    Locked,
+}
+impl ToString for PullRequestLockedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Locked => "locked".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestLockedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "locked" => Ok(Self::Locked),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestOpened {
+    pub action: PullRequestOpenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestOpenedAction {
+    #[serde(rename = "opened")]
+    Opened,
+}
+impl ToString for PullRequestOpenedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Opened => "opened".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestOpenedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "opened" => Ok(Self::Opened),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReadyForReview {
+    pub action: PullRequestReadyForReviewAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReadyForReviewAction {
+    #[serde(rename = "ready_for_review")]
+    ReadyForReview,
+}
+impl ToString for PullRequestReadyForReviewAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::ReadyForReview => "ready_for_review".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReadyForReviewAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ready_for_review" => Ok(Self::ReadyForReview),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReopened {
+    pub action: PullRequestReopenedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReopenedAction {
+    #[serde(rename = "reopened")]
+    Reopened,
+}
+impl ToString for PullRequestReopenedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Reopened => "reopened".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReopenedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "reopened" => Ok(Self::Reopened),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
 }
-#[doc = "State of this Pull Request. Either `open` or `closed`."]
+#[doc = "The [comment](https://docs.github.com/en/rest/reference/pulls#comments) itself."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewComment {
+    pub author_association: AuthorAssociation,
+    #[doc = "The text of the comment."]
+    pub body: String,
+    #[doc = "The SHA of the commit to which the comment applies."]
+    pub commit_id: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The diff of the line that the comment refers to."]
+    pub diff_hunk: String,
+    #[doc = "HTML URL for the pull request review comment."]
+    pub html_url: String,
+    #[doc = "The ID of the pull request review comment."]
+    pub id: i64,
+    #[doc = "The comment ID to reply to."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to_id: Option<i64>,
+    #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
+    pub line: Option<i64>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewCommentLinks,
+    #[doc = "The node ID of the pull request review comment."]
+    pub node_id: String,
+    #[doc = "The SHA of the original commit to which the comment applies."]
+    pub original_commit_id: String,
+    #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
+    pub original_line: i64,
+    #[doc = "The index of the original line in the diff to which the comment applies."]
+    pub original_position: i64,
+    #[doc = "The first line of the range for a multi-line comment."]
+    pub original_start_line: Option<i64>,
+    #[doc = "The relative path of the file to which the comment applies."]
+    pub path: String,
+    #[doc = "The line index in the diff to which the comment applies."]
+    pub position: Option<i64>,
+    #[doc = "The ID of the pull request review to which the comment belongs."]
+    pub pull_request_review_id: i64,
+    #[doc = "URL for the pull request that the review comment belongs to."]
+    pub pull_request_url: String,
+    #[doc = "The side of the first line of the range for a multi-line comment."]
+    pub side: PullRequestReviewCommentSide,
+    #[doc = "The first line of the range for a multi-line comment."]
+    pub start_line: Option<i64>,
+    #[doc = "The side of the first line of the range for a multi-line comment."]
+    pub start_side: Option<PullRequestReviewCommentStartSide>,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the pull request review comment"]
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentCreated {
+    pub action: PullRequestReviewCommentCreatedAction,
+    pub comment: PullRequestReviewComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequestReviewCommentCreatedPullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestState {
+pub enum PullRequestReviewCommentCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for PullRequestReviewCommentCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentCreatedPullRequest {
+    pub active_lock_reason: Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[serde(default)]
+    pub auto_merge: (),
+    pub base: PullRequestReviewCommentCreatedPullRequestBase,
+    pub body: String,
+    pub closed_at: Option<String>,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub created_at: String,
+    pub diff_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
+    pub head: PullRequestReviewCommentCreatedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewCommentCreatedPullRequestLinks,
+    pub locked: bool,
+    pub merge_commit_sha: Option<String>,
+    pub merged_at: Option<String>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    pub patch_url: String,
+    pub requested_reviewers: Vec<PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments_url: String,
+    pub state: PullRequestReviewCommentCreatedPullRequestState,
+    pub statuses_url: String,
+    pub title: String,
+    pub updated_at: String,
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentCreatedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentCreatedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentCreatedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentCreatedPullRequestState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for PullRequestState {
+impl ToString for PullRequestReviewCommentCreatedPullRequestState {
     fn to_string(&self) -> String {
         match *self {
             Self::Open => "open".to_string(),
@@ -13769,7 +12418,7 @@ impl ToString for PullRequestState {
         }
     }
 }
-impl std::str::FromStr for PullRequestState {
+impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
@@ -13778,6 +12427,409 @@ impl std::str::FromStr for PullRequestState {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentDeleted {
+    pub action: PullRequestReviewCommentDeletedAction,
+    pub comment: PullRequestReviewComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequestReviewCommentDeletedPullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for PullRequestReviewCommentDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentDeletedPullRequest {
+    pub active_lock_reason: Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[serde(default)]
+    pub auto_merge: (),
+    pub base: PullRequestReviewCommentDeletedPullRequestBase,
+    pub body: String,
+    pub closed_at: Option<String>,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub created_at: String,
+    pub diff_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
+    pub head: PullRequestReviewCommentDeletedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewCommentDeletedPullRequestLinks,
+    pub locked: bool,
+    pub merge_commit_sha: Option<String>,
+    pub merged_at: Option<String>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    pub patch_url: String,
+    pub requested_reviewers: Vec<PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments_url: String,
+    pub state: PullRequestReviewCommentDeletedPullRequestState,
+    pub statuses_url: String,
+    pub title: String,
+    pub updated_at: String,
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentDeletedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentDeletedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentDeletedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentDeletedPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl ToString for PullRequestReviewCommentDeletedPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEdited {
+    pub action: PullRequestReviewCommentEditedAction,
+    pub changes: PullRequestReviewCommentEditedChanges,
+    pub comment: PullRequestReviewComment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequestReviewCommentEditedPullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for PullRequestReviewCommentEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the comment."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<PullRequestReviewCommentEditedChangesBody>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedChangesBody {
+    #[doc = "The previous version of the body."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedPullRequest {
+    pub active_lock_reason: Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[serde(default)]
+    pub auto_merge: (),
+    pub base: PullRequestReviewCommentEditedPullRequestBase,
+    pub body: String,
+    pub closed_at: Option<String>,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub created_at: String,
+    pub diff_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
+    pub head: PullRequestReviewCommentEditedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewCommentEditedPullRequestLinks,
+    pub locked: bool,
+    pub merge_commit_sha: Option<String>,
+    pub merged_at: Option<String>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    pub patch_url: String,
+    pub requested_reviewers: Vec<PullRequestReviewCommentEditedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments_url: String,
+    pub state: PullRequestReviewCommentEditedPullRequestState,
+    pub statuses_url: String,
+    pub title: String,
+    pub updated_at: String,
+    pub url: String,
+    pub user: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewCommentEditedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewCommentEditedPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl ToString for PullRequestReviewCommentEditedPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum PullRequestReviewCommentEvent {
+    #[doc = "pull_request_review_comment created event"]
+    #[serde(rename = "created")]
+    Created {
+        comment: PullRequestReviewComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequestReviewCommentCreatedPullRequest,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "pull_request_review_comment deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        comment: PullRequestReviewComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequestReviewCommentDeletedPullRequest,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "pull_request_review_comment edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: PullRequestReviewCommentEditedChanges,
+        comment: PullRequestReviewComment,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequestReviewCommentEditedPullRequest,
+        repository: Repository,
+        sender: User,
+    },
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -13839,124 +12891,114 @@ impl std::str::FromStr for PullRequestReviewCommentStartSide {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestAssignedAction {
-    #[serde(rename = "assigned")]
-    Assigned,
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewDismissed {
+    pub action: PullRequestReviewDismissedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: SimplePullRequest,
+    pub repository: Repository,
+    pub review: PullRequestReviewDismissedReview,
+    pub sender: User,
 }
-impl ToString for PullRequestAssignedAction {
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewDismissedAction {
+    #[serde(rename = "dismissed")]
+    Dismissed,
+}
+impl ToString for PullRequestReviewDismissedAction {
     fn to_string(&self) -> String {
         match *self {
-            Self::Assigned => "assigned".to_string(),
+            Self::Dismissed => "dismissed".to_string(),
         }
     }
 }
-impl std::str::FromStr for PullRequestAssignedAction {
+impl std::str::FromStr for PullRequestReviewDismissedAction {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "assigned" => Ok(Self::Assigned),
+            "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestAutoMergeDisabledAction {
-    #[serde(rename = "auto_merge_disabled")]
-    AutoMergeDisabled,
+#[doc = "The review that was affected."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewDismissedReview {
+    pub author_association: AuthorAssociation,
+    #[doc = "The text of the review."]
+    pub body: Option<String>,
+    #[doc = "A commit SHA for the review."]
+    pub commit_id: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the review"]
+    pub id: i64,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewDismissedReviewLinks,
+    pub node_id: String,
+    pub pull_request_url: String,
+    pub state: PullRequestReviewDismissedReviewState,
+    pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
 }
-impl ToString for PullRequestAutoMergeDisabledAction {
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewDismissedReviewLinks {
+    pub html: Link,
+    pub pull_request: Link,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReviewDismissedReviewState {
+    #[serde(rename = "dismissed")]
+    Dismissed,
+}
+impl ToString for PullRequestReviewDismissedReviewState {
     fn to_string(&self) -> String {
         match *self {
-            Self::AutoMergeDisabled => "auto_merge_disabled".to_string(),
+            Self::Dismissed => "dismissed".to_string(),
         }
     }
 }
-impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
+impl std::str::FromStr for PullRequestReviewDismissedReviewState {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "auto_merge_disabled" => Ok(Self::AutoMergeDisabled),
+            "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestAutoMergeEnabledAction {
-    #[serde(rename = "auto_merge_enabled")]
-    AutoMergeEnabled,
-}
-impl ToString for PullRequestAutoMergeEnabledAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::AutoMergeEnabled => "auto_merge_enabled".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "auto_merge_enabled" => Ok(Self::AutoMergeEnabled),
-            _ => Err("invalid value"),
-        }
-    }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewEdited {
+    pub action: PullRequestReviewEditedAction,
+    pub changes: PullRequestReviewEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: SimplePullRequest,
+    pub repository: Repository,
+    pub review: PullRequestReviewEditedReview,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestClosedAction {
-    #[serde(rename = "closed")]
-    Closed,
-}
-impl ToString for PullRequestClosedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Closed => "closed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestConvertedToDraftAction {
-    #[serde(rename = "converted_to_draft")]
-    ConvertedToDraft,
-}
-impl ToString for PullRequestConvertedToDraftAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::ConvertedToDraft => "converted_to_draft".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestConvertedToDraftAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "converted_to_draft" => Ok(Self::ConvertedToDraft),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestEditedAction {
+pub enum PullRequestReviewEditedAction {
     #[serde(rename = "edited")]
     Edited,
 }
-impl ToString for PullRequestEditedAction {
+impl ToString for PullRequestReviewEditedAction {
     fn to_string(&self) -> String {
         match *self {
             Self::Edited => "edited".to_string(),
         }
     }
 }
-impl std::str::FromStr for PullRequestEditedAction {
+impl std::str::FromStr for PullRequestReviewEditedAction {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
@@ -13967,129 +13009,112 @@ impl std::str::FromStr for PullRequestEditedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestEditedChangesBody {
+pub struct PullRequestReviewEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<PullRequestReviewEditedChangesBody>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReviewEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: String,
 }
+#[doc = "The review that was affected."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestEditedChangesTitle {
-    #[doc = "The previous version of the title if the action was `edited`."]
-    pub from: String,
+pub struct PullRequestReviewEditedReview {
+    pub author_association: AuthorAssociation,
+    #[doc = "The text of the review."]
+    pub body: Option<String>,
+    #[doc = "A commit SHA for the review."]
+    pub commit_id: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the review"]
+    pub id: i64,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReviewEditedReviewLinks,
+    pub node_id: String,
+    pub pull_request_url: String,
+    pub state: String,
+    pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
 }
-#[doc = "The changes to the comment if the action was `edited`."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<PullRequestEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<PullRequestEditedChangesTitle>,
+pub struct PullRequestReviewEditedReviewLinks {
+    pub html: Link,
+    pub pull_request: Link,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestLabeledAction {
-    #[serde(rename = "labeled")]
-    Labeled,
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum PullRequestReviewEvent {
+    #[doc = "pull_request_review dismissed event"]
+    #[serde(rename = "dismissed")]
+    Dismissed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: SimplePullRequest,
+        repository: Repository,
+        review: PullRequestReviewDismissedReview,
+        sender: User,
+    },
+    #[doc = "pull_request_review edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: PullRequestReviewEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: SimplePullRequest,
+        repository: Repository,
+        review: PullRequestReviewEditedReview,
+        sender: User,
+    },
+    #[doc = "pull_request_review submitted event"]
+    #[serde(rename = "submitted")]
+    Submitted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: SimplePullRequest,
+        repository: Repository,
+        review: PullRequestReviewSubmittedReview,
+        sender: User,
+    },
 }
-impl ToString for PullRequestLabeledAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Labeled => "labeled".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestLabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "labeled" => Ok(Self::Labeled),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestLockedAction {
-    #[serde(rename = "locked")]
-    Locked,
-}
-impl ToString for PullRequestLockedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Locked => "locked".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestLockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestOpenedAction {
-    #[serde(rename = "opened")]
-    Opened,
-}
-impl ToString for PullRequestOpenedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Opened => "opened".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestOpenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "opened" => Ok(Self::Opened),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReadyForReviewAction {
-    #[serde(rename = "ready_for_review")]
-    ReadyForReview,
-}
-impl ToString for PullRequestReadyForReviewAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::ReadyForReview => "ready_for_review".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReadyForReviewAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "ready_for_review" => Ok(Self::ReadyForReview),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReopenedAction {
-    #[serde(rename = "reopened")]
-    Reopened,
-}
-impl ToString for PullRequestReopenedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Reopened => "reopened".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
-        }
-    }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum PullRequestReviewRequestRemoved {
+    Variant0 {
+        action: PullRequestReviewRequestRemovedVariant0Action,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The pull request number."]
+        number: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequest,
+        repository: Repository,
+        requested_reviewer: User,
+        sender: User,
+    },
+    Variant1 {
+        action: PullRequestReviewRequestRemovedVariant1Action,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The pull request number."]
+        number: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequest,
+        repository: Repository,
+        requested_team: Team,
+        sender: User,
+    },
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewRequestRemovedVariant0Action {
@@ -14133,6 +13158,36 @@ impl std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum PullRequestReviewRequested {
+    Variant0 {
+        action: PullRequestReviewRequestedVariant0Action,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The pull request number."]
+        number: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequest,
+        repository: Repository,
+        requested_reviewer: User,
+        sender: User,
+    },
+    Variant1 {
+        action: PullRequestReviewRequestedVariant1Action,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[doc = "The pull request number."]
+        number: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        pull_request: PullRequest,
+        repository: Repository,
+        requested_team: Team,
+        sender: User,
+    },
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewRequestedVariant0Action {
     #[serde(rename = "review_requested")]
@@ -14175,216 +13230,18 @@ impl std::str::FromStr for PullRequestReviewRequestedVariant1Action {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestSynchronizeAction {
-    #[serde(rename = "synchronize")]
-    Synchronize,
-}
-impl ToString for PullRequestSynchronizeAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Synchronize => "synchronize".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestSynchronizeAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "synchronize" => Ok(Self::Synchronize),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestUnassignedAction {
-    #[serde(rename = "unassigned")]
-    Unassigned,
-}
-impl ToString for PullRequestUnassignedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unassigned => "unassigned".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestUnassignedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unassigned" => Ok(Self::Unassigned),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestUnlabeledAction {
-    #[serde(rename = "unlabeled")]
-    Unlabeled,
-}
-impl ToString for PullRequestUnlabeledAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unlabeled => "unlabeled".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestUnlabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unlabeled" => Ok(Self::Unlabeled),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestUnlockedAction {
-    #[serde(rename = "unlocked")]
-    Unlocked,
-}
-impl ToString for PullRequestUnlockedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unlocked => "unlocked".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestUnlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unlocked" => Ok(Self::Unlocked),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewDismissedAction {
-    #[serde(rename = "dismissed")]
-    Dismissed,
-}
-impl ToString for PullRequestReviewDismissedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Dismissed => "dismissed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewDismissedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
-        }
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestReviewDismissedReviewLinks {
-    pub html: Link,
-    pub pull_request: Link,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewDismissedReviewState {
-    #[serde(rename = "dismissed")]
-    Dismissed,
-}
-impl ToString for PullRequestReviewDismissedReviewState {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Dismissed => "dismissed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewDismissedReviewState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[doc = "The review that was affected."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewDismissedReview {
-    pub author_association: AuthorAssociation,
-    #[doc = "The text of the review."]
-    pub body: Option<String>,
-    #[doc = "A commit SHA for the review."]
-    pub commit_id: String,
-    pub html_url: String,
-    #[doc = "Unique identifier of the review"]
-    pub id: i64,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewDismissedReviewLinks,
-    pub node_id: String,
-    pub pull_request_url: String,
-    pub state: PullRequestReviewDismissedReviewState,
-    pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
-    pub user: User,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for PullRequestReviewEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewEditedChangesBody {
-    #[doc = "The previous version of the body if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewEditedChanges {
+pub struct PullRequestReviewSubmitted {
+    pub action: PullRequestReviewSubmittedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<PullRequestReviewEditedChangesBody>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewEditedReviewLinks {
-    pub html: Link,
-    pub pull_request: Link,
-}
-#[doc = "The review that was affected."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewEditedReview {
-    pub author_association: AuthorAssociation,
-    #[doc = "The text of the review."]
-    pub body: Option<String>,
-    #[doc = "A commit SHA for the review."]
-    pub commit_id: String,
-    pub html_url: String,
-    #[doc = "Unique identifier of the review"]
-    pub id: i64,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewEditedReviewLinks,
-    pub node_id: String,
-    pub pull_request_url: String,
-    pub state: String,
-    pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
-    pub user: User,
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: SimplePullRequest,
+    pub repository: Repository,
+    pub review: PullRequestReviewSubmittedReview,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewSubmittedAction {
@@ -14407,12 +13264,6 @@ impl std::str::FromStr for PullRequestReviewSubmittedAction {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewSubmittedReviewLinks {
-    pub html: Link,
-    pub pull_request: Link,
-}
 #[doc = "The review that was affected."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -14433,107 +13284,21 @@ pub struct PullRequestReviewSubmittedReview {
     pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for PullRequestReviewCommentCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentCreatedPullRequestLinks {
-    pub comments: Link,
-    pub commits: Link,
+pub struct PullRequestReviewSubmittedReviewLinks {
     pub html: Link,
-    pub issue: Link,
-    pub review_comment: Link,
-    pub review_comments: Link,
-    #[serde(rename = "self")]
-    pub self_: Link,
-    pub statuses: Link,
+    pub pull_request: Link,
 }
+#[doc = "State of this Pull Request. Either `open` or `closed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    #[serde(rename = "resolved")]
-    Resolved,
-    #[serde(rename = "off-topic")]
-    OffTopic,
-    #[serde(rename = "too heated")]
-    TooHeated,
-    #[serde(rename = "spam")]
-    Spam,
-}
-impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "resolved" => Ok(Self::Resolved),
-            "off-topic" => Ok(Self::OffTopic),
-            "too heated" => Ok(Self::TooHeated),
-            "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentCreatedPullRequestBase {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentCreatedPullRequestHead {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
-    User(User),
-    Team(Team),
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentCreatedPullRequestState {
+pub enum PullRequestState {
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
     Closed,
 }
-impl ToString for PullRequestReviewCommentCreatedPullRequestState {
+impl ToString for PullRequestState {
     fn to_string(&self) -> String {
         match *self {
             Self::Open => "open".to_string(),
@@ -14541,7 +13306,7 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestState {
         }
     }
 }
-impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
+impl std::str::FromStr for PullRequestState {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
@@ -14553,548 +13318,221 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentCreatedPullRequest {
-    pub active_lock_reason: Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    #[serde(default)]
-    pub auto_merge: (),
-    pub base: PullRequestReviewCommentCreatedPullRequestBase,
-    pub body: String,
-    pub closed_at: Option<String>,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub created_at: String,
-    pub diff_url: String,
+pub struct PullRequestSynchronize {
+    pub action: PullRequestSynchronizeAction,
+    pub after: String,
+    pub before: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub draft: Option<bool>,
-    pub head: PullRequestReviewCommentCreatedPullRequestHead,
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestSynchronizeAction {
+    #[serde(rename = "synchronize")]
+    Synchronize,
+}
+impl ToString for PullRequestSynchronizeAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Synchronize => "synchronize".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestSynchronizeAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "synchronize" => Ok(Self::Synchronize),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestUnassigned {
+    pub action: PullRequestUnassignedAction,
+    pub assignee: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestUnassignedAction {
+    #[serde(rename = "unassigned")]
+    Unassigned,
+}
+impl ToString for PullRequestUnassignedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unassigned => "unassigned".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestUnassignedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unassigned" => Ok(Self::Unassigned),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestUnlabeled {
+    pub action: PullRequestUnlabeledAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub label: Label,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestUnlabeledAction {
+    #[serde(rename = "unlabeled")]
+    Unlabeled,
+}
+impl ToString for PullRequestUnlabeledAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unlabeled => "unlabeled".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestUnlabeledAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unlabeled" => Ok(Self::Unlabeled),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestUnlocked {
+    pub action: PullRequestUnlockedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[doc = "The pull request number."]
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestUnlockedAction {
+    #[serde(rename = "unlocked")]
+    Unlocked,
+}
+impl ToString for PullRequestUnlockedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unlocked => "unlocked".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestUnlockedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unlocked" => Ok(Self::Unlocked),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PushEvent {
+    #[doc = "The SHA of the most recent commit on `ref` after the push."]
+    pub after: String,
+    pub base_ref: Option<String>,
+    #[doc = "The SHA of the most recent commit on `ref` before the push."]
+    pub before: String,
+    #[doc = "An array of commit objects describing the pushed commits."]
+    pub commits: Vec<Commit>,
+    pub compare: String,
+    pub created: bool,
+    pub deleted: bool,
+    pub forced: bool,
+    pub head_commit: Option<Commit>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub pusher: Committer,
+    #[doc = "The full git ref that was pushed. Example: `refs/heads/main`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[doc = "The [release](https://docs.github.com/en/rest/reference/repos/#get-a-release) object."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Release {
+    pub assets: Vec<ReleaseAsset>,
+    pub assets_url: String,
+    pub author: User,
+    pub body: String,
+    pub created_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "Wether the release is a draft or published"]
+    pub draft: bool,
     pub html_url: String,
     pub id: i64,
-    pub issue_url: String,
-    pub labels: Vec<Label>,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewCommentCreatedPullRequestLinks,
-    pub locked: bool,
-    pub merge_commit_sha: Option<String>,
-    pub merged_at: Option<String>,
-    pub milestone: Option<Milestone>,
+    pub name: String,
     pub node_id: String,
-    pub number: i64,
-    pub patch_url: String,
-    pub requested_reviewers: Vec<PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem>,
-    pub requested_teams: Vec<Team>,
-    pub review_comment_url: String,
-    pub review_comments_url: String,
-    pub state: PullRequestReviewCommentCreatedPullRequestState,
-    pub statuses_url: String,
-    pub title: String,
-    pub updated_at: String,
+    #[doc = "Whether the release is identified as a prerelease or a full release."]
+    pub prerelease: bool,
+    pub published_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "The name of the tag."]
+    pub tag_name: String,
+    pub tarball_url: Option<String>,
+    #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
+    pub target_commitish: String,
+    pub upload_url: String,
     pub url: String,
-    pub user: User,
+    pub zipball_url: Option<String>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for PullRequestReviewCommentDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
+#[doc = "Data related to a release."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentDeletedPullRequestLinks {
-    pub comments: Link,
-    pub commits: Link,
-    pub html: Link,
-    pub issue: Link,
-    pub review_comment: Link,
-    pub review_comments: Link,
-    #[serde(rename = "self")]
-    pub self_: Link,
-    pub statuses: Link,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    #[serde(rename = "resolved")]
-    Resolved,
-    #[serde(rename = "off-topic")]
-    OffTopic,
-    #[serde(rename = "too heated")]
-    TooHeated,
-    #[serde(rename = "spam")]
-    Spam,
-}
-impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "resolved" => Ok(Self::Resolved),
-            "off-topic" => Ok(Self::OffTopic),
-            "too heated" => Ok(Self::TooHeated),
-            "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentDeletedPullRequestBase {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentDeletedPullRequestHead {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
-    User(User),
-    Team(Team),
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentDeletedPullRequestState {
-    #[serde(rename = "open")]
-    Open,
-    #[serde(rename = "closed")]
-    Closed,
-}
-impl ToString for PullRequestReviewCommentDeletedPullRequestState {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "open" => Ok(Self::Open),
-            "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentDeletedPullRequest {
-    pub active_lock_reason: Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    #[serde(default)]
-    pub auto_merge: (),
-    pub base: PullRequestReviewCommentDeletedPullRequestBase,
-    pub body: String,
-    pub closed_at: Option<String>,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub created_at: String,
-    pub diff_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub draft: Option<bool>,
-    pub head: PullRequestReviewCommentDeletedPullRequestHead,
-    pub html_url: String,
+pub struct ReleaseAsset {
+    pub browser_download_url: String,
+    pub content_type: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub download_count: i64,
     pub id: i64,
-    pub issue_url: String,
-    pub labels: Vec<Label>,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewCommentDeletedPullRequestLinks,
-    pub locked: bool,
-    pub merge_commit_sha: Option<String>,
-    pub merged_at: Option<String>,
-    pub milestone: Option<Milestone>,
+    pub label: Option<String>,
+    #[doc = "The file name of the asset."]
+    pub name: String,
     pub node_id: String,
-    pub number: i64,
-    pub patch_url: String,
-    pub requested_reviewers: Vec<PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem>,
-    pub requested_teams: Vec<Team>,
-    pub review_comment_url: String,
-    pub review_comments_url: String,
-    pub state: PullRequestReviewCommentDeletedPullRequestState,
-    pub statuses_url: String,
-    pub title: String,
-    pub updated_at: String,
+    pub size: i64,
+    #[doc = "State of the release asset."]
+    pub state: ReleaseAssetState,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uploader: Option<User>,
     pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for PullRequestReviewCommentEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedChangesBody {
-    #[doc = "The previous version of the body."]
-    pub from: String,
-}
-#[doc = "The changes to the comment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<PullRequestReviewCommentEditedChangesBody>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedPullRequestLinks {
-    pub comments: Link,
-    pub commits: Link,
-    pub html: Link,
-    pub issue: Link,
-    pub review_comment: Link,
-    pub review_comments: Link,
-    #[serde(rename = "self")]
-    pub self_: Link,
-    pub statuses: Link,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    #[serde(rename = "resolved")]
-    Resolved,
-    #[serde(rename = "off-topic")]
-    OffTopic,
-    #[serde(rename = "too heated")]
-    TooHeated,
-    #[serde(rename = "spam")]
-    Spam,
-}
-impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "resolved" => Ok(Self::Resolved),
-            "off-topic" => Ok(Self::OffTopic),
-            "too heated" => Ok(Self::TooHeated),
-            "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedPullRequestBase {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedPullRequestHead {
-    pub label: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-    pub repo: Repository,
-    pub sha: String,
-    pub user: User,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
-    User(User),
-    Team(Team),
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PullRequestReviewCommentEditedPullRequestState {
-    #[serde(rename = "open")]
-    Open,
-    #[serde(rename = "closed")]
-    Closed,
-}
-impl ToString for PullRequestReviewCommentEditedPullRequestState {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "open" => Ok(Self::Open),
-            "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PullRequestReviewCommentEditedPullRequest {
-    pub active_lock_reason: Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
-    pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub author_association: AuthorAssociation,
-    #[serde(default)]
-    pub auto_merge: (),
-    pub base: PullRequestReviewCommentEditedPullRequestBase,
-    pub body: String,
-    pub closed_at: Option<String>,
-    pub comments_url: String,
-    pub commits_url: String,
-    pub created_at: String,
-    pub diff_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub draft: Option<bool>,
-    pub head: PullRequestReviewCommentEditedPullRequestHead,
-    pub html_url: String,
-    pub id: i64,
-    pub issue_url: String,
-    pub labels: Vec<Label>,
-    #[serde(rename = "_links")]
-    pub links: PullRequestReviewCommentEditedPullRequestLinks,
-    pub locked: bool,
-    pub merge_commit_sha: Option<String>,
-    pub merged_at: Option<String>,
-    pub milestone: Option<Milestone>,
-    pub node_id: String,
-    pub number: i64,
-    pub patch_url: String,
-    pub requested_reviewers: Vec<PullRequestReviewCommentEditedPullRequestRequestedReviewersItem>,
-    pub requested_teams: Vec<Team>,
-    pub review_comment_url: String,
-    pub review_comments_url: String,
-    pub state: PullRequestReviewCommentEditedPullRequestState,
-    pub statuses_url: String,
-    pub title: String,
-    pub updated_at: String,
-    pub url: String,
-    pub user: User,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleaseCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for ReleaseCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleaseCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleaseDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for ReleaseDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleaseDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleaseEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for ReleaseEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleaseEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseEditedChangesBody {
-    #[doc = "The previous version of the body if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseEditedChangesName {
-    #[doc = "The previous version of the name if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReleaseEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<ReleaseEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<ReleaseEditedChangesName>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleasePrereleasedAction {
-    #[serde(rename = "prereleased")]
-    Prereleased,
-}
-impl ToString for ReleasePrereleasedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Prereleased => "prereleased".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleasePrereleasedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "prereleased" => Ok(Self::Prereleased),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleasePublishedAction {
-    #[serde(rename = "published")]
-    Published,
-}
-impl ToString for ReleasePublishedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Published => "published".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleasePublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "published" => Ok(Self::Published),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleaseReleasedAction {
-    #[serde(rename = "released")]
-    Released,
-}
-impl ToString for ReleaseReleasedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Released => "released".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleaseReleasedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "released" => Ok(Self::Released),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ReleaseUnpublishedAction {
-    #[serde(rename = "unpublished")]
-    Unpublished,
-}
-impl ToString for ReleaseUnpublishedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unpublished => "unpublished".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for ReleaseUnpublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unpublished" => Ok(Self::Unpublished),
-            _ => Err("invalid value"),
-        }
-    }
 }
 #[doc = "State of the release asset."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15119,28 +13557,473 @@ impl std::str::FromStr for ReleaseAssetState {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum RepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(chrono::DateTime<chrono::offset::Utc>),
+#[serde(deny_unknown_fields)]
+pub struct ReleaseCreated {
+    pub action: ReleaseCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleaseCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for ReleaseCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleaseCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct RepositoryPermissions {
-    pub admin: bool,
+pub struct ReleaseDeleted {
+    pub action: ReleaseDeletedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maintain: Option<bool>,
-    pub pull: bool,
-    pub push: bool,
+    pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub triage: Option<bool>,
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleaseDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for ReleaseDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleaseDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum RepositoryPushedAt {
-    Variant0(i64),
-    Variant1(chrono::DateTime<chrono::offset::Utc>),
-    Variant2,
+#[serde(deny_unknown_fields)]
+pub struct ReleaseEdited {
+    pub action: ReleaseEditedAction,
+    pub changes: ReleaseEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleaseEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for ReleaseEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleaseEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<ReleaseEditedChangesBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<ReleaseEditedChangesName>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseEditedChangesBody {
+    #[doc = "The previous version of the body if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseEditedChangesName {
+    #[doc = "The previous version of the name if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum ReleaseEvent {
+    #[doc = "release created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: ReleaseEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release prereleased event"]
+    #[serde(rename = "prereleased")]
+    Prereleased {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release published event"]
+    #[serde(rename = "published")]
+    Published {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release released event"]
+    #[serde(rename = "released")]
+    Released {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "release unpublished event"]
+    #[serde(rename = "unpublished")]
+    Unpublished {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        release: Release,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleasePrereleased {
+    pub action: ReleasePrereleasedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleasePrereleasedAction {
+    #[serde(rename = "prereleased")]
+    Prereleased,
+}
+impl ToString for ReleasePrereleasedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Prereleased => "prereleased".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleasePrereleasedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "prereleased" => Ok(Self::Prereleased),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleasePublished {
+    pub action: ReleasePublishedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleasePublishedAction {
+    #[serde(rename = "published")]
+    Published,
+}
+impl ToString for ReleasePublishedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Published => "published".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleasePublishedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "published" => Ok(Self::Published),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseReleased {
+    pub action: ReleaseReleasedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleaseReleasedAction {
+    #[serde(rename = "released")]
+    Released,
+}
+impl ToString for ReleaseReleasedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Released => "released".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleaseReleasedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "released" => Ok(Self::Released),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseUnpublished {
+    pub action: ReleaseUnpublishedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub release: Release,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ReleaseUnpublishedAction {
+    #[serde(rename = "unpublished")]
+    Unpublished,
+}
+impl ToString for ReleaseUnpublishedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unpublished => "unpublished".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for ReleaseUnpublishedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unpublished" => Ok(Self::Unpublished),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepoRef {
+    pub id: i64,
+    pub name: String,
+    pub url: String,
+}
+#[doc = "A git repository"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Repository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<false>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<false>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<false>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: RepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<RepositoryPermissions>,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: RepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryArchived {
+    pub action: RepositoryArchivedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryArchivedAction {
@@ -15163,6 +14046,17 @@ impl std::str::FromStr for RepositoryArchivedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryCreated {
+    pub action: RepositoryCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryCreatedAction {
     #[serde(rename = "created")]
@@ -15184,6 +14078,23 @@ impl std::str::FromStr for RepositoryCreatedAction {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryDeleted {
+    pub action: RepositoryDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryDeletedAction {
     #[serde(rename = "deleted")]
@@ -15204,6 +14115,66 @@ impl std::str::FromStr for RepositoryDeletedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum RepositoryDispatchEvent {
+    #[doc = "repository_dispatch on-demand-test event"]
+    #[serde(rename = "on-demand-test")]
+    OnDemandTest {
+        branch: String,
+        client_payload: std::collections::HashMap<String, serde_json::Value>,
+        installation: InstallationLite,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryDispatchOnDemandTest {
+    pub action: RepositoryDispatchOnDemandTestAction,
+    pub branch: String,
+    pub client_payload: std::collections::HashMap<String, serde_json::Value>,
+    pub installation: InstallationLite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryDispatchOnDemandTestAction {
+    #[serde(rename = "on-demand-test")]
+    OnDemandTest,
+}
+impl ToString for RepositoryDispatchOnDemandTestAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::OnDemandTest => "on-demand-test".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "on-demand-test" => Ok(Self::OnDemandTest),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryEdited {
+    pub action: RepositoryEditedAction,
+    pub changes: RepositoryEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryEditedAction {
@@ -15228,6 +14199,16 @@ impl std::str::FromStr for RepositoryEditedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct RepositoryEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<RepositoryEditedChangesDefaultBranch>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<RepositoryEditedChangesDescription>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<RepositoryEditedChangesHomepage>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDefaultBranch {
     pub from: String,
 }
@@ -15242,171 +14223,112 @@ pub struct RepositoryEditedChangesHomepage {
     pub from: Option<String>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_branch: Option<RepositoryEditedChangesDefaultBranch>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<RepositoryEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub homepage: Option<RepositoryEditedChangesHomepage>,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryPrivatizedAction {
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum RepositoryEvent {
+    #[doc = "repository archived event"]
+    #[serde(rename = "archived")]
+    Archived {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: RepositoryEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository privatized event"]
     #[serde(rename = "privatized")]
-    Privatized,
-}
-impl ToString for RepositoryPrivatizedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Privatized => "privatized".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryPrivatizedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "privatized" => Ok(Self::Privatized),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryPublicizedAction {
+    Privatized {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository publicized event"]
     #[serde(rename = "publicized")]
-    Publicized,
-}
-impl ToString for RepositoryPublicizedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Publicized => "publicized".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryPublicizedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "publicized" => Ok(Self::Publicized),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryRenamedAction {
+    Publicized {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository renamed event"]
     #[serde(rename = "renamed")]
-    Renamed,
-}
-impl ToString for RepositoryRenamedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Renamed => "renamed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryRenamedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "renamed" => Ok(Self::Renamed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryRenamedChangesRepositoryName {
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryRenamedChangesRepository {
-    pub name: RepositoryRenamedChangesRepositoryName,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryRenamedChanges {
-    pub repository: RepositoryRenamedChangesRepository,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryTransferredAction {
+    Renamed {
+        changes: RepositoryRenamedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository transferred event"]
     #[serde(rename = "transferred")]
-    Transferred,
-}
-impl ToString for RepositoryTransferredAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Transferred => "transferred".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryTransferredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "transferred" => Ok(Self::Transferred),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryTransferredChangesOwnerFrom {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub user: Option<User>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryTransferredChangesOwner {
-    pub from: RepositoryTransferredChangesOwnerFrom,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepositoryTransferredChanges {
-    pub owner: RepositoryTransferredChangesOwner,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryUnarchivedAction {
+    Transferred {
+        changes: RepositoryTransferredChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository unarchived event"]
     #[serde(rename = "unarchived")]
-    Unarchived,
+    Unarchived {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
 }
-impl ToString for RepositoryUnarchivedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Unarchived => "unarchived".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryUnarchivedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "unarchived" => Ok(Self::Unarchived),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RepositoryDispatchOnDemandTestAction {
-    #[serde(rename = "on-demand-test")]
-    OnDemandTest,
-}
-impl ToString for RepositoryDispatchOnDemandTestAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::OnDemandTest => "on-demand-test".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "on-demand-test" => Ok(Self::OnDemandTest),
-            _ => Err("invalid value"),
-        }
-    }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryImportEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub status: RepositoryImportEventStatus,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryImportEventStatus {
@@ -15436,6 +14358,280 @@ impl std::str::FromStr for RepositoryImportEventStatus {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryLite {
+    pub archive_url: String,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub languages_url: String,
+    pub merges_url: String,
+    pub milestones_url: String,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub owner: User,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+    pub pulls_url: String,
+    pub releases_url: String,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPrivatized {
+    pub action: RepositoryPrivatizedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryPrivatizedAction {
+    #[serde(rename = "privatized")]
+    Privatized,
+}
+impl ToString for RepositoryPrivatizedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Privatized => "privatized".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryPrivatizedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "privatized" => Ok(Self::Privatized),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPublicized {
+    pub action: RepositoryPublicizedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryPublicizedAction {
+    #[serde(rename = "publicized")]
+    Publicized,
+}
+impl ToString for RepositoryPublicizedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Publicized => "publicized".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryPublicizedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "publicized" => Ok(Self::Publicized),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRenamed {
+    pub action: RepositoryRenamedAction,
+    pub changes: RepositoryRenamedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryRenamedAction {
+    #[serde(rename = "renamed")]
+    Renamed,
+}
+impl ToString for RepositoryRenamedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Renamed => "renamed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryRenamedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "renamed" => Ok(Self::Renamed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRenamedChanges {
+    pub repository: RepositoryRenamedChangesRepository,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRenamedChangesRepository {
+    pub name: RepositoryRenamedChangesRepositoryName,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRenamedChangesRepositoryName {
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryTransferred {
+    pub action: RepositoryTransferredAction,
+    pub changes: RepositoryTransferredChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryTransferredAction {
+    #[serde(rename = "transferred")]
+    Transferred,
+}
+impl ToString for RepositoryTransferredAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Transferred => "transferred".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryTransferredAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "transferred" => Ok(Self::Transferred),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryTransferredChanges {
+    pub owner: RepositoryTransferredChangesOwner,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryTransferredChangesOwner {
+    pub from: RepositoryTransferredChangesOwnerFrom,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryTransferredChangesOwnerFrom {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryUnarchived {
+    pub action: RepositoryUnarchivedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum RepositoryUnarchivedAction {
+    #[serde(rename = "unarchived")]
+    Unarchived,
+}
+impl ToString for RepositoryUnarchivedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Unarchived => "unarchived".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for RepositoryUnarchivedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unarchived" => Ok(Self::Unarchived),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryVulnerabilityAlertCreate {
+    pub action: RepositoryVulnerabilityAlertCreateAction,
+    pub alert: RepositoryVulnerabilityAlertCreateAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryVulnerabilityAlertCreateAction {
@@ -15481,6 +14677,16 @@ pub struct RepositoryVulnerabilityAlertCreateAlert {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryVulnerabilityAlertDismiss {
+    pub action: RepositoryVulnerabilityAlertDismissAction,
+    pub alert: RepositoryVulnerabilityAlertDismissAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryVulnerabilityAlertDismissAction {
     #[serde(rename = "dismiss")]
@@ -15521,6 +14727,47 @@ pub struct RepositoryVulnerabilityAlertDismissAlert {
     pub id: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum RepositoryVulnerabilityAlertEvent {
+    #[doc = "repository_vulnerability_alert create event"]
+    #[serde(rename = "create")]
+    Create {
+        alert: RepositoryVulnerabilityAlertCreateAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository_vulnerability_alert dismiss event"]
+    #[serde(rename = "dismiss")]
+    Dismiss {
+        alert: RepositoryVulnerabilityAlertDismissAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "repository_vulnerability_alert resolve event"]
+    #[serde(rename = "resolve")]
+    Resolve {
+        alert: RepositoryVulnerabilityAlertResolveAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryVulnerabilityAlertResolve {
+    pub action: RepositoryVulnerabilityAlertResolveAction,
+    pub alert: RepositoryVulnerabilityAlertResolveAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum RepositoryVulnerabilityAlertResolveAction {
@@ -15566,6 +14813,17 @@ pub struct RepositoryVulnerabilityAlertResolveAlert {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretScanningAlertCreated {
+    pub action: SecretScanningAlertCreatedAction,
+    pub alert: SecretScanningAlertCreatedAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecretScanningAlertCreatedAction {
     #[serde(rename = "created")]
@@ -15596,6 +14854,54 @@ pub struct SecretScanningAlertCreatedAlert {
     pub resolved_at: (),
     pub resolved_by: (),
     pub secret_type: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum SecretScanningAlertEvent {
+    #[doc = "secret_scanning_alert created event"]
+    #[serde(rename = "created")]
+    Created {
+        alert: SecretScanningAlertCreatedAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+    },
+    #[doc = "secret_scanning_alert reopened event"]
+    #[serde(rename = "reopened")]
+    Reopened {
+        alert: SecretScanningAlertReopenedAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+    #[doc = "secret_scanning_alert resolved event"]
+    #[serde(rename = "resolved")]
+    Resolved {
+        alert: SecretScanningAlertResolvedAlert,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretScanningAlertReopened {
+    pub action: SecretScanningAlertReopenedAction,
+    pub alert: SecretScanningAlertReopenedAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecretScanningAlertReopenedAction {
@@ -15628,6 +14934,18 @@ pub struct SecretScanningAlertReopenedAlert {
     pub resolved_by: (),
     pub secret_type: String,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretScanningAlertResolved {
+    pub action: SecretScanningAlertResolvedAction,
+    pub alert: SecretScanningAlertResolvedAlert,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecretScanningAlertResolvedAction {
     #[serde(rename = "resolved")]
@@ -15648,6 +14966,16 @@ impl std::str::FromStr for SecretScanningAlertResolvedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The secret scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretScanningAlertResolvedAlert {
+    pub number: i64,
+    pub resolution: SecretScanningAlertResolvedAlertResolution,
+    pub resolved_at: String,
+    pub resolved_by: User,
+    pub secret_type: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecretScanningAlertResolvedAlertResolution {
@@ -15682,15 +15010,27 @@ impl std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
         }
     }
 }
-#[doc = "The secret scanning alert involved in the event."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", content = "security_advisory")]
+pub enum SecurityAdvisoryEvent {
+    #[doc = "security_advisory performed event"]
+    #[serde(rename = "performed")]
+    Performed(SecurityAdvisoryPerformedSecurityAdvisory),
+    #[doc = "security_advisory published event"]
+    #[serde(rename = "published")]
+    Published(SecurityAdvisoryPublishedSecurityAdvisory),
+    #[doc = "security_advisory updated event"]
+    #[serde(rename = "updated")]
+    Updated(SecurityAdvisoryUpdatedSecurityAdvisory),
+    #[doc = "security_advisory withdrawn event"]
+    #[serde(rename = "withdrawn")]
+    Withdrawn(SecurityAdvisoryWithdrawnSecurityAdvisory),
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SecretScanningAlertResolvedAlert {
-    pub number: i64,
-    pub resolution: SecretScanningAlertResolvedAlertResolution,
-    pub resolved_at: String,
-    pub resolved_by: User,
-    pub secret_type: String,
+pub struct SecurityAdvisoryPerformed {
+    pub action: SecurityAdvisoryPerformedAction,
+    pub security_advisory: SecurityAdvisoryPerformedSecurityAdvisory,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecurityAdvisoryPerformedAction {
@@ -15712,6 +15052,23 @@ impl std::str::FromStr for SecurityAdvisoryPerformedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The details of the security advisory, including summary, description, and severity."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryPerformedSecurityAdvisory {
+    pub cvss: SecurityAdvisoryPerformedSecurityAdvisoryCvss,
+    pub cwes: Vec<SecurityAdvisoryPerformedSecurityAdvisoryCwesItem>,
+    pub description: String,
+    pub ghsa_id: String,
+    pub identifiers: Vec<SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem>,
+    pub published_at: String,
+    pub references: Vec<SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem>,
+    pub severity: String,
+    pub summary: String,
+    pub updated_at: String,
+    pub vulnerabilities: Vec<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>,
+    pub withdrawn_at: Option<String>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15739,6 +15096,15 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
+    pub first_patched_version:
+        Option<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
+    pub package: SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage,
+    pub severity: String,
+    pub vulnerable_version_range: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
@@ -15750,29 +15116,9 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
-    pub first_patched_version:
-        Option<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
-    pub package: SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage,
-    pub severity: String,
-    pub vulnerable_version_range: String,
-}
-#[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPerformedSecurityAdvisory {
-    pub cvss: SecurityAdvisoryPerformedSecurityAdvisoryCvss,
-    pub cwes: Vec<SecurityAdvisoryPerformedSecurityAdvisoryCwesItem>,
-    pub description: String,
-    pub ghsa_id: String,
-    pub identifiers: Vec<SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem>,
-    pub published_at: String,
-    pub references: Vec<SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem>,
-    pub severity: String,
-    pub summary: String,
-    pub updated_at: String,
-    pub vulnerabilities: Vec<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>,
-    pub withdrawn_at: Option<String>,
+pub struct SecurityAdvisoryPublished {
+    pub action: SecurityAdvisoryPublishedAction,
+    pub security_advisory: SecurityAdvisoryPublishedSecurityAdvisory,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecurityAdvisoryPublishedAction {
@@ -15794,6 +15140,23 @@ impl std::str::FromStr for SecurityAdvisoryPublishedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The details of the security advisory, including summary, description, and severity."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryPublishedSecurityAdvisory {
+    pub cvss: SecurityAdvisoryPublishedSecurityAdvisoryCvss,
+    pub cwes: Vec<SecurityAdvisoryPublishedSecurityAdvisoryCwesItem>,
+    pub description: String,
+    pub ghsa_id: String,
+    pub identifiers: Vec<SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem>,
+    pub published_at: String,
+    pub references: Vec<SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem>,
+    pub severity: String,
+    pub summary: String,
+    pub updated_at: String,
+    pub vulnerabilities: Vec<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>,
+    pub withdrawn_at: Option<String>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15821,6 +15184,15 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
+    pub first_patched_version:
+        Option<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
+    pub package: SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage,
+    pub severity: String,
+    pub vulnerable_version_range: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
@@ -15832,29 +15204,9 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
-    pub first_patched_version:
-        Option<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
-    pub package: SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage,
-    pub severity: String,
-    pub vulnerable_version_range: String,
-}
-#[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryPublishedSecurityAdvisory {
-    pub cvss: SecurityAdvisoryPublishedSecurityAdvisoryCvss,
-    pub cwes: Vec<SecurityAdvisoryPublishedSecurityAdvisoryCwesItem>,
-    pub description: String,
-    pub ghsa_id: String,
-    pub identifiers: Vec<SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem>,
-    pub published_at: String,
-    pub references: Vec<SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem>,
-    pub severity: String,
-    pub summary: String,
-    pub updated_at: String,
-    pub vulnerabilities: Vec<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>,
-    pub withdrawn_at: Option<String>,
+pub struct SecurityAdvisoryUpdated {
+    pub action: SecurityAdvisoryUpdatedAction,
+    pub security_advisory: SecurityAdvisoryUpdatedSecurityAdvisory,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecurityAdvisoryUpdatedAction {
@@ -15876,6 +15228,23 @@ impl std::str::FromStr for SecurityAdvisoryUpdatedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The details of the security advisory, including summary, description, and severity."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
+    pub cvss: SecurityAdvisoryUpdatedSecurityAdvisoryCvss,
+    pub cwes: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem>,
+    pub description: String,
+    pub ghsa_id: String,
+    pub identifiers: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem>,
+    pub published_at: String,
+    pub references: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem>,
+    pub severity: String,
+    pub summary: String,
+    pub updated_at: String,
+    pub vulnerabilities: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>,
+    pub withdrawn_at: Option<String>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15903,6 +15272,15 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
+    pub first_patched_version:
+        Option<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
+    pub package: SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage,
+    pub severity: String,
+    pub vulnerable_version_range: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
@@ -15914,29 +15292,9 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
-    pub first_patched_version:
-        Option<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
-    pub package: SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage,
-    pub severity: String,
-    pub vulnerable_version_range: String,
-}
-#[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
-    pub cvss: SecurityAdvisoryUpdatedSecurityAdvisoryCvss,
-    pub cwes: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem>,
-    pub description: String,
-    pub ghsa_id: String,
-    pub identifiers: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem>,
-    pub published_at: String,
-    pub references: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem>,
-    pub severity: String,
-    pub summary: String,
-    pub updated_at: String,
-    pub vulnerabilities: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>,
-    pub withdrawn_at: Option<String>,
+pub struct SecurityAdvisoryWithdrawn {
+    pub action: SecurityAdvisoryWithdrawnAction,
+    pub security_advisory: SecurityAdvisoryWithdrawnSecurityAdvisory,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SecurityAdvisoryWithdrawnAction {
@@ -15958,6 +15316,23 @@ impl std::str::FromStr for SecurityAdvisoryWithdrawnAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[doc = "The details of the security advisory, including summary, description, and severity."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
+    pub cvss: SecurityAdvisoryWithdrawnSecurityAdvisoryCvss,
+    pub cwes: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem>,
+    pub description: String,
+    pub ghsa_id: String,
+    pub identifiers: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem>,
+    pub published_at: String,
+    pub references: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem>,
+    pub severity: String,
+    pub summary: String,
+    pub updated_at: String,
+    pub vulnerabilities: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>,
+    pub withdrawn_at: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15985,6 +15360,15 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
+    pub first_patched_version:
+        Option<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
+    pub package: SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage,
+    pub severity: String,
+    pub vulnerable_version_range: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
@@ -15996,42 +15380,44 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
-    pub first_patched_version:
-        Option<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion>,
-    pub package: SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage,
-    pub severity: String,
-    pub vulnerable_version_range: String,
-}
-#[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
-    pub cvss: SecurityAdvisoryWithdrawnSecurityAdvisoryCvss,
-    pub cwes: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem>,
-    pub description: String,
-    pub ghsa_id: String,
-    pub identifiers: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem>,
-    pub published_at: String,
-    pub references: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem>,
-    pub severity: String,
-    pub summary: String,
+pub struct SimplePullRequest {
+    pub active_lock_reason: Option<SimplePullRequestActiveLockReason>,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: SimplePullRequestBase,
+    pub body: String,
+    pub closed_at: Option<String>,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub created_at: String,
+    pub diff_url: String,
+    pub draft: bool,
+    pub head: SimplePullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: SimplePullRequestLinks,
+    pub locked: bool,
+    pub merge_commit_sha: Option<String>,
+    pub merged_at: Option<String>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    pub patch_url: String,
+    pub requested_reviewers: Vec<SimplePullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments_url: String,
+    pub state: SimplePullRequestState,
+    pub statuses_url: String,
+    pub title: String,
     pub updated_at: String,
-    pub vulnerabilities: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>,
-    pub withdrawn_at: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SimplePullRequestLinks {
-    pub comments: Link,
-    pub commits: Link,
-    pub html: Link,
-    pub issue: Link,
-    pub review_comment: Link,
-    pub review_comments: Link,
-    #[serde(rename = "self")]
-    pub self_: Link,
-    pub statuses: Link,
+    pub url: String,
+    pub user: User,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SimplePullRequestActiveLockReason {
@@ -16087,6 +15473,19 @@ pub struct SimplePullRequestHead {
     pub user: User,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SimplePullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SimplePullRequestRequestedReviewersItem {
     User(User),
@@ -16116,6 +15515,13 @@ impl std::str::FromStr for SimplePullRequestState {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipCancelled {
+    pub action: SponsorshipCancelledAction,
+    pub sender: User,
+    pub sponsorship: SponsorshipCancelledSponsorship,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipCancelledAction {
@@ -16148,6 +15554,13 @@ pub struct SponsorshipCancelledSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipCreated {
+    pub action: SponsorshipCreatedAction,
+    pub sender: User,
+    pub sponsorship: SponsorshipCreatedSponsorship,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipCreatedAction {
     #[serde(rename = "created")]
@@ -16179,6 +15592,14 @@ pub struct SponsorshipCreatedSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipEdited {
+    pub action: SponsorshipEditedAction,
+    pub changes: SponsorshipEditedChanges,
+    pub sender: User,
+    pub sponsorship: SponsorshipEditedSponsorship,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipEditedAction {
     #[serde(rename = "edited")]
@@ -16202,15 +15623,15 @@ impl std::str::FromStr for SponsorshipEditedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SponsorshipEditedChangesPrivacyLevel {
-    #[doc = "The `edited` event types include the details about the change when someone edits a sponsorship to change the privacy."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub privacy_level: Option<SponsorshipEditedChangesPrivacyLevel>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipEditedChangesPrivacyLevel {
+    #[doc = "The `edited` event types include the details about the change when someone edits a sponsorship to change the privacy."]
+    pub from: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -16221,6 +15642,65 @@ pub struct SponsorshipEditedSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum SponsorshipEvent {
+    #[doc = "sponsorship cancelled event"]
+    #[serde(rename = "cancelled")]
+    Cancelled {
+        sender: User,
+        sponsorship: SponsorshipCancelledSponsorship,
+    },
+    #[doc = "sponsorship created event"]
+    #[serde(rename = "created")]
+    Created {
+        sender: User,
+        sponsorship: SponsorshipCreatedSponsorship,
+    },
+    #[doc = "sponsorship edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: SponsorshipEditedChanges,
+        sender: User,
+        sponsorship: SponsorshipEditedSponsorship,
+    },
+    #[doc = "sponsorship pending_cancellation event"]
+    #[serde(rename = "pending_cancellation")]
+    PendingCancellation {
+        #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        effective_date: Option<String>,
+        sender: User,
+        sponsorship: SponsorshipPendingCancellationSponsorship,
+    },
+    #[doc = "sponsorship pending_tier_change event"]
+    #[serde(rename = "pending_tier_change")]
+    PendingTierChange {
+        changes: SponsorshipPendingTierChangeChanges,
+        #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        effective_date: Option<String>,
+        sender: User,
+        sponsorship: SponsorshipPendingTierChangeSponsorship,
+    },
+    #[doc = "sponsorship tier_changed event"]
+    #[serde(rename = "tier_changed")]
+    TierChanged {
+        changes: SponsorshipTierChangedChanges,
+        sender: User,
+        sponsorship: SponsorshipTierChangedSponsorship,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipPendingCancellation {
+    pub action: SponsorshipPendingCancellationAction,
+    #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_date: Option<String>,
+    pub sender: User,
+    pub sponsorship: SponsorshipPendingCancellationSponsorship,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipPendingCancellationAction {
@@ -16253,6 +15733,17 @@ pub struct SponsorshipPendingCancellationSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipPendingTierChange {
+    pub action: SponsorshipPendingTierChangeAction,
+    pub changes: SponsorshipPendingTierChangeChanges,
+    #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_date: Option<String>,
+    pub sender: User,
+    pub sponsorship: SponsorshipPendingTierChangeSponsorship,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipPendingTierChangeAction {
     #[serde(rename = "pending_tier_change")]
@@ -16276,13 +15767,13 @@ impl std::str::FromStr for SponsorshipPendingTierChangeAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SponsorshipPendingTierChangeChangesTier {
-    pub from: SponsorshipTier,
+pub struct SponsorshipPendingTierChangeChanges {
+    pub tier: SponsorshipPendingTierChangeChangesTier,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SponsorshipPendingTierChangeChanges {
-    pub tier: SponsorshipPendingTierChangeChangesTier,
+pub struct SponsorshipPendingTierChangeChangesTier {
+    pub from: SponsorshipTier,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -16293,6 +15784,27 @@ pub struct SponsorshipPendingTierChangeSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
+}
+#[doc = "The `tier_changed` and `pending_tier_change` will include the original tier before the change or pending change. For more information, see the pending tier change payload."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipTier {
+    pub created_at: String,
+    pub description: String,
+    pub is_custom_ammount: bool,
+    pub is_one_time: bool,
+    pub monthly_price_in_cents: i64,
+    pub monthly_price_in_dollars: i64,
+    pub name: String,
+    pub node_id: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SponsorshipTierChanged {
+    pub action: SponsorshipTierChangedAction,
+    pub changes: SponsorshipTierChangedChanges,
+    pub sender: User,
+    pub sponsorship: SponsorshipTierChangedSponsorship,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SponsorshipTierChangedAction {
@@ -16317,13 +15829,13 @@ impl std::str::FromStr for SponsorshipTierChangedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SponsorshipTierChangedChangesTier {
-    pub from: SponsorshipTier,
+pub struct SponsorshipTierChangedChanges {
+    pub tier: SponsorshipTierChangedChangesTier,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct SponsorshipTierChangedChanges {
-    pub tier: SponsorshipTierChangedChangesTier,
+pub struct SponsorshipTierChangedChangesTier {
+    pub from: SponsorshipTier,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -16334,6 +15846,19 @@ pub struct SponsorshipTierChangedSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StarCreated {
+    pub action: StarCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
+    pub starred_at: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StarCreatedAction {
@@ -16355,6 +15880,19 @@ impl std::str::FromStr for StarCreatedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StarDeleted {
+    pub action: StarDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
+    pub starred_at: (),
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StarDeletedAction {
@@ -16378,10 +15916,61 @@ impl std::str::FromStr for StarDeletedAction {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum StarEvent {
+    #[doc = "star created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
+        starred_at: String,
+    },
+    #[doc = "star deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
+        starred_at: (),
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct StatusEventBranchesItemCommit {
+pub struct StatusEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+    #[doc = "An array of branch objects containing the status' SHA. Each branch contains the given SHA, but the SHA may or may not be the head of the branch. The array includes a maximum of 10 branches."]
+    pub branches: Vec<StatusEventBranchesItem>,
+    pub commit: StatusEventCommit,
+    pub context: String,
+    pub created_at: String,
+    #[doc = "The optional human-readable description added to the status."]
+    pub description: Option<String>,
+    #[doc = "The unique identifier of the status."]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    #[doc = "The Commit SHA."]
     pub sha: String,
-    pub url: String,
+    #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
+    pub state: StatusEventState,
+    #[doc = "The optional link added to the status."]
+    pub target_url: Option<String>,
+    pub updated_at: String,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -16392,9 +15981,47 @@ pub struct StatusEventBranchesItem {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct StatusEventBranchesItemCommit {
+    pub sha: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusEventCommit {
+    pub author: Option<User>,
+    pub comments_url: String,
+    pub commit: StatusEventCommitCommit,
+    pub committer: Option<User>,
+    pub html_url: String,
+    pub node_id: String,
+    pub parents: Vec<StatusEventCommitParentsItem>,
+    pub sha: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusEventCommitCommit {
+    pub author: Committer,
+    pub comment_count: i64,
+    pub committer: Committer,
+    pub message: String,
+    pub tree: StatusEventCommitCommitTree,
+    pub url: String,
+    pub verification: StatusEventCommitCommitVerification,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitTree {
     pub sha: String,
     pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusEventCommitCommitVerification {
+    pub payload: Option<String>,
+    pub reason: StatusEventCommitCommitVerificationReason,
+    pub signature: Option<String>,
+    pub verified: bool,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StatusEventCommitCommitVerificationReason {
@@ -16467,40 +16094,8 @@ impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct StatusEventCommitCommitVerification {
-    pub payload: Option<String>,
-    pub reason: StatusEventCommitCommitVerificationReason,
-    pub signature: Option<String>,
-    pub verified: bool,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct StatusEventCommitCommit {
-    pub author: Committer,
-    pub comment_count: i64,
-    pub committer: Committer,
-    pub message: String,
-    pub tree: StatusEventCommitCommitTree,
-    pub url: String,
-    pub verification: StatusEventCommitCommitVerification,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct StatusEventCommitParentsItem {
     pub html_url: String,
-    pub sha: String,
-    pub url: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct StatusEventCommit {
-    pub author: Option<User>,
-    pub comments_url: String,
-    pub commit: StatusEventCommitCommit,
-    pub committer: Option<User>,
-    pub html_url: String,
-    pub node_id: String,
-    pub parents: Vec<StatusEventCommitParentsItem>,
     pub sha: String,
     pub url: String,
 }
@@ -16538,6 +16133,306 @@ impl std::str::FromStr for StatusEventState {
         }
     }
 }
+#[doc = "Groups of organization members that gives permissions on specified repositories."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Team {
+    #[doc = "Description of the team"]
+    pub description: Option<String>,
+    pub html_url: String,
+    #[doc = "Unique identifier of the team"]
+    pub id: i64,
+    pub members_url: String,
+    #[doc = "Name of the team"]
+    pub name: String,
+    pub node_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<TeamParent>,
+    #[doc = "Permission that the team will have for its repositories"]
+    pub permission: String,
+    pub privacy: TeamPrivacy,
+    pub repositories_url: String,
+    pub slug: String,
+    #[doc = "URL for the team"]
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamAddEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    pub repository: Repository,
+    pub sender: User,
+    pub team: Team,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamAddedToRepository {
+    pub action: TeamAddedToRepositoryAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    pub sender: User,
+    pub team: Team,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum TeamAddedToRepositoryAction {
+    #[serde(rename = "added_to_repository")]
+    AddedToRepository,
+}
+impl ToString for TeamAddedToRepositoryAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::AddedToRepository => "added_to_repository".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for TeamAddedToRepositoryAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "added_to_repository" => Ok(Self::AddedToRepository),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamCreated {
+    pub action: TeamCreatedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    pub sender: User,
+    pub team: Team,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum TeamCreatedAction {
+    #[serde(rename = "created")]
+    Created,
+}
+impl ToString for TeamCreatedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Created => "created".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for TeamCreatedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "created" => Ok(Self::Created),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamDeleted {
+    pub action: TeamDeletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    pub sender: User,
+    pub team: Team,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum TeamDeletedAction {
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl ToString for TeamDeletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Deleted => "deleted".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for TeamDeletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deleted" => Ok(Self::Deleted),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEdited {
+    pub action: TeamEditedAction,
+    pub changes: TeamEditedChanges,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    pub sender: User,
+    pub team: Team,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum TeamEditedAction {
+    #[serde(rename = "edited")]
+    Edited,
+}
+impl ToString for TeamEditedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Edited => "edited".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for TeamEditedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "edited" => Ok(Self::Edited),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[doc = "The changes to the team if the action was `edited`."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<TeamEditedChangesDescription>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<TeamEditedChangesName>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub privacy: Option<TeamEditedChangesPrivacy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<TeamEditedChangesRepository>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesDescription {
+    #[doc = "The previous version of the description if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesName {
+    #[doc = "The previous version of the name if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesPrivacy {
+    #[doc = "The previous version of the team's privacy if the action was `edited`."]
+    pub from: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesRepository {
+    pub permissions: TeamEditedChangesRepositoryPermissions,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesRepositoryPermissions {
+    pub from: TeamEditedChangesRepositoryPermissionsFrom,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamEditedChangesRepositoryPermissionsFrom {
+    #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin: Option<bool>,
+    #[doc = "The previous version of the team member's `pull` permission on a repository, if the action was `edited`."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull: Option<bool>,
+    #[doc = "The previous version of the team member's `push` permission on a repository, if the action was `edited`."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub push: Option<bool>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum TeamEvent {
+    #[doc = "team added_to_repository event"]
+    #[serde(rename = "added_to_repository")]
+    AddedToRepository {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository: Option<Repository>,
+        sender: User,
+        team: Team,
+    },
+    #[doc = "team created event"]
+    #[serde(rename = "created")]
+    Created {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository: Option<Repository>,
+        sender: User,
+        team: Team,
+    },
+    #[doc = "team deleted event"]
+    #[serde(rename = "deleted")]
+    Deleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository: Option<Repository>,
+        sender: User,
+        team: Team,
+    },
+    #[doc = "team edited event"]
+    #[serde(rename = "edited")]
+    Edited {
+        changes: TeamEditedChanges,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository: Option<Repository>,
+        sender: User,
+        team: Team,
+    },
+    #[doc = "team removed_from_repository event"]
+    #[serde(rename = "removed_from_repository")]
+    RemovedFromRepository {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        organization: Organization,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository: Option<Repository>,
+        sender: User,
+        team: Team,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamParent {
+    #[doc = "Description of the team"]
+    pub description: Option<String>,
+    pub html_url: String,
+    #[doc = "Unique identifier of the team"]
+    pub id: i64,
+    pub members_url: String,
+    #[doc = "Name of the team"]
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Permission that the team will have for its repositories"]
+    pub permission: String,
+    pub privacy: TeamParentPrivacy,
+    pub repositories_url: String,
+    pub slug: String,
+    #[doc = "URL for the team"]
+    pub url: String,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TeamParentPrivacy {
     #[serde(rename = "open")]
@@ -16566,26 +16461,6 @@ impl std::str::FromStr for TeamParentPrivacy {
             _ => Err("invalid value"),
         }
     }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamParent {
-    #[doc = "Description of the team"]
-    pub description: Option<String>,
-    pub html_url: String,
-    #[doc = "Unique identifier of the team"]
-    pub id: i64,
-    pub members_url: String,
-    #[doc = "Name of the team"]
-    pub name: String,
-    pub node_id: String,
-    #[doc = "Permission that the team will have for its repositories"]
-    pub permission: String,
-    pub privacy: TeamParentPrivacy,
-    pub repositories_url: String,
-    pub slug: String,
-    #[doc = "URL for the team"]
-    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TeamPrivacy {
@@ -16616,143 +16491,17 @@ impl std::str::FromStr for TeamPrivacy {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum TeamAddedToRepositoryAction {
-    #[serde(rename = "added_to_repository")]
-    AddedToRepository,
-}
-impl ToString for TeamAddedToRepositoryAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::AddedToRepository => "added_to_repository".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for TeamAddedToRepositoryAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "added_to_repository" => Ok(Self::AddedToRepository),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum TeamCreatedAction {
-    #[serde(rename = "created")]
-    Created,
-}
-impl ToString for TeamCreatedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Created => "created".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for TeamCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum TeamDeletedAction {
-    #[serde(rename = "deleted")]
-    Deleted,
-}
-impl ToString for TeamDeletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Deleted => "deleted".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for TeamDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum TeamEditedAction {
-    #[serde(rename = "edited")]
-    Edited,
-}
-impl ToString for TeamEditedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Edited => "edited".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for TeamEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
-        }
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesDescription {
-    #[doc = "The previous version of the description if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesName {
-    #[doc = "The previous version of the name if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesPrivacy {
-    #[doc = "The previous version of the team's privacy if the action was `edited`."]
-    pub from: String,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesRepositoryPermissionsFrom {
-    #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
+pub struct TeamRemovedFromRepository {
+    pub action: TeamRemovedFromRepositoryAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub admin: Option<bool>,
-    #[doc = "The previous version of the team member's `pull` permission on a repository, if the action was `edited`."]
+    pub installation: Option<InstallationLite>,
+    pub organization: Organization,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pull: Option<bool>,
-    #[doc = "The previous version of the team member's `push` permission on a repository, if the action was `edited`."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub push: Option<bool>,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesRepositoryPermissions {
-    pub from: TeamEditedChangesRepositoryPermissionsFrom,
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChangesRepository {
-    pub permissions: TeamEditedChangesRepositoryPermissions,
-}
-#[doc = "The changes to the team if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TeamEditedChanges {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<TeamEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<TeamEditedChangesName>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub privacy: Option<TeamEditedChangesPrivacy>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<TeamEditedChangesRepository>,
+    pub repository: Option<Repository>,
+    pub sender: User,
+    pub team: Team,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TeamRemovedFromRepositoryAction {
@@ -16774,6 +16523,33 @@ impl std::str::FromStr for TeamRemovedFromRepositoryAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct User {
+    pub avatar_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub node_id: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: UserType,
+    pub url: String,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum UserType {
@@ -16801,6 +16577,31 @@ impl std::str::FromStr for UserType {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum WatchEvent {
+    #[doc = "watch started event"]
+    #[serde(rename = "started")]
+    Started {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatchStarted {
+    pub action: WatchStartedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WatchStartedAction {
     #[serde(rename = "started")]
@@ -16821,6 +16622,12 @@ impl std::str::FromStr for WatchStartedAction {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum WebhookEvents {
+    Variant0(Vec<WebhookEventsVariant0Item>),
+    Variant1(Vec<String>),
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WebhookEventsVariant0Item {
@@ -17027,6 +16834,86 @@ impl std::str::FromStr for WebhookEventsVariant0Item {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Workflow {
+    pub badge_url: String,
+    pub created_at: String,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    pub path: String,
+    pub state: String,
+    pub updated_at: String,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowDispatchEvent {
+    pub inputs: Option<std::collections::HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJob {
+    pub check_run_url: String,
+    pub completed_at: Option<String>,
+    pub conclusion: Option<WorkflowJobConclusion>,
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<String>,
+    pub name: String,
+    pub node_id: String,
+    pub run_id: f64,
+    pub run_url: String,
+    pub started_at: String,
+    pub status: WorkflowJobStatus,
+    pub steps: Vec<WorkflowStep>,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobCompleted {
+    pub action: WorkflowJobCompletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow_job: WorkflowJob,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobCompletedAction {
+    #[serde(rename = "completed")]
+    Completed,
+}
+impl ToString for WorkflowJobCompletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Completed => "completed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobCompletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "completed" => Ok(Self::Completed),
+            _ => Err("invalid value"),
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowJobConclusion {
     #[serde(rename = "success")]
@@ -17048,6 +16935,149 @@ impl std::str::FromStr for WorkflowJobConclusion {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum WorkflowJobEvent {
+    #[doc = "workflow_job completed event"]
+    #[serde(rename = "completed")]
+    Completed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow_job: WorkflowJob,
+    },
+    #[doc = "workflow_job queued event"]
+    #[serde(rename = "queued")]
+    Queued {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow_job: WorkflowJobQueuedWorkflowJob,
+    },
+    #[doc = "workflow_job started event"]
+    #[serde(rename = "started")]
+    Started {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow_job: WorkflowJob,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobQueued {
+    pub action: WorkflowJobQueuedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow_job: WorkflowJobQueuedWorkflowJob,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobQueuedAction {
+    #[serde(rename = "queued")]
+    Queued,
+}
+impl ToString for WorkflowJobQueuedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Queued => "queued".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobQueuedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobQueuedWorkflowJob {
+    pub check_run_url: String,
+    pub completed_at: (),
+    pub conclusion: (),
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<String>,
+    pub name: String,
+    pub node_id: String,
+    pub run_id: f64,
+    pub run_url: String,
+    pub started_at: chrono::DateTime<chrono::offset::Utc>,
+    pub status: WorkflowJobQueuedWorkflowJobStatus,
+    pub steps: Vec<WorkflowStep>,
+    pub url: String,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobQueuedWorkflowJobStatus {
+    #[serde(rename = "queued")]
+    Queued,
+}
+impl ToString for WorkflowJobQueuedWorkflowJobStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Queued => "queued".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobStarted {
+    pub action: WorkflowJobStartedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow_job: WorkflowJob,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobStartedAction {
+    #[serde(rename = "started")]
+    Started,
+}
+impl ToString for WorkflowJobStartedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Started => "started".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobStartedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "started" => Ok(Self::Started),
             _ => Err("invalid value"),
         }
     }
@@ -17076,6 +17106,71 @@ impl std::str::FromStr for WorkflowJobStatus {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRun {
+    pub artifacts_url: String,
+    pub cancel_url: String,
+    pub check_suite_id: i64,
+    pub check_suite_node_id: String,
+    pub check_suite_url: String,
+    pub conclusion: Option<WorkflowRunConclusion>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub event: String,
+    pub head_branch: String,
+    pub head_commit: CommitSimple,
+    pub head_repository: RepositoryLite,
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub jobs_url: String,
+    pub logs_url: String,
+    pub name: String,
+    pub node_id: String,
+    pub pull_requests: Vec<WorkflowRunPullRequestsItem>,
+    pub repository: RepositoryLite,
+    pub rerun_url: String,
+    pub run_number: i64,
+    pub status: WorkflowRunStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub workflow_id: i64,
+    pub workflow_url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunCompleted {
+    pub action: WorkflowRunCompletedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow: Workflow,
+    pub workflow_run: WorkflowRun,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowRunCompletedAction {
+    #[serde(rename = "completed")]
+    Completed,
+}
+impl ToString for WorkflowRunCompletedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Completed => "completed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowRunCompletedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
@@ -17127,6 +17222,43 @@ impl std::str::FromStr for WorkflowRunConclusion {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "action", deny_unknown_fields)]
+pub enum WorkflowRunEvent {
+    #[doc = "workflow_run completed event"]
+    #[serde(rename = "completed")]
+    Completed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow: Workflow,
+        workflow_run: WorkflowRun,
+    },
+    #[doc = "workflow_run requested event"]
+    #[serde(rename = "requested")]
+    Requested {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        installation: Option<InstallationLite>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<Organization>,
+        repository: Repository,
+        sender: User,
+        workflow: Workflow,
+        workflow_run: WorkflowRun,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunPullRequestsItem {
+    pub base: WorkflowRunPullRequestsItemBase,
+    pub head: WorkflowRunPullRequestsItemHead,
+    pub id: f64,
+    pub number: f64,
+    pub url: String,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItemBase {
     #[serde(rename = "ref")]
@@ -17144,12 +17276,37 @@ pub struct WorkflowRunPullRequestsItemHead {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct WorkflowRunPullRequestsItem {
-    pub base: WorkflowRunPullRequestsItemBase,
-    pub head: WorkflowRunPullRequestsItemHead,
-    pub id: f64,
-    pub number: f64,
-    pub url: String,
+pub struct WorkflowRunRequested {
+    pub action: WorkflowRunRequestedAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installation: Option<InstallationLite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
+    pub repository: Repository,
+    pub sender: User,
+    pub workflow: Workflow,
+    pub workflow_run: WorkflowRun,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowRunRequestedAction {
+    #[serde(rename = "requested")]
+    Requested,
+}
+impl ToString for WorkflowRunRequestedAction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Requested => "requested".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowRunRequestedAction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "requested" => Ok(Self::Requested),
+            _ => Err("invalid value"),
+        }
+    }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowRunStatus {
@@ -17183,6 +17340,38 @@ impl std::str::FromStr for WorkflowRunStatus {
             _ => Err("invalid value"),
         }
     }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "status", deny_unknown_fields)]
+pub enum WorkflowStep {
+    #[doc = "Workflow Step (In Progress)"]
+    #[serde(rename = "in_progress")]
+    InProgress {
+        completed_at: (),
+        conclusion: (),
+        name: String,
+        number: i64,
+        started_at: String,
+    },
+    #[doc = "Workflow Step (Completed)"]
+    #[serde(rename = "completed")]
+    Completed {
+        completed_at: String,
+        conclusion: WorkflowStepCompletedConclusion,
+        name: String,
+        number: i64,
+        started_at: String,
+    },
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowStepCompleted {
+    pub completed_at: String,
+    pub conclusion: WorkflowStepCompletedConclusion,
+    pub name: String,
+    pub number: i64,
+    pub started_at: String,
+    pub status: WorkflowStepCompletedStatus,
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowStepCompletedConclusion {
@@ -17234,6 +17423,16 @@ impl std::str::FromStr for WorkflowStepCompletedStatus {
         }
     }
 }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowStepInProgress {
+    pub completed_at: (),
+    pub conclusion: (),
+    pub name: String,
+    pub number: i64,
+    pub started_at: String,
+    pub status: WorkflowStepInProgressStatus,
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowStepInProgressStatus {
     #[serde(rename = "in_progress")]
@@ -17255,207 +17454,8 @@ impl std::str::FromStr for WorkflowStepInProgressStatus {
         }
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowJobCompletedAction {
-    #[serde(rename = "completed")]
-    Completed,
-}
-impl ToString for WorkflowJobCompletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Completed => "completed".to_string(),
-        }
+mod defaults {
+    pub(super) fn default_bool<const V: bool>() -> bool {
+        V
     }
-}
-impl std::str::FromStr for WorkflowJobCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowJobQueuedAction {
-    #[serde(rename = "queued")]
-    Queued,
-}
-impl ToString for WorkflowJobQueuedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Queued => "queued".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for WorkflowJobQueuedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowJobQueuedWorkflowJobStatus {
-    #[serde(rename = "queued")]
-    Queued,
-}
-impl ToString for WorkflowJobQueuedWorkflowJobStatus {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Queued => "queued".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkflowJobQueuedWorkflowJob {
-    pub check_run_url: String,
-    pub completed_at: (),
-    pub conclusion: (),
-    pub head_sha: String,
-    pub html_url: String,
-    pub id: i64,
-    pub labels: Vec<String>,
-    pub name: String,
-    pub node_id: String,
-    pub run_id: f64,
-    pub run_url: String,
-    pub started_at: chrono::DateTime<chrono::offset::Utc>,
-    pub status: WorkflowJobQueuedWorkflowJobStatus,
-    pub steps: Vec<WorkflowStep>,
-    pub url: String,
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowJobStartedAction {
-    #[serde(rename = "started")]
-    Started,
-}
-impl ToString for WorkflowJobStartedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Started => "started".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for WorkflowJobStartedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "started" => Ok(Self::Started),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowRunCompletedAction {
-    #[serde(rename = "completed")]
-    Completed,
-}
-impl ToString for WorkflowRunCompletedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Completed => "completed".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for WorkflowRunCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum WorkflowRunRequestedAction {
-    #[serde(rename = "requested")]
-    Requested,
-}
-impl ToString for WorkflowRunRequestedAction {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Requested => "requested".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for WorkflowRunRequestedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "requested" => Ok(Self::Requested),
-            _ => Err("invalid value"),
-        }
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum Everything {
-    BranchProtectionRuleEvent(BranchProtectionRuleEvent),
-    CheckRunEvent(CheckRunEvent),
-    CheckSuiteEvent(CheckSuiteEvent),
-    CodeScanningAlertEvent(CodeScanningAlertEvent),
-    CommitCommentEvent(CommitCommentEvent),
-    ContentReferenceEvent(ContentReferenceEvent),
-    CreateEvent(CreateEvent),
-    DeleteEvent(DeleteEvent),
-    DeployKeyEvent(DeployKeyEvent),
-    DeploymentEvent(DeploymentEvent),
-    DeploymentStatusEvent(DeploymentStatusEvent),
-    DiscussionEvent(DiscussionEvent),
-    DiscussionCommentEvent(DiscussionCommentEvent),
-    ForkEvent(ForkEvent),
-    GithubAppAuthorizationEvent(GithubAppAuthorizationEvent),
-    GollumEvent(GollumEvent),
-    InstallationEvent(InstallationEvent),
-    InstallationRepositoriesEvent(InstallationRepositoriesEvent),
-    IssueCommentEvent(IssueCommentEvent),
-    IssuesEvent(IssuesEvent),
-    LabelEvent(LabelEvent),
-    MarketplacePurchaseEvent(MarketplacePurchaseEvent),
-    MemberEvent(MemberEvent),
-    MembershipEvent(MembershipEvent),
-    MetaEvent(MetaEvent),
-    MilestoneEvent(MilestoneEvent),
-    OrgBlockEvent(OrgBlockEvent),
-    OrganizationEvent(OrganizationEvent),
-    PackageEvent(PackageEvent),
-    PageBuildEvent(PageBuildEvent),
-    PingEvent(PingEvent),
-    ProjectEvent(ProjectEvent),
-    ProjectCardEvent(ProjectCardEvent),
-    ProjectColumnEvent(ProjectColumnEvent),
-    PublicEvent(PublicEvent),
-    PullRequestEvent(PullRequestEvent),
-    PullRequestReviewEvent(PullRequestReviewEvent),
-    PullRequestReviewCommentEvent(PullRequestReviewCommentEvent),
-    PushEvent(PushEvent),
-    ReleaseEvent(ReleaseEvent),
-    RepositoryEvent(RepositoryEvent),
-    RepositoryDispatchEvent(RepositoryDispatchEvent),
-    RepositoryImportEvent(RepositoryImportEvent),
-    RepositoryVulnerabilityAlertEvent(RepositoryVulnerabilityAlertEvent),
-    SecretScanningAlertEvent(SecretScanningAlertEvent),
-    SecurityAdvisoryEvent(SecurityAdvisoryEvent),
-    SponsorshipEvent(SponsorshipEvent),
-    StarEvent(StarEvent),
-    StatusEvent(StatusEvent),
-    TeamEvent(TeamEvent),
-    TeamAddEvent(TeamAddEvent),
-    WatchEvent(WatchEvent),
-    WorkflowDispatchEvent(WorkflowDispatchEvent),
-    WorkflowJobEvent(WorkflowJobEvent),
-    WorkflowRunEvent(WorkflowRunEvent),
 }

--- a/typify-impl/tests/test_generation.rs
+++ b/typify-impl/tests/test_generation.rs
@@ -1,9 +1,9 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 use quote::quote;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::Serialize;
-use typify_impl::TypeSpace;
+use typify_impl::{TypeSpace, TypeSpaceSettings};
 
 #[allow(dead_code)]
 #[derive(JsonSchema)]
@@ -13,7 +13,7 @@ struct CompoundType {
 }
 
 #[allow(dead_code)]
-#[derive(JsonSchema)]
+#[derive(JsonSchema, Serialize)]
 enum StringEnum {
     One,
     Two,
@@ -24,14 +24,14 @@ enum StringEnum {
 #[derive(JsonSchema, Serialize)]
 #[serde(default = "default_pair")]
 struct Pair {
-    a: String,
-    b: String,
+    a: StringEnum,
+    b: StringEnum,
 }
 
 fn default_pair() -> Pair {
     Pair {
-        a: "A".to_string(),
-        b: "B".to_string(),
+        a: StringEnum::One,
+        b: StringEnum::Two,
     }
 }
 
@@ -43,10 +43,12 @@ fn add_type<T: JsonSchema>(generator: &mut SchemaGenerator) -> Schema {
 
 #[test]
 fn test_generation() {
-    let mut type_space = TypeSpace::default();
-
-    type_space.add_derive(quote! { JsonSchema });
-    type_space.set_type_mod("types");
+    let mut type_space = TypeSpace::new(
+        TypeSpaceSettings::default()
+            .with_derive("JsonSchema".to_string())
+            .with_type_mod("types")
+            .with_struct_builder(true),
+    );
 
     let mut generator = SchemaGenerator::default();
     let body_schema = add_type::<CompoundType>(&mut generator);

--- a/typify-impl/tests/test_github.rs
+++ b/typify-impl/tests/test_github.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 use std::{fs::File, io::BufReader, path::Path};
 

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 //! Typify lets you convert JSON Schema documents into Rust types. It can be
 //! used via a macro [`import_types!`] or a `build.rs` file.
@@ -49,8 +49,8 @@
 //!
 //! Typify exports a [TypeSpace] interface that is intended for programmatic
 //! construction of types. This can be for something simple like a `build.rs`
-//! script or something more complex like a generated that includes types as
-//! part of its definition.
+//! script or something more complex like a generator whose input includes JSON
+//! schema type definitions.
 //!
 //! # Mapping JSON Schema to Rust
 //!
@@ -68,5 +68,6 @@ pub use typify_impl::TypeEnumVariant;
 pub use typify_impl::TypeId;
 pub use typify_impl::TypeNewtype;
 pub use typify_impl::TypeSpace;
+pub use typify_impl::TypeSpaceSettings;
 pub use typify_impl::TypeStruct;
 pub use typify_macro::import_types;


### PR DESCRIPTION
This optionally adds a `Type::Builder()` interface for generated struct types. This can be turned into the `Type` using a fallible `try_into()` call. It will fail if required fields have not been specified or if a conversion failed.