### PR TITLE
Support telling serde where it is, i.e. when re-exported as a transitive dependency.

### DIFF
--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -173,6 +173,7 @@ pub struct TypeSpaceSettings {
     type_mod: Option<String>,
     extra_derives: Vec<String>,
     struct_builder: bool,
+    serde_crate_location: Option<String>,
 }
 
 impl TypeSpaceSettings {
@@ -190,6 +191,11 @@ impl TypeSpaceSettings {
 
     pub fn with_struct_builder(&mut self, struct_builder: bool) -> &mut Self {
         self.struct_builder = struct_builder;
+        self
+    }
+
+    pub fn with_serde_crate_location(&mut self, crate_location: String) -> &mut Self {
+        self.serde_crate_location = Some(crate_location);
         self
     }
 }


### PR DESCRIPTION
 Supported by the `serde()` annotation in derive macros, which otherwise will assume that serde is a direct crate dependency. When a macro emits a type that derives Serialize/Deserialize, the user of that macro would normally have to directly depend on serde themselves for the resulting expansion of those derive macros. This can be cumbersome when consuming serde transitively via some other crate (i.e. progenitor).

https://github.com/serde-rs/serde/blob/5a8dcac2ed1407fab3f7fd23f2d56af42dcd448f/serde_derive/src/internals/attr.rs#L556-L561