### PR TITLE
generated default functions contain an extraneous `super::` for built-in types

### DIFF
--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -316,12 +316,12 @@ impl TypeEntry {
         if let Some(fn_name) = maybe_builtin {
             (fn_name, None)
         } else {
-            let n = self.type_ident(type_space, &None);
+            let n = self.type_ident(type_space, &Some("super".to_string()));
             let value = self.output_value(type_space, default).unwrap();
             let fn_name = sanitize(&format!("{}_{}", type_name, prop_name), Case::Snake);
             let fn_ident = format_ident!("{}", fn_name);
             let def = quote! {
-                pub(super) fn #fn_ident() -> super::#n {
+                pub(super) fn #fn_ident() -> #n {
                     #value
                 }
             };

--- a/typify-test/build.rs
+++ b/typify-test/build.rs
@@ -17,6 +17,8 @@ struct TestStruct {
     d: i32,
     #[schemars(default = "things")]
     e: Things,
+    #[schemars(default = "yes_yes")]
+    f: Option<bool>,
 }
 
 fn nope() -> bool {
@@ -26,6 +28,11 @@ fn nope() -> bool {
 fn answer() -> i32 {
     42
 }
+
+fn yes_yes() -> Option<bool> {
+    Some(true)
+}
+
 #[allow(dead_code)]
 #[derive(JsonSchema, Serialize)]
 struct Things {


### PR DESCRIPTION
functions generated to return values for use as defaults need to insert `super::` only for types that are typify-generated (rather than built-in). Fortunately, the mechanism already exists to conditionally prepend a mod only for generated types.

@luqmana FYI