### PR TITLE
Avoid duplicate derives

### DIFF
--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1665,7 +1665,7 @@ mod tests {
         type_entry.output(&type_space, &mut output);
         let actual = output.into_stream();
         let expected = quote! {
-            #[derive(Clone, Debug, Deserialize, Serialize, A, B, C, D)]
+            #[derive(A, B, C, Clone, D, Debug, Deserialize, Serialize)]
             pub enum ResultX {
                 Ok(u32),
                 Err(String),

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -192,7 +192,9 @@ impl TypeSpaceSettings {
 
     /// Add an additional derive macro to apply to all defined types.
     pub fn with_derive(&mut self, derive: String) -> &mut Self {
-        self.extra_derives.push(derive);
+        if !self.extra_derives.contains(&derive.to_string()) {
+            self.extra_derives.push(derive);
+        }
         self
     }
 

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1232,15 +1232,14 @@ fn strings_to_derives<'a>(
     type_derives: &'a BTreeSet<String>,
     extra_derives: &'a [String],
 ) -> impl Iterator<Item = TokenStream> + 'a {
-    derive_set
-        .into_iter()
-        .chain(type_derives.iter().map(String::as_str))
-        .chain(extra_derives.iter().map(String::as_str))
-        .map(|derive| {
-            syn::parse_str::<syn::Path>(derive)
-                .unwrap()
-                .into_token_stream()
-        })
+    let mut combined_derives = derive_set.clone();
+    combined_derives.extend(extra_derives.iter().map(String::as_str));
+    combined_derives.extend(type_derives.iter().map(String::as_str));
+    combined_derives.into_iter().map(|derive| {
+        syn::parse_str::<syn::Path>(derive)
+            .unwrap()
+            .into_token_stream()
+    })
 }
 
 fn untagged_newtype_variants(

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,6 +1,6 @@
 mod types {
     #[derive(
-        Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd, JsonSchema,
+        Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
     )]
     pub struct AllTheTraits {
         pub ok: String,
@@ -10,7 +10,7 @@ mod types {
             builder::AllTheTraits::default()
         }
     }
-    #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
     pub struct CompoundType {
         pub value1: String,
         pub value2: u64,
@@ -20,7 +20,7 @@ mod types {
             builder::CompoundType::default()
         }
     }
-    #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
     pub struct Pair {
         #[serde(default = "defaults::pair_a")]
         pub a: StringEnum,
@@ -33,7 +33,7 @@ mod types {
         }
     }
     #[derive(
-        Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, JsonSchema,
+        Clone, Copy, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
     )]
     pub enum StringEnum {
         One,


### PR DESCRIPTION
If code was using `with_derive("Foo")`, and `Foo` is added to the base derive list, the result is a duplicate derive.

This prevents that from being a failure, and also sorts the combined derives.