### PR TITLE
Allow for per-type renames and additional derives macros

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -426,9 +426,8 @@ impl TypeSpace {
                     let type_id = self.assign_type(string);
                     Ok((
                         TypeEntryNewtype::from_metadata_with_string_validation(
-                            type_name, metadata, type_id, validation,
-                        )
-                        .into(),
+                            self, type_name, metadata, type_id, validation,
+                        ),
                         metadata,
                     ))
                 }
@@ -514,13 +513,13 @@ impl TypeSpace {
             }
         } else {
             let mut ty = TypeEntryEnum::from_metadata(
+                self,
                 type_name,
                 metadata,
                 EnumTagType::External,
                 variants,
                 false,
-            )
-            .into();
+            );
 
             if has_null {
                 ty = self.type_to_option(ty);
@@ -725,12 +724,12 @@ impl TypeSpace {
 
                 Ok((
                     TypeEntryStruct::from_metadata(
+                        self,
                         type_name,
                         metadata,
                         properties,
                         deny_unknown_fields,
-                    )
-                    .into(),
+                    ),
                     &None,
                 ))
             }
@@ -1001,12 +1000,12 @@ impl TypeSpace {
         let type_id = self.assign_type(type_entry);
 
         let newtype_entry = TypeEntryNewtype::from_metadata_with_enum_values(
+            self,
             type_name,
             metadata,
             type_id,
             enum_values,
-        )
-        .into();
+        );
 
         Ok((
             newtype_entry,

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -453,7 +453,7 @@ fn validate_default_tuple(
     default: &serde_json::Value,
 ) -> Option<DefaultKind> {
     let arr = default.as_array()?;
-    (arr.len() == types.len()).then(|| ())?;
+    (arr.len() == types.len()).then_some(())?;
 
     types
         .iter()
@@ -466,7 +466,7 @@ fn validate_default_tuple(
                 .validate_value(type_space, value)
                 .is_ok()
         })
-        .then(|| DefaultKind::Specific)
+        .then_some(DefaultKind::Specific)
 }
 
 fn validate_default_struct_props(
@@ -518,7 +518,7 @@ fn validate_default_struct_props(
                     let type_entry = type_space.id_to_entry.get(type_id).unwrap();
                     type_entry.validate_value(type_space, default_value).is_ok()
                 })
-                .then(|| ())
+                .then_some(())
         }
     })?;
 
