### PR TITLE
simplify enumerated strings with validation constraints

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -6,11 +6,11 @@ use crate::type_entry::{
     EnumTagType, TypeEntry, TypeEntryDetails, TypeEntryEnum, TypeEntryNewtype, TypeEntryStruct,
     Variant, VariantDetails,
 };
-use crate::util::{all_mutually_exclusive, none_or_single, recase, Case};
+use crate::util::{all_mutually_exclusive, none_or_single, recase, Case, StringValidator};
 use log::info;
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
-    SubschemaValidation,
+    StringValidation, SubschemaValidation,
 };
 
 use crate::util::get_type_name;
@@ -88,14 +88,17 @@ impl TypeSpace {
                 const_value: None,
                 subschemas: None,
                 number: None,
-                string: validation,
+                string,
                 array: None,
                 object: None,
                 reference: None,
                 extensions: _,
-            } if single.as_ref() == &InstanceType::String => {
-                self.convert_string(type_name, metadata, format, validation)
-            }
+            } if single.as_ref() == &InstanceType::String => self.convert_string(
+                type_name,
+                metadata,
+                format,
+                string.as_ref().map(Box::as_ref),
+            ),
 
             // Strings with the type omitted, but validation present
             SchemaObject {
@@ -106,14 +109,19 @@ impl TypeSpace {
                 const_value: None,
                 subschemas: None,
                 number: None,
-                string: validation @ Some(_),
+                string: string @ Some(_),
                 array: None,
                 object: None,
                 reference: None,
                 extensions: _,
-            } => self.convert_string(type_name, metadata, format, validation),
+            } => self.convert_string(
+                type_name,
+                metadata,
+                format,
+                string.as_ref().map(Box::as_ref),
+            ),
 
-            // Simple string enum
+            // Enumerated string type
             SchemaObject {
                 metadata,
                 instance_type: Some(SingleOrVec::Single(single)),
@@ -122,14 +130,17 @@ impl TypeSpace {
                 const_value: None,
                 subschemas: None,
                 number: None,
-                string: None,
+                string,
                 array: None,
                 object: None,
                 reference: None,
                 extensions: _,
-            } if single.as_ref() == &InstanceType::String => {
-                self.convert_enum_string(type_name, metadata, enum_values)
-            }
+            } if single.as_ref() == &InstanceType::String => self.convert_enum_string(
+                type_name,
+                metadata,
+                enum_values,
+                string.as_ref().map(Box::as_ref),
+            ),
 
             // Integers
             SchemaObject {
@@ -401,10 +412,10 @@ impl TypeSpace {
         type_name: Name,
         metadata: &'a Option<Box<Metadata>>,
         format: &Option<String>,
-        validation: &Option<Box<schemars::schema::StringValidation>>,
+        validation: Option<&StringValidation>,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
         match format.as_ref().map(String::as_str) {
-            None => match validation.as_ref().map(Box::as_ref) {
+            None => match validation {
                 // It would be unusual for the StringValidation to be Some, but
                 // all its fields to be None, but ... whatever.
                 None
@@ -479,6 +490,7 @@ impl TypeSpace {
         type_name: Name,
         metadata: &'a Option<Box<Metadata>>,
         enum_values: &[serde_json::Value],
+        validation: Option<&StringValidation>,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
         // We expect all enum values to be either a string **or** a null. We
         // gather them all up and then choose to either be an enum of simple
@@ -492,6 +504,8 @@ impl TypeSpace {
         // JSON schema.
         let mut has_null = false;
 
+        let validator = StringValidator::new(validation)?;
+
         let variants = enum_values
             .iter()
             .flat_map(|value| match value {
@@ -501,7 +515,7 @@ impl TypeSpace {
                     has_null = true;
                     None
                 }
-                serde_json::Value::String(value) => {
+                serde_json::Value::String(value) if validator.is_valid(value) => {
                     let (name, rename) = recase(value, Case::Pascal);
                     Some(Ok(Variant {
                         name,
@@ -510,6 +524,13 @@ impl TypeSpace {
                         details: VariantDetails::Simple,
                     }))
                 }
+
+                // Ignore enum variants whose strings don't match the given
+                // constraints. If we wanted to get fancy we could include
+                // these variants in the enum but exclude them from the FromStr
+                // conversion... but that seems like unnecessary swag.
+                serde_json::Value::String(_) => None,
+
                 _ => Some(Err(Error::BadValue("string".to_string(), value.clone()))),
             })
             .collect::<Result<Vec<Variant>>>()?;
@@ -1050,9 +1071,12 @@ impl TypeSpace {
             .collect::<HashSet<_>>();
 
         match (instance_types.len(), instance_types.iter().next()) {
-            (1, Some(InstanceType::String)) => {
-                self.convert_enum_string(type_name, &schema.metadata, enum_values)
-            }
+            (1, Some(InstanceType::String)) => self.convert_enum_string(
+                type_name,
+                &schema.metadata,
+                enum_values,
+                schema.string.as_ref().map(Box::as_ref),
+            ),
 
             // TOD0 We're ignoring booleans for the moment because some of the
             // tests show that this may require more careful consideration.

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -908,7 +908,12 @@ mod tests {
 
         let mut type_space = TypeSpace::default();
         let (te, _) = type_space
-            .convert_enum_string(Name::Required("OnTheGo".to_string()), &None, &enum_values)
+            .convert_enum_string(
+                Name::Required("OnTheGo".to_string()),
+                &None,
+                &enum_values,
+                None,
+            )
             .unwrap();
 
         if let TypeEntryDetails::Option(id) = &te.details {

--- a/typify/tests/schemas/extraneous-enum.json
+++ b/typify/tests/schemas/extraneous-enum.json
@@ -1,0 +1,15 @@
+{
+  "title": "LetterBox",
+  "type": "object",
+  "properties": {
+    "letter": {
+      "type": "string",
+      "enum": [
+        "a",
+        "b",
+        "cee"
+      ],
+      "maxLength": 2
+    }
+  }
+}

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LetterBox {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub letter: Option<LetterBoxLetter>,
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LetterBoxLetter {
+    #[serde(rename = "a")]
+    A,
+    #[serde(rename = "b")]
+    B,
+}
+impl ToString for LetterBoxLetter {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::A => "a".to_string(),
+            Self::B => "b".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LetterBoxLetter {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "a" => Ok(Self::A),
+            "b" => Ok(Self::B),
+            _ => Err("invalid value"),
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Simplifies the output for JSON schema to eliminate an intermediate struct and replace it with an enum.

```json
{
  "title": "LetterBox",
  "type": "object",
  "properties": {
    "letter": {
      "type": "string",
      "enum": [
        "a",
        "b",
        "cee"
      ],
      "maxLength": 2
    }
  }
}
```

generates this

```rust
use serde::{Deserialize, Serialize};
#[derive(Clone, Debug, Deserialize, Serialize)]
pub struct LetterBox {
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub letter: Option<LetterBoxLetter>,
}
#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
pub enum LetterBoxLetter {
    #[serde(rename = "a")]
    A,
    #[serde(rename = "b")]
    B,
}
```