### PR TITLE
Generate a `ToString` impl for untagged enums with trivial variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ version = "0.0.11-dev"
 dependencies = [
  "expectorate",
  "glob",
+ "regress",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,13 +492,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "trybuild"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db29f438342820400f2d9acfec0d363e987a38b2950bdb50a7069ed17b2148ee"
+dependencies = [
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "typify"
 version = "0.0.11-dev"
 dependencies = [
+ "expectorate",
+ "glob",
  "schemars",
  "serde",
+ "serde_json",
+ "trybuild",
  "typify-impl",
  "typify-macro",
+ "uuid",
 ]
 
 [[package]]
@@ -557,6 +592,9 @@ name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "walkdir"

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -435,13 +435,13 @@ impl TypeSpace {
 
             Some("uuid") => {
                 self.uses_uuid = true;
-                Ok((TypeEntry::new_builtin("uuid::Uuid"), metadata))
+                Ok((TypeEntry::new_builtin("uuid::Uuid", &["Display"]), metadata))
             }
 
             Some("date") => {
                 self.uses_chrono = true;
                 Ok((
-                    TypeEntry::new_builtin("chrono::Date<chrono::offset::Utc>"),
+                    TypeEntry::new_builtin("chrono::Date<chrono::offset::Utc>", &["Display"]),
                     metadata,
                 ))
             }
@@ -449,14 +449,23 @@ impl TypeSpace {
             Some("date-time") => {
                 self.uses_chrono = true;
                 Ok((
-                    TypeEntry::new_builtin("chrono::DateTime<chrono::offset::Utc>"),
+                    TypeEntry::new_builtin("chrono::DateTime<chrono::offset::Utc>", &["Display"]),
                     metadata,
                 ))
             }
 
-            Some("ip") => Ok((TypeEntry::new_builtin("std::net::IpAddr"), metadata)),
-            Some("ipv4") => Ok((TypeEntry::new_builtin("std::net::Ipv4Addr"), metadata)),
-            Some("ipv6") => Ok((TypeEntry::new_builtin("std::net::Ipv6Addr"), metadata)),
+            Some("ip") => Ok((
+                TypeEntry::new_builtin("std::net::IpAddr", &["Display"]),
+                metadata,
+            )),
+            Some("ipv4") => Ok((
+                TypeEntry::new_builtin("std::net::Ipv4Addr", &["Display"]),
+                metadata,
+            )),
+            Some("ipv6") => Ok((
+                TypeEntry::new_builtin("std::net::Ipv6Addr", &["Display"]),
+                metadata,
+            )),
 
             Some(unhandled) => {
                 info!("treating a string format '{}' as a String", unhandled);
@@ -950,7 +959,7 @@ impl TypeSpace {
         &mut self,
         metadata: &'a Option<Box<Metadata>>,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
-        let any = TypeEntry::new_builtin("serde_json::Value");
+        let any = TypeEntry::new_builtin("serde_json::Value", &[]);
         let type_id = self.assign_type(any);
         Ok((TypeEntryDetails::Array(type_id).into(), metadata))
     }
@@ -968,7 +977,7 @@ impl TypeSpace {
         metadata: &'a Option<Box<Metadata>>,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
         self.uses_serde_json = true;
-        Ok((TypeEntry::new_builtin("serde_json::Value"), metadata))
+        Ok((TypeEntry::new_builtin("serde_json::Value", &[]), metadata))
     }
 
     fn convert_typed_enum<'a>(

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -620,6 +620,7 @@ mod tests {
         let type_entry = TypeEntry {
             details: crate::type_entry::TypeEntryDetails::Box(type_id),
             derives: Default::default(),
+            impls: Default::default(),
         };
 
         assert!(matches!(

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -412,6 +412,7 @@ mod tests {
         let type_entry = TypeEntry {
             details: crate::type_entry::TypeEntryDetails::Box(type_id),
             derives: Default::default(),
+            impls: Default::default(),
         };
 
         assert_eq!(

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -17,6 +17,7 @@ typify-impl = { version = "0.0.11-dev", path = "../typify-impl" }
 [dev-dependencies]
 expectorate = "1.0.5"
 glob = "0.3.0"
+regress = "0.4.1"
 schemars = "0.8.11"
 serde = "1.0.148"
 serde_json = "1.0.89"

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -15,5 +15,10 @@ typify-macro = { version = "0.0.11-dev", path = "../typify-macro" }
 typify-impl = { version = "0.0.11-dev", path = "../typify-impl" }
 
 [dev-dependencies]
+expectorate = "1.0.5"
+glob = "0.3.0"
 schemars = "0.8.11"
-serde = "1.0"
+serde = "1.0.148"
+serde_json = "1.0.89"
+trybuild = "1.0.72"
+uuid = { version = "1.2.2", features = ["serde"] }

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -1,0 +1,58 @@
+// Copyright 2022 Oxide Computer Company
+
+use std::{error::Error, fs::File, io::BufReader};
+
+use expectorate::assert_contents;
+use glob::glob;
+use schemars::schema::{RootSchema, Schema};
+use typify::TypeSpace;
+
+#[test]
+fn test_schemas() {
+    for entry in glob("tests/schemas/*.json").expect("Failed to read glob pattern") {
+        validate_schema(entry.unwrap()).unwrap();
+    }
+
+    let t = trybuild::TestCases::new();
+    t.pass("tests/schemas/*.rs");
+
+    //panic!();
+}
+
+fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {
+    let mut out_path = path.clone();
+    out_path.set_extension("rs");
+
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+
+    // Read the JSON contents of the file as an instance of `User`.
+    let root_schema: RootSchema = serde_json::from_reader(reader)?;
+
+    let mut type_space = TypeSpace::default();
+    type_space.add_ref_types(root_schema.definitions)?;
+
+    let base_type = &root_schema.schema;
+
+    // Only convert the top-level type if it has a name
+    if base_type
+        .metadata
+        .as_ref()
+        .and_then(|m| m.title.as_ref())
+        .is_some()
+    {
+        let _ = type_space
+            .add_type(&Schema::Object(root_schema.schema))
+            .unwrap();
+    }
+
+    let code = format!(
+        "{}\n{}\nfn main() {{}}\n",
+        "use serde::{Deserialize, Serialize};",
+        type_space.to_string()
+    );
+
+    assert_contents(out_path, &code);
+
+    Ok(())
+}

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -9,14 +9,13 @@ use typify::TypeSpace;
 
 #[test]
 fn test_schemas() {
+    // Make sure output is up to date.
     for entry in glob("tests/schemas/*.json").expect("Failed to read glob pattern") {
         validate_schema(entry.unwrap()).unwrap();
     }
 
-    let t = trybuild::TestCases::new();
-    t.pass("tests/schemas/*.rs");
-
-    //panic!();
+    // Make sure it all compiles.
+    trybuild::TestCases::new().pass("tests/schemas/*.rs");
 }
 
 fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {

--- a/typify/tests/schemas/id-or-name.json
+++ b/typify/tests/schemas/id-or-name.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IdOrName",
+  "oneOf": [
+    {
+      "title": "Id",
+      "allOf": [
+        {
+          "type": "string",
+          "format": "uuid"
+        }
+      ]
+    },
+    {
+      "title": "Name",
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/typify/tests/schemas/id-or-name.json
+++ b/typify/tests/schemas/id-or-name.json
@@ -15,9 +15,18 @@
       "title": "Name",
       "allOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/Name"
         }
       ]
     }
-  ]
+  ],
+  "definitions": {
+    "Name": {
+      "title": "A name unique within the parent collection",
+      "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",
+      "type": "string",
+      "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$",
+      "maxLength": 63
+    }
+  }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IdOrName {
+    Id(uuid::Uuid),
+    Name(String),
+}
+
+fn main() {}

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -5,6 +5,14 @@ pub enum IdOrName {
     Id(uuid::Uuid),
     Name(Name),
 }
+impl ToString for IdOrName {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Id(x) => x.to_string(),
+            Self::Name(x) => x.to_string(),
+        }
+    }
+}
 #[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID."]
 #[derive(Clone, Debug, Serialize)]
 pub struct Name(String);

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -3,7 +3,47 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum IdOrName {
     Id(uuid::Uuid),
-    Name(String),
+    Name(Name),
+}
+#[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID."]
+#[derive(Clone, Debug, Serialize)]
+pub struct Name(String);
+impl std::ops::Deref for Name {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::convert::TryFrom<&str> for Name {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() > 63usize {
+            return Err("longer than 63 characters");
+        }
+        if regress :: Regex :: new ("^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$") . unwrap () . find (value) . is_none () { return Err ("doesn't match pattern \"^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$\"") ; }
+        Ok(Self(value.to_string()))
+    }
+}
+impl std::convert::TryFrom<&String> for Name {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+impl std::convert::TryFrom<String> for Name {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::try_from(String::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+    }
 }
 
 fn main() {}


### PR DESCRIPTION
Fixes #144 

For enums of this form:

```rust
enum EnumType {
    WrappedString1(WrappedString1),
    WrappedString2(WrappedString2),
}
```

This generates a `impl ToString`.

This also introduces a test harness that converts json schema documents into rust and compiles them (I've wanted this for awhile).

Here's the key output from the new test case:

```rust
impl ToString for IdOrName {
    fn to_string(&self) -> String {
        match self {
            Self::Id(x) => x.to_string(),
            Self::Name(x) => x.to_string(),
        }
    }
}
```