@@ -619,7 +619,7 @@ mod tests {
 
         let type_entry = TypeEntry {
             details: crate::type_entry::TypeEntryDetails::Box(type_id),
-            derives: None,
+            derives: Default::default(),
         };
 
         assert!(matches!(

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -225,16 +225,14 @@ impl TypeSpace {
             })
             .collect::<Option<Vec<_>>>()?;
 
-        Some(
-            TypeEntryEnum::from_metadata(
-                type_name,
-                metadata,
-                EnumTagType::External,
-                variants,
-                deny_unknown_fields,
-            )
-            .into(),
-        )
+        Some(TypeEntryEnum::from_metadata(
+            self,
+            type_name,
+            metadata,
+            EnumTagType::External,
+            variants,
+            deny_unknown_fields,
+        ))
     }
 
     fn external_variant(
@@ -443,16 +441,14 @@ impl TypeSpace {
             .collect::<Result<Vec<_>>>()
             .ok()?;
 
-        Some(
-            TypeEntryEnum::from_metadata(
-                type_name,
-                metadata,
-                EnumTagType::Internal { tag: tag.clone() },
-                variants,
-                deny_unknown_fields,
-            )
-            .into(),
-        )
+        Some(TypeEntryEnum::from_metadata(
+            self,
+            type_name,
+            metadata,
+            EnumTagType::Internal { tag: tag.clone() },
+            variants,
+            deny_unknown_fields,
+        ))
     }
 
     fn internal_variant(
@@ -586,16 +582,14 @@ impl TypeSpace {
             .collect::<Result<Vec<_>>>()
             .ok()?;
 
-        Some(
-            TypeEntryEnum::from_metadata(
-                type_name,
-                metadata,
-                EnumTagType::Adjacent { tag, content },
-                variants,
-                deny_unknown_fields,
-            )
-            .into(),
-        )
+        Some(TypeEntryEnum::from_metadata(
+            self,
+            type_name,
+            metadata,
+            EnumTagType::Adjacent { tag, content },
+            variants,
+            deny_unknown_fields,
+        ))
     }
 
     fn adjacent_variant(
@@ -743,7 +737,7 @@ impl TypeSpace {
             .enumerate()
             .map(|(idx, (details, good_name))| {
                 let name = if names_from_variants {
-                    (&good_name.unwrap()[common_prefix_index..]).to_string()
+                    good_name.unwrap()[common_prefix_index..].to_string()
                 } else {
                     format!("Variant{}", idx)
                 };
@@ -757,14 +751,14 @@ impl TypeSpace {
             .collect();
 
         Ok(TypeEntryEnum::from_metadata(
+            self,
             // TODO should this be tmp_type_name?
             type_name,
             metadata,
             EnumTagType::Untagged,
             variants,
             deny_unknown_fields,
-        )
-        .into())
+        ))
     }
 }
 

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -172,12 +172,13 @@ pub(crate) enum DefaultImpl {
 pub struct TypeSpaceSettings {
     type_mod: Option<String>,
     extra_derives: Vec<String>,
-    type_adjustments: BTreeMap<String, TypeAdjustment>,
+    patch: BTreeMap<String, TypeSpacePatch>,
     struct_builder: bool,
 }
 
+/// Per-type modifications.
 #[derive(Debug, Default, Clone)]
-pub struct TypeAdjustment {
+pub struct TypeSpacePatch {
     rename: Option<String>,
     derives: Vec<String>,
 }
@@ -195,28 +196,34 @@ impl TypeSpaceSettings {
         self
     }
 
+    /// For structs, include a "builder" type that can be used to construct it.
     pub fn with_struct_builder(&mut self, struct_builder: bool) -> &mut Self {
         self.struct_builder = struct_builder;
         self
     }
 
-    pub fn with_type_adjustment<S: AsRef<str>>(
+    /// Modify a type with the given name. Note that specifying a type not
+    /// created by the input JSON schema does **not** result in an error and is
+    /// silently ignored.
+    pub fn with_patch<S: AsRef<str>>(
         &mut self,
         type_name: S,
-        type_adjustment: &TypeAdjustment,
+        type_patch: &TypeSpacePatch,
     ) -> &mut Self {
-        self.type_adjustments
-            .insert(type_name.as_ref().to_string(), type_adjustment.clone());
+        self.patch
+            .insert(type_name.as_ref().to_string(), type_patch.clone());
         self
     }
 }
 
-impl TypeAdjustment {
+impl TypeSpacePatch {
+    /// Specify the new name for patched type.
     pub fn with_rename<S: AsRef<str>>(&mut self, rename: S) -> &mut Self {
         self.rename = Some(rename.as_ref().to_string());
         self
     }
 
+    /// Specify extra derives to apply to the patched type.
     pub fn with_derive<S: AsRef<str>>(&mut self, derive: S) -> &mut Self {
         self.derives.push(derive.as_ref().to_string());
         self

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -240,7 +240,7 @@ impl TypeSpace {
             .collect::<Result<Vec<_>>>()?;
 
         Ok((
-            TypeEntryStruct::from_metadata(type_name, metadata, properties, false).into(),
+            TypeEntryStruct::from_metadata(self, type_name, metadata, properties, false),
             metadata,
         ))
     }
@@ -333,18 +333,16 @@ impl TypeSpace {
             .collect::<Result<Vec<_>>>()
             .ok()?;
 
-        Some(
-            TypeEntryStruct::from_metadata(
-                type_name,
-                metadata,
-                named_properties
-                    .into_iter()
-                    .chain(unnamed_properties.into_iter())
-                    .collect(),
-                deny,
-            )
-            .into(),
-        )
+        Some(TypeEntryStruct::from_metadata(
+            self,
+            type_name,
+            metadata,
+            named_properties
+                .into_iter()
+                .chain(unnamed_properties.into_iter())
+                .collect(),
+            deny,
+        ))
     }
 
     /// This handles the case where an allOf is used to denote constraints.
@@ -394,7 +392,7 @@ impl TypeSpace {
 
         let (named_schema, _) = named.first()?;
 
-        let (_, _, validation) = get_object(Name::Unknown, *named_schema, &self.definitions)?;
+        let (_, _, validation) = get_object(Name::Unknown, named_schema, &self.definitions)?;
 
         if validation.additional_properties.as_ref().map(Box::as_ref) != Some(&Schema::Bool(false))
         {
@@ -404,7 +402,7 @@ impl TypeSpace {
         unnamed
             .into_iter()
             .all(|constraint_schema| is_obj_subset(validation, constraint_schema))
-            .then(|| ())?;
+            .then_some(())?;
 
         let (type_entry, _) = self.convert_schema(type_name, named_schema).ok()?;
         Some(type_entry)

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -11,7 +11,7 @@ use crate::{
     enums::output_variant,
     output::{OutputSpace, OutputSpaceMod},
     structs::{generate_serde_attr, DefaultFunction},
-    util::{get_type_name, metadata_description, type_adjust},
+    util::{get_type_name, metadata_description, type_patch},
     DefaultImpl, Name, TypeId, TypeSpace,
 };
 
@@ -178,7 +178,7 @@ impl TypeEntryEnum {
         let rename = None;
         let description = metadata_description(metadata);
 
-        let (name, derives) = type_adjust(type_space, name);
+        let (name, derives) = type_patch(type_space, name);
 
         let details = TypeEntryDetails::Enum(Self {
             name,
@@ -211,7 +211,7 @@ impl TypeEntryStruct {
             .cloned()
             .map(WrappedValue::new);
 
-        let (name, derives) = type_adjust(type_space, name);
+        let (name, derives) = type_patch(type_space, name);
 
         let details = TypeEntryDetails::Struct(Self {
             name,
@@ -237,7 +237,7 @@ impl TypeEntryNewtype {
         let rename = None;
         let description = metadata_description(metadata);
 
-        let (name, derives) = type_adjust(type_space, name);
+        let (name, derives) = type_patch(type_space, name);
 
         let details = TypeEntryDetails::Newtype(Self {
             name,
@@ -262,7 +262,7 @@ impl TypeEntryNewtype {
         let rename = None;
         let description = metadata_description(metadata);
 
-        let (name, derives) = type_adjust(type_space, name);
+        let (name, derives) = type_patch(type_space, name);
 
         let details = TypeEntryDetails::Newtype(Self {
             name,
@@ -295,7 +295,7 @@ impl TypeEntryNewtype {
             pattern,
         } = validation.clone();
 
-        let (name, derives) = type_adjust(type_space, name);
+        let (name, derives) = type_patch(type_space, name);
 
         let details = TypeEntryDetails::Newtype(Self {
             name,

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Oxide Computer Company
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
@@ -8,7 +8,7 @@ use schemars::schema::{
 };
 use unicode_ident::{is_xid_continue, is_xid_start};
 
-use crate::Name;
+use crate::{Name, TypeSpace};
 
 pub(crate) fn metadata_description(metadata: &Option<Box<Metadata>>) -> Option<String> {
     metadata
@@ -496,7 +496,7 @@ pub(crate) fn schema_is_named(schema: &Schema) -> Option<String> {
             extensions: _,
         }) => {
             let idx = reference.rfind('/')?;
-            Some((&reference[idx + 1..]).to_string())
+            Some(reference[idx + 1..].to_string())
         }
         Schema::Object(SchemaObject {
             metadata: Some(metadata),
@@ -603,6 +603,19 @@ pub(crate) fn get_type_name(type_name: &Name, metadata: &Option<Box<Metadata>>) 
     };
 
     Some(sanitize(&name, Case::Pascal))
+}
+
+pub(crate) fn type_adjust(type_space: &TypeSpace, type_name: String) -> (String, BTreeSet<String>) {
+    match type_space.settings.type_adjustments.get(&type_name) {
+        None => (type_name, Default::default()),
+
+        Some(adj) => {
+            let name = adj.rename.clone().unwrap_or(type_name);
+            let derives = adj.derives.iter().cloned().collect();
+
+            (name, derives)
+        }
+    }
 }
 
 pub(crate) fn none_or_single<T>(test: &Option<SingleOrVec<T>>, value: &T) -> bool

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -605,8 +605,8 @@ pub(crate) fn get_type_name(type_name: &Name, metadata: &Option<Box<Metadata>>) 
     Some(sanitize(&name, Case::Pascal))
 }
 
-pub(crate) fn type_adjust(type_space: &TypeSpace, type_name: String) -> (String, BTreeSet<String>) {
-    match type_space.settings.type_adjustments.get(&type_name) {
+pub(crate) fn type_patch(type_space: &TypeSpace, type_name: String) -> (String, BTreeSet<String>) {
+    match type_space.settings.patch.get(&type_name) {
         None => (type_name, Default::default()),
 
         Some(adj) => {

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -609,9 +609,9 @@ pub(crate) fn type_patch(type_space: &TypeSpace, type_name: String) -> (String, 
     match type_space.settings.patch.get(&type_name) {
         None => (type_name, Default::default()),
 
-        Some(adj) => {
-            let name = adj.rename.clone().unwrap_or(type_name);
-            let derives = adj.derives.iter().cloned().collect();
+        Some(patch) => {
+            let name = patch.rename.clone().unwrap_or(type_name);
+            let derives = patch.derives.iter().cloned().collect();
 
             (name, derives)
         }

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -411,7 +411,7 @@ mod tests {
 
         let type_entry = TypeEntry {
             details: crate::type_entry::TypeEntryDetails::Box(type_id),
-            derives: None,
+            derives: Default::default(),
         };
 
         assert_eq!(

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,4 +1,15 @@
 mod types {
+    #[derive(
+        Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd, JsonSchema,
+    )]
+    pub struct AllTheTraits {
+        pub ok: String,
+    }
+    impl AllTheTraits {
+        pub fn builder() -> builder::AllTheTraits {
+            builder::AllTheTraits::default()
+        }
+    }
     #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
     pub struct CompoundType {
         pub value1: String,
@@ -50,6 +61,34 @@ mod types {
         }
     }
     mod builder {
+        pub struct AllTheTraits {
+            ok: Result<String, String>,
+        }
+        impl Default for AllTheTraits {
+            fn default() -> Self {
+                Self {
+                    ok: Err("no value supplied for ok".to_string()),
+                }
+            }
+        }
+        impl AllTheTraits {
+            pub fn ok<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<String>,
+                T::Error: std::fmt::Display,
+            {
+                self.ok = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for ok: {}", e));
+                self
+            }
+        }
+        impl std::convert::TryFrom<AllTheTraits> for super::AllTheTraits {
+            type Error = String;
+            fn try_from(value: AllTheTraits) -> Result<Self, Self::Error> {
+                Ok(Self { ok: value.ok? })
+            }
+        }
         pub struct CompoundType {
             value1: Result<String, String>,
             value2: Result<u64, String>,

--- a/typify-impl/tests/test_generation.rs
+++ b/typify-impl/tests/test_generation.rs
@@ -3,7 +3,7 @@
 use quote::quote;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::Serialize;
-use typify_impl::{TypeAdjustment, TypeSpace, TypeSpaceSettings};
+use typify_impl::{TypeSpace, TypeSpacePatch, TypeSpaceSettings};
 
 #[allow(dead_code)]
 #[derive(JsonSchema)]
@@ -54,9 +54,9 @@ fn test_generation() {
             .with_derive("JsonSchema".to_string())
             .with_type_mod("types")
             .with_struct_builder(true)
-            .with_type_adjustment(
+            .with_patch(
                 "AllTheTraits",
-                TypeAdjustment::default()
+                TypeSpacePatch::default()
                     .with_derive("Hash")
                     .with_derive("Ord")
                     .with_derive("PartialOrd")

--- a/typify-impl/tests/test_generation.rs
+++ b/typify-impl/tests/test_generation.rs
@@ -3,7 +3,7 @@
 use quote::quote;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::Serialize;
-use typify_impl::{TypeSpace, TypeSpaceSettings};
+use typify_impl::{TypeAdjustment, TypeSpace, TypeSpaceSettings};
 
 #[allow(dead_code)]
 #[derive(JsonSchema)]
@@ -35,6 +35,12 @@ fn default_pair() -> Pair {
     }
 }
 
+#[derive(JsonSchema)]
+#[allow(dead_code)]
+struct AllTheTraits {
+    ok: String,
+}
+
 fn add_type<T: JsonSchema>(generator: &mut SchemaGenerator) -> Schema {
     let mut schema = T::json_schema(generator).into_object();
     schema.metadata().title = Some(T::schema_name());
@@ -47,7 +53,16 @@ fn test_generation() {
         TypeSpaceSettings::default()
             .with_derive("JsonSchema".to_string())
             .with_type_mod("types")
-            .with_struct_builder(true),
+            .with_struct_builder(true)
+            .with_type_adjustment(
+                "AllTheTraits",
+                TypeAdjustment::default()
+                    .with_derive("Hash")
+                    .with_derive("Ord")
+                    .with_derive("PartialOrd")
+                    .with_derive("Eq")
+                    .with_derive("PartialEq"),
+            ),
     );
 
     let mut generator = SchemaGenerator::default();
@@ -56,8 +71,7 @@ fn test_generation() {
     let opt_int_schema = add_type::<Option<u32>>(&mut generator);
     let strenum_schema = add_type::<StringEnum>(&mut generator);
     let pair_schema = add_type::<Pair>(&mut generator);
-
-    println!("{:#?}", pair_schema);
+    let all_the_traits = add_type::<AllTheTraits>(&mut generator);
 
     type_space
         .add_ref_types(generator.take_definitions())
@@ -75,6 +89,7 @@ fn test_generation() {
     let strenum_id = type_space.add_type(&strenum_schema).unwrap();
     let strenum = type_space.get_type(&strenum_id).unwrap().parameter_ident();
     let _ = type_space.add_type(&pair_schema).unwrap();
+    let _ = type_space.add_type(&all_the_traits).unwrap();
 
     let types = type_space.to_stream();
 

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -44,7 +44,7 @@ struct Settings {
     #[serde(default)]
     derives: Vec<ParseWrapper<syn::Path>>,
     #[serde(default)]
-    adjustments: HashMap<String, Adjustment>,
+    adjustments: HashMap<ParseWrapper<syn::Type>, Adjustment>,
     #[serde(default)]
     struct_builder: bool,
 }

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -8,7 +8,7 @@ use schemars::schema::Schema;
 use serde::Deserialize;
 use serde_tokenstream::ParseWrapper;
 use syn::LitStr;
-use typify_impl::{TypeAdjustment, TypeSpace, TypeSpaceSettings};
+use typify_impl::{TypeSpace, TypeSpacePatch, TypeSpaceSettings};
 
 /// Import types from a schema file. This may be invoked with simply a pathname
 /// for a JSON Schema file (relative to `$CARGO_MANIFEST_DIR`), or it may be
@@ -25,11 +25,14 @@ use typify_impl::{TypeAdjustment, TypeSpace, TypeSpaceSettings};
 /// - `schema`: string literal; the JSON schema file
 ///
 /// - `derives`: optional array of derive macro paths; the derive macros to be
-/// applied to all generated types
+///   applied to all generated types
 ///
+/// - `patch`: optional map of type to an object with the optional members
+///   `rename` and `derives` for type-specific renames and derive macros.
+///   
 /// - `struct_builder`: optional boolean; (if true) generates a `::builder()`
-/// method for each generated struct that can be used to specify each property
-/// and construct the struct
+///   method for each generated struct that can be used to specify each
+///   property and construct the struct
 #[proc_macro]
 pub fn import_types(item: TokenStream) -> TokenStream {
     match do_import_types(item) {
@@ -39,26 +42,26 @@ pub fn import_types(item: TokenStream) -> TokenStream {
 }
 
 #[derive(Deserialize)]
-struct Settings {
+struct MacroSettings {
     schema: ParseWrapper<LitStr>,
     #[serde(default)]
     derives: Vec<ParseWrapper<syn::Path>>,
     #[serde(default)]
-    adjustments: HashMap<ParseWrapper<syn::Type>, Adjustment>,
+    patch: HashMap<ParseWrapper<syn::Type>, MacroPatch>,
     #[serde(default)]
     struct_builder: bool,
 }
 
 #[derive(Deserialize)]
-struct Adjustment {
+struct MacroPatch {
     #[serde(default)]
     rename: Option<String>,
     #[serde(default)]
     derives: Vec<ParseWrapper<syn::Path>>,
 }
 
-impl From<Adjustment> for TypeAdjustment {
-    fn from(a: Adjustment) -> Self {
+impl From<MacroPatch> for TypeSpacePatch {
+    fn from(a: MacroPatch) -> Self {
         let mut s = Self::default();
         a.rename.iter().for_each(|rename| {
             s.with_rename(rename);
@@ -75,18 +78,18 @@ fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
     let (schema, settings) = if let Ok(ll) = syn::parse::<LitStr>(item.clone()) {
         (ll, TypeSpaceSettings::default())
     } else {
-        let Settings {
+        let MacroSettings {
             schema,
             derives,
-            adjustments,
+            patch,
             struct_builder,
         } = serde_tokenstream::from_tokenstream(&item.into())?;
         let mut settings = TypeSpaceSettings::default();
         derives.into_iter().for_each(|derive| {
             settings.with_derive(derive.to_token_stream().to_string());
         });
-        adjustments.into_iter().for_each(|(type_name, adjustment)| {
-            settings.with_type_adjustment(type_name, &adjustment.into());
+        patch.into_iter().for_each(|(type_name, patch)| {
+            settings.with_patch(type_name.to_token_stream().to_string(), &patch.into());
         });
         settings.with_struct_builder(struct_builder);
         (schema.into_inner(), settings)

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -93,13 +93,13 @@
 
 pub use typify_impl::Error;
 pub use typify_impl::Type;
-pub use typify_impl::TypeAdjustment;
 pub use typify_impl::TypeDetails;
 pub use typify_impl::TypeEnum;
 pub use typify_impl::TypeEnumVariant;
 pub use typify_impl::TypeId;
 pub use typify_impl::TypeNewtype;
 pub use typify_impl::TypeSpace;
+pub use typify_impl::TypeSpacePatch;
 pub use typify_impl::TypeSpaceSettings;
 pub use typify_impl::TypeStruct;
 pub use typify_macro::import_types;

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -93,6 +93,7 @@
 
 pub use typify_impl::Error;
 pub use typify_impl::Type;
+pub use typify_impl::TypeAdjustment;
 pub use typify_impl::TypeDetails;
 pub use typify_impl::TypeEnum;
 pub use typify_impl::TypeEnumVariant;


### PR DESCRIPTION
Part 1 of what we discussed @andrewjstone 

I'll need to pick this up in progenitor as well