### PR TITLE
Improve generated code for FromStr and TryFrom impls

### DIFF
--- a/example-build/build.rs
+++ b/example-build/build.rs
@@ -15,7 +15,7 @@ fn main() {
         let _ = type_space.add_type(&Schema::Object(schema.schema)).unwrap();
     }
 
-    let content = format!(
+    let contents = format!(
         "{}\n{}",
         "use serde::{Deserialize, Serialize};",
         type_space.to_string()
@@ -23,5 +23,5 @@ fn main() {
 
     let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
     out_file.push("codegen.rs");
-    fs::write(out_file, &content).unwrap();
+    fs::write(out_file, contents).unwrap();
 }

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -544,8 +544,8 @@ impl TypeSpace {
                             .collect::<BTreeSet<_>>();
                         let properties = validation
                             .properties
-                            .iter()
-                            .map(|(prop_name, _)| prop_name.clone())
+                            .keys()
+                            .cloned()
                             .collect::<BTreeSet<_>>();
 
                         Some((constants, properties))

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -222,7 +222,7 @@ impl TypeSpaceSettings {
 
     /// Add an additional derive macro to apply to all defined types.
     pub fn with_derive(&mut self, derive: String) -> &mut Self {
-        if !self.extra_derives.contains(&derive.to_string()) {
+        if !self.extra_derives.contains(&derive) {
             self.extra_derives.push(derive);
         }
         self

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -322,6 +322,11 @@ impl TypeSpace {
             .map(|(schema, property_name)| {
                 let (type_id, metadata) = self.id_for_schema(type_name.clone(), schema)?;
                 let (name, _) = recase(property_name, Case::Snake);
+                let name = if validation.properties.contains_key(&name) {
+                    format!("{}__", name)
+                } else {
+                    name
+                };
                 Ok(StructProperty {
                     name,
                     rename: StructPropertyRename::Flatten,

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -381,7 +381,7 @@ impl TypeEntryNewtype {
 impl From<TypeEntryDetails> for TypeEntry {
     fn from(details: TypeEntryDetails) -> Self {
         let impls = match details {
-            TypeEntryDetails::String => ["Display", "FromStr"]
+            TypeEntryDetails::Integer(_) | TypeEntryDetails::String => ["Display", "FromStr"]
                 .into_iter()
                 .map(ToString::to_string)
                 .collect(),
@@ -411,11 +411,7 @@ impl TypeEntry {
         }
     }
     pub(crate) fn new_integer<S: ToString>(type_name: S) -> Self {
-        TypeEntry {
-            details: TypeEntryDetails::Integer(type_name.to_string()),
-            derives: Default::default(),
-            impls: Default::default(),
-        }
+        TypeEntryDetails::Integer(type_name.to_string()).into()
     }
     pub(crate) fn new_float<S: ToString>(type_name: S) -> Self {
         TypeEntry {
@@ -560,13 +556,25 @@ impl TypeEntry {
                 impl std::str::FromStr for #type_name {
                     type Err = &'static str;
 
-                    fn from_str(
-                        value: &str
-                    ) -> Result<Self, Self::Err> {
+                    fn from_str(value: &str) -> Result<Self, Self::Err> {
                         match value {
                             #(#match_strs => Ok(Self::#match_variants),)*
                             _ => Err("invalid value"),
                         }
+                    }
+                }
+                impl std::convert::TryFrom<&str> for #type_name {
+                    type Error = <Self as std::str::FromStr>::Err;
+
+                    fn try_from(value: &str) -> Result<Self, Self::Error> {
+                        value.parse()
+                    }
+                }
+                impl std::convert::TryFrom<&String> for #type_name {
+                    type Error = <Self as std::str::FromStr>::Err;
+
+                    fn try_from(value: &String) -> Result<Self, Self::Error> {
+                        value.parse()
                     }
                 }
             }
@@ -585,56 +593,38 @@ impl TypeEntry {
 
         let untagged_newtype_from_string_impl =
             untagged_newtype_variants(type_space, tag_type, variants, "FromStr").then(|| {
-                let (variant_name, variant_type): (Vec<_>, Vec<_>) = variants
+                let variant_name = variants
                     .iter()
-                    .map(|variant| {
-                        if let VariantDetails::Item(type_id) = &variant.details {
-                            let type_entry = type_space.id_to_entry.get(type_id).unwrap();
+                    .map(|variant| format_ident!("{}", variant.name));
 
-                            (
-                                format_ident!("{}", variant.name),
-                                type_entry.type_ident(type_space, &None),
-                            )
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .unzip();
-
-                // Implement From<String> by doing a try_from() for each
-                // variant.
+                // Implement FromStr by trying to parse() into each variant.
                 quote! {
+                    impl std::str::FromStr for #type_name {
+                        type Err = &'static str;
+
+                        fn from_str(value: &str) -> Result<Self, Self::Err> {
+                            #(
+                                if let Ok(v) = value.parse() {
+                                    Ok(Self::#variant_name(v))
+                                } else
+                            )*
+                            {
+                                Err("string conversion failed for all variants")
+                            }
+                        }
+                    }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = &'static str;
+                        type Error = <Self as std::str::FromStr>::Err;
 
                         fn try_from(value: &str) -> Result<Self, Self::Error> {
-                            // Seed with an error to make successive cases more
-                            // consistent; this will never reach the user.
-                            Err("")
-                            #(
-                                .or_else(|_: Self::Error| {
-                                    Ok(Self::#variant_name(
-                                        #variant_type::try_from(value)?,
-                                    ))
-                                })
-                            )*
-                            .map_err(|_: Self::Error| {
-                                "string conversion failed for all variants"
-                            })
+                            value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = &'static str;
+                        type Error = <Self as std::str::FromStr>::Err;
 
                         fn try_from(value: &String) -> Result<Self, Self::Error> {
-                            Self::try_from(value.as_str())
-                        }
-                    }
-                    impl std::convert::TryFrom<String> for #type_name {
-                        type Error = &'static str;
-
-                        fn try_from(value: String) -> Result<Self, Self::Error> {
-                            Self::try_from(value.as_str())
+                            value.parse()
                         }
                     }
                 }
@@ -962,10 +952,10 @@ impl TypeEntry {
                 derive_set.remove("Deserialize");
 
                 Some(quote! {
-                    impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = &'static str;
+                    impl std::str::FromStr for #type_name {
+                        type Err = &'static str;
 
-                        fn try_from(value: &str) -> Result<Self, Self::Error> {
+                        fn from_str(value: &str) -> Result<Self, Self::Err> {
                             #max
                             #min
                             #pat
@@ -973,18 +963,18 @@ impl TypeEntry {
                             Ok(Self(value.to_string()))
                         }
                     }
-                    impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = &'static str;
+                    impl std::convert::TryFrom<&str> for #type_name {
+                        type Error = <Self as std::str::FromStr>::Err;
 
-                        fn try_from(value: &String) -> Result<Self, Self::Error> {
-                            Self::try_from(value.as_str())
+                        fn try_from(value: &str) -> Result<Self, Self::Error> {
+                            value.parse()
                         }
                     }
-                    impl std::convert::TryFrom<String> for #type_name {
-                        type Error = &'static str;
+                    impl std::convert::TryFrom<&String> for #type_name {
+                        type Error = <Self as std::str::FromStr>::Err;
 
-                        fn try_from(value: String) -> Result<Self, Self::Error> {
-                            Self::try_from(value.as_str())
+                        fn try_from(value: &String) -> Result<Self, Self::Error> {
+                            value.parse()
                         }
                     }
                     impl<'de> serde::Deserialize<'de> for #type_name {
@@ -992,8 +982,9 @@ impl TypeEntry {
                         where
                             D: serde::Deserializer<'de>,
                         {
-                            Self::try_from(String::deserialize(deserializer)?)
-                                .map_err(|e| {
+                            String::deserialize(deserializer)?
+                                .parse()
+                                .map_err(|e: <Self as std::str::FromStr>::Err| {
                                     <D::Error as serde::de::Error>::custom(
                                         e.to_string(),
                                     )

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -556,7 +556,7 @@ impl TypeEntry {
                 impl std::str::FromStr for #type_name {
                     type Err = &'static str;
 
-                    fn from_str(value: &str) -> Result<Self, Self::Err> {
+                    fn from_str(value: &str) -> Result<Self, &'static str> {
                         match value {
                             #(#match_strs => Ok(Self::#match_variants),)*
                             _ => Err("invalid value"),
@@ -564,16 +564,16 @@ impl TypeEntry {
                     }
                 }
                 impl std::convert::TryFrom<&str> for #type_name {
-                    type Error = <Self as std::str::FromStr>::Err;
+                    type Error = &'static str;
 
-                    fn try_from(value: &str) -> Result<Self, Self::Error> {
+                    fn try_from(value: &str) -> Result<Self, &'static str> {
                         value.parse()
                     }
                 }
                 impl std::convert::TryFrom<&String> for #type_name {
-                    type Error = <Self as std::str::FromStr>::Err;
+                    type Error = &'static str;
 
-                    fn try_from(value: &String) -> Result<Self, Self::Error> {
+                    fn try_from(value: &String) -> Result<Self, &'static str> {
                         value.parse()
                     }
                 }
@@ -597,12 +597,12 @@ impl TypeEntry {
                     .iter()
                     .map(|variant| format_ident!("{}", variant.name));
 
-                // Implement FromStr by trying to parse() into each variant.
                 quote! {
                     impl std::str::FromStr for #type_name {
                         type Err = &'static str;
 
-                        fn from_str(value: &str) -> Result<Self, Self::Err> {
+                        // Try to parse() into each variant.
+                        fn from_str(value: &str) -> Result<Self, &'static str> {
                             #(
                                 if let Ok(v) = value.parse() {
                                     Ok(Self::#variant_name(v))
@@ -614,16 +614,16 @@ impl TypeEntry {
                         }
                     }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = <Self as std::str::FromStr>::Err;
+                        type Error = &'static str;
 
-                        fn try_from(value: &str) -> Result<Self, Self::Error> {
+                        fn try_from(value: &str) -> Result<Self, &'static str> {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = <Self as std::str::FromStr>::Err;
+                        type Error = &'static str;
 
-                        fn try_from(value: &String) -> Result<Self, Self::Error> {
+                        fn try_from(value: &String) -> Result<Self, &'static str> {
                             value.parse()
                         }
                     }
@@ -844,7 +844,7 @@ impl TypeEntry {
                         type Error = String;
 
                         fn try_from(value: #type_name)
-                            -> Result<Self, Self::Error>
+                            -> Result<Self, String>
                         {
                             Ok(Self {
                                 #(
@@ -902,7 +902,7 @@ impl TypeEntry {
 
                         fn try_from(
                             value: #sub_type_name
-                        ) -> Result<Self, Self::Error> {
+                        ) -> Result<Self, &'static str> {
                             if #not [
                                 #(#value_output,)*
                             ].contains(&value) {
@@ -955,7 +955,7 @@ impl TypeEntry {
                     impl std::str::FromStr for #type_name {
                         type Err = &'static str;
 
-                        fn from_str(value: &str) -> Result<Self, Self::Err> {
+                        fn from_str(value: &str) -> Result<Self, &'static str> {
                             #max
                             #min
                             #pat
@@ -964,16 +964,16 @@ impl TypeEntry {
                         }
                     }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = <Self as std::str::FromStr>::Err;
+                        type Error = &'static str;
 
-                        fn try_from(value: &str) -> Result<Self, Self::Error> {
+                        fn try_from(value: &str) -> Result<Self, &'static str> {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = <Self as std::str::FromStr>::Err;
+                        type Error = &'static str;
 
-                        fn try_from(value: &String) -> Result<Self, Self::Error> {
+                        fn try_from(value: &String) -> Result<Self, &'static str> {
                             value.parse()
                         }
                     }
@@ -984,7 +984,7 @@ impl TypeEntry {
                         {
                             String::deserialize(deserializer)?
                                 .parse()
-                                .map_err(|e: <Self as std::str::FromStr>::Err| {
+                                .map_err(|e: &'static str| {
                                     <D::Error as serde::de::Error>::custom(
                                         e.to_string(),
                                     )
@@ -1027,7 +1027,7 @@ impl TypeEntry {
 
             impl std::ops::Deref for #type_name {
                 type Target = #sub_type_name;
-                fn deref(&self) -> &Self::Target {
+                fn deref(&self) -> &#sub_type_name {
                     &self.0
                 }
             }

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -60,6 +60,18 @@ mod types {
             }
         }
     }
+    impl std::convert::TryFrom<&str> for StringEnum {
+        type Error = <Self as std::str::FromStr>::Err;
+        fn try_from(value: &str) -> Result<Self, Self::Error> {
+            value.parse()
+        }
+    }
+    impl std::convert::TryFrom<&String> for StringEnum {
+        type Error = <Self as std::str::FromStr>::Err;
+        fn try_from(value: &String) -> Result<Self, Self::Error> {
+            value.parse()
+        }
+    }
     mod builder {
         pub struct AllTheTraits {
             ok: Result<String, String>,

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -51,7 +51,7 @@ mod types {
     }
     impl std::str::FromStr for StringEnum {
         type Err = &'static str;
-        fn from_str(value: &str) -> Result<Self, Self::Err> {
+        fn from_str(value: &str) -> Result<Self, &'static str> {
             match value {
                 "One" => Ok(Self::One),
                 "Two" => Ok(Self::Two),
@@ -61,14 +61,14 @@ mod types {
         }
     }
     impl std::convert::TryFrom<&str> for StringEnum {
-        type Error = <Self as std::str::FromStr>::Err;
-        fn try_from(value: &str) -> Result<Self, Self::Error> {
+        type Error = &'static str;
+        fn try_from(value: &str) -> Result<Self, &'static str> {
             value.parse()
         }
     }
     impl std::convert::TryFrom<&String> for StringEnum {
-        type Error = <Self as std::str::FromStr>::Err;
-        fn try_from(value: &String) -> Result<Self, Self::Error> {
+        type Error = &'static str;
+        fn try_from(value: &String) -> Result<Self, &'static str> {
             value.parse()
         }
     }
@@ -97,7 +97,7 @@ mod types {
         }
         impl std::convert::TryFrom<AllTheTraits> for super::AllTheTraits {
             type Error = String;
-            fn try_from(value: AllTheTraits) -> Result<Self, Self::Error> {
+            fn try_from(value: AllTheTraits) -> Result<Self, String> {
                 Ok(Self { ok: value.ok? })
             }
         }
@@ -137,7 +137,7 @@ mod types {
         }
         impl std::convert::TryFrom<CompoundType> for super::CompoundType {
             type Error = String;
-            fn try_from(value: CompoundType) -> Result<Self, Self::Error> {
+            fn try_from(value: CompoundType) -> Result<Self, String> {
                 Ok(Self {
                     value1: value.value1?,
                     value2: value.value2?,
@@ -180,7 +180,7 @@ mod types {
         }
         impl std::convert::TryFrom<Pair> for super::Pair {
             type Error = String;
-            fn try_from(value: Pair) -> Result<Self, Self::Error> {
+            fn try_from(value: Pair) -> Result<Self, String> {
                 Ok(Self {
                     a: value.a?,
                     b: value.b?,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -69,6 +69,18 @@ impl std::str::FromStr for AlertInstanceState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AlertInstanceState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AlertInstanceState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -286,6 +298,18 @@ impl std::str::FromStr for AppEventsItem {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppEventsItem {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppEventsItem {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The set of permissions for the GitHub app"]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -384,6 +408,18 @@ impl std::str::FromStr for AppPermissionsActions {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsActions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsActions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsAdministration {
     #[serde(rename = "read")]
@@ -407,6 +443,18 @@ impl std::str::FromStr for AppPermissionsAdministration {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -434,6 +482,18 @@ impl std::str::FromStr for AppPermissionsChecks {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsChecks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsChecks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsContentReferences {
     #[serde(rename = "read")]
@@ -457,6 +517,18 @@ impl std::str::FromStr for AppPermissionsContentReferences {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsContentReferences {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsContentReferences {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -484,6 +556,18 @@ impl std::str::FromStr for AppPermissionsContents {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsContents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsContents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsDeployments {
     #[serde(rename = "read")]
@@ -507,6 +591,18 @@ impl std::str::FromStr for AppPermissionsDeployments {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsDeployments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsDeployments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -534,6 +630,18 @@ impl std::str::FromStr for AppPermissionsDiscussions {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsEmails {
     #[serde(rename = "read")]
@@ -557,6 +665,18 @@ impl std::str::FromStr for AppPermissionsEmails {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsEmails {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsEmails {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -584,6 +704,18 @@ impl std::str::FromStr for AppPermissionsEnvironments {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsEnvironments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsEnvironments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsIssues {
     #[serde(rename = "read")]
@@ -607,6 +739,18 @@ impl std::str::FromStr for AppPermissionsIssues {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsIssues {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsIssues {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -634,6 +778,18 @@ impl std::str::FromStr for AppPermissionsMembers {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsMembers {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsMembers {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsMetadata {
     #[serde(rename = "read")]
@@ -657,6 +813,18 @@ impl std::str::FromStr for AppPermissionsMetadata {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsMetadata {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsMetadata {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -684,6 +852,18 @@ impl std::str::FromStr for AppPermissionsOrganizationAdministration {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsOrganizationHooks {
     #[serde(rename = "read")]
@@ -707,6 +887,18 @@ impl std::str::FromStr for AppPermissionsOrganizationHooks {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -734,6 +926,18 @@ impl std::str::FromStr for AppPermissionsOrganizationPackages {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsOrganizationPlan {
     #[serde(rename = "read")]
@@ -757,6 +961,18 @@ impl std::str::FromStr for AppPermissionsOrganizationPlan {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPlan {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPlan {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -784,6 +1000,18 @@ impl std::str::FromStr for AppPermissionsOrganizationProjects {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsOrganizationSecrets {
     #[serde(rename = "read")]
@@ -807,6 +1035,18 @@ impl std::str::FromStr for AppPermissionsOrganizationSecrets {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -834,6 +1074,18 @@ impl std::str::FromStr for AppPermissionsOrganizationSelfHostedRunners {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSelfHostedRunners {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSelfHostedRunners {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsOrganizationUserBlocking {
     #[serde(rename = "read")]
@@ -857,6 +1109,18 @@ impl std::str::FromStr for AppPermissionsOrganizationUserBlocking {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsOrganizationUserBlocking {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsOrganizationUserBlocking {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -884,6 +1148,18 @@ impl std::str::FromStr for AppPermissionsPackages {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsPages {
     #[serde(rename = "read")]
@@ -907,6 +1183,18 @@ impl std::str::FromStr for AppPermissionsPages {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsPages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsPages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -934,6 +1222,18 @@ impl std::str::FromStr for AppPermissionsPullRequests {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsPullRequests {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsPullRequests {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsRepositoryHooks {
     #[serde(rename = "read")]
@@ -957,6 +1257,18 @@ impl std::str::FromStr for AppPermissionsRepositoryHooks {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsRepositoryHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsRepositoryHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -984,6 +1296,18 @@ impl std::str::FromStr for AppPermissionsRepositoryProjects {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsRepositoryProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsRepositoryProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsSecretScanningAlerts {
     #[serde(rename = "read")]
@@ -1007,6 +1331,18 @@ impl std::str::FromStr for AppPermissionsSecretScanningAlerts {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsSecretScanningAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsSecretScanningAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1034,6 +1370,18 @@ impl std::str::FromStr for AppPermissionsSecrets {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsSecurityEvents {
     #[serde(rename = "read")]
@@ -1057,6 +1405,18 @@ impl std::str::FromStr for AppPermissionsSecurityEvents {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsSecurityEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsSecurityEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1084,6 +1444,18 @@ impl std::str::FromStr for AppPermissionsSecurityScanningAlert {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsSecurityScanningAlert {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsSecurityScanningAlert {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsSingleFile {
     #[serde(rename = "read")]
@@ -1107,6 +1479,18 @@ impl std::str::FromStr for AppPermissionsSingleFile {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsSingleFile {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsSingleFile {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1134,6 +1518,18 @@ impl std::str::FromStr for AppPermissionsStatuses {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsStatuses {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsStatuses {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsTeamDiscussions {
     #[serde(rename = "read")]
@@ -1157,6 +1553,18 @@ impl std::str::FromStr for AppPermissionsTeamDiscussions {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsTeamDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsTeamDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1184,6 +1592,18 @@ impl std::str::FromStr for AppPermissionsVulnerabilityAlerts {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AppPermissionsVulnerabilityAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsVulnerabilityAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AppPermissionsWorkflows {
     #[serde(rename = "read")]
@@ -1207,6 +1627,18 @@ impl std::str::FromStr for AppPermissionsWorkflows {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AppPermissionsWorkflows {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AppPermissionsWorkflows {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "How the author is associated with the repository."]
@@ -1257,6 +1689,18 @@ impl std::str::FromStr for AuthorAssociation {
             "OWNER" => Ok(Self::Owner),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AuthorAssociation {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AuthorAssociation {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The branch protection rule. Includes a `name` and all the [branch protection settings](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-settings) applied to branches that match the name. Binary settings are boolean. Multi-level configurations are one of `off`, `non_admins`, or `everyone`. Actor and build lists are arrays of strings."]
@@ -1323,6 +1767,18 @@ impl std::str::FromStr for BranchProtectionRuleAllowDeletionsEnforcementLevel {
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleAllowForcePushesEnforcementLevel {
     #[serde(rename = "off")]
@@ -1350,6 +1806,18 @@ impl std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLevel 
             "everyone" => Ok(Self::Everyone),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
@@ -1386,6 +1854,18 @@ impl std::str::FromStr for BranchProtectionRuleCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRuleCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -1418,6 +1898,18 @@ impl std::str::FromStr for BranchProtectionRuleDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
@@ -1453,6 +1945,18 @@ impl std::str::FromStr for BranchProtectionRuleEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "If the action was `edited`, the changes to the rule."]
@@ -1541,6 +2045,20 @@ impl std::str::FromStr for BranchProtectionRuleLinearHistoryRequirementEnforceme
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleMergeQueueEnforcementLevel {
     #[serde(rename = "off")]
@@ -1568,6 +2086,18 @@ impl std::str::FromStr for BranchProtectionRuleMergeQueueEnforcementLevel {
             "everyone" => Ok(Self::Everyone),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleMergeQueueEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleMergeQueueEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1599,6 +2129,18 @@ impl std::str::FromStr for BranchProtectionRulePullRequestReviewsEnforcementLeve
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleRequiredConversationResolutionLevel {
     #[serde(rename = "off")]
@@ -1626,6 +2168,18 @@ impl std::str::FromStr for BranchProtectionRuleRequiredConversationResolutionLev
             "everyone" => Ok(Self::Everyone),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredConversationResolutionLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredConversationResolutionLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1657,6 +2211,18 @@ impl std::str::FromStr for BranchProtectionRuleRequiredDeploymentsEnforcementLev
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     #[serde(rename = "off")]
@@ -1686,6 +2252,18 @@ impl std::str::FromStr for BranchProtectionRuleRequiredStatusChecksEnforcementLe
         }
     }
 }
+impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BranchProtectionRuleSignatureRequirementEnforcementLevel {
     #[serde(rename = "off")]
@@ -1713,6 +2291,18 @@ impl std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcementLe
             "everyone" => Ok(Self::Everyone),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1749,6 +2339,18 @@ impl std::str::FromStr for CheckRunCompletedAction {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
@@ -1849,6 +2451,18 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCompletedCheckRunCheckSuiteStatus {
     #[serde(rename = "in_progress")]
@@ -1876,6 +2490,18 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
@@ -1928,6 +2554,18 @@ impl std::str::FromStr for CheckRunCompletedCheckRunConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunOutput {
@@ -1958,6 +2596,18 @@ impl std::str::FromStr for CheckRunCompletedCheckRunStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The action requested by the user."]
@@ -2002,6 +2652,18 @@ impl std::str::FromStr for CheckRunCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
@@ -2102,6 +2764,18 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunCreatedCheckRunCheckSuiteStatus {
     #[serde(rename = "queued")]
@@ -2129,6 +2803,18 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
@@ -2181,6 +2867,18 @@ impl std::str::FromStr for CheckRunCreatedCheckRunConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunOutput {
@@ -2219,6 +2917,18 @@ impl std::str::FromStr for CheckRunCreatedCheckRunStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The action requested by the user."]
@@ -2362,6 +3072,18 @@ impl std::str::FromStr for CheckRunRequestedActionAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunRequestedActionAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRequestedActionAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -2460,6 +3182,18 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteStatus {
     #[serde(rename = "queued")]
@@ -2487,6 +3221,18 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
@@ -2539,6 +3285,18 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunOutput {
@@ -2577,6 +3335,18 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The action requested by the user."]
@@ -2621,6 +3391,18 @@ impl std::str::FromStr for CheckRunRerequestedAction {
             "rerequested" => Ok(Self::Rerequested),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunRerequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRerequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
@@ -2721,6 +3503,18 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteStatus {
     #[serde(rename = "completed")]
@@ -2740,6 +3534,18 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
@@ -2792,6 +3598,18 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunOutput {
@@ -2822,6 +3640,18 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The action requested by the user."]
@@ -2863,6 +3693,18 @@ impl std::str::FromStr for CheckSuiteCompletedAction {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckSuiteCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
@@ -2938,6 +3780,18 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteCompletedCheckSuiteStatus {
@@ -2970,6 +3824,18 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3040,6 +3906,18 @@ impl std::str::FromStr for CheckSuiteRequestedAction {
             "requested" => Ok(Self::Requested),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckSuiteRequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
@@ -3115,6 +3993,18 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteRequestedCheckSuiteStatus {
@@ -3149,6 +4039,18 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRerequested {
@@ -3180,6 +4082,18 @@ impl std::str::FromStr for CheckSuiteRerequestedAction {
             "rerequested" => Ok(Self::Rerequested),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckSuiteRerequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRerequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
@@ -3255,6 +4169,18 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CheckSuiteRerequestedCheckSuiteStatus {
@@ -3287,6 +4213,18 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3325,6 +4263,18 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAction {
             "appeared_in_branch" => Ok(Self::AppearedInBranch),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The code scanning alert involved in the event."]
@@ -3381,6 +4331,18 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertDismissedReason
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlertRule {
@@ -3425,6 +4387,18 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertAppearedInBranchAlertState {
@@ -3453,6 +4427,18 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertState {
             "fixed" => Ok(Self::Fixed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3499,6 +4485,18 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAction {
             "closed_by_user" => Ok(Self::ClosedByUser),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The code scanning alert involved in the event."]
@@ -3555,6 +4553,18 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertDismissedReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertRule {
@@ -3607,6 +4617,18 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertClosedByUserAlertState {
@@ -3627,6 +4649,18 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertState {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3675,6 +4709,18 @@ impl std::str::FromStr for CodeScanningAlertCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The code scanning alert involved in the event."]
@@ -3753,6 +4799,18 @@ impl std::str::FromStr for CodeScanningAlertCreatedAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertCreatedAlertState {
@@ -3777,6 +4835,18 @@ impl std::str::FromStr for CodeScanningAlertCreatedAlertState {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3927,6 +4997,18 @@ impl std::str::FromStr for CodeScanningAlertFixedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The code scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -3983,6 +5065,18 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertDismissedReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertDismissedReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertRule {
@@ -4035,6 +5129,18 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertFixedAlertState {
@@ -4055,6 +5161,18 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertState {
             "fixed" => Ok(Self::Fixed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4103,6 +5221,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedAction {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The code scanning alert involved in the event."]
@@ -4181,6 +5311,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertReopenedAlertState {
@@ -4209,6 +5351,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedAlertState {
             "fixed" => Ok(Self::Fixed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4257,6 +5411,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAction {
             "reopened_by_user" => Ok(Self::ReopenedByUser),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The code scanning alert involved in the event."]
@@ -4327,6 +5493,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertRuleSeverity {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of a code scanning alert."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CodeScanningAlertReopenedByUserAlertState {
@@ -4347,6 +5525,18 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertState {
             "open" => Ok(Self::Open),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4413,6 +5603,18 @@ impl std::str::FromStr for CommitCommentCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CommitCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CommitCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [commit comment](https://docs.github.com/en/rest/reference/repos#get-a-commit-comment) resource."]
@@ -4510,6 +5712,18 @@ impl std::str::FromStr for ContentReferenceCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ContentReferenceCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ContentReferenceCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContentReferenceCreatedContentReference {
@@ -4579,6 +5793,18 @@ impl std::str::FromStr for CreateEventRefType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CreateEventRefType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CreateEventRefType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "A Git branch or tag is deleted."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -4623,6 +5849,18 @@ impl std::str::FromStr for DeleteEventRefType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DeleteEventRefType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DeleteEventRefType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreated {
@@ -4654,6 +5892,18 @@ impl std::str::FromStr for DeployKeyCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DeployKeyCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DeployKeyCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [`deploy key`](https://docs.github.com/en/rest/reference/repos#get-a-deploy-key) resource."]
@@ -4699,6 +5949,18 @@ impl std::str::FromStr for DeployKeyDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DeployKeyDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DeployKeyDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [`deploy key`](https://docs.github.com/en/rest/reference/repos#get-a-deploy-key) resource."]
@@ -4772,6 +6034,18 @@ impl std::str::FromStr for DeploymentCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DeploymentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DeploymentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments)."]
@@ -4849,6 +6123,18 @@ impl std::str::FromStr for DeploymentStatusCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DeploymentStatusCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DeploymentStatusCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments) that this status is associated with."]
@@ -4971,6 +6257,18 @@ impl std::str::FromStr for DiscussionAnsweredAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionAnsweredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionAnsweredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredAnswer {
@@ -5034,6 +6332,18 @@ impl std::str::FromStr for DiscussionCategoryChangedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionCategoryChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCategoryChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChanges {
@@ -5090,6 +6400,18 @@ impl std::str::FromStr for DiscussionCommentCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentCreatedComment {
@@ -5137,6 +6459,18 @@ impl std::str::FromStr for DiscussionCommentDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5187,6 +6521,18 @@ impl std::str::FromStr for DiscussionCommentEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5286,6 +6632,18 @@ impl std::str::FromStr for DiscussionCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionDeleted {
@@ -5317,6 +6675,18 @@ impl std::str::FromStr for DiscussionDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5352,6 +6722,18 @@ impl std::str::FromStr for DiscussionEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5561,6 +6943,18 @@ impl std::str::FromStr for DiscussionLabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLocked {
@@ -5592,6 +6986,18 @@ impl std::str::FromStr for DiscussionLockedAction {
             "locked" => Ok(Self::Locked),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5627,6 +7033,18 @@ impl std::str::FromStr for DiscussionPinnedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionPinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionPinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DiscussionState {
     #[serde(rename = "open")]
@@ -5654,6 +7072,18 @@ impl std::str::FromStr for DiscussionState {
             "converting" => Ok(Self::Converting),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5688,6 +7118,18 @@ impl std::str::FromStr for DiscussionTransferredAction {
             "transferred" => Ok(Self::Transferred),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5728,6 +7170,18 @@ impl std::str::FromStr for DiscussionUnansweredAction {
             "unanswered" => Ok(Self::Unanswered),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionUnansweredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnansweredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5780,6 +7234,18 @@ impl std::str::FromStr for DiscussionUnlabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlocked {
@@ -5813,6 +7279,18 @@ impl std::str::FromStr for DiscussionUnlockedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DiscussionUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnpinned {
@@ -5844,6 +7322,18 @@ impl std::str::FromStr for DiscussionUnpinnedAction {
             "unpinned" => Ok(Self::Unpinned),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionUnpinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnpinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5952,6 +7442,18 @@ impl std::str::FromStr for GithubAppAuthorizationRevokedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for GithubAppAuthorizationRevokedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GithubAppAuthorizationRevokedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubOrg {
@@ -6033,6 +7535,18 @@ impl std::str::FromStr for GollumEventPagesItemAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for GollumEventPagesItemAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GollumEventPagesItemAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The GitHub App installation."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -6096,11 +7610,31 @@ impl std::str::FromStr for InstallationCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum InstallationCreatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
     Variant1(i64),
+}
+impl ToString for InstallationCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -6145,6 +7679,18 @@ impl std::str::FromStr for InstallationDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6415,6 +7961,18 @@ impl std::str::FromStr for InstallationEventsItem {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationEventsItem {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationEventsItem {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "Installation"]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -6454,6 +8012,18 @@ impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
             "new_permissions_accepted" => Ok(Self::NewPermissionsAccepted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationNewPermissionsAcceptedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationNewPermissionsAcceptedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6568,6 +8138,18 @@ impl std::str::FromStr for InstallationPermissionsActions {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsActions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsActions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsAdministration {
     #[serde(rename = "read")]
@@ -6591,6 +8173,18 @@ impl std::str::FromStr for InstallationPermissionsAdministration {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6618,6 +8212,18 @@ impl std::str::FromStr for InstallationPermissionsChecks {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsChecks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsChecks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsContentReferences {
     #[serde(rename = "read")]
@@ -6641,6 +8247,18 @@ impl std::str::FromStr for InstallationPermissionsContentReferences {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsContentReferences {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsContentReferences {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6668,6 +8286,18 @@ impl std::str::FromStr for InstallationPermissionsContents {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsContents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsContents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsDeployments {
     #[serde(rename = "read")]
@@ -6691,6 +8321,18 @@ impl std::str::FromStr for InstallationPermissionsDeployments {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsDeployments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsDeployments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6718,6 +8360,18 @@ impl std::str::FromStr for InstallationPermissionsDiscussions {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsEmails {
     #[serde(rename = "read")]
@@ -6741,6 +8395,18 @@ impl std::str::FromStr for InstallationPermissionsEmails {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsEmails {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsEmails {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6768,6 +8434,18 @@ impl std::str::FromStr for InstallationPermissionsEnvironments {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsEnvironments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsEnvironments {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsIssues {
     #[serde(rename = "read")]
@@ -6791,6 +8469,18 @@ impl std::str::FromStr for InstallationPermissionsIssues {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsIssues {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsIssues {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6818,6 +8508,18 @@ impl std::str::FromStr for InstallationPermissionsMembers {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsMembers {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsMembers {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsMetadata {
     #[serde(rename = "read")]
@@ -6841,6 +8543,18 @@ impl std::str::FromStr for InstallationPermissionsMetadata {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsMetadata {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsMetadata {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6868,6 +8582,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationAdministration {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationAdministration {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsOrganizationEvents {
     #[serde(rename = "read")]
@@ -6891,6 +8617,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationEvents {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6918,6 +8656,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationHooks {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsOrganizationPackages {
     #[serde(rename = "read")]
@@ -6941,6 +8691,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationPackages {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6968,6 +8730,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationPlan {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPlan {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPlan {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsOrganizationProjects {
     #[serde(rename = "read")]
@@ -6991,6 +8765,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationProjects {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7018,6 +8804,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationSecrets {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsOrganizationSelfHostedRunners {
     #[serde(rename = "read")]
@@ -7041,6 +8839,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationSelfHostedRunners 
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSelfHostedRunners {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSelfHostedRunners {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7068,6 +8878,18 @@ impl std::str::FromStr for InstallationPermissionsOrganizationUserBlocking {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationUserBlocking {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationUserBlocking {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsPackages {
     #[serde(rename = "read")]
@@ -7091,6 +8913,18 @@ impl std::str::FromStr for InstallationPermissionsPackages {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsPackages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7118,6 +8952,18 @@ impl std::str::FromStr for InstallationPermissionsPages {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsPages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsPages {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsPullRequests {
     #[serde(rename = "read")]
@@ -7141,6 +8987,18 @@ impl std::str::FromStr for InstallationPermissionsPullRequests {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsPullRequests {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsPullRequests {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7168,6 +9026,18 @@ impl std::str::FromStr for InstallationPermissionsRepositoryHooks {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryHooks {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsRepositoryProjects {
     #[serde(rename = "read")]
@@ -7191,6 +9061,18 @@ impl std::str::FromStr for InstallationPermissionsRepositoryProjects {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryProjects {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7218,6 +9100,18 @@ impl std::str::FromStr for InstallationPermissionsSecretScanningAlerts {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsSecretScanningAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsSecretScanningAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsSecrets {
     #[serde(rename = "read")]
@@ -7241,6 +9135,18 @@ impl std::str::FromStr for InstallationPermissionsSecrets {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsSecrets {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7268,6 +9174,18 @@ impl std::str::FromStr for InstallationPermissionsSecurityEvents {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityEvents {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsSecurityScanningAlert {
     #[serde(rename = "read")]
@@ -7291,6 +9209,18 @@ impl std::str::FromStr for InstallationPermissionsSecurityScanningAlert {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityScanningAlert {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityScanningAlert {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7318,6 +9248,18 @@ impl std::str::FromStr for InstallationPermissionsSingleFile {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsSingleFile {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsSingleFile {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsStatuses {
     #[serde(rename = "read")]
@@ -7341,6 +9283,18 @@ impl std::str::FromStr for InstallationPermissionsStatuses {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsStatuses {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsStatuses {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7368,6 +9322,18 @@ impl std::str::FromStr for InstallationPermissionsTeamDiscussions {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsTeamDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsTeamDiscussions {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsVulnerabilityAlerts {
     #[serde(rename = "read")]
@@ -7393,6 +9359,18 @@ impl std::str::FromStr for InstallationPermissionsVulnerabilityAlerts {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationPermissionsVulnerabilityAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsVulnerabilityAlerts {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationPermissionsWorkflows {
     #[serde(rename = "read")]
@@ -7416,6 +9394,18 @@ impl std::str::FromStr for InstallationPermissionsWorkflows {
             "write" => Ok(Self::Write),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationPermissionsWorkflows {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationPermissionsWorkflows {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7451,6 +9441,18 @@ impl std::str::FromStr for InstallationRepositoriesAddedAction {
             "added" => Ok(Self::Added),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7506,6 +9508,18 @@ impl std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
             "selected" => Ok(Self::Selected),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7573,6 +9587,18 @@ impl std::str::FromStr for InstallationRepositoriesRemovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemovedRepositoriesAddedItem {
@@ -7623,6 +9649,18 @@ impl std::str::FromStr for InstallationRepositoriesRemovedRepositorySelection {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum InstallationRepositorySelection {
@@ -7647,6 +9685,18 @@ impl std::str::FromStr for InstallationRepositorySelection {
             "selected" => Ok(Self::Selected),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationRepositorySelection {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7680,6 +9730,18 @@ impl std::str::FromStr for InstallationSuspendAction {
             "suspend" => Ok(Self::Suspend),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7717,6 +9779,18 @@ impl std::str::FromStr for InstallationTargetType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationTargetType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationTargetType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspend {
@@ -7750,6 +9824,18 @@ impl std::str::FromStr for InstallationUnsuspendAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for InstallationUnsuspendAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendRepositoriesItem {
@@ -7767,6 +9853,14 @@ pub struct InstallationUnsuspendRepositoriesItem {
 pub enum InstallationUpdatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
     Variant1(i64),
+}
+impl ToString for InstallationUpdatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
 }
 #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7842,6 +9936,18 @@ impl std::str::FromStr for IssueActiveLockReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssueActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The [comment](https://docs.github.com/en/rest/reference/issues#comments) itself."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -7896,6 +10002,18 @@ impl std::str::FromStr for IssueCommentCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssueCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeleted {
@@ -7929,6 +10047,18 @@ impl std::str::FromStr for IssueCommentDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7965,6 +10095,18 @@ impl std::str::FromStr for IssueCommentEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the comment."]
@@ -8062,6 +10204,18 @@ impl std::str::FromStr for IssueState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssueState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "Activity related to an issue. The type of activity is specified in the action property."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -8101,6 +10255,18 @@ impl std::str::FromStr for IssuesAssignedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesAssignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesAssignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosed {
@@ -8137,6 +10303,18 @@ impl std::str::FromStr for IssuesClosedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDeleted {
@@ -8168,6 +10346,18 @@ impl std::str::FromStr for IssuesDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8204,6 +10394,18 @@ impl std::str::FromStr for IssuesDemilestonedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesDemilestonedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesDemilestonedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEdited {
@@ -8238,6 +10440,18 @@ impl std::str::FromStr for IssuesEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the issue."]
@@ -8498,6 +10712,18 @@ impl std::str::FromStr for IssuesLabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLocked {
@@ -8529,6 +10755,18 @@ impl std::str::FromStr for IssuesLockedAction {
             "locked" => Ok(Self::Locked),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8565,6 +10803,18 @@ impl std::str::FromStr for IssuesMilestonedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesMilestonedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesMilestonedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpened {
@@ -8598,6 +10848,18 @@ impl std::str::FromStr for IssuesOpenedAction {
             "opened" => Ok(Self::Opened),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8639,6 +10901,18 @@ impl std::str::FromStr for IssuesPinnedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesPinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesPinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopened {
@@ -8670,6 +10944,18 @@ impl std::str::FromStr for IssuesReopenedAction {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8704,6 +10990,18 @@ impl std::str::FromStr for IssuesTransferredAction {
             "transferred" => Ok(Self::Transferred),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8750,6 +11048,18 @@ impl std::str::FromStr for IssuesUnassignedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesUnassignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesUnassignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlabeled {
@@ -8786,6 +11096,18 @@ impl std::str::FromStr for IssuesUnlabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlocked {
@@ -8819,6 +11141,18 @@ impl std::str::FromStr for IssuesUnlockedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IssuesUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnpinned {
@@ -8850,6 +11184,18 @@ impl std::str::FromStr for IssuesUnpinnedAction {
             "unpinned" => Ok(Self::Unpinned),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesUnpinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesUnpinnedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8900,6 +11246,18 @@ impl std::str::FromStr for LabelCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LabelCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LabelCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelDeleted {
@@ -8932,6 +11290,18 @@ impl std::str::FromStr for LabelDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LabelDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LabelDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8968,6 +11338,18 @@ impl std::str::FromStr for LabelEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LabelEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LabelEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the label if the action was `edited`."]
@@ -9108,6 +11490,18 @@ impl std::str::FromStr for MarketplacePurchaseCancelledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MarketplacePurchaseCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarketplacePurchaseCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledSender {
@@ -9160,6 +11554,18 @@ impl std::str::FromStr for MarketplacePurchaseChangedAction {
             "changed" => Ok(Self::Changed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MarketplacePurchaseChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarketplacePurchaseChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9265,6 +11671,18 @@ impl std::str::FromStr for MarketplacePurchasePendingChangeAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelled {
@@ -9294,6 +11712,18 @@ impl std::str::FromStr for MarketplacePurchasePendingChangeCancelledAction {
             "pending_change_cancelled" => Ok(Self::PendingChangeCancelled),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9386,6 +11816,18 @@ impl std::str::FromStr for MarketplacePurchasePurchasedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MarketplacePurchasePurchasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarketplacePurchasePurchasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedSender {
@@ -9444,6 +11886,18 @@ impl std::str::FromStr for MemberAddedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MemberAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MemberAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChanges {
@@ -9480,6 +11934,18 @@ impl std::str::FromStr for MemberAddedChangesPermissionTo {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MemberAddedChangesPermissionTo {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MemberAddedChangesPermissionTo {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEdited {
@@ -9511,6 +11977,18 @@ impl std::str::FromStr for MemberEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MemberEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MemberEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the collaborator permissions"]
@@ -9594,6 +12072,18 @@ impl std::str::FromStr for MemberRemovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MemberRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MemberRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The membership between the user and the organization. Not present when the action is `member_invited`."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9640,6 +12130,18 @@ impl std::str::FromStr for MembershipAddedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MembershipAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MembershipAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The scope of the membership. Currently, can only be `team`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MembershipAddedScope {
@@ -9660,6 +12162,18 @@ impl std::str::FromStr for MembershipAddedScope {
             "team" => Ok(Self::Team),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MembershipAddedScope {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MembershipAddedScope {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9730,6 +12244,18 @@ impl std::str::FromStr for MembershipRemovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MembershipRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MembershipRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The scope of the membership. Currently, can only be `team`."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MembershipRemovedScope {
@@ -9754,6 +12280,18 @@ impl std::str::FromStr for MembershipRemovedScope {
             "organization" => Ok(Self::Organization),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MembershipRemovedScope {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MembershipRemovedScope {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
@@ -9797,6 +12335,18 @@ impl std::str::FromStr for MetaDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MetaDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MetaDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The modified webhook. This will contain different keys based on the type of webhook it is: repository, organization, business, app, or GitHub Marketplace."]
@@ -9843,6 +12393,18 @@ impl std::str::FromStr for MetaDeletedHookConfigContentType {
             "form" => Ok(Self::Form),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MetaDeletedHookConfigContentType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MetaDeletedHookConfigContentType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9915,6 +12477,18 @@ impl std::str::FromStr for MilestoneClosedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MilestoneClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneCreated {
@@ -9946,6 +12520,18 @@ impl std::str::FromStr for MilestoneCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9981,6 +12567,18 @@ impl std::str::FromStr for MilestoneDeletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MilestoneDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEdited {
@@ -10013,6 +12611,18 @@ impl std::str::FromStr for MilestoneEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the milestone if the action was `edited`."]
@@ -10137,6 +12747,18 @@ impl std::str::FromStr for MilestoneOpenedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for MilestoneOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The state of the milestone."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum MilestoneState {
@@ -10161,6 +12783,18 @@ impl std::str::FromStr for MilestoneState {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10193,6 +12827,18 @@ impl std::str::FromStr for OrgBlockBlockedAction {
             "blocked" => Ok(Self::Blocked),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for OrgBlockBlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrgBlockBlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10251,6 +12897,18 @@ impl std::str::FromStr for OrgBlockUnblockedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for OrgBlockUnblockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrgBlockUnblockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Organization {
@@ -10298,6 +12956,18 @@ impl std::str::FromStr for OrganizationDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for OrganizationDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrganizationDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10381,6 +13051,18 @@ impl std::str::FromStr for OrganizationMemberAddedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for OrganizationMemberAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrganizationMemberAddedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvited {
@@ -10411,6 +13093,18 @@ impl std::str::FromStr for OrganizationMemberInvitedAction {
             "member_invited" => Ok(Self::MemberInvited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for OrganizationMemberInvitedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrganizationMemberInvitedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The invitation for the user or email if the action is `member_invited`."]
@@ -10460,6 +13154,18 @@ impl std::str::FromStr for OrganizationMemberRemovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for OrganizationMemberRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrganizationMemberRemovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationRenamed {
@@ -10489,6 +13195,18 @@ impl std::str::FromStr for OrganizationRenamedAction {
             "renamed" => Ok(Self::Renamed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for OrganizationRenamedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrganizationRenamedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10542,6 +13260,18 @@ impl std::str::FromStr for PackagePublishedAction {
             "published" => Ok(Self::Published),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PackagePublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PackagePublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "Information about the package."]
@@ -10657,6 +13387,18 @@ impl std::str::FromStr for PackageUpdatedAction {
             "updated" => Ok(Self::Updated),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PackageUpdatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PackageUpdatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "Information about the package."]
@@ -10845,6 +13587,18 @@ impl std::str::FromStr for PingEventHookConfigContentType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PingEventHookConfigContentType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PingEventHookConfigContentType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHookLastResponse {
@@ -10927,6 +13681,18 @@ impl std::str::FromStr for ProjectCardConvertedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectCardConvertedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCardConvertedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChanges {
@@ -10970,6 +13736,18 @@ impl std::str::FromStr for ProjectCardCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectCardCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCardCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardDeleted {
@@ -11001,6 +13779,18 @@ impl std::str::FromStr for ProjectCardDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectCardDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCardDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11035,6 +13825,18 @@ impl std::str::FromStr for ProjectCardEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectCardEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCardEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11143,6 +13945,18 @@ impl std::str::FromStr for ProjectCardMovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectCardMovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCardMovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChanges {
@@ -11184,6 +13998,18 @@ impl std::str::FromStr for ProjectClosedAction {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11233,6 +14059,18 @@ impl std::str::FromStr for ProjectColumnCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectColumnCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectColumnCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnDeleted {
@@ -11264,6 +14102,18 @@ impl std::str::FromStr for ProjectColumnDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectColumnDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectColumnDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11298,6 +14148,18 @@ impl std::str::FromStr for ProjectColumnEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectColumnEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectColumnEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11393,6 +14255,18 @@ impl std::str::FromStr for ProjectColumnMovedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectColumnMovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectColumnMovedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCreated {
@@ -11424,6 +14298,18 @@ impl std::str::FromStr for ProjectCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11459,6 +14345,18 @@ impl std::str::FromStr for ProjectDeletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEdited {
@@ -11491,6 +14389,18 @@ impl std::str::FromStr for ProjectEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the project if the action was `edited`."]
@@ -11607,6 +14517,18 @@ impl std::str::FromStr for ProjectReopenedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ProjectReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "State of the project; either 'open' or 'closed'"]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ProjectState {
@@ -11631,6 +14553,18 @@ impl std::str::FromStr for ProjectState {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "When a private repository is made public."]
@@ -11735,6 +14669,18 @@ impl std::str::FromStr for PullRequestActiveLockReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAssigned {
@@ -11771,6 +14717,18 @@ impl std::str::FromStr for PullRequestAssignedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestAssignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestAssignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeDisabled {
@@ -11805,6 +14763,18 @@ impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestAutoMergeDisabledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestAutoMergeDisabledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeEnabled {
@@ -11837,6 +14807,18 @@ impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
             "auto_merge_enabled" => Ok(Self::AutoMergeEnabled),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestAutoMergeEnabledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestAutoMergeEnabledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11884,6 +14866,18 @@ impl std::str::FromStr for PullRequestClosedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestClosedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraft {
@@ -11917,6 +14911,18 @@ impl std::str::FromStr for PullRequestConvertedToDraftAction {
             "converted_to_draft" => Ok(Self::ConvertedToDraft),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11953,6 +14959,18 @@ impl std::str::FromStr for PullRequestEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the comment if the action was `edited`."]
@@ -12043,6 +15061,18 @@ impl std::str::FromStr for PullRequestLabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestLabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLinks {
@@ -12091,6 +15121,18 @@ impl std::str::FromStr for PullRequestLockedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestLockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpened {
@@ -12124,6 +15166,18 @@ impl std::str::FromStr for PullRequestOpenedAction {
             "opened" => Ok(Self::Opened),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestOpenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12161,6 +15215,18 @@ impl std::str::FromStr for PullRequestReadyForReviewAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReadyForReviewAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReadyForReviewAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopened {
@@ -12194,6 +15260,18 @@ impl std::str::FromStr for PullRequestReopenedAction {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12288,6 +15366,18 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequest {
@@ -12364,6 +15454,18 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockR
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestBase {
@@ -12428,6 +15530,18 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeleted {
@@ -12460,6 +15574,18 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12538,6 +15664,18 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockR
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestBase {
@@ -12602,6 +15740,18 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEdited {
@@ -12635,6 +15785,18 @@ impl std::str::FromStr for PullRequestReviewCommentEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the comment."]
@@ -12726,6 +15888,18 @@ impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockRe
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestBase {
@@ -12788,6 +15962,18 @@ impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12865,6 +16051,18 @@ impl std::str::FromStr for PullRequestReviewCommentSide {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentSide {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentSide {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The side of the first line of the range for a multi-line comment."]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewCommentStartSide {
@@ -12889,6 +16087,18 @@ impl std::str::FromStr for PullRequestReviewCommentStartSide {
             "RIGHT" => Ok(Self::Right),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewCommentStartSide {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewCommentStartSide {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12923,6 +16133,18 @@ impl std::str::FromStr for PullRequestReviewDismissedAction {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewDismissedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewDismissedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The review that was affected."]
@@ -12972,6 +16194,18 @@ impl std::str::FromStr for PullRequestReviewDismissedReviewState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewDismissedReviewState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewDismissedReviewState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEdited {
@@ -13005,6 +16239,18 @@ impl std::str::FromStr for PullRequestReviewEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13137,6 +16383,18 @@ impl std::str::FromStr for PullRequestReviewRequestRemovedVariant0Action {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant0Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant0Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewRequestRemovedVariant1Action {
     #[serde(rename = "review_request_removed")]
@@ -13156,6 +16414,18 @@ impl std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
             "review_request_removed" => Ok(Self::ReviewRequestRemoved),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant1Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant1Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13209,6 +16479,18 @@ impl std::str::FromStr for PullRequestReviewRequestedVariant0Action {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant0Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant0Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewRequestedVariant1Action {
     #[serde(rename = "review_requested")]
@@ -13228,6 +16510,18 @@ impl std::str::FromStr for PullRequestReviewRequestedVariant1Action {
             "review_requested" => Ok(Self::ReviewRequested),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant1Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant1Action {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13262,6 +16556,18 @@ impl std::str::FromStr for PullRequestReviewSubmittedAction {
             "submitted" => Ok(Self::Submitted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReviewSubmittedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReviewSubmittedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The review that was affected."]
@@ -13316,6 +16622,18 @@ impl std::str::FromStr for PullRequestState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestSynchronize {
@@ -13351,6 +16669,18 @@ impl std::str::FromStr for PullRequestSynchronizeAction {
             "synchronize" => Ok(Self::Synchronize),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestSynchronizeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestSynchronizeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13389,6 +16719,18 @@ impl std::str::FromStr for PullRequestUnassignedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestUnassignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestUnassignedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlabeled {
@@ -13425,6 +16767,18 @@ impl std::str::FromStr for PullRequestUnlabeledAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PullRequestUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestUnlabeledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlocked {
@@ -13458,6 +16812,18 @@ impl std::str::FromStr for PullRequestUnlockedAction {
             "unlocked" => Ok(Self::Unlocked),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestUnlockedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13556,6 +16922,18 @@ impl std::str::FromStr for ReleaseAssetState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ReleaseAssetState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseAssetState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseCreated {
@@ -13587,6 +16965,18 @@ impl std::str::FromStr for ReleaseCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ReleaseCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13622,6 +17012,18 @@ impl std::str::FromStr for ReleaseDeletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ReleaseDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEdited {
@@ -13654,6 +17056,18 @@ impl std::str::FromStr for ReleaseEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ReleaseEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13791,6 +17205,18 @@ impl std::str::FromStr for ReleasePrereleasedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ReleasePrereleasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleasePrereleasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePublished {
@@ -13822,6 +17248,18 @@ impl std::str::FromStr for ReleasePublishedAction {
             "published" => Ok(Self::Published),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ReleasePublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleasePublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13857,6 +17295,18 @@ impl std::str::FromStr for ReleaseReleasedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ReleaseReleasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseReleasedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseUnpublished {
@@ -13888,6 +17338,18 @@ impl std::str::FromStr for ReleaseUnpublishedAction {
             "unpublished" => Ok(Self::Unpublished),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ReleaseUnpublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReleaseUnpublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14046,6 +17508,18 @@ impl std::str::FromStr for RepositoryArchivedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryArchivedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryArchivedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryCreated {
@@ -14078,11 +17552,31 @@ impl std::str::FromStr for RepositoryCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RepositoryCreatedAt {
     Variant0(i64),
     Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl ToString for RepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -14114,6 +17608,18 @@ impl std::str::FromStr for RepositoryDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14164,6 +17670,18 @@ impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryDispatchOnDemandTestAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryDispatchOnDemandTestAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEdited {
@@ -14195,6 +17713,18 @@ impl std::str::FromStr for RepositoryEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14359,6 +17889,18 @@ impl std::str::FromStr for RepositoryImportEventStatus {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryImportEventStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryImportEventStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryLite {
@@ -14455,6 +17997,18 @@ impl std::str::FromStr for RepositoryPrivatizedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryPrivatizedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryPrivatizedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicized {
@@ -14485,6 +18039,18 @@ impl std::str::FromStr for RepositoryPublicizedAction {
             "publicized" => Ok(Self::Publicized),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryPublicizedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryPublicizedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14525,6 +18091,18 @@ impl std::str::FromStr for RepositoryRenamedAction {
             "renamed" => Ok(Self::Renamed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryRenamedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryRenamedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14575,6 +18153,18 @@ impl std::str::FromStr for RepositoryTransferredAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryTransferredAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChanges {
@@ -14623,6 +18213,18 @@ impl std::str::FromStr for RepositoryUnarchivedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryUnarchivedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryUnarchivedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertCreate {
@@ -14652,6 +18254,18 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertCreateAction {
             "create" => Ok(Self::Create),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertCreateAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertCreateAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The security alert of the vulnerable dependency."]
@@ -14706,6 +18320,18 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertDismissAction {
             "dismiss" => Ok(Self::Dismiss),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertDismissAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertDismissAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The security alert of the vulnerable dependency."]
@@ -14790,6 +18416,18 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertResolveAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertResolveAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertResolveAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The security alert of the vulnerable dependency."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -14843,6 +18481,18 @@ impl std::str::FromStr for SecretScanningAlertCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SecretScanningAlertCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecretScanningAlertCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The secret scanning alert involved in the event."]
@@ -14924,6 +18574,18 @@ impl std::str::FromStr for SecretScanningAlertReopenedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SecretScanningAlertReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecretScanningAlertReopenedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The secret scanning alert involved in the event."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -14965,6 +18627,18 @@ impl std::str::FromStr for SecretScanningAlertResolvedAction {
             "resolved" => Ok(Self::Resolved),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The secret scanning alert involved in the event."]
@@ -15010,6 +18684,18 @@ impl std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAlertResolution {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAlertResolution {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "action", content = "security_advisory")]
 pub enum SecurityAdvisoryEvent {
@@ -15051,6 +18737,18 @@ impl std::str::FromStr for SecurityAdvisoryPerformedAction {
             "performed" => Ok(Self::Performed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SecurityAdvisoryPerformedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecurityAdvisoryPerformedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
@@ -15141,6 +18839,18 @@ impl std::str::FromStr for SecurityAdvisoryPublishedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SecurityAdvisoryPublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecurityAdvisoryPublishedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The details of the security advisory, including summary, description, and severity."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15229,6 +18939,18 @@ impl std::str::FromStr for SecurityAdvisoryUpdatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SecurityAdvisoryUpdatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecurityAdvisoryUpdatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[doc = "The details of the security advisory, including summary, description, and severity."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -15315,6 +19037,18 @@ impl std::str::FromStr for SecurityAdvisoryWithdrawnAction {
             "withdrawn" => Ok(Self::Withdrawn),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SecurityAdvisoryWithdrawnAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SecurityAdvisoryWithdrawnAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
@@ -15452,6 +19186,18 @@ impl std::str::FromStr for SimplePullRequestActiveLockReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SimplePullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SimplePullRequestActiveLockReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestBase {
@@ -15516,6 +19262,18 @@ impl std::str::FromStr for SimplePullRequestState {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SimplePullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SimplePullRequestState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCancelled {
@@ -15542,6 +19300,18 @@ impl std::str::FromStr for SponsorshipCancelledAction {
             "cancelled" => Ok(Self::Cancelled),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SponsorshipCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipCancelledAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15582,6 +19352,18 @@ impl std::str::FromStr for SponsorshipCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SponsorshipCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCreatedSponsorship {
@@ -15619,6 +19401,18 @@ impl std::str::FromStr for SponsorshipEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SponsorshipEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15723,6 +19517,18 @@ impl std::str::FromStr for SponsorshipPendingCancellationAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SponsorshipPendingCancellationAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipPendingCancellationAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingCancellationSponsorship {
@@ -15763,6 +19569,18 @@ impl std::str::FromStr for SponsorshipPendingTierChangeAction {
             "pending_tier_change" => Ok(Self::PendingTierChange),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SponsorshipPendingTierChangeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipPendingTierChangeAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15827,6 +19645,18 @@ impl std::str::FromStr for SponsorshipTierChangedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SponsorshipTierChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SponsorshipTierChangedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChanges {
@@ -15881,6 +19711,18 @@ impl std::str::FromStr for StarCreatedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for StarCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StarCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StarDeleted {
@@ -15913,6 +19755,18 @@ impl std::str::FromStr for StarDeletedAction {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StarDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StarDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16092,6 +19946,18 @@ impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
         }
     }
 }
+impl std::convert::TryFrom<&str> for StatusEventCommitCommitVerificationReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StatusEventCommitCommitVerificationReason {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitParentsItem {
@@ -16131,6 +19997,18 @@ impl std::str::FromStr for StatusEventState {
             "error" => Ok(Self::Error),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StatusEventState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StatusEventState {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "Groups of organization members that gives permissions on specified repositories."]
@@ -16199,6 +20077,18 @@ impl std::str::FromStr for TeamAddedToRepositoryAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TeamAddedToRepositoryAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamAddedToRepositoryAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamCreated {
@@ -16230,6 +20120,18 @@ impl std::str::FromStr for TeamCreatedAction {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TeamCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamCreatedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16265,6 +20167,18 @@ impl std::str::FromStr for TeamDeletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TeamDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamDeletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEdited {
@@ -16297,6 +20211,18 @@ impl std::str::FromStr for TeamEditedAction {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TeamEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamEditedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[doc = "The changes to the team if the action was `edited`."]
@@ -16462,6 +20388,18 @@ impl std::str::FromStr for TeamParentPrivacy {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TeamParentPrivacy {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamParentPrivacy {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TeamPrivacy {
     #[serde(rename = "open")]
@@ -16489,6 +20427,18 @@ impl std::str::FromStr for TeamPrivacy {
             "secret" => Ok(Self::Secret),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TeamPrivacy {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamPrivacy {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16522,6 +20472,18 @@ impl std::str::FromStr for TeamRemovedFromRepositoryAction {
             "removed_from_repository" => Ok(Self::RemovedFromRepository),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TeamRemovedFromRepositoryAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TeamRemovedFromRepositoryAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16577,6 +20539,18 @@ impl std::str::FromStr for UserType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for UserType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for UserType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum WatchEvent {
@@ -16621,6 +20595,18 @@ impl std::str::FromStr for WatchStartedAction {
             "started" => Ok(Self::Started),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WatchStartedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WatchStartedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16834,6 +20820,18 @@ impl std::str::FromStr for WebhookEventsVariant0Item {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WebhookEventsVariant0Item {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WebhookEventsVariant0Item {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Workflow {
@@ -16914,6 +20912,18 @@ impl std::str::FromStr for WorkflowJobCompletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowJobCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowJobConclusion {
     #[serde(rename = "success")]
@@ -16937,6 +20947,18 @@ impl std::str::FromStr for WorkflowJobConclusion {
             "failure" => Ok(Self::Failure),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17009,6 +21031,18 @@ impl std::str::FromStr for WorkflowJobQueuedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowJobQueuedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobQueuedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueuedWorkflowJob {
@@ -17049,6 +21083,18 @@ impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowJobQueuedWorkflowJobStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobQueuedWorkflowJobStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobStarted {
@@ -17082,6 +21128,18 @@ impl std::str::FromStr for WorkflowJobStartedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowJobStartedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobStartedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowJobStatus {
     #[serde(rename = "queued")]
@@ -17109,6 +21167,18 @@ impl std::str::FromStr for WorkflowJobStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17176,6 +21246,18 @@ impl std::str::FromStr for WorkflowRunCompletedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowRunCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunCompletedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowRunConclusion {
     #[serde(rename = "success")]
@@ -17219,6 +21301,18 @@ impl std::str::FromStr for WorkflowRunConclusion {
             "stale" => Ok(Self::Stale),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17308,6 +21402,18 @@ impl std::str::FromStr for WorkflowRunRequestedAction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowRunRequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunRequestedAction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowRunStatus {
     #[serde(rename = "requested")]
@@ -17339,6 +21445,18 @@ impl std::str::FromStr for WorkflowRunStatus {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17402,6 +21520,18 @@ impl std::str::FromStr for WorkflowStepCompletedConclusion {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WorkflowStepCompletedConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowStepCompletedConclusion {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum WorkflowStepCompletedStatus {
     #[serde(rename = "completed")]
@@ -17421,6 +21551,18 @@ impl std::str::FromStr for WorkflowStepCompletedStatus {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowStepCompletedStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowStepCompletedStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17452,6 +21594,18 @@ impl std::str::FromStr for WorkflowStepInProgressStatus {
             "in_progress" => Ok(Self::InProgress),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowStepInProgressStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowStepInProgressStatus {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 mod defaults {

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -60,7 +60,7 @@ impl ToString for AlertInstanceState {
 }
 impl std::str::FromStr for AlertInstanceState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
@@ -70,14 +70,14 @@ impl std::str::FromStr for AlertInstanceState {
     }
 }
 impl std::convert::TryFrom<&str> for AlertInstanceState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlertInstanceState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -248,7 +248,7 @@ impl ToString for AppEventsItem {
 }
 impl std::str::FromStr for AppEventsItem {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -299,14 +299,14 @@ impl std::str::FromStr for AppEventsItem {
     }
 }
 impl std::convert::TryFrom<&str> for AppEventsItem {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppEventsItem {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -400,7 +400,7 @@ impl ToString for AppPermissionsActions {
 }
 impl std::str::FromStr for AppPermissionsActions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -409,14 +409,14 @@ impl std::str::FromStr for AppPermissionsActions {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsActions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsActions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -437,7 +437,7 @@ impl ToString for AppPermissionsAdministration {
 }
 impl std::str::FromStr for AppPermissionsAdministration {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -446,14 +446,14 @@ impl std::str::FromStr for AppPermissionsAdministration {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -474,7 +474,7 @@ impl ToString for AppPermissionsChecks {
 }
 impl std::str::FromStr for AppPermissionsChecks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -483,14 +483,14 @@ impl std::str::FromStr for AppPermissionsChecks {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsChecks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsChecks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -511,7 +511,7 @@ impl ToString for AppPermissionsContentReferences {
 }
 impl std::str::FromStr for AppPermissionsContentReferences {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -520,14 +520,14 @@ impl std::str::FromStr for AppPermissionsContentReferences {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsContentReferences {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsContentReferences {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -548,7 +548,7 @@ impl ToString for AppPermissionsContents {
 }
 impl std::str::FromStr for AppPermissionsContents {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -557,14 +557,14 @@ impl std::str::FromStr for AppPermissionsContents {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsContents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsContents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -585,7 +585,7 @@ impl ToString for AppPermissionsDeployments {
 }
 impl std::str::FromStr for AppPermissionsDeployments {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -594,14 +594,14 @@ impl std::str::FromStr for AppPermissionsDeployments {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsDeployments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsDeployments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -622,7 +622,7 @@ impl ToString for AppPermissionsDiscussions {
 }
 impl std::str::FromStr for AppPermissionsDiscussions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -631,14 +631,14 @@ impl std::str::FromStr for AppPermissionsDiscussions {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -659,7 +659,7 @@ impl ToString for AppPermissionsEmails {
 }
 impl std::str::FromStr for AppPermissionsEmails {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -668,14 +668,14 @@ impl std::str::FromStr for AppPermissionsEmails {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsEmails {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsEmails {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -696,7 +696,7 @@ impl ToString for AppPermissionsEnvironments {
 }
 impl std::str::FromStr for AppPermissionsEnvironments {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -705,14 +705,14 @@ impl std::str::FromStr for AppPermissionsEnvironments {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsEnvironments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsEnvironments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -733,7 +733,7 @@ impl ToString for AppPermissionsIssues {
 }
 impl std::str::FromStr for AppPermissionsIssues {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -742,14 +742,14 @@ impl std::str::FromStr for AppPermissionsIssues {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsIssues {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsIssues {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -770,7 +770,7 @@ impl ToString for AppPermissionsMembers {
 }
 impl std::str::FromStr for AppPermissionsMembers {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -779,14 +779,14 @@ impl std::str::FromStr for AppPermissionsMembers {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsMembers {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsMembers {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -807,7 +807,7 @@ impl ToString for AppPermissionsMetadata {
 }
 impl std::str::FromStr for AppPermissionsMetadata {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -816,14 +816,14 @@ impl std::str::FromStr for AppPermissionsMetadata {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsMetadata {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsMetadata {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -844,7 +844,7 @@ impl ToString for AppPermissionsOrganizationAdministration {
 }
 impl std::str::FromStr for AppPermissionsOrganizationAdministration {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -853,14 +853,14 @@ impl std::str::FromStr for AppPermissionsOrganizationAdministration {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -881,7 +881,7 @@ impl ToString for AppPermissionsOrganizationHooks {
 }
 impl std::str::FromStr for AppPermissionsOrganizationHooks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -890,14 +890,14 @@ impl std::str::FromStr for AppPermissionsOrganizationHooks {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -918,7 +918,7 @@ impl ToString for AppPermissionsOrganizationPackages {
 }
 impl std::str::FromStr for AppPermissionsOrganizationPackages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -927,14 +927,14 @@ impl std::str::FromStr for AppPermissionsOrganizationPackages {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -955,7 +955,7 @@ impl ToString for AppPermissionsOrganizationPlan {
 }
 impl std::str::FromStr for AppPermissionsOrganizationPlan {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -964,14 +964,14 @@ impl std::str::FromStr for AppPermissionsOrganizationPlan {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPlan {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPlan {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -992,7 +992,7 @@ impl ToString for AppPermissionsOrganizationProjects {
 }
 impl std::str::FromStr for AppPermissionsOrganizationProjects {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1001,14 +1001,14 @@ impl std::str::FromStr for AppPermissionsOrganizationProjects {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1029,7 +1029,7 @@ impl ToString for AppPermissionsOrganizationSecrets {
 }
 impl std::str::FromStr for AppPermissionsOrganizationSecrets {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1038,14 +1038,14 @@ impl std::str::FromStr for AppPermissionsOrganizationSecrets {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1066,7 +1066,7 @@ impl ToString for AppPermissionsOrganizationSelfHostedRunners {
 }
 impl std::str::FromStr for AppPermissionsOrganizationSelfHostedRunners {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1075,14 +1075,14 @@ impl std::str::FromStr for AppPermissionsOrganizationSelfHostedRunners {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSelfHostedRunners {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSelfHostedRunners {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1103,7 +1103,7 @@ impl ToString for AppPermissionsOrganizationUserBlocking {
 }
 impl std::str::FromStr for AppPermissionsOrganizationUserBlocking {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1112,14 +1112,14 @@ impl std::str::FromStr for AppPermissionsOrganizationUserBlocking {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationUserBlocking {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationUserBlocking {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1140,7 +1140,7 @@ impl ToString for AppPermissionsPackages {
 }
 impl std::str::FromStr for AppPermissionsPackages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1149,14 +1149,14 @@ impl std::str::FromStr for AppPermissionsPackages {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1177,7 +1177,7 @@ impl ToString for AppPermissionsPages {
 }
 impl std::str::FromStr for AppPermissionsPages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1186,14 +1186,14 @@ impl std::str::FromStr for AppPermissionsPages {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1214,7 +1214,7 @@ impl ToString for AppPermissionsPullRequests {
 }
 impl std::str::FromStr for AppPermissionsPullRequests {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1223,14 +1223,14 @@ impl std::str::FromStr for AppPermissionsPullRequests {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPullRequests {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPullRequests {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1251,7 +1251,7 @@ impl ToString for AppPermissionsRepositoryHooks {
 }
 impl std::str::FromStr for AppPermissionsRepositoryHooks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1260,14 +1260,14 @@ impl std::str::FromStr for AppPermissionsRepositoryHooks {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsRepositoryHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsRepositoryHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1288,7 +1288,7 @@ impl ToString for AppPermissionsRepositoryProjects {
 }
 impl std::str::FromStr for AppPermissionsRepositoryProjects {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1297,14 +1297,14 @@ impl std::str::FromStr for AppPermissionsRepositoryProjects {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsRepositoryProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsRepositoryProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1325,7 +1325,7 @@ impl ToString for AppPermissionsSecretScanningAlerts {
 }
 impl std::str::FromStr for AppPermissionsSecretScanningAlerts {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1334,14 +1334,14 @@ impl std::str::FromStr for AppPermissionsSecretScanningAlerts {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecretScanningAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecretScanningAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1362,7 +1362,7 @@ impl ToString for AppPermissionsSecrets {
 }
 impl std::str::FromStr for AppPermissionsSecrets {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1371,14 +1371,14 @@ impl std::str::FromStr for AppPermissionsSecrets {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1399,7 +1399,7 @@ impl ToString for AppPermissionsSecurityEvents {
 }
 impl std::str::FromStr for AppPermissionsSecurityEvents {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1408,14 +1408,14 @@ impl std::str::FromStr for AppPermissionsSecurityEvents {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecurityEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecurityEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1436,7 +1436,7 @@ impl ToString for AppPermissionsSecurityScanningAlert {
 }
 impl std::str::FromStr for AppPermissionsSecurityScanningAlert {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1445,14 +1445,14 @@ impl std::str::FromStr for AppPermissionsSecurityScanningAlert {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecurityScanningAlert {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecurityScanningAlert {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1473,7 +1473,7 @@ impl ToString for AppPermissionsSingleFile {
 }
 impl std::str::FromStr for AppPermissionsSingleFile {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1482,14 +1482,14 @@ impl std::str::FromStr for AppPermissionsSingleFile {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSingleFile {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSingleFile {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1510,7 +1510,7 @@ impl ToString for AppPermissionsStatuses {
 }
 impl std::str::FromStr for AppPermissionsStatuses {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1519,14 +1519,14 @@ impl std::str::FromStr for AppPermissionsStatuses {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsStatuses {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsStatuses {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1547,7 +1547,7 @@ impl ToString for AppPermissionsTeamDiscussions {
 }
 impl std::str::FromStr for AppPermissionsTeamDiscussions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1556,14 +1556,14 @@ impl std::str::FromStr for AppPermissionsTeamDiscussions {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsTeamDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsTeamDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1584,7 +1584,7 @@ impl ToString for AppPermissionsVulnerabilityAlerts {
 }
 impl std::str::FromStr for AppPermissionsVulnerabilityAlerts {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1593,14 +1593,14 @@ impl std::str::FromStr for AppPermissionsVulnerabilityAlerts {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsVulnerabilityAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsVulnerabilityAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1621,7 +1621,7 @@ impl ToString for AppPermissionsWorkflows {
 }
 impl std::str::FromStr for AppPermissionsWorkflows {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -1630,14 +1630,14 @@ impl std::str::FromStr for AppPermissionsWorkflows {
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsWorkflows {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsWorkflows {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1677,7 +1677,7 @@ impl ToString for AuthorAssociation {
 }
 impl std::str::FromStr for AuthorAssociation {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "COLLABORATOR" => Ok(Self::Collaborator),
             "CONTRIBUTOR" => Ok(Self::Contributor),
@@ -1692,14 +1692,14 @@ impl std::str::FromStr for AuthorAssociation {
     }
 }
 impl std::convert::TryFrom<&str> for AuthorAssociation {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AuthorAssociation {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1758,7 +1758,7 @@ impl ToString for BranchProtectionRuleAllowDeletionsEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleAllowDeletionsEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -1768,14 +1768,14 @@ impl std::str::FromStr for BranchProtectionRuleAllowDeletionsEnforcementLevel {
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1799,7 +1799,7 @@ impl ToString for BranchProtectionRuleAllowForcePushesEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -1809,14 +1809,14 @@ impl std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLevel 
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1847,7 +1847,7 @@ impl ToString for BranchProtectionRuleCreatedAction {
 }
 impl std::str::FromStr for BranchProtectionRuleCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -1855,14 +1855,14 @@ impl std::str::FromStr for BranchProtectionRuleCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1893,7 +1893,7 @@ impl ToString for BranchProtectionRuleDeletedAction {
 }
 impl std::str::FromStr for BranchProtectionRuleDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -1901,14 +1901,14 @@ impl std::str::FromStr for BranchProtectionRuleDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1940,7 +1940,7 @@ impl ToString for BranchProtectionRuleEditedAction {
 }
 impl std::str::FromStr for BranchProtectionRuleEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -1948,14 +1948,14 @@ impl std::str::FromStr for BranchProtectionRuleEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2036,7 +2036,7 @@ impl ToString for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2046,16 +2046,16 @@ impl std::str::FromStr for BranchProtectionRuleLinearHistoryRequirementEnforceme
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2079,7 +2079,7 @@ impl ToString for BranchProtectionRuleMergeQueueEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleMergeQueueEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2089,14 +2089,14 @@ impl std::str::FromStr for BranchProtectionRuleMergeQueueEnforcementLevel {
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2120,7 +2120,7 @@ impl ToString for BranchProtectionRulePullRequestReviewsEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRulePullRequestReviewsEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2130,14 +2130,14 @@ impl std::str::FromStr for BranchProtectionRulePullRequestReviewsEnforcementLeve
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2161,7 +2161,7 @@ impl ToString for BranchProtectionRuleRequiredConversationResolutionLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredConversationResolutionLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2171,14 +2171,14 @@ impl std::str::FromStr for BranchProtectionRuleRequiredConversationResolutionLev
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2202,7 +2202,7 @@ impl ToString for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2212,14 +2212,14 @@ impl std::str::FromStr for BranchProtectionRuleRequiredDeploymentsEnforcementLev
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2243,7 +2243,7 @@ impl ToString for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2253,14 +2253,14 @@ impl std::str::FromStr for BranchProtectionRuleRequiredStatusChecksEnforcementLe
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2284,7 +2284,7 @@ impl ToString for BranchProtectionRuleSignatureRequirementEnforcementLevel {
 }
 impl std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcementLevel {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
@@ -2294,14 +2294,14 @@ impl std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcementLe
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2334,7 +2334,7 @@ impl ToString for CheckRunCompletedAction {
 }
 impl std::str::FromStr for CheckRunCompletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -2342,14 +2342,14 @@ impl std::str::FromStr for CheckRunCompletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2438,7 +2438,7 @@ impl ToString for CheckRunCompletedCheckRunCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -2452,14 +2452,14 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2483,7 +2483,7 @@ impl ToString for CheckRunCompletedCheckRunCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
@@ -2493,14 +2493,14 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2540,7 +2540,7 @@ impl ToString for CheckRunCompletedCheckRunConclusion {
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -2555,14 +2555,14 @@ impl std::str::FromStr for CheckRunCompletedCheckRunConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2591,7 +2591,7 @@ impl ToString for CheckRunCompletedCheckRunStatus {
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -2599,14 +2599,14 @@ impl std::str::FromStr for CheckRunCompletedCheckRunStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2647,7 +2647,7 @@ impl ToString for CheckRunCreatedAction {
 }
 impl std::str::FromStr for CheckRunCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -2655,14 +2655,14 @@ impl std::str::FromStr for CheckRunCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2751,7 +2751,7 @@ impl ToString for CheckRunCreatedCheckRunCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -2765,14 +2765,14 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2796,7 +2796,7 @@ impl ToString for CheckRunCreatedCheckRunCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
@@ -2806,14 +2806,14 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2853,7 +2853,7 @@ impl ToString for CheckRunCreatedCheckRunConclusion {
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -2868,14 +2868,14 @@ impl std::str::FromStr for CheckRunCreatedCheckRunConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2910,7 +2910,7 @@ impl ToString for CheckRunCreatedCheckRunStatus {
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
@@ -2920,14 +2920,14 @@ impl std::str::FromStr for CheckRunCreatedCheckRunStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3065,7 +3065,7 @@ impl ToString for CheckRunRequestedActionAction {
 }
 impl std::str::FromStr for CheckRunRequestedActionAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested_action" => Ok(Self::RequestedAction),
             _ => Err("invalid value"),
@@ -3073,14 +3073,14 @@ impl std::str::FromStr for CheckRunRequestedActionAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3169,7 +3169,7 @@ impl ToString for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3183,14 +3183,14 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3214,7 +3214,7 @@ impl ToString for CheckRunRequestedActionCheckRunCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
@@ -3224,14 +3224,14 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3271,7 +3271,7 @@ impl ToString for CheckRunRequestedActionCheckRunConclusion {
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3286,14 +3286,14 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3328,7 +3328,7 @@ impl ToString for CheckRunRequestedActionCheckRunStatus {
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
@@ -3338,14 +3338,14 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3386,7 +3386,7 @@ impl ToString for CheckRunRerequestedAction {
 }
 impl std::str::FromStr for CheckRunRerequestedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "rerequested" => Ok(Self::Rerequested),
             _ => Err("invalid value"),
@@ -3394,14 +3394,14 @@ impl std::str::FromStr for CheckRunRerequestedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3490,7 +3490,7 @@ impl ToString for CheckRunRerequestedCheckRunCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3504,14 +3504,14 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3529,7 +3529,7 @@ impl ToString for CheckRunRerequestedCheckRunCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -3537,14 +3537,14 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3584,7 +3584,7 @@ impl ToString for CheckRunRerequestedCheckRunConclusion {
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3599,14 +3599,14 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3635,7 +3635,7 @@ impl ToString for CheckRunRerequestedCheckRunStatus {
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -3643,14 +3643,14 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3688,7 +3688,7 @@ impl ToString for CheckSuiteCompletedAction {
 }
 impl std::str::FromStr for CheckSuiteCompletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -3696,14 +3696,14 @@ impl std::str::FromStr for CheckSuiteCompletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3767,7 +3767,7 @@ impl ToString for CheckSuiteCompletedCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckSuiteCompletedCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3781,14 +3781,14 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3816,7 +3816,7 @@ impl ToString for CheckSuiteCompletedCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
@@ -3827,14 +3827,14 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3901,7 +3901,7 @@ impl ToString for CheckSuiteRequestedAction {
 }
 impl std::str::FromStr for CheckSuiteRequestedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             _ => Err("invalid value"),
@@ -3909,14 +3909,14 @@ impl std::str::FromStr for CheckSuiteRequestedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3980,7 +3980,7 @@ impl ToString for CheckSuiteRequestedCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckSuiteRequestedCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -3994,14 +3994,14 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4029,7 +4029,7 @@ impl ToString for CheckSuiteRequestedCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
@@ -4040,14 +4040,14 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4077,7 +4077,7 @@ impl ToString for CheckSuiteRerequestedAction {
 }
 impl std::str::FromStr for CheckSuiteRerequestedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "rerequested" => Ok(Self::Rerequested),
             _ => Err("invalid value"),
@@ -4085,14 +4085,14 @@ impl std::str::FromStr for CheckSuiteRerequestedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4156,7 +4156,7 @@ impl ToString for CheckSuiteRerequestedCheckSuiteConclusion {
 }
 impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -4170,14 +4170,14 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4205,7 +4205,7 @@ impl ToString for CheckSuiteRerequestedCheckSuiteStatus {
 }
 impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
@@ -4216,14 +4216,14 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4258,7 +4258,7 @@ impl ToString for CodeScanningAlertAppearedInBranchAction {
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "appeared_in_branch" => Ok(Self::AppearedInBranch),
             _ => Err("invalid value"),
@@ -4266,14 +4266,14 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4322,7 +4322,7 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertDismissedReason {
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertDismissedReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
@@ -4332,14 +4332,14 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertDismissedReason
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4377,7 +4377,7 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -4388,14 +4388,14 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4420,7 +4420,7 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
@@ -4430,14 +4430,14 @@ impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4480,7 +4480,7 @@ impl ToString for CodeScanningAlertClosedByUserAction {
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "closed_by_user" => Ok(Self::ClosedByUser),
             _ => Err("invalid value"),
@@ -4488,14 +4488,14 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4544,7 +4544,7 @@ impl ToString for CodeScanningAlertClosedByUserAlertDismissedReason {
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertDismissedReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
@@ -4554,14 +4554,14 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertDismissedReason {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4607,7 +4607,7 @@ impl ToString for CodeScanningAlertClosedByUserAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -4618,14 +4618,14 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4644,7 +4644,7 @@ impl ToString for CodeScanningAlertClosedByUserAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
@@ -4652,14 +4652,14 @@ impl std::str::FromStr for CodeScanningAlertClosedByUserAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4704,7 +4704,7 @@ impl ToString for CodeScanningAlertCreatedAction {
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -4712,14 +4712,14 @@ impl std::str::FromStr for CodeScanningAlertCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4789,7 +4789,7 @@ impl ToString for CodeScanningAlertCreatedAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -4800,14 +4800,14 @@ impl std::str::FromStr for CodeScanningAlertCreatedAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4829,7 +4829,7 @@ impl ToString for CodeScanningAlertCreatedAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
@@ -4838,14 +4838,14 @@ impl std::str::FromStr for CodeScanningAlertCreatedAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4990,7 +4990,7 @@ impl ToString for CodeScanningAlertFixedAction {
 }
 impl std::str::FromStr for CodeScanningAlertFixedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "fixed" => Ok(Self::Fixed),
             _ => Err("invalid value"),
@@ -4998,14 +4998,14 @@ impl std::str::FromStr for CodeScanningAlertFixedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5056,7 +5056,7 @@ impl ToString for CodeScanningAlertFixedAlertDismissedReason {
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertDismissedReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
@@ -5066,14 +5066,14 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertDismissedReason {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertDismissedReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5119,7 +5119,7 @@ impl ToString for CodeScanningAlertFixedAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -5130,14 +5130,14 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5156,7 +5156,7 @@ impl ToString for CodeScanningAlertFixedAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "fixed" => Ok(Self::Fixed),
             _ => Err("invalid value"),
@@ -5164,14 +5164,14 @@ impl std::str::FromStr for CodeScanningAlertFixedAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5216,7 +5216,7 @@ impl ToString for CodeScanningAlertReopenedAction {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
@@ -5224,14 +5224,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5301,7 +5301,7 @@ impl ToString for CodeScanningAlertReopenedAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -5312,14 +5312,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5344,7 +5344,7 @@ impl ToString for CodeScanningAlertReopenedAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
@@ -5354,14 +5354,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5406,7 +5406,7 @@ impl ToString for CodeScanningAlertReopenedByUserAction {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened_by_user" => Ok(Self::ReopenedByUser),
             _ => Err("invalid value"),
@@ -5414,14 +5414,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAction {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5483,7 +5483,7 @@ impl ToString for CodeScanningAlertReopenedByUserAlertRuleSeverity {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertRuleSeverity {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
@@ -5494,14 +5494,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertRuleSeverity {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5520,7 +5520,7 @@ impl ToString for CodeScanningAlertReopenedByUserAlertState {
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             _ => Err("invalid value"),
@@ -5528,14 +5528,14 @@ impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertState {
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5598,7 +5598,7 @@ impl ToString for CommitCommentCreatedAction {
 }
 impl std::str::FromStr for CommitCommentCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -5606,14 +5606,14 @@ impl std::str::FromStr for CommitCommentCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for CommitCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CommitCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5705,7 +5705,7 @@ impl ToString for ContentReferenceCreatedAction {
 }
 impl std::str::FromStr for ContentReferenceCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -5713,14 +5713,14 @@ impl std::str::FromStr for ContentReferenceCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ContentReferenceCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ContentReferenceCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5785,7 +5785,7 @@ impl ToString for CreateEventRefType {
 }
 impl std::str::FromStr for CreateEventRefType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "tag" => Ok(Self::Tag),
             "branch" => Ok(Self::Branch),
@@ -5794,14 +5794,14 @@ impl std::str::FromStr for CreateEventRefType {
     }
 }
 impl std::convert::TryFrom<&str> for CreateEventRefType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CreateEventRefType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5841,7 +5841,7 @@ impl ToString for DeleteEventRefType {
 }
 impl std::str::FromStr for DeleteEventRefType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "tag" => Ok(Self::Tag),
             "branch" => Ok(Self::Branch),
@@ -5850,14 +5850,14 @@ impl std::str::FromStr for DeleteEventRefType {
     }
 }
 impl std::convert::TryFrom<&str> for DeleteEventRefType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeleteEventRefType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5887,7 +5887,7 @@ impl ToString for DeployKeyCreatedAction {
 }
 impl std::str::FromStr for DeployKeyCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -5895,14 +5895,14 @@ impl std::str::FromStr for DeployKeyCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DeployKeyCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeployKeyCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5944,7 +5944,7 @@ impl ToString for DeployKeyDeletedAction {
 }
 impl std::str::FromStr for DeployKeyDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -5952,14 +5952,14 @@ impl std::str::FromStr for DeployKeyDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DeployKeyDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeployKeyDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6029,7 +6029,7 @@ impl ToString for DeploymentCreatedAction {
 }
 impl std::str::FromStr for DeploymentCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -6037,14 +6037,14 @@ impl std::str::FromStr for DeploymentCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DeploymentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeploymentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6118,7 +6118,7 @@ impl ToString for DeploymentStatusCreatedAction {
 }
 impl std::str::FromStr for DeploymentStatusCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -6126,14 +6126,14 @@ impl std::str::FromStr for DeploymentStatusCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DeploymentStatusCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeploymentStatusCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6250,7 +6250,7 @@ impl ToString for DiscussionAnsweredAction {
 }
 impl std::str::FromStr for DiscussionAnsweredAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "answered" => Ok(Self::Answered),
             _ => Err("invalid value"),
@@ -6258,14 +6258,14 @@ impl std::str::FromStr for DiscussionAnsweredAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionAnsweredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionAnsweredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6325,7 +6325,7 @@ impl ToString for DiscussionCategoryChangedAction {
 }
 impl std::str::FromStr for DiscussionCategoryChangedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "category_changed" => Ok(Self::CategoryChanged),
             _ => Err("invalid value"),
@@ -6333,14 +6333,14 @@ impl std::str::FromStr for DiscussionCategoryChangedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCategoryChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCategoryChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6393,7 +6393,7 @@ impl ToString for DiscussionCommentCreatedAction {
 }
 impl std::str::FromStr for DiscussionCommentCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -6401,14 +6401,14 @@ impl std::str::FromStr for DiscussionCommentCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6454,7 +6454,7 @@ impl ToString for DiscussionCommentDeletedAction {
 }
 impl std::str::FromStr for DiscussionCommentDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -6462,14 +6462,14 @@ impl std::str::FromStr for DiscussionCommentDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6516,7 +6516,7 @@ impl ToString for DiscussionCommentEditedAction {
 }
 impl std::str::FromStr for DiscussionCommentEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -6524,14 +6524,14 @@ impl std::str::FromStr for DiscussionCommentEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6625,7 +6625,7 @@ impl ToString for DiscussionCreatedAction {
 }
 impl std::str::FromStr for DiscussionCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -6633,14 +6633,14 @@ impl std::str::FromStr for DiscussionCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6670,7 +6670,7 @@ impl ToString for DiscussionDeletedAction {
 }
 impl std::str::FromStr for DiscussionDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -6678,14 +6678,14 @@ impl std::str::FromStr for DiscussionDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6717,7 +6717,7 @@ impl ToString for DiscussionEditedAction {
 }
 impl std::str::FromStr for DiscussionEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -6725,14 +6725,14 @@ impl std::str::FromStr for DiscussionEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6936,7 +6936,7 @@ impl ToString for DiscussionLabeledAction {
 }
 impl std::str::FromStr for DiscussionLabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "labeled" => Ok(Self::Labeled),
             _ => Err("invalid value"),
@@ -6944,14 +6944,14 @@ impl std::str::FromStr for DiscussionLabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6981,7 +6981,7 @@ impl ToString for DiscussionLockedAction {
 }
 impl std::str::FromStr for DiscussionLockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "locked" => Ok(Self::Locked),
             _ => Err("invalid value"),
@@ -6989,14 +6989,14 @@ impl std::str::FromStr for DiscussionLockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7026,7 +7026,7 @@ impl ToString for DiscussionPinnedAction {
 }
 impl std::str::FromStr for DiscussionPinnedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pinned" => Ok(Self::Pinned),
             _ => Err("invalid value"),
@@ -7034,14 +7034,14 @@ impl std::str::FromStr for DiscussionPinnedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionPinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionPinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7065,7 +7065,7 @@ impl ToString for DiscussionState {
 }
 impl std::str::FromStr for DiscussionState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "locked" => Ok(Self::Locked),
@@ -7075,14 +7075,14 @@ impl std::str::FromStr for DiscussionState {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7113,7 +7113,7 @@ impl ToString for DiscussionTransferredAction {
 }
 impl std::str::FromStr for DiscussionTransferredAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "transferred" => Ok(Self::Transferred),
             _ => Err("invalid value"),
@@ -7121,14 +7121,14 @@ impl std::str::FromStr for DiscussionTransferredAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7165,7 +7165,7 @@ impl ToString for DiscussionUnansweredAction {
 }
 impl std::str::FromStr for DiscussionUnansweredAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unanswered" => Ok(Self::Unanswered),
             _ => Err("invalid value"),
@@ -7173,14 +7173,14 @@ impl std::str::FromStr for DiscussionUnansweredAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnansweredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnansweredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7227,7 +7227,7 @@ impl ToString for DiscussionUnlabeledAction {
 }
 impl std::str::FromStr for DiscussionUnlabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
             _ => Err("invalid value"),
@@ -7235,14 +7235,14 @@ impl std::str::FromStr for DiscussionUnlabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7272,7 +7272,7 @@ impl ToString for DiscussionUnlockedAction {
 }
 impl std::str::FromStr for DiscussionUnlockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
             _ => Err("invalid value"),
@@ -7280,14 +7280,14 @@ impl std::str::FromStr for DiscussionUnlockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7317,7 +7317,7 @@ impl ToString for DiscussionUnpinnedAction {
 }
 impl std::str::FromStr for DiscussionUnpinnedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unpinned" => Ok(Self::Unpinned),
             _ => Err("invalid value"),
@@ -7325,14 +7325,14 @@ impl std::str::FromStr for DiscussionUnpinnedAction {
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnpinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnpinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7435,7 +7435,7 @@ impl ToString for GithubAppAuthorizationRevokedAction {
 }
 impl std::str::FromStr for GithubAppAuthorizationRevokedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "revoked" => Ok(Self::Revoked),
             _ => Err("invalid value"),
@@ -7443,14 +7443,14 @@ impl std::str::FromStr for GithubAppAuthorizationRevokedAction {
     }
 }
 impl std::convert::TryFrom<&str> for GithubAppAuthorizationRevokedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GithubAppAuthorizationRevokedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7527,7 +7527,7 @@ impl ToString for GollumEventPagesItemAction {
 }
 impl std::str::FromStr for GollumEventPagesItemAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             "edited" => Ok(Self::Edited),
@@ -7536,14 +7536,14 @@ impl std::str::FromStr for GollumEventPagesItemAction {
     }
 }
 impl std::convert::TryFrom<&str> for GollumEventPagesItemAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GollumEventPagesItemAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7603,7 +7603,7 @@ impl ToString for InstallationCreatedAction {
 }
 impl std::str::FromStr for InstallationCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -7611,14 +7611,14 @@ impl std::str::FromStr for InstallationCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7674,7 +7674,7 @@ impl ToString for InstallationDeletedAction {
 }
 impl std::str::FromStr for InstallationDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -7682,14 +7682,14 @@ impl std::str::FromStr for InstallationDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7910,7 +7910,7 @@ impl ToString for InstallationEventsItem {
 }
 impl std::str::FromStr for InstallationEventsItem {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -7962,14 +7962,14 @@ impl std::str::FromStr for InstallationEventsItem {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationEventsItem {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationEventsItem {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8007,7 +8007,7 @@ impl ToString for InstallationNewPermissionsAcceptedAction {
 }
 impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "new_permissions_accepted" => Ok(Self::NewPermissionsAccepted),
             _ => Err("invalid value"),
@@ -8015,14 +8015,14 @@ impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationNewPermissionsAcceptedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationNewPermissionsAcceptedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8130,7 +8130,7 @@ impl ToString for InstallationPermissionsActions {
 }
 impl std::str::FromStr for InstallationPermissionsActions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8139,14 +8139,14 @@ impl std::str::FromStr for InstallationPermissionsActions {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsActions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsActions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8167,7 +8167,7 @@ impl ToString for InstallationPermissionsAdministration {
 }
 impl std::str::FromStr for InstallationPermissionsAdministration {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8176,14 +8176,14 @@ impl std::str::FromStr for InstallationPermissionsAdministration {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8204,7 +8204,7 @@ impl ToString for InstallationPermissionsChecks {
 }
 impl std::str::FromStr for InstallationPermissionsChecks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8213,14 +8213,14 @@ impl std::str::FromStr for InstallationPermissionsChecks {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsChecks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsChecks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8241,7 +8241,7 @@ impl ToString for InstallationPermissionsContentReferences {
 }
 impl std::str::FromStr for InstallationPermissionsContentReferences {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8250,14 +8250,14 @@ impl std::str::FromStr for InstallationPermissionsContentReferences {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsContentReferences {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsContentReferences {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8278,7 +8278,7 @@ impl ToString for InstallationPermissionsContents {
 }
 impl std::str::FromStr for InstallationPermissionsContents {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8287,14 +8287,14 @@ impl std::str::FromStr for InstallationPermissionsContents {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsContents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsContents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8315,7 +8315,7 @@ impl ToString for InstallationPermissionsDeployments {
 }
 impl std::str::FromStr for InstallationPermissionsDeployments {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8324,14 +8324,14 @@ impl std::str::FromStr for InstallationPermissionsDeployments {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsDeployments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsDeployments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8352,7 +8352,7 @@ impl ToString for InstallationPermissionsDiscussions {
 }
 impl std::str::FromStr for InstallationPermissionsDiscussions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8361,14 +8361,14 @@ impl std::str::FromStr for InstallationPermissionsDiscussions {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8389,7 +8389,7 @@ impl ToString for InstallationPermissionsEmails {
 }
 impl std::str::FromStr for InstallationPermissionsEmails {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8398,14 +8398,14 @@ impl std::str::FromStr for InstallationPermissionsEmails {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsEmails {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsEmails {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8426,7 +8426,7 @@ impl ToString for InstallationPermissionsEnvironments {
 }
 impl std::str::FromStr for InstallationPermissionsEnvironments {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8435,14 +8435,14 @@ impl std::str::FromStr for InstallationPermissionsEnvironments {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsEnvironments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsEnvironments {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8463,7 +8463,7 @@ impl ToString for InstallationPermissionsIssues {
 }
 impl std::str::FromStr for InstallationPermissionsIssues {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8472,14 +8472,14 @@ impl std::str::FromStr for InstallationPermissionsIssues {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsIssues {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsIssues {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8500,7 +8500,7 @@ impl ToString for InstallationPermissionsMembers {
 }
 impl std::str::FromStr for InstallationPermissionsMembers {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8509,14 +8509,14 @@ impl std::str::FromStr for InstallationPermissionsMembers {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsMembers {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsMembers {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8537,7 +8537,7 @@ impl ToString for InstallationPermissionsMetadata {
 }
 impl std::str::FromStr for InstallationPermissionsMetadata {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8546,14 +8546,14 @@ impl std::str::FromStr for InstallationPermissionsMetadata {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsMetadata {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsMetadata {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8574,7 +8574,7 @@ impl ToString for InstallationPermissionsOrganizationAdministration {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationAdministration {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8583,14 +8583,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationAdministration {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationAdministration {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8611,7 +8611,7 @@ impl ToString for InstallationPermissionsOrganizationEvents {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationEvents {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8620,14 +8620,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationEvents {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8648,7 +8648,7 @@ impl ToString for InstallationPermissionsOrganizationHooks {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationHooks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8657,14 +8657,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationHooks {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8685,7 +8685,7 @@ impl ToString for InstallationPermissionsOrganizationPackages {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationPackages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8694,14 +8694,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationPackages {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8722,7 +8722,7 @@ impl ToString for InstallationPermissionsOrganizationPlan {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationPlan {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8731,14 +8731,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationPlan {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPlan {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPlan {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8759,7 +8759,7 @@ impl ToString for InstallationPermissionsOrganizationProjects {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationProjects {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8768,14 +8768,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationProjects {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8796,7 +8796,7 @@ impl ToString for InstallationPermissionsOrganizationSecrets {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationSecrets {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8805,14 +8805,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationSecrets {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8833,7 +8833,7 @@ impl ToString for InstallationPermissionsOrganizationSelfHostedRunners {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationSelfHostedRunners {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8842,14 +8842,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationSelfHostedRunners 
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8870,7 +8870,7 @@ impl ToString for InstallationPermissionsOrganizationUserBlocking {
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationUserBlocking {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8879,14 +8879,14 @@ impl std::str::FromStr for InstallationPermissionsOrganizationUserBlocking {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationUserBlocking {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationUserBlocking {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8907,7 +8907,7 @@ impl ToString for InstallationPermissionsPackages {
 }
 impl std::str::FromStr for InstallationPermissionsPackages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8916,14 +8916,14 @@ impl std::str::FromStr for InstallationPermissionsPackages {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPackages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8944,7 +8944,7 @@ impl ToString for InstallationPermissionsPages {
 }
 impl std::str::FromStr for InstallationPermissionsPages {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8953,14 +8953,14 @@ impl std::str::FromStr for InstallationPermissionsPages {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPages {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8981,7 +8981,7 @@ impl ToString for InstallationPermissionsPullRequests {
 }
 impl std::str::FromStr for InstallationPermissionsPullRequests {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -8990,14 +8990,14 @@ impl std::str::FromStr for InstallationPermissionsPullRequests {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPullRequests {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPullRequests {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9018,7 +9018,7 @@ impl ToString for InstallationPermissionsRepositoryHooks {
 }
 impl std::str::FromStr for InstallationPermissionsRepositoryHooks {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9027,14 +9027,14 @@ impl std::str::FromStr for InstallationPermissionsRepositoryHooks {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryHooks {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9055,7 +9055,7 @@ impl ToString for InstallationPermissionsRepositoryProjects {
 }
 impl std::str::FromStr for InstallationPermissionsRepositoryProjects {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9064,14 +9064,14 @@ impl std::str::FromStr for InstallationPermissionsRepositoryProjects {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryProjects {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9092,7 +9092,7 @@ impl ToString for InstallationPermissionsSecretScanningAlerts {
 }
 impl std::str::FromStr for InstallationPermissionsSecretScanningAlerts {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9101,14 +9101,14 @@ impl std::str::FromStr for InstallationPermissionsSecretScanningAlerts {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecretScanningAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecretScanningAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9129,7 +9129,7 @@ impl ToString for InstallationPermissionsSecrets {
 }
 impl std::str::FromStr for InstallationPermissionsSecrets {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9138,14 +9138,14 @@ impl std::str::FromStr for InstallationPermissionsSecrets {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecrets {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9166,7 +9166,7 @@ impl ToString for InstallationPermissionsSecurityEvents {
 }
 impl std::str::FromStr for InstallationPermissionsSecurityEvents {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9175,14 +9175,14 @@ impl std::str::FromStr for InstallationPermissionsSecurityEvents {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityEvents {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9203,7 +9203,7 @@ impl ToString for InstallationPermissionsSecurityScanningAlert {
 }
 impl std::str::FromStr for InstallationPermissionsSecurityScanningAlert {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9212,14 +9212,14 @@ impl std::str::FromStr for InstallationPermissionsSecurityScanningAlert {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityScanningAlert {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityScanningAlert {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9240,7 +9240,7 @@ impl ToString for InstallationPermissionsSingleFile {
 }
 impl std::str::FromStr for InstallationPermissionsSingleFile {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9249,14 +9249,14 @@ impl std::str::FromStr for InstallationPermissionsSingleFile {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSingleFile {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSingleFile {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9277,7 +9277,7 @@ impl ToString for InstallationPermissionsStatuses {
 }
 impl std::str::FromStr for InstallationPermissionsStatuses {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9286,14 +9286,14 @@ impl std::str::FromStr for InstallationPermissionsStatuses {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsStatuses {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsStatuses {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9314,7 +9314,7 @@ impl ToString for InstallationPermissionsTeamDiscussions {
 }
 impl std::str::FromStr for InstallationPermissionsTeamDiscussions {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9323,14 +9323,14 @@ impl std::str::FromStr for InstallationPermissionsTeamDiscussions {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsTeamDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsTeamDiscussions {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9351,7 +9351,7 @@ impl ToString for InstallationPermissionsVulnerabilityAlerts {
 }
 impl std::str::FromStr for InstallationPermissionsVulnerabilityAlerts {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9360,14 +9360,14 @@ impl std::str::FromStr for InstallationPermissionsVulnerabilityAlerts {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsVulnerabilityAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsVulnerabilityAlerts {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9388,7 +9388,7 @@ impl ToString for InstallationPermissionsWorkflows {
 }
 impl std::str::FromStr for InstallationPermissionsWorkflows {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
@@ -9397,14 +9397,14 @@ impl std::str::FromStr for InstallationPermissionsWorkflows {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsWorkflows {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsWorkflows {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9436,7 +9436,7 @@ impl ToString for InstallationRepositoriesAddedAction {
 }
 impl std::str::FromStr for InstallationRepositoriesAddedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "added" => Ok(Self::Added),
             _ => Err("invalid value"),
@@ -9444,14 +9444,14 @@ impl std::str::FromStr for InstallationRepositoriesAddedAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9502,7 +9502,7 @@ impl ToString for InstallationRepositoriesAddedRepositorySelection {
 }
 impl std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
@@ -9511,14 +9511,14 @@ impl std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9580,7 +9580,7 @@ impl ToString for InstallationRepositoriesRemovedAction {
 }
 impl std::str::FromStr for InstallationRepositoriesRemovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "removed" => Ok(Self::Removed),
             _ => Err("invalid value"),
@@ -9588,14 +9588,14 @@ impl std::str::FromStr for InstallationRepositoriesRemovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9641,7 +9641,7 @@ impl ToString for InstallationRepositoriesRemovedRepositorySelection {
 }
 impl std::str::FromStr for InstallationRepositoriesRemovedRepositorySelection {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
@@ -9650,14 +9650,14 @@ impl std::str::FromStr for InstallationRepositoriesRemovedRepositorySelection {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9679,7 +9679,7 @@ impl ToString for InstallationRepositorySelection {
 }
 impl std::str::FromStr for InstallationRepositorySelection {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
@@ -9688,14 +9688,14 @@ impl std::str::FromStr for InstallationRepositorySelection {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositorySelection {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9725,7 +9725,7 @@ impl ToString for InstallationSuspendAction {
 }
 impl std::str::FromStr for InstallationSuspendAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "suspend" => Ok(Self::Suspend),
             _ => Err("invalid value"),
@@ -9733,14 +9733,14 @@ impl std::str::FromStr for InstallationSuspendAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9771,7 +9771,7 @@ impl ToString for InstallationTargetType {
 }
 impl std::str::FromStr for InstallationTargetType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
@@ -9780,14 +9780,14 @@ impl std::str::FromStr for InstallationTargetType {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationTargetType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationTargetType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9817,7 +9817,7 @@ impl ToString for InstallationUnsuspendAction {
 }
 impl std::str::FromStr for InstallationUnsuspendAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unsuspend" => Ok(Self::Unsuspend),
             _ => Err("invalid value"),
@@ -9825,14 +9825,14 @@ impl std::str::FromStr for InstallationUnsuspendAction {
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9926,7 +9926,7 @@ impl ToString for IssueActiveLockReason {
 }
 impl std::str::FromStr for IssueActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -9937,14 +9937,14 @@ impl std::str::FromStr for IssueActiveLockReason {
     }
 }
 impl std::convert::TryFrom<&str> for IssueActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9995,7 +9995,7 @@ impl ToString for IssueCommentCreatedAction {
 }
 impl std::str::FromStr for IssueCommentCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -10003,14 +10003,14 @@ impl std::str::FromStr for IssueCommentCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10042,7 +10042,7 @@ impl ToString for IssueCommentDeletedAction {
 }
 impl std::str::FromStr for IssueCommentDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -10050,14 +10050,14 @@ impl std::str::FromStr for IssueCommentDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10090,7 +10090,7 @@ impl ToString for IssueCommentEditedAction {
 }
 impl std::str::FromStr for IssueCommentEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -10098,14 +10098,14 @@ impl std::str::FromStr for IssueCommentEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10196,7 +10196,7 @@ impl ToString for IssueState {
 }
 impl std::str::FromStr for IssueState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -10205,14 +10205,14 @@ impl std::str::FromStr for IssueState {
     }
 }
 impl std::convert::TryFrom<&str> for IssueState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10248,7 +10248,7 @@ impl ToString for IssuesAssignedAction {
 }
 impl std::str::FromStr for IssuesAssignedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "assigned" => Ok(Self::Assigned),
             _ => Err("invalid value"),
@@ -10256,14 +10256,14 @@ impl std::str::FromStr for IssuesAssignedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesAssignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesAssignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10296,7 +10296,7 @@ impl ToString for IssuesClosedAction {
 }
 impl std::str::FromStr for IssuesClosedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
@@ -10304,14 +10304,14 @@ impl std::str::FromStr for IssuesClosedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10341,7 +10341,7 @@ impl ToString for IssuesDeletedAction {
 }
 impl std::str::FromStr for IssuesDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -10349,14 +10349,14 @@ impl std::str::FromStr for IssuesDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10387,7 +10387,7 @@ impl ToString for IssuesDemilestonedAction {
 }
 impl std::str::FromStr for IssuesDemilestonedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "demilestoned" => Ok(Self::Demilestoned),
             _ => Err("invalid value"),
@@ -10395,14 +10395,14 @@ impl std::str::FromStr for IssuesDemilestonedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDemilestonedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDemilestonedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10435,7 +10435,7 @@ impl ToString for IssuesEditedAction {
 }
 impl std::str::FromStr for IssuesEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -10443,14 +10443,14 @@ impl std::str::FromStr for IssuesEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10705,7 +10705,7 @@ impl ToString for IssuesLabeledAction {
 }
 impl std::str::FromStr for IssuesLabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "labeled" => Ok(Self::Labeled),
             _ => Err("invalid value"),
@@ -10713,14 +10713,14 @@ impl std::str::FromStr for IssuesLabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10750,7 +10750,7 @@ impl ToString for IssuesLockedAction {
 }
 impl std::str::FromStr for IssuesLockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "locked" => Ok(Self::Locked),
             _ => Err("invalid value"),
@@ -10758,14 +10758,14 @@ impl std::str::FromStr for IssuesLockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10796,7 +10796,7 @@ impl ToString for IssuesMilestonedAction {
 }
 impl std::str::FromStr for IssuesMilestonedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "milestoned" => Ok(Self::Milestoned),
             _ => Err("invalid value"),
@@ -10804,14 +10804,14 @@ impl std::str::FromStr for IssuesMilestonedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesMilestonedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesMilestonedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10843,7 +10843,7 @@ impl ToString for IssuesOpenedAction {
 }
 impl std::str::FromStr for IssuesOpenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "opened" => Ok(Self::Opened),
             _ => Err("invalid value"),
@@ -10851,14 +10851,14 @@ impl std::str::FromStr for IssuesOpenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10894,7 +10894,7 @@ impl ToString for IssuesPinnedAction {
 }
 impl std::str::FromStr for IssuesPinnedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pinned" => Ok(Self::Pinned),
             _ => Err("invalid value"),
@@ -10902,14 +10902,14 @@ impl std::str::FromStr for IssuesPinnedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesPinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesPinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10939,7 +10939,7 @@ impl ToString for IssuesReopenedAction {
 }
 impl std::str::FromStr for IssuesReopenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
@@ -10947,14 +10947,14 @@ impl std::str::FromStr for IssuesReopenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10985,7 +10985,7 @@ impl ToString for IssuesTransferredAction {
 }
 impl std::str::FromStr for IssuesTransferredAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "transferred" => Ok(Self::Transferred),
             _ => Err("invalid value"),
@@ -10993,14 +10993,14 @@ impl std::str::FromStr for IssuesTransferredAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11041,7 +11041,7 @@ impl ToString for IssuesUnassignedAction {
 }
 impl std::str::FromStr for IssuesUnassignedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unassigned" => Ok(Self::Unassigned),
             _ => Err("invalid value"),
@@ -11049,14 +11049,14 @@ impl std::str::FromStr for IssuesUnassignedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnassignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnassignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11089,7 +11089,7 @@ impl ToString for IssuesUnlabeledAction {
 }
 impl std::str::FromStr for IssuesUnlabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
             _ => Err("invalid value"),
@@ -11097,14 +11097,14 @@ impl std::str::FromStr for IssuesUnlabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11134,7 +11134,7 @@ impl ToString for IssuesUnlockedAction {
 }
 impl std::str::FromStr for IssuesUnlockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
             _ => Err("invalid value"),
@@ -11142,14 +11142,14 @@ impl std::str::FromStr for IssuesUnlockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11179,7 +11179,7 @@ impl ToString for IssuesUnpinnedAction {
 }
 impl std::str::FromStr for IssuesUnpinnedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unpinned" => Ok(Self::Unpinned),
             _ => Err("invalid value"),
@@ -11187,14 +11187,14 @@ impl std::str::FromStr for IssuesUnpinnedAction {
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnpinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnpinnedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11239,7 +11239,7 @@ impl ToString for LabelCreatedAction {
 }
 impl std::str::FromStr for LabelCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -11247,14 +11247,14 @@ impl std::str::FromStr for LabelCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for LabelCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11285,7 +11285,7 @@ impl ToString for LabelDeletedAction {
 }
 impl std::str::FromStr for LabelDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -11293,14 +11293,14 @@ impl std::str::FromStr for LabelDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for LabelDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11333,7 +11333,7 @@ impl ToString for LabelEditedAction {
 }
 impl std::str::FromStr for LabelEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -11341,14 +11341,14 @@ impl std::str::FromStr for LabelEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for LabelEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11483,7 +11483,7 @@ impl ToString for MarketplacePurchaseCancelledAction {
 }
 impl std::str::FromStr for MarketplacePurchaseCancelledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "cancelled" => Ok(Self::Cancelled),
             _ => Err("invalid value"),
@@ -11491,14 +11491,14 @@ impl std::str::FromStr for MarketplacePurchaseCancelledAction {
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchaseCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchaseCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11549,7 +11549,7 @@ impl ToString for MarketplacePurchaseChangedAction {
 }
 impl std::str::FromStr for MarketplacePurchaseChangedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "changed" => Ok(Self::Changed),
             _ => Err("invalid value"),
@@ -11557,14 +11557,14 @@ impl std::str::FromStr for MarketplacePurchaseChangedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchaseChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchaseChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11664,7 +11664,7 @@ impl ToString for MarketplacePurchasePendingChangeAction {
 }
 impl std::str::FromStr for MarketplacePurchasePendingChangeAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pending_change" => Ok(Self::PendingChange),
             _ => Err("invalid value"),
@@ -11672,14 +11672,14 @@ impl std::str::FromStr for MarketplacePurchasePendingChangeAction {
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11707,7 +11707,7 @@ impl ToString for MarketplacePurchasePendingChangeCancelledAction {
 }
 impl std::str::FromStr for MarketplacePurchasePendingChangeCancelledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pending_change_cancelled" => Ok(Self::PendingChangeCancelled),
             _ => Err("invalid value"),
@@ -11715,14 +11715,14 @@ impl std::str::FromStr for MarketplacePurchasePendingChangeCancelledAction {
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11809,7 +11809,7 @@ impl ToString for MarketplacePurchasePurchasedAction {
 }
 impl std::str::FromStr for MarketplacePurchasePurchasedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "purchased" => Ok(Self::Purchased),
             _ => Err("invalid value"),
@@ -11817,14 +11817,14 @@ impl std::str::FromStr for MarketplacePurchasePurchasedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePurchasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePurchasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11879,7 +11879,7 @@ impl ToString for MemberAddedAction {
 }
 impl std::str::FromStr for MemberAddedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "added" => Ok(Self::Added),
             _ => Err("invalid value"),
@@ -11887,14 +11887,14 @@ impl std::str::FromStr for MemberAddedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MemberAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11926,7 +11926,7 @@ impl ToString for MemberAddedChangesPermissionTo {
 }
 impl std::str::FromStr for MemberAddedChangesPermissionTo {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "write" => Ok(Self::Write),
             "admin" => Ok(Self::Admin),
@@ -11935,14 +11935,14 @@ impl std::str::FromStr for MemberAddedChangesPermissionTo {
     }
 }
 impl std::convert::TryFrom<&str> for MemberAddedChangesPermissionTo {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberAddedChangesPermissionTo {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11972,7 +11972,7 @@ impl ToString for MemberEditedAction {
 }
 impl std::str::FromStr for MemberEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -11980,14 +11980,14 @@ impl std::str::FromStr for MemberEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MemberEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12065,7 +12065,7 @@ impl ToString for MemberRemovedAction {
 }
 impl std::str::FromStr for MemberRemovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "removed" => Ok(Self::Removed),
             _ => Err("invalid value"),
@@ -12073,14 +12073,14 @@ impl std::str::FromStr for MemberRemovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MemberRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12123,7 +12123,7 @@ impl ToString for MembershipAddedAction {
 }
 impl std::str::FromStr for MembershipAddedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "added" => Ok(Self::Added),
             _ => Err("invalid value"),
@@ -12131,14 +12131,14 @@ impl std::str::FromStr for MembershipAddedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MembershipAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12157,7 +12157,7 @@ impl ToString for MembershipAddedScope {
 }
 impl std::str::FromStr for MembershipAddedScope {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "team" => Ok(Self::Team),
             _ => Err("invalid value"),
@@ -12165,14 +12165,14 @@ impl std::str::FromStr for MembershipAddedScope {
     }
 }
 impl std::convert::TryFrom<&str> for MembershipAddedScope {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipAddedScope {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12237,7 +12237,7 @@ impl ToString for MembershipRemovedAction {
 }
 impl std::str::FromStr for MembershipRemovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "removed" => Ok(Self::Removed),
             _ => Err("invalid value"),
@@ -12245,14 +12245,14 @@ impl std::str::FromStr for MembershipRemovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MembershipRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12274,7 +12274,7 @@ impl ToString for MembershipRemovedScope {
 }
 impl std::str::FromStr for MembershipRemovedScope {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "team" => Ok(Self::Team),
             "organization" => Ok(Self::Organization),
@@ -12283,14 +12283,14 @@ impl std::str::FromStr for MembershipRemovedScope {
     }
 }
 impl std::convert::TryFrom<&str> for MembershipRemovedScope {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipRemovedScope {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12330,7 +12330,7 @@ impl ToString for MetaDeletedAction {
 }
 impl std::str::FromStr for MetaDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -12338,14 +12338,14 @@ impl std::str::FromStr for MetaDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MetaDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MetaDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12387,7 +12387,7 @@ impl ToString for MetaDeletedHookConfigContentType {
 }
 impl std::str::FromStr for MetaDeletedHookConfigContentType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "json" => Ok(Self::Json),
             "form" => Ok(Self::Form),
@@ -12396,14 +12396,14 @@ impl std::str::FromStr for MetaDeletedHookConfigContentType {
     }
 }
 impl std::convert::TryFrom<&str> for MetaDeletedHookConfigContentType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MetaDeletedHookConfigContentType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12470,7 +12470,7 @@ impl ToString for MilestoneClosedAction {
 }
 impl std::str::FromStr for MilestoneClosedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
@@ -12478,14 +12478,14 @@ impl std::str::FromStr for MilestoneClosedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12515,7 +12515,7 @@ impl ToString for MilestoneCreatedAction {
 }
 impl std::str::FromStr for MilestoneCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -12523,14 +12523,14 @@ impl std::str::FromStr for MilestoneCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12560,7 +12560,7 @@ impl ToString for MilestoneDeletedAction {
 }
 impl std::str::FromStr for MilestoneDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -12568,14 +12568,14 @@ impl std::str::FromStr for MilestoneDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12606,7 +12606,7 @@ impl ToString for MilestoneEditedAction {
 }
 impl std::str::FromStr for MilestoneEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -12614,14 +12614,14 @@ impl std::str::FromStr for MilestoneEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12740,7 +12740,7 @@ impl ToString for MilestoneOpenedAction {
 }
 impl std::str::FromStr for MilestoneOpenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "opened" => Ok(Self::Opened),
             _ => Err("invalid value"),
@@ -12748,14 +12748,14 @@ impl std::str::FromStr for MilestoneOpenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12777,7 +12777,7 @@ impl ToString for MilestoneState {
 }
 impl std::str::FromStr for MilestoneState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -12786,14 +12786,14 @@ impl std::str::FromStr for MilestoneState {
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12822,7 +12822,7 @@ impl ToString for OrgBlockBlockedAction {
 }
 impl std::str::FromStr for OrgBlockBlockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "blocked" => Ok(Self::Blocked),
             _ => Err("invalid value"),
@@ -12830,14 +12830,14 @@ impl std::str::FromStr for OrgBlockBlockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrgBlockBlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrgBlockBlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12890,7 +12890,7 @@ impl ToString for OrgBlockUnblockedAction {
 }
 impl std::str::FromStr for OrgBlockUnblockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unblocked" => Ok(Self::Unblocked),
             _ => Err("invalid value"),
@@ -12898,14 +12898,14 @@ impl std::str::FromStr for OrgBlockUnblockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrgBlockUnblockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrgBlockUnblockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12951,7 +12951,7 @@ impl ToString for OrganizationDeletedAction {
 }
 impl std::str::FromStr for OrganizationDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -12959,14 +12959,14 @@ impl std::str::FromStr for OrganizationDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13044,7 +13044,7 @@ impl ToString for OrganizationMemberAddedAction {
 }
 impl std::str::FromStr for OrganizationMemberAddedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "member_added" => Ok(Self::MemberAdded),
             _ => Err("invalid value"),
@@ -13052,14 +13052,14 @@ impl std::str::FromStr for OrganizationMemberAddedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberAddedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13088,7 +13088,7 @@ impl ToString for OrganizationMemberInvitedAction {
 }
 impl std::str::FromStr for OrganizationMemberInvitedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "member_invited" => Ok(Self::MemberInvited),
             _ => Err("invalid value"),
@@ -13096,14 +13096,14 @@ impl std::str::FromStr for OrganizationMemberInvitedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberInvitedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberInvitedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13147,7 +13147,7 @@ impl ToString for OrganizationMemberRemovedAction {
 }
 impl std::str::FromStr for OrganizationMemberRemovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "member_removed" => Ok(Self::MemberRemoved),
             _ => Err("invalid value"),
@@ -13155,14 +13155,14 @@ impl std::str::FromStr for OrganizationMemberRemovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberRemovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13190,7 +13190,7 @@ impl ToString for OrganizationRenamedAction {
 }
 impl std::str::FromStr for OrganizationRenamedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "renamed" => Ok(Self::Renamed),
             _ => Err("invalid value"),
@@ -13198,14 +13198,14 @@ impl std::str::FromStr for OrganizationRenamedAction {
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationRenamedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationRenamedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13255,7 +13255,7 @@ impl ToString for PackagePublishedAction {
 }
 impl std::str::FromStr for PackagePublishedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "published" => Ok(Self::Published),
             _ => Err("invalid value"),
@@ -13263,14 +13263,14 @@ impl std::str::FromStr for PackagePublishedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PackagePublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackagePublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13382,7 +13382,7 @@ impl ToString for PackageUpdatedAction {
 }
 impl std::str::FromStr for PackageUpdatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "updated" => Ok(Self::Updated),
             _ => Err("invalid value"),
@@ -13390,14 +13390,14 @@ impl std::str::FromStr for PackageUpdatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PackageUpdatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackageUpdatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13579,7 +13579,7 @@ impl ToString for PingEventHookConfigContentType {
 }
 impl std::str::FromStr for PingEventHookConfigContentType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "json" => Ok(Self::Json),
             "form" => Ok(Self::Form),
@@ -13588,14 +13588,14 @@ impl std::str::FromStr for PingEventHookConfigContentType {
     }
 }
 impl std::convert::TryFrom<&str> for PingEventHookConfigContentType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PingEventHookConfigContentType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13674,7 +13674,7 @@ impl ToString for ProjectCardConvertedAction {
 }
 impl std::str::FromStr for ProjectCardConvertedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "converted" => Ok(Self::Converted),
             _ => Err("invalid value"),
@@ -13682,14 +13682,14 @@ impl std::str::FromStr for ProjectCardConvertedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardConvertedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardConvertedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13729,7 +13729,7 @@ impl ToString for ProjectCardCreatedAction {
 }
 impl std::str::FromStr for ProjectCardCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -13737,14 +13737,14 @@ impl std::str::FromStr for ProjectCardCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13774,7 +13774,7 @@ impl ToString for ProjectCardDeletedAction {
 }
 impl std::str::FromStr for ProjectCardDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -13782,14 +13782,14 @@ impl std::str::FromStr for ProjectCardDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13820,7 +13820,7 @@ impl ToString for ProjectCardEditedAction {
 }
 impl std::str::FromStr for ProjectCardEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -13828,14 +13828,14 @@ impl std::str::FromStr for ProjectCardEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13938,7 +13938,7 @@ impl ToString for ProjectCardMovedAction {
 }
 impl std::str::FromStr for ProjectCardMovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "moved" => Ok(Self::Moved),
             _ => Err("invalid value"),
@@ -13946,14 +13946,14 @@ impl std::str::FromStr for ProjectCardMovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardMovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardMovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13993,7 +13993,7 @@ impl ToString for ProjectClosedAction {
 }
 impl std::str::FromStr for ProjectClosedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
@@ -14001,14 +14001,14 @@ impl std::str::FromStr for ProjectClosedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14052,7 +14052,7 @@ impl ToString for ProjectColumnCreatedAction {
 }
 impl std::str::FromStr for ProjectColumnCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -14060,14 +14060,14 @@ impl std::str::FromStr for ProjectColumnCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14097,7 +14097,7 @@ impl ToString for ProjectColumnDeletedAction {
 }
 impl std::str::FromStr for ProjectColumnDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -14105,14 +14105,14 @@ impl std::str::FromStr for ProjectColumnDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14143,7 +14143,7 @@ impl ToString for ProjectColumnEditedAction {
 }
 impl std::str::FromStr for ProjectColumnEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -14151,14 +14151,14 @@ impl std::str::FromStr for ProjectColumnEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14248,7 +14248,7 @@ impl ToString for ProjectColumnMovedAction {
 }
 impl std::str::FromStr for ProjectColumnMovedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "moved" => Ok(Self::Moved),
             _ => Err("invalid value"),
@@ -14256,14 +14256,14 @@ impl std::str::FromStr for ProjectColumnMovedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnMovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnMovedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14293,7 +14293,7 @@ impl ToString for ProjectCreatedAction {
 }
 impl std::str::FromStr for ProjectCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -14301,14 +14301,14 @@ impl std::str::FromStr for ProjectCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14338,7 +14338,7 @@ impl ToString for ProjectDeletedAction {
 }
 impl std::str::FromStr for ProjectDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -14346,14 +14346,14 @@ impl std::str::FromStr for ProjectDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14384,7 +14384,7 @@ impl ToString for ProjectEditedAction {
 }
 impl std::str::FromStr for ProjectEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -14392,14 +14392,14 @@ impl std::str::FromStr for ProjectEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14510,7 +14510,7 @@ impl ToString for ProjectReopenedAction {
 }
 impl std::str::FromStr for ProjectReopenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
@@ -14518,14 +14518,14 @@ impl std::str::FromStr for ProjectReopenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14547,7 +14547,7 @@ impl ToString for ProjectState {
 }
 impl std::str::FromStr for ProjectState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -14556,14 +14556,14 @@ impl std::str::FromStr for ProjectState {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14659,7 +14659,7 @@ impl ToString for PullRequestActiveLockReason {
 }
 impl std::str::FromStr for PullRequestActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -14670,14 +14670,14 @@ impl std::str::FromStr for PullRequestActiveLockReason {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14710,7 +14710,7 @@ impl ToString for PullRequestAssignedAction {
 }
 impl std::str::FromStr for PullRequestAssignedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "assigned" => Ok(Self::Assigned),
             _ => Err("invalid value"),
@@ -14718,14 +14718,14 @@ impl std::str::FromStr for PullRequestAssignedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAssignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAssignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14756,7 +14756,7 @@ impl ToString for PullRequestAutoMergeDisabledAction {
 }
 impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto_merge_disabled" => Ok(Self::AutoMergeDisabled),
             _ => Err("invalid value"),
@@ -14764,14 +14764,14 @@ impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAutoMergeDisabledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAutoMergeDisabledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14802,7 +14802,7 @@ impl ToString for PullRequestAutoMergeEnabledAction {
 }
 impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto_merge_enabled" => Ok(Self::AutoMergeEnabled),
             _ => Err("invalid value"),
@@ -14810,14 +14810,14 @@ impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAutoMergeEnabledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAutoMergeEnabledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14859,7 +14859,7 @@ impl ToString for PullRequestClosedAction {
 }
 impl std::str::FromStr for PullRequestClosedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "closed" => Ok(Self::Closed),
             _ => Err("invalid value"),
@@ -14867,14 +14867,14 @@ impl std::str::FromStr for PullRequestClosedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestClosedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14906,7 +14906,7 @@ impl ToString for PullRequestConvertedToDraftAction {
 }
 impl std::str::FromStr for PullRequestConvertedToDraftAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "converted_to_draft" => Ok(Self::ConvertedToDraft),
             _ => Err("invalid value"),
@@ -14914,14 +14914,14 @@ impl std::str::FromStr for PullRequestConvertedToDraftAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14954,7 +14954,7 @@ impl ToString for PullRequestEditedAction {
 }
 impl std::str::FromStr for PullRequestEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -14962,14 +14962,14 @@ impl std::str::FromStr for PullRequestEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15054,7 +15054,7 @@ impl ToString for PullRequestLabeledAction {
 }
 impl std::str::FromStr for PullRequestLabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "labeled" => Ok(Self::Labeled),
             _ => Err("invalid value"),
@@ -15062,14 +15062,14 @@ impl std::str::FromStr for PullRequestLabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestLabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15114,7 +15114,7 @@ impl ToString for PullRequestLockedAction {
 }
 impl std::str::FromStr for PullRequestLockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "locked" => Ok(Self::Locked),
             _ => Err("invalid value"),
@@ -15122,14 +15122,14 @@ impl std::str::FromStr for PullRequestLockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestLockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15161,7 +15161,7 @@ impl ToString for PullRequestOpenedAction {
 }
 impl std::str::FromStr for PullRequestOpenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "opened" => Ok(Self::Opened),
             _ => Err("invalid value"),
@@ -15169,14 +15169,14 @@ impl std::str::FromStr for PullRequestOpenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestOpenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15208,7 +15208,7 @@ impl ToString for PullRequestReadyForReviewAction {
 }
 impl std::str::FromStr for PullRequestReadyForReviewAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "ready_for_review" => Ok(Self::ReadyForReview),
             _ => Err("invalid value"),
@@ -15216,14 +15216,14 @@ impl std::str::FromStr for PullRequestReadyForReviewAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReadyForReviewAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReadyForReviewAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15255,7 +15255,7 @@ impl ToString for PullRequestReopenedAction {
 }
 impl std::str::FromStr for PullRequestReopenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
@@ -15263,14 +15263,14 @@ impl std::str::FromStr for PullRequestReopenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15359,7 +15359,7 @@ impl ToString for PullRequestReviewCommentCreatedAction {
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -15367,14 +15367,14 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15444,7 +15444,7 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -15455,14 +15455,14 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockR
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15522,7 +15522,7 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestState {
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -15531,14 +15531,14 @@ impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15569,7 +15569,7 @@ impl ToString for PullRequestReviewCommentDeletedAction {
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -15577,14 +15577,14 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15654,7 +15654,7 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -15665,14 +15665,14 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockR
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15732,7 +15732,7 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestState {
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -15741,14 +15741,14 @@ impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15780,7 +15780,7 @@ impl ToString for PullRequestReviewCommentEditedAction {
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -15788,14 +15788,14 @@ impl std::str::FromStr for PullRequestReviewCommentEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15878,7 +15878,7 @@ impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -15889,14 +15889,14 @@ impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockRe
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15956,7 +15956,7 @@ impl ToString for PullRequestReviewCommentEditedPullRequestState {
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -15965,14 +15965,14 @@ impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16043,7 +16043,7 @@ impl ToString for PullRequestReviewCommentSide {
 }
 impl std::str::FromStr for PullRequestReviewCommentSide {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "LEFT" => Ok(Self::Left),
             "RIGHT" => Ok(Self::Right),
@@ -16052,14 +16052,14 @@ impl std::str::FromStr for PullRequestReviewCommentSide {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentSide {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentSide {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16081,7 +16081,7 @@ impl ToString for PullRequestReviewCommentStartSide {
 }
 impl std::str::FromStr for PullRequestReviewCommentStartSide {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "LEFT" => Ok(Self::Left),
             "RIGHT" => Ok(Self::Right),
@@ -16090,14 +16090,14 @@ impl std::str::FromStr for PullRequestReviewCommentStartSide {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentStartSide {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentStartSide {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16128,7 +16128,7 @@ impl ToString for PullRequestReviewDismissedAction {
 }
 impl std::str::FromStr for PullRequestReviewDismissedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
@@ -16136,14 +16136,14 @@ impl std::str::FromStr for PullRequestReviewDismissedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewDismissedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewDismissedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16187,7 +16187,7 @@ impl ToString for PullRequestReviewDismissedReviewState {
 }
 impl std::str::FromStr for PullRequestReviewDismissedReviewState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
             _ => Err("invalid value"),
@@ -16195,14 +16195,14 @@ impl std::str::FromStr for PullRequestReviewDismissedReviewState {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewDismissedReviewState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewDismissedReviewState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16234,7 +16234,7 @@ impl ToString for PullRequestReviewEditedAction {
 }
 impl std::str::FromStr for PullRequestReviewEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -16242,14 +16242,14 @@ impl std::str::FromStr for PullRequestReviewEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16376,7 +16376,7 @@ impl ToString for PullRequestReviewRequestRemovedVariant0Action {
 }
 impl std::str::FromStr for PullRequestReviewRequestRemovedVariant0Action {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "review_request_removed" => Ok(Self::ReviewRequestRemoved),
             _ => Err("invalid value"),
@@ -16384,14 +16384,14 @@ impl std::str::FromStr for PullRequestReviewRequestRemovedVariant0Action {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant0Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant0Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16409,7 +16409,7 @@ impl ToString for PullRequestReviewRequestRemovedVariant1Action {
 }
 impl std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "review_request_removed" => Ok(Self::ReviewRequestRemoved),
             _ => Err("invalid value"),
@@ -16417,14 +16417,14 @@ impl std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant1Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant1Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16472,7 +16472,7 @@ impl ToString for PullRequestReviewRequestedVariant0Action {
 }
 impl std::str::FromStr for PullRequestReviewRequestedVariant0Action {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "review_requested" => Ok(Self::ReviewRequested),
             _ => Err("invalid value"),
@@ -16480,14 +16480,14 @@ impl std::str::FromStr for PullRequestReviewRequestedVariant0Action {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant0Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant0Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16505,7 +16505,7 @@ impl ToString for PullRequestReviewRequestedVariant1Action {
 }
 impl std::str::FromStr for PullRequestReviewRequestedVariant1Action {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "review_requested" => Ok(Self::ReviewRequested),
             _ => Err("invalid value"),
@@ -16513,14 +16513,14 @@ impl std::str::FromStr for PullRequestReviewRequestedVariant1Action {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant1Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant1Action {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16551,7 +16551,7 @@ impl ToString for PullRequestReviewSubmittedAction {
 }
 impl std::str::FromStr for PullRequestReviewSubmittedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "submitted" => Ok(Self::Submitted),
             _ => Err("invalid value"),
@@ -16559,14 +16559,14 @@ impl std::str::FromStr for PullRequestReviewSubmittedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewSubmittedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewSubmittedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16614,7 +16614,7 @@ impl ToString for PullRequestState {
 }
 impl std::str::FromStr for PullRequestState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -16623,14 +16623,14 @@ impl std::str::FromStr for PullRequestState {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16664,7 +16664,7 @@ impl ToString for PullRequestSynchronizeAction {
 }
 impl std::str::FromStr for PullRequestSynchronizeAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "synchronize" => Ok(Self::Synchronize),
             _ => Err("invalid value"),
@@ -16672,14 +16672,14 @@ impl std::str::FromStr for PullRequestSynchronizeAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestSynchronizeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestSynchronizeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16712,7 +16712,7 @@ impl ToString for PullRequestUnassignedAction {
 }
 impl std::str::FromStr for PullRequestUnassignedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unassigned" => Ok(Self::Unassigned),
             _ => Err("invalid value"),
@@ -16720,14 +16720,14 @@ impl std::str::FromStr for PullRequestUnassignedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnassignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnassignedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16760,7 +16760,7 @@ impl ToString for PullRequestUnlabeledAction {
 }
 impl std::str::FromStr for PullRequestUnlabeledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
             _ => Err("invalid value"),
@@ -16768,14 +16768,14 @@ impl std::str::FromStr for PullRequestUnlabeledAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnlabeledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16807,7 +16807,7 @@ impl ToString for PullRequestUnlockedAction {
 }
 impl std::str::FromStr for PullRequestUnlockedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
             _ => Err("invalid value"),
@@ -16815,14 +16815,14 @@ impl std::str::FromStr for PullRequestUnlockedAction {
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnlockedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16915,7 +16915,7 @@ impl ToString for ReleaseAssetState {
 }
 impl std::str::FromStr for ReleaseAssetState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "uploaded" => Ok(Self::Uploaded),
             _ => Err("invalid value"),
@@ -16923,14 +16923,14 @@ impl std::str::FromStr for ReleaseAssetState {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseAssetState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseAssetState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16960,7 +16960,7 @@ impl ToString for ReleaseCreatedAction {
 }
 impl std::str::FromStr for ReleaseCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -16968,14 +16968,14 @@ impl std::str::FromStr for ReleaseCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17005,7 +17005,7 @@ impl ToString for ReleaseDeletedAction {
 }
 impl std::str::FromStr for ReleaseDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -17013,14 +17013,14 @@ impl std::str::FromStr for ReleaseDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17051,7 +17051,7 @@ impl ToString for ReleaseEditedAction {
 }
 impl std::str::FromStr for ReleaseEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -17059,14 +17059,14 @@ impl std::str::FromStr for ReleaseEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17198,7 +17198,7 @@ impl ToString for ReleasePrereleasedAction {
 }
 impl std::str::FromStr for ReleasePrereleasedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "prereleased" => Ok(Self::Prereleased),
             _ => Err("invalid value"),
@@ -17206,14 +17206,14 @@ impl std::str::FromStr for ReleasePrereleasedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleasePrereleasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleasePrereleasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17243,7 +17243,7 @@ impl ToString for ReleasePublishedAction {
 }
 impl std::str::FromStr for ReleasePublishedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "published" => Ok(Self::Published),
             _ => Err("invalid value"),
@@ -17251,14 +17251,14 @@ impl std::str::FromStr for ReleasePublishedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleasePublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleasePublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17288,7 +17288,7 @@ impl ToString for ReleaseReleasedAction {
 }
 impl std::str::FromStr for ReleaseReleasedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "released" => Ok(Self::Released),
             _ => Err("invalid value"),
@@ -17296,14 +17296,14 @@ impl std::str::FromStr for ReleaseReleasedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseReleasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseReleasedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17333,7 +17333,7 @@ impl ToString for ReleaseUnpublishedAction {
 }
 impl std::str::FromStr for ReleaseUnpublishedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unpublished" => Ok(Self::Unpublished),
             _ => Err("invalid value"),
@@ -17341,14 +17341,14 @@ impl std::str::FromStr for ReleaseUnpublishedAction {
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseUnpublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseUnpublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17501,7 +17501,7 @@ impl ToString for RepositoryArchivedAction {
 }
 impl std::str::FromStr for RepositoryArchivedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "archived" => Ok(Self::Archived),
             _ => Err("invalid value"),
@@ -17509,14 +17509,14 @@ impl std::str::FromStr for RepositoryArchivedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryArchivedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryArchivedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17545,7 +17545,7 @@ impl ToString for RepositoryCreatedAction {
 }
 impl std::str::FromStr for RepositoryCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -17553,14 +17553,14 @@ impl std::str::FromStr for RepositoryCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17603,7 +17603,7 @@ impl ToString for RepositoryDeletedAction {
 }
 impl std::str::FromStr for RepositoryDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -17611,14 +17611,14 @@ impl std::str::FromStr for RepositoryDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17663,7 +17663,7 @@ impl ToString for RepositoryDispatchOnDemandTestAction {
 }
 impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "on-demand-test" => Ok(Self::OnDemandTest),
             _ => Err("invalid value"),
@@ -17671,14 +17671,14 @@ impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryDispatchOnDemandTestAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryDispatchOnDemandTestAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17708,7 +17708,7 @@ impl ToString for RepositoryEditedAction {
 }
 impl std::str::FromStr for RepositoryEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -17716,14 +17716,14 @@ impl std::str::FromStr for RepositoryEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17880,7 +17880,7 @@ impl ToString for RepositoryImportEventStatus {
 }
 impl std::str::FromStr for RepositoryImportEventStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "cancelled" => Ok(Self::Cancelled),
@@ -17890,14 +17890,14 @@ impl std::str::FromStr for RepositoryImportEventStatus {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryImportEventStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryImportEventStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17990,7 +17990,7 @@ impl ToString for RepositoryPrivatizedAction {
 }
 impl std::str::FromStr for RepositoryPrivatizedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "privatized" => Ok(Self::Privatized),
             _ => Err("invalid value"),
@@ -17998,14 +17998,14 @@ impl std::str::FromStr for RepositoryPrivatizedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPrivatizedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPrivatizedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18034,7 +18034,7 @@ impl ToString for RepositoryPublicizedAction {
 }
 impl std::str::FromStr for RepositoryPublicizedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "publicized" => Ok(Self::Publicized),
             _ => Err("invalid value"),
@@ -18042,14 +18042,14 @@ impl std::str::FromStr for RepositoryPublicizedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPublicizedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPublicizedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18086,7 +18086,7 @@ impl ToString for RepositoryRenamedAction {
 }
 impl std::str::FromStr for RepositoryRenamedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "renamed" => Ok(Self::Renamed),
             _ => Err("invalid value"),
@@ -18094,14 +18094,14 @@ impl std::str::FromStr for RepositoryRenamedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryRenamedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryRenamedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18146,7 +18146,7 @@ impl ToString for RepositoryTransferredAction {
 }
 impl std::str::FromStr for RepositoryTransferredAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "transferred" => Ok(Self::Transferred),
             _ => Err("invalid value"),
@@ -18154,14 +18154,14 @@ impl std::str::FromStr for RepositoryTransferredAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryTransferredAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18206,7 +18206,7 @@ impl ToString for RepositoryUnarchivedAction {
 }
 impl std::str::FromStr for RepositoryUnarchivedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "unarchived" => Ok(Self::Unarchived),
             _ => Err("invalid value"),
@@ -18214,14 +18214,14 @@ impl std::str::FromStr for RepositoryUnarchivedAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryUnarchivedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryUnarchivedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18249,7 +18249,7 @@ impl ToString for RepositoryVulnerabilityAlertCreateAction {
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertCreateAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "create" => Ok(Self::Create),
             _ => Err("invalid value"),
@@ -18257,14 +18257,14 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertCreateAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18315,7 +18315,7 @@ impl ToString for RepositoryVulnerabilityAlertDismissAction {
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertDismissAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dismiss" => Ok(Self::Dismiss),
             _ => Err("invalid value"),
@@ -18323,14 +18323,14 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertDismissAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18409,7 +18409,7 @@ impl ToString for RepositoryVulnerabilityAlertResolveAction {
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertResolveAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolve" => Ok(Self::Resolve),
             _ => Err("invalid value"),
@@ -18417,14 +18417,14 @@ impl std::str::FromStr for RepositoryVulnerabilityAlertResolveAction {
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18476,7 +18476,7 @@ impl ToString for SecretScanningAlertCreatedAction {
 }
 impl std::str::FromStr for SecretScanningAlertCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -18484,14 +18484,14 @@ impl std::str::FromStr for SecretScanningAlertCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18567,7 +18567,7 @@ impl ToString for SecretScanningAlertReopenedAction {
 }
 impl std::str::FromStr for SecretScanningAlertReopenedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "reopened" => Ok(Self::Reopened),
             _ => Err("invalid value"),
@@ -18575,14 +18575,14 @@ impl std::str::FromStr for SecretScanningAlertReopenedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertReopenedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18622,7 +18622,7 @@ impl ToString for SecretScanningAlertResolvedAction {
 }
 impl std::str::FromStr for SecretScanningAlertResolvedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             _ => Err("invalid value"),
@@ -18630,14 +18630,14 @@ impl std::str::FromStr for SecretScanningAlertResolvedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18674,7 +18674,7 @@ impl ToString for SecretScanningAlertResolvedAlertResolution {
 }
 impl std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "false_positive" => Ok(Self::FalsePositive),
             "wontfix" => Ok(Self::Wontfix),
@@ -18685,14 +18685,14 @@ impl std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAlertResolution {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAlertResolution {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18732,7 +18732,7 @@ impl ToString for SecurityAdvisoryPerformedAction {
 }
 impl std::str::FromStr for SecurityAdvisoryPerformedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "performed" => Ok(Self::Performed),
             _ => Err("invalid value"),
@@ -18740,14 +18740,14 @@ impl std::str::FromStr for SecurityAdvisoryPerformedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryPerformedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryPerformedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18832,7 +18832,7 @@ impl ToString for SecurityAdvisoryPublishedAction {
 }
 impl std::str::FromStr for SecurityAdvisoryPublishedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "published" => Ok(Self::Published),
             _ => Err("invalid value"),
@@ -18840,14 +18840,14 @@ impl std::str::FromStr for SecurityAdvisoryPublishedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryPublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryPublishedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18932,7 +18932,7 @@ impl ToString for SecurityAdvisoryUpdatedAction {
 }
 impl std::str::FromStr for SecurityAdvisoryUpdatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "updated" => Ok(Self::Updated),
             _ => Err("invalid value"),
@@ -18940,14 +18940,14 @@ impl std::str::FromStr for SecurityAdvisoryUpdatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryUpdatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryUpdatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19032,7 +19032,7 @@ impl ToString for SecurityAdvisoryWithdrawnAction {
 }
 impl std::str::FromStr for SecurityAdvisoryWithdrawnAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "withdrawn" => Ok(Self::Withdrawn),
             _ => Err("invalid value"),
@@ -19040,14 +19040,14 @@ impl std::str::FromStr for SecurityAdvisoryWithdrawnAction {
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryWithdrawnAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryWithdrawnAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19176,7 +19176,7 @@ impl ToString for SimplePullRequestActiveLockReason {
 }
 impl std::str::FromStr for SimplePullRequestActiveLockReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
@@ -19187,14 +19187,14 @@ impl std::str::FromStr for SimplePullRequestActiveLockReason {
     }
 }
 impl std::convert::TryFrom<&str> for SimplePullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SimplePullRequestActiveLockReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19254,7 +19254,7 @@ impl ToString for SimplePullRequestState {
 }
 impl std::str::FromStr for SimplePullRequestState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -19263,14 +19263,14 @@ impl std::str::FromStr for SimplePullRequestState {
     }
 }
 impl std::convert::TryFrom<&str> for SimplePullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SimplePullRequestState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19295,7 +19295,7 @@ impl ToString for SponsorshipCancelledAction {
 }
 impl std::str::FromStr for SponsorshipCancelledAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "cancelled" => Ok(Self::Cancelled),
             _ => Err("invalid value"),
@@ -19303,14 +19303,14 @@ impl std::str::FromStr for SponsorshipCancelledAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipCancelledAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19345,7 +19345,7 @@ impl ToString for SponsorshipCreatedAction {
 }
 impl std::str::FromStr for SponsorshipCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -19353,14 +19353,14 @@ impl std::str::FromStr for SponsorshipCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19396,7 +19396,7 @@ impl ToString for SponsorshipEditedAction {
 }
 impl std::str::FromStr for SponsorshipEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -19404,14 +19404,14 @@ impl std::str::FromStr for SponsorshipEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19510,7 +19510,7 @@ impl ToString for SponsorshipPendingCancellationAction {
 }
 impl std::str::FromStr for SponsorshipPendingCancellationAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pending_cancellation" => Ok(Self::PendingCancellation),
             _ => Err("invalid value"),
@@ -19518,14 +19518,14 @@ impl std::str::FromStr for SponsorshipPendingCancellationAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipPendingCancellationAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipPendingCancellationAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19564,7 +19564,7 @@ impl ToString for SponsorshipPendingTierChangeAction {
 }
 impl std::str::FromStr for SponsorshipPendingTierChangeAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pending_tier_change" => Ok(Self::PendingTierChange),
             _ => Err("invalid value"),
@@ -19572,14 +19572,14 @@ impl std::str::FromStr for SponsorshipPendingTierChangeAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipPendingTierChangeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipPendingTierChangeAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19638,7 +19638,7 @@ impl ToString for SponsorshipTierChangedAction {
 }
 impl std::str::FromStr for SponsorshipTierChangedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "tier_changed" => Ok(Self::TierChanged),
             _ => Err("invalid value"),
@@ -19646,14 +19646,14 @@ impl std::str::FromStr for SponsorshipTierChangedAction {
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipTierChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipTierChangedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19704,7 +19704,7 @@ impl ToString for StarCreatedAction {
 }
 impl std::str::FromStr for StarCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -19712,14 +19712,14 @@ impl std::str::FromStr for StarCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for StarCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StarCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19750,7 +19750,7 @@ impl ToString for StarDeletedAction {
 }
 impl std::str::FromStr for StarDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -19758,14 +19758,14 @@ impl std::str::FromStr for StarDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for StarDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StarDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19927,7 +19927,7 @@ impl ToString for StatusEventCommitCommitVerificationReason {
 }
 impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "expired_key" => Ok(Self::ExpiredKey),
             "not_signing_key" => Ok(Self::NotSigningKey),
@@ -19947,14 +19947,14 @@ impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
     }
 }
 impl std::convert::TryFrom<&str> for StatusEventCommitCommitVerificationReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StatusEventCommitCommitVerificationReason {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -19989,7 +19989,7 @@ impl ToString for StatusEventState {
 }
 impl std::str::FromStr for StatusEventState {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pending" => Ok(Self::Pending),
             "success" => Ok(Self::Success),
@@ -20000,14 +20000,14 @@ impl std::str::FromStr for StatusEventState {
     }
 }
 impl std::convert::TryFrom<&str> for StatusEventState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StatusEventState {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20070,7 +20070,7 @@ impl ToString for TeamAddedToRepositoryAction {
 }
 impl std::str::FromStr for TeamAddedToRepositoryAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "added_to_repository" => Ok(Self::AddedToRepository),
             _ => Err("invalid value"),
@@ -20078,14 +20078,14 @@ impl std::str::FromStr for TeamAddedToRepositoryAction {
     }
 }
 impl std::convert::TryFrom<&str> for TeamAddedToRepositoryAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamAddedToRepositoryAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20115,7 +20115,7 @@ impl ToString for TeamCreatedAction {
 }
 impl std::str::FromStr for TeamCreatedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "created" => Ok(Self::Created),
             _ => Err("invalid value"),
@@ -20123,14 +20123,14 @@ impl std::str::FromStr for TeamCreatedAction {
     }
 }
 impl std::convert::TryFrom<&str> for TeamCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamCreatedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20160,7 +20160,7 @@ impl ToString for TeamDeletedAction {
 }
 impl std::str::FromStr for TeamDeletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "deleted" => Ok(Self::Deleted),
             _ => Err("invalid value"),
@@ -20168,14 +20168,14 @@ impl std::str::FromStr for TeamDeletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for TeamDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamDeletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20206,7 +20206,7 @@ impl ToString for TeamEditedAction {
 }
 impl std::str::FromStr for TeamEditedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "edited" => Ok(Self::Edited),
             _ => Err("invalid value"),
@@ -20214,14 +20214,14 @@ impl std::str::FromStr for TeamEditedAction {
     }
 }
 impl std::convert::TryFrom<&str> for TeamEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamEditedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20379,7 +20379,7 @@ impl ToString for TeamParentPrivacy {
 }
 impl std::str::FromStr for TeamParentPrivacy {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -20389,14 +20389,14 @@ impl std::str::FromStr for TeamParentPrivacy {
     }
 }
 impl std::convert::TryFrom<&str> for TeamParentPrivacy {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamParentPrivacy {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20420,7 +20420,7 @@ impl ToString for TeamPrivacy {
 }
 impl std::str::FromStr for TeamPrivacy {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
@@ -20430,14 +20430,14 @@ impl std::str::FromStr for TeamPrivacy {
     }
 }
 impl std::convert::TryFrom<&str> for TeamPrivacy {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamPrivacy {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20467,7 +20467,7 @@ impl ToString for TeamRemovedFromRepositoryAction {
 }
 impl std::str::FromStr for TeamRemovedFromRepositoryAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "removed_from_repository" => Ok(Self::RemovedFromRepository),
             _ => Err("invalid value"),
@@ -20475,14 +20475,14 @@ impl std::str::FromStr for TeamRemovedFromRepositoryAction {
     }
 }
 impl std::convert::TryFrom<&str> for TeamRemovedFromRepositoryAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamRemovedFromRepositoryAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20530,7 +20530,7 @@ impl ToString for UserType {
 }
 impl std::str::FromStr for UserType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
@@ -20540,14 +20540,14 @@ impl std::str::FromStr for UserType {
     }
 }
 impl std::convert::TryFrom<&str> for UserType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for UserType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20590,7 +20590,7 @@ impl ToString for WatchStartedAction {
 }
 impl std::str::FromStr for WatchStartedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "started" => Ok(Self::Started),
             _ => Err("invalid value"),
@@ -20598,14 +20598,14 @@ impl std::str::FromStr for WatchStartedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WatchStartedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WatchStartedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20767,7 +20767,7 @@ impl ToString for WebhookEventsVariant0Item {
 }
 impl std::str::FromStr for WebhookEventsVariant0Item {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -20821,14 +20821,14 @@ impl std::str::FromStr for WebhookEventsVariant0Item {
     }
 }
 impl std::convert::TryFrom<&str> for WebhookEventsVariant0Item {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WebhookEventsVariant0Item {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20905,7 +20905,7 @@ impl ToString for WorkflowJobCompletedAction {
 }
 impl std::str::FromStr for WorkflowJobCompletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -20913,14 +20913,14 @@ impl std::str::FromStr for WorkflowJobCompletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -20941,7 +20941,7 @@ impl ToString for WorkflowJobConclusion {
 }
 impl std::str::FromStr for WorkflowJobConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -20950,14 +20950,14 @@ impl std::str::FromStr for WorkflowJobConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21024,7 +21024,7 @@ impl ToString for WorkflowJobQueuedAction {
 }
 impl std::str::FromStr for WorkflowJobQueuedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
@@ -21032,14 +21032,14 @@ impl std::str::FromStr for WorkflowJobQueuedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobQueuedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobQueuedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21076,7 +21076,7 @@ impl ToString for WorkflowJobQueuedWorkflowJobStatus {
 }
 impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             _ => Err("invalid value"),
@@ -21084,14 +21084,14 @@ impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21121,7 +21121,7 @@ impl ToString for WorkflowJobStartedAction {
 }
 impl std::str::FromStr for WorkflowJobStartedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "started" => Ok(Self::Started),
             _ => Err("invalid value"),
@@ -21129,14 +21129,14 @@ impl std::str::FromStr for WorkflowJobStartedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobStartedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobStartedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21160,7 +21160,7 @@ impl ToString for WorkflowJobStatus {
 }
 impl std::str::FromStr for WorkflowJobStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
@@ -21170,14 +21170,14 @@ impl std::str::FromStr for WorkflowJobStatus {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21239,7 +21239,7 @@ impl ToString for WorkflowRunCompletedAction {
 }
 impl std::str::FromStr for WorkflowRunCompletedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -21247,14 +21247,14 @@ impl std::str::FromStr for WorkflowRunCompletedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunCompletedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21290,7 +21290,7 @@ impl ToString for WorkflowRunConclusion {
 }
 impl std::str::FromStr for WorkflowRunConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -21304,14 +21304,14 @@ impl std::str::FromStr for WorkflowRunConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21395,7 +21395,7 @@ impl ToString for WorkflowRunRequestedAction {
 }
 impl std::str::FromStr for WorkflowRunRequestedAction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             _ => Err("invalid value"),
@@ -21403,14 +21403,14 @@ impl std::str::FromStr for WorkflowRunRequestedAction {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunRequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunRequestedAction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21437,7 +21437,7 @@ impl ToString for WorkflowRunStatus {
 }
 impl std::str::FromStr for WorkflowRunStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
@@ -21448,14 +21448,14 @@ impl std::str::FromStr for WorkflowRunStatus {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21511,7 +21511,7 @@ impl ToString for WorkflowStepCompletedConclusion {
 }
 impl std::str::FromStr for WorkflowStepCompletedConclusion {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "failure" => Ok(Self::Failure),
             "skipped" => Ok(Self::Skipped),
@@ -21521,14 +21521,14 @@ impl std::str::FromStr for WorkflowStepCompletedConclusion {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepCompletedConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepCompletedConclusion {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21546,7 +21546,7 @@ impl ToString for WorkflowStepCompletedStatus {
 }
 impl std::str::FromStr for WorkflowStepCompletedStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "completed" => Ok(Self::Completed),
             _ => Err("invalid value"),
@@ -21554,14 +21554,14 @@ impl std::str::FromStr for WorkflowStepCompletedStatus {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepCompletedStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepCompletedStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -21589,7 +21589,7 @@ impl ToString for WorkflowStepInProgressStatus {
 }
 impl std::str::FromStr for WorkflowStepInProgressStatus {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "in_progress" => Ok(Self::InProgress),
             _ => Err("invalid value"),
@@ -21597,14 +21597,14 @@ impl std::str::FromStr for WorkflowStepInProgressStatus {
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepInProgressStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepInProgressStatus {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -174,7 +174,7 @@ impl ToString for AggregateTransformOpsVariant0ItemVariant0 {
 }
 impl std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -205,14 +205,14 @@ impl std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AggregateTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AggregateTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -230,7 +230,7 @@ impl ToString for AggregateTransformType {
 }
 impl std::str::FromStr for AggregateTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "aggregate" => Ok(Self::Aggregate),
             _ => Err("invalid value"),
@@ -238,14 +238,14 @@ impl std::str::FromStr for AggregateTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for AggregateTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AggregateTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -314,7 +314,7 @@ impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -324,16 +324,16 @@ impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -401,7 +401,7 @@ impl ToString for AlignValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for AlignValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -411,14 +411,14 @@ impl std::str::FromStr for AlignValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -499,7 +499,7 @@ impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -509,16 +509,16 @@ impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Varian
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -586,7 +586,7 @@ impl ToString for AnchorValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for AnchorValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -596,14 +596,14 @@ impl std::str::FromStr for AnchorValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -867,7 +867,7 @@ impl ToString for AutosizeVariant0 {
 }
 impl std::str::FromStr for AutosizeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pad" => Ok(Self::Pad),
             "fit" => Ok(Self::Fit),
@@ -879,14 +879,14 @@ impl std::str::FromStr for AutosizeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -907,7 +907,7 @@ impl ToString for AutosizeVariant1Contains {
 }
 impl std::str::FromStr for AutosizeVariant1Contains {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "content" => Ok(Self::Content),
             "padding" => Ok(Self::Padding),
@@ -916,14 +916,14 @@ impl std::str::FromStr for AutosizeVariant1Contains {
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant1Contains {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant1Contains {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -953,7 +953,7 @@ impl ToString for AutosizeVariant1Type {
 }
 impl std::str::FromStr for AutosizeVariant1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pad" => Ok(Self::Pad),
             "fit" => Ok(Self::Fit),
@@ -965,14 +965,14 @@ impl std::str::FromStr for AutosizeVariant1Type {
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1417,7 +1417,7 @@ impl ToString for AxisFormatTypeVariant0 {
 }
 impl std::str::FromStr for AxisFormatTypeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
@@ -1427,14 +1427,14 @@ impl std::str::FromStr for AxisFormatTypeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisFormatTypeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisFormatTypeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1501,7 +1501,7 @@ impl ToString for AxisLabelAlignVariant0 {
 }
 impl std::str::FromStr for AxisLabelAlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -1511,14 +1511,14 @@ impl std::str::FromStr for AxisLabelAlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisLabelAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisLabelAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1563,7 +1563,7 @@ impl ToString for AxisLabelBaselineVariant0 {
 }
 impl std::str::FromStr for AxisLabelBaselineVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -1576,14 +1576,14 @@ impl std::str::FromStr for AxisLabelBaselineVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisLabelBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisLabelBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1709,7 +1709,7 @@ impl ToString for AxisOrientVariant0 {
 }
 impl std::str::FromStr for AxisOrientVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
@@ -1720,14 +1720,14 @@ impl std::str::FromStr for AxisOrientVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1818,7 +1818,7 @@ impl ToString for AxisTitleAlignVariant0 {
 }
 impl std::str::FromStr for AxisTitleAlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -1828,14 +1828,14 @@ impl std::str::FromStr for AxisTitleAlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1865,7 +1865,7 @@ impl ToString for AxisTitleAnchorVariant0 {
 }
 impl std::str::FromStr for AxisTitleAnchorVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -1875,14 +1875,14 @@ impl std::str::FromStr for AxisTitleAnchorVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleAnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleAnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -1927,7 +1927,7 @@ impl ToString for AxisTitleBaselineVariant0 {
 }
 impl std::str::FromStr for AxisTitleBaselineVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -1940,14 +1940,14 @@ impl std::str::FromStr for AxisTitleBaselineVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2028,7 +2028,7 @@ pub enum AxisTranslate {
 pub struct Background(pub StringOrSignal);
 impl std::ops::Deref for Background {
     type Target = StringOrSignal;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &StringOrSignal {
         &self.0
     }
 }
@@ -2175,7 +2175,7 @@ impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 }
 impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -2188,16 +2188,16 @@ impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Vari
 impl std::convert::TryFrom<&str>
     for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2268,7 +2268,7 @@ impl ToString for BaselineValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for BaselineValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -2279,14 +2279,14 @@ impl std::str::FromStr for BaselineValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2459,7 +2459,7 @@ impl ToString for BinTransformType {
 }
 impl std::str::FromStr for BinTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "bin" => Ok(Self::Bin),
             _ => Err("invalid value"),
@@ -2467,14 +2467,14 @@ impl std::str::FromStr for BinTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for BinTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BinTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2548,7 +2548,7 @@ impl ToString for BindVariant0Input {
 }
 impl std::str::FromStr for BindVariant0Input {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "checkbox" => Ok(Self::Checkbox),
             _ => Err("invalid value"),
@@ -2556,14 +2556,14 @@ impl std::str::FromStr for BindVariant0Input {
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant0Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant0Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2584,7 +2584,7 @@ impl ToString for BindVariant1Input {
 }
 impl std::str::FromStr for BindVariant1Input {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "radio" => Ok(Self::Radio),
             "select" => Ok(Self::Select),
@@ -2593,14 +2593,14 @@ impl std::str::FromStr for BindVariant1Input {
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant1Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant1Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2618,7 +2618,7 @@ impl ToString for BindVariant2Input {
 }
 impl std::str::FromStr for BindVariant2Input {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "range" => Ok(Self::Range),
             _ => Err("invalid value"),
@@ -2626,14 +2626,14 @@ impl std::str::FromStr for BindVariant2Input {
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant2Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant2Input {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2641,13 +2641,13 @@ impl std::convert::TryFrom<&String> for BindVariant2Input {
 pub struct BindVariant3Input(String);
 impl std::ops::Deref for BindVariant3Input {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::convert::TryFrom<String> for BindVariant3Input {
     type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, &'static str> {
         if [
             "checkbox".to_string(),
             "radio".to_string(),
@@ -2763,7 +2763,7 @@ impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "multiply" => Ok(Self::Multiply),
             "screen" => Ok(Self::Screen),
@@ -2785,16 +2785,16 @@ impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -2898,7 +2898,7 @@ impl ToString for BlendValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for BlendValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "multiply" => Ok(Self::Multiply),
             "screen" => Ok(Self::Screen),
@@ -2920,14 +2920,14 @@ impl std::str::FromStr for BlendValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3074,7 +3074,7 @@ impl ToString for CollectTransformType {
 }
 impl std::str::FromStr for CollectTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "collect" => Ok(Self::Collect),
             _ => Err("invalid value"),
@@ -3082,14 +3082,14 @@ impl std::str::FromStr for CollectTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for CollectTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CollectTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3255,7 +3255,7 @@ impl ToString for ContourTransformType {
 }
 impl std::str::FromStr for ContourTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "contour" => Ok(Self::Contour),
             _ => Err("invalid value"),
@@ -3263,14 +3263,14 @@ impl std::str::FromStr for ContourTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ContourTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ContourTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3365,7 +3365,7 @@ impl ToString for CountpatternTransformCaseVariant0 {
 }
 impl std::str::FromStr for CountpatternTransformCaseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "upper" => Ok(Self::Upper),
             "lower" => Ok(Self::Lower),
@@ -3375,14 +3375,14 @@ impl std::str::FromStr for CountpatternTransformCaseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for CountpatternTransformCaseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CountpatternTransformCaseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3419,7 +3419,7 @@ impl ToString for CountpatternTransformType {
 }
 impl std::str::FromStr for CountpatternTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "countpattern" => Ok(Self::Countpattern),
             _ => Err("invalid value"),
@@ -3427,14 +3427,14 @@ impl std::str::FromStr for CountpatternTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for CountpatternTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CountpatternTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3476,7 +3476,7 @@ impl ToString for CrossTransformType {
 }
 impl std::str::FromStr for CrossTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "cross" => Ok(Self::Cross),
             _ => Err("invalid value"),
@@ -3484,14 +3484,14 @@ impl std::str::FromStr for CrossTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for CrossTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CrossTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3538,7 +3538,7 @@ impl ToString for CrossfilterTransformType {
 }
 impl std::str::FromStr for CrossfilterTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "crossfilter" => Ok(Self::Crossfilter),
             _ => Err("invalid value"),
@@ -3546,14 +3546,14 @@ impl std::str::FromStr for CrossfilterTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for CrossfilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CrossfilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3659,7 +3659,7 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -3667,14 +3667,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3707,7 +3707,7 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -3720,16 +3720,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3737,13 +3737,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3757,16 +3757,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3779,9 +3779,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3823,7 +3821,7 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -3831,14 +3829,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3871,7 +3869,7 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -3884,16 +3882,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3901,13 +3899,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3921,16 +3919,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -3943,9 +3941,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3962,7 +3958,7 @@ impl ToString for DataVariant2FormatVariant0Subtype1Type {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "json" => Ok(Self::Json),
             _ => Err("invalid value"),
@@ -3970,14 +3966,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4018,7 +4014,7 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -4026,14 +4022,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4066,7 +4062,7 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -4079,16 +4075,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4096,13 +4092,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4116,16 +4112,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4138,9 +4134,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4160,7 +4154,7 @@ impl ToString for DataVariant2FormatVariant0Subtype2Type {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "csv" => Ok(Self::Csv),
             "tsv" => Ok(Self::Tsv),
@@ -4169,14 +4163,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4218,7 +4212,7 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -4226,14 +4220,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4266,7 +4260,7 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -4279,16 +4273,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4296,13 +4290,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4316,16 +4310,16 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4338,9 +4332,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4357,7 +4349,7 @@ impl ToString for DataVariant2FormatVariant0Subtype3Type {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dsv" => Ok(Self::Dsv),
             _ => Err("invalid value"),
@@ -4365,14 +4357,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4410,7 +4402,7 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant0Type {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant0Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
@@ -4418,14 +4410,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant0Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4446,7 +4438,7 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant1Filter {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Filter {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "interior" => Ok(Self::Interior),
             "exterior" => Ok(Self::Exterior),
@@ -4455,14 +4447,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Filter {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4480,7 +4472,7 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant1Type {
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
@@ -4488,14 +4480,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4552,7 +4544,7 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -4560,14 +4552,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4600,7 +4592,7 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -4613,16 +4605,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4630,13 +4622,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4650,16 +4642,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4672,9 +4664,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4716,7 +4706,7 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -4724,14 +4714,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4764,7 +4754,7 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -4777,16 +4767,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4794,13 +4784,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4814,16 +4804,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4836,9 +4826,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4855,7 +4843,7 @@ impl ToString for DataVariant3FormatVariant0Subtype1Type {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "json" => Ok(Self::Json),
             _ => Err("invalid value"),
@@ -4863,14 +4851,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4911,7 +4899,7 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -4919,14 +4907,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4959,7 +4947,7 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -4972,16 +4960,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -4989,13 +4977,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -5009,16 +4997,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5031,9 +5019,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5053,7 +5039,7 @@ impl ToString for DataVariant3FormatVariant0Subtype2Type {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "csv" => Ok(Self::Csv),
             "tsv" => Ok(Self::Tsv),
@@ -5062,14 +5048,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5111,7 +5097,7 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant0 {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "auto" => Ok(Self::Auto),
             _ => Err("invalid value"),
@@ -5119,14 +5105,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5159,7 +5145,7 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVaria
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
@@ -5172,16 +5158,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5189,13 +5175,13 @@ impl std::convert::TryFrom<&String>
 pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -5209,16 +5195,16 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraE
 impl std::convert::TryFrom<&str>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5231,9 +5217,7 @@ impl<'de> serde::Deserialize<'de>
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5250,7 +5234,7 @@ impl ToString for DataVariant3FormatVariant0Subtype3Type {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dsv" => Ok(Self::Dsv),
             _ => Err("invalid value"),
@@ -5258,14 +5242,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5303,7 +5287,7 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant0Type {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant0Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
@@ -5311,14 +5295,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant0Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5339,7 +5323,7 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant1Filter {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Filter {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "interior" => Ok(Self::Interior),
             "exterior" => Ok(Self::Exterior),
@@ -5348,14 +5332,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Filter {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5373,7 +5357,7 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant1Type {
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
@@ -5381,14 +5365,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Type {
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5486,7 +5470,7 @@ impl ToString for DensityTransformDistributionVariant0Function {
 }
 impl std::str::FromStr for DensityTransformDistributionVariant0Function {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "normal" => Ok(Self::Normal),
             _ => Err("invalid value"),
@@ -5494,14 +5478,14 @@ impl std::str::FromStr for DensityTransformDistributionVariant0Function {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant0Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant0Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5531,7 +5515,7 @@ impl ToString for DensityTransformDistributionVariant1Function {
 }
 impl std::str::FromStr for DensityTransformDistributionVariant1Function {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "lognormal" => Ok(Self::Lognormal),
             _ => Err("invalid value"),
@@ -5539,14 +5523,14 @@ impl std::str::FromStr for DensityTransformDistributionVariant1Function {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant1Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant1Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5576,7 +5560,7 @@ impl ToString for DensityTransformDistributionVariant2Function {
 }
 impl std::str::FromStr for DensityTransformDistributionVariant2Function {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "uniform" => Ok(Self::Uniform),
             _ => Err("invalid value"),
@@ -5584,14 +5568,14 @@ impl std::str::FromStr for DensityTransformDistributionVariant2Function {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant2Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant2Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5634,7 +5618,7 @@ impl ToString for DensityTransformDistributionVariant3Function {
 }
 impl std::str::FromStr for DensityTransformDistributionVariant3Function {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "kde" => Ok(Self::Kde),
             _ => Err("invalid value"),
@@ -5642,14 +5626,14 @@ impl std::str::FromStr for DensityTransformDistributionVariant3Function {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant3Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant3Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5673,7 +5657,7 @@ impl ToString for DensityTransformDistributionVariant4Function {
 }
 impl std::str::FromStr for DensityTransformDistributionVariant4Function {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "mixture" => Ok(Self::Mixture),
             _ => Err("invalid value"),
@@ -5681,14 +5665,14 @@ impl std::str::FromStr for DensityTransformDistributionVariant4Function {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant4Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant4Function {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5757,7 +5741,7 @@ impl ToString for DensityTransformType {
 }
 impl std::str::FromStr for DensityTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "density" => Ok(Self::Density),
             _ => Err("invalid value"),
@@ -5765,14 +5749,14 @@ impl std::str::FromStr for DensityTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5838,7 +5822,7 @@ impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Valu
 }
 impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
@@ -5849,16 +5833,16 @@ impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Var
 impl std::convert::TryFrom<&str>
     for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -5923,7 +5907,7 @@ impl ToString for DirectionValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for DirectionValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
@@ -5932,14 +5916,14 @@ impl std::str::FromStr for DirectionValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6024,7 +6008,7 @@ impl ToString for DotbinTransformType {
 }
 impl std::str::FromStr for DotbinTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "dotbin" => Ok(Self::Dotbin),
             _ => Err("invalid value"),
@@ -6032,14 +6016,14 @@ impl std::str::FromStr for DotbinTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for DotbinTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DotbinTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6047,7 +6031,7 @@ impl std::convert::TryFrom<&String> for DotbinTransformType {
 pub struct Element(pub String);
 impl std::ops::Deref for Element {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -6313,7 +6297,7 @@ pub struct Expr {
 pub struct ExprString(pub String);
 impl std::ops::Deref for ExprString {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -6347,7 +6331,7 @@ impl ToString for ExtentTransformType {
 }
 impl std::str::FromStr for ExtentTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "extent" => Ok(Self::Extent),
             _ => Err("invalid value"),
@@ -6355,14 +6339,14 @@ impl std::str::FromStr for ExtentTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ExtentTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ExtentTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6449,7 +6433,7 @@ impl ToString for FilterTransformType {
 }
 impl std::str::FromStr for FilterTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "filter" => Ok(Self::Filter),
             _ => Err("invalid value"),
@@ -6457,14 +6441,14 @@ impl std::str::FromStr for FilterTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for FilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6526,7 +6510,7 @@ impl ToString for FlattenTransformType {
 }
 impl std::str::FromStr for FlattenTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "flatten" => Ok(Self::Flatten),
             _ => Err("invalid value"),
@@ -6534,14 +6518,14 @@ impl std::str::FromStr for FlattenTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for FlattenTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FlattenTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6595,7 +6579,7 @@ impl ToString for FoldTransformType {
 }
 impl std::str::FromStr for FoldTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "fold" => Ok(Self::Fold),
             _ => Err("invalid value"),
@@ -6603,14 +6587,14 @@ impl std::str::FromStr for FoldTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for FoldTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FoldTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6857,7 +6841,7 @@ impl ToString for ForceTransformForcesItemVariant0Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant0Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "center" => Ok(Self::Center),
             _ => Err("invalid value"),
@@ -6865,14 +6849,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant0Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant0Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant0Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6902,7 +6886,7 @@ impl ToString for ForceTransformForcesItemVariant1Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant1Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "collide" => Ok(Self::Collide),
             _ => Err("invalid value"),
@@ -6910,14 +6894,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant1Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant1Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant1Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -6967,7 +6951,7 @@ impl ToString for ForceTransformForcesItemVariant2Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant2Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "nbody" => Ok(Self::Nbody),
             _ => Err("invalid value"),
@@ -6975,14 +6959,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant2Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant2Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant2Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7020,7 +7004,7 @@ impl ToString for ForceTransformForcesItemVariant3Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant3Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "link" => Ok(Self::Link),
             _ => Err("invalid value"),
@@ -7028,14 +7012,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant3Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant3Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant3Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7074,7 +7058,7 @@ impl ToString for ForceTransformForcesItemVariant4Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant4Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "x" => Ok(Self::X),
             _ => Err("invalid value"),
@@ -7082,14 +7066,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant4Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant4Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant4Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7120,7 +7104,7 @@ impl ToString for ForceTransformForcesItemVariant5Force {
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant5Force {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "y" => Ok(Self::Y),
             _ => Err("invalid value"),
@@ -7128,14 +7112,14 @@ impl std::str::FromStr for ForceTransformForcesItemVariant5Force {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant5Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant5Force {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7184,7 +7168,7 @@ impl ToString for ForceTransformType {
 }
 impl std::str::FromStr for ForceTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "force" => Ok(Self::Force),
             _ => Err("invalid value"),
@@ -7192,14 +7176,14 @@ impl std::str::FromStr for ForceTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7248,7 +7232,7 @@ impl ToString for FormulaTransformType {
 }
 impl std::str::FromStr for FormulaTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "formula" => Ok(Self::Formula),
             _ => Err("invalid value"),
@@ -7256,14 +7240,14 @@ impl std::str::FromStr for FormulaTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for FormulaTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FormulaTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7322,7 +7306,7 @@ impl ToString for GeojsonTransformType {
 }
 impl std::str::FromStr for GeojsonTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "geojson" => Ok(Self::Geojson),
             _ => Err("invalid value"),
@@ -7330,14 +7314,14 @@ impl std::str::FromStr for GeojsonTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for GeojsonTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeojsonTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7396,7 +7380,7 @@ impl ToString for GeopathTransformType {
 }
 impl std::str::FromStr for GeopathTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "geopath" => Ok(Self::Geopath),
             _ => Err("invalid value"),
@@ -7404,14 +7388,14 @@ impl std::str::FromStr for GeopathTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for GeopathTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeopathTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7469,7 +7453,7 @@ impl ToString for GeopointTransformType {
 }
 impl std::str::FromStr for GeopointTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "geopoint" => Ok(Self::Geopoint),
             _ => Err("invalid value"),
@@ -7477,14 +7461,14 @@ impl std::str::FromStr for GeopointTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for GeopointTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeopointTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7543,7 +7527,7 @@ impl ToString for GeoshapeTransformType {
 }
 impl std::str::FromStr for GeoshapeTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "geoshape" => Ok(Self::Geoshape),
             _ => Err("invalid value"),
@@ -7551,14 +7535,14 @@ impl std::str::FromStr for GeoshapeTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for GeoshapeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeoshapeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7566,7 +7550,7 @@ impl std::convert::TryFrom<&String> for GeoshapeTransformType {
 pub struct GradientStops(pub Vec<GradientStopsItem>);
 impl std::ops::Deref for GradientStops {
     type Target = Vec<GradientStopsItem>;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &Vec<GradientStopsItem> {
         &self.0
     }
 }
@@ -7695,7 +7679,7 @@ impl ToString for GraticuleTransformType {
 }
 impl std::str::FromStr for GraticuleTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "graticule" => Ok(Self::Graticule),
             _ => Err("invalid value"),
@@ -7703,14 +7687,14 @@ impl std::str::FromStr for GraticuleTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for GraticuleTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GraticuleTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7794,7 +7778,7 @@ impl ToString for HeatmapTransformResolveVariant0 {
 }
 impl std::str::FromStr for HeatmapTransformResolveVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
@@ -7803,14 +7787,14 @@ impl std::str::FromStr for HeatmapTransformResolveVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for HeatmapTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for HeatmapTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7828,7 +7812,7 @@ impl ToString for HeatmapTransformType {
 }
 impl std::str::FromStr for HeatmapTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "heatmap" => Ok(Self::Heatmap),
             _ => Err("invalid value"),
@@ -7836,14 +7820,14 @@ impl std::str::FromStr for HeatmapTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for HeatmapTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for HeatmapTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7877,7 +7861,7 @@ impl ToString for IdentifierTransformType {
 }
 impl std::str::FromStr for IdentifierTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "identifier" => Ok(Self::Identifier),
             _ => Err("invalid value"),
@@ -7885,14 +7869,14 @@ impl std::str::FromStr for IdentifierTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for IdentifierTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdentifierTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -7979,7 +7963,7 @@ impl ToString for ImputeTransformMethodVariant0 {
 }
 impl std::str::FromStr for ImputeTransformMethodVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "value" => Ok(Self::Value),
             "mean" => Ok(Self::Mean),
@@ -7991,14 +7975,14 @@ impl std::str::FromStr for ImputeTransformMethodVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ImputeTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ImputeTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8016,7 +8000,7 @@ impl ToString for ImputeTransformType {
 }
 impl std::str::FromStr for ImputeTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "impute" => Ok(Self::Impute),
             _ => Err("invalid value"),
@@ -8024,14 +8008,14 @@ impl std::str::FromStr for ImputeTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ImputeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ImputeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8112,7 +8096,7 @@ impl ToString for IsocontourTransformResolveVariant0 {
 }
 impl std::str::FromStr for IsocontourTransformResolveVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
@@ -8121,14 +8105,14 @@ impl std::str::FromStr for IsocontourTransformResolveVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for IsocontourTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IsocontourTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8186,7 +8170,7 @@ impl ToString for IsocontourTransformType {
 }
 impl std::str::FromStr for IsocontourTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "isocontour" => Ok(Self::Isocontour),
             _ => Err("invalid value"),
@@ -8194,14 +8178,14 @@ impl std::str::FromStr for IsocontourTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for IsocontourTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IsocontourTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8371,7 +8355,7 @@ impl ToString for JoinaggregateTransformOpsVariant0ItemVariant0 {
 }
 impl std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -8402,14 +8386,14 @@ impl std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8427,7 +8411,7 @@ impl ToString for JoinaggregateTransformType {
 }
 impl std::str::FromStr for JoinaggregateTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "joinaggregate" => Ok(Self::Joinaggregate),
             _ => Err("invalid value"),
@@ -8435,14 +8419,14 @@ impl std::str::FromStr for JoinaggregateTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for JoinaggregateTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JoinaggregateTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8541,7 +8525,7 @@ impl ToString for Kde2dTransformType {
 }
 impl std::str::FromStr for Kde2dTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "kde2d" => Ok(Self::Kde2d),
             _ => Err("invalid value"),
@@ -8549,14 +8533,14 @@ impl std::str::FromStr for Kde2dTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for Kde2dTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Kde2dTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8707,7 +8691,7 @@ impl ToString for KdeTransformResolveVariant0 {
 }
 impl std::str::FromStr for KdeTransformResolveVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
@@ -8716,14 +8700,14 @@ impl std::str::FromStr for KdeTransformResolveVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for KdeTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for KdeTransformResolveVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8747,7 +8731,7 @@ impl ToString for KdeTransformType {
 }
 impl std::str::FromStr for KdeTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "kde" => Ok(Self::Kde),
             _ => Err("invalid value"),
@@ -8755,14 +8739,14 @@ impl std::str::FromStr for KdeTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for KdeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for KdeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8790,7 +8774,7 @@ impl ToString for LabelOverlapVariant1 {
 }
 impl std::str::FromStr for LabelOverlapVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "parity" => Ok(Self::Parity),
             "greedy" => Ok(Self::Greedy),
@@ -8799,14 +8783,14 @@ impl std::str::FromStr for LabelOverlapVariant1 {
     }
 }
 impl std::convert::TryFrom<&str> for LabelOverlapVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelOverlapVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -8954,7 +8938,7 @@ impl ToString for LabelTransformType {
 }
 impl std::str::FromStr for LabelTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "label" => Ok(Self::Label),
             _ => Err("invalid value"),
@@ -8962,14 +8946,14 @@ impl std::str::FromStr for LabelTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for LabelTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9049,7 +9033,7 @@ impl ToString for LayoutVariant0AlignVariant0Variant0 {
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
@@ -9059,14 +9043,14 @@ impl std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant0Variant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant0Variant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9096,7 +9080,7 @@ impl ToString for LayoutVariant0AlignVariant1ColumnVariant0 {
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
@@ -9106,14 +9090,14 @@ impl std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9143,7 +9127,7 @@ impl ToString for LayoutVariant0AlignVariant1RowVariant0 {
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
@@ -9153,14 +9137,14 @@ impl std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1RowVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1RowVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9187,7 +9171,7 @@ impl ToString for LayoutVariant0BoundsVariant0 {
 }
 impl std::str::FromStr for LayoutVariant0BoundsVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "full" => Ok(Self::Full),
             "flush" => Ok(Self::Flush),
@@ -9196,14 +9180,14 @@ impl std::str::FromStr for LayoutVariant0BoundsVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0BoundsVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0BoundsVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9321,7 +9305,7 @@ impl ToString for LayoutVariant0TitleAnchorVariant0Variant0 {
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
@@ -9330,14 +9314,14 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9364,7 +9348,7 @@ impl ToString for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
@@ -9373,14 +9357,14 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9407,7 +9391,7 @@ impl ToString for LayoutVariant0TitleAnchorVariant1RowVariant0 {
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
@@ -9416,14 +9400,14 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9805,7 +9789,7 @@ impl ToString for LegendSubtype0Direction {
 }
 impl std::str::FromStr for LegendSubtype0Direction {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
@@ -9814,14 +9798,14 @@ impl std::str::FromStr for LegendSubtype0Direction {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0Direction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0Direction {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9902,7 +9886,7 @@ impl ToString for LegendSubtype0FormatTypeVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0FormatTypeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
@@ -9912,14 +9896,14 @@ impl std::str::FromStr for LegendSubtype0FormatTypeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0FormatTypeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0FormatTypeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -9968,7 +9952,7 @@ impl ToString for LegendSubtype0GridAlignVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0GridAlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
@@ -9978,14 +9962,14 @@ impl std::str::FromStr for LegendSubtype0GridAlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0GridAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0GridAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10015,7 +9999,7 @@ impl ToString for LegendSubtype0LabelAlignVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0LabelAlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -10025,14 +10009,14 @@ impl std::str::FromStr for LegendSubtype0LabelAlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0LabelAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0LabelAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10071,7 +10055,7 @@ impl ToString for LegendSubtype0LabelBaselineVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0LabelBaselineVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -10084,14 +10068,14 @@ impl std::str::FromStr for LegendSubtype0LabelBaselineVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0LabelBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0LabelBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10206,7 +10190,7 @@ impl ToString for LegendSubtype0OrientVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0OrientVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -10222,14 +10206,14 @@ impl std::str::FromStr for LegendSubtype0OrientVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0OrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0OrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10328,7 +10312,7 @@ impl ToString for LegendSubtype0TitleAlignVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0TitleAlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -10338,14 +10322,14 @@ impl std::str::FromStr for LegendSubtype0TitleAlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleAlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10375,7 +10359,7 @@ impl ToString for LegendSubtype0TitleAnchorVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0TitleAnchorVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -10385,14 +10369,14 @@ impl std::str::FromStr for LegendSubtype0TitleAnchorVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleAnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleAnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10431,7 +10415,7 @@ impl ToString for LegendSubtype0TitleBaselineVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0TitleBaselineVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -10444,14 +10428,14 @@ impl std::str::FromStr for LegendSubtype0TitleBaselineVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleBaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10533,7 +10517,7 @@ impl ToString for LegendSubtype0TitleOrientVariant0 {
 }
 impl std::str::FromStr for LegendSubtype0TitleOrientVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -10544,14 +10528,14 @@ impl std::str::FromStr for LegendSubtype0TitleOrientVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10578,7 +10562,7 @@ impl ToString for LegendSubtype0Type {
 }
 impl std::str::FromStr for LegendSubtype0Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
@@ -10587,14 +10571,14 @@ impl std::str::FromStr for LegendSubtype0Type {
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10639,7 +10623,7 @@ impl ToString for LinearGradientGradient {
 }
 impl std::str::FromStr for LinearGradientGradient {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "linear" => Ok(Self::Linear),
             _ => Err("invalid value"),
@@ -10647,14 +10631,14 @@ impl std::str::FromStr for LinearGradientGradient {
     }
 }
 impl std::convert::TryFrom<&str> for LinearGradientGradient {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinearGradientGradient {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10714,7 +10698,7 @@ impl ToString for LinkpathTransformOrientVariant0 {
 }
 impl std::str::FromStr for LinkpathTransformOrientVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
@@ -10724,14 +10708,14 @@ impl std::str::FromStr for LinkpathTransformOrientVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformOrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10767,7 +10751,7 @@ impl ToString for LinkpathTransformShapeVariant0 {
 }
 impl std::str::FromStr for LinkpathTransformShapeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "line" => Ok(Self::Line),
             "arc" => Ok(Self::Arc),
@@ -10779,14 +10763,14 @@ impl std::str::FromStr for LinkpathTransformShapeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformShapeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformShapeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10832,7 +10816,7 @@ impl ToString for LinkpathTransformType {
 }
 impl std::str::FromStr for LinkpathTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "linkpath" => Ok(Self::Linkpath),
             _ => Err("invalid value"),
@@ -10840,14 +10824,14 @@ impl std::str::FromStr for LinkpathTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -10919,7 +10903,7 @@ impl ToString for LoessTransformType {
 }
 impl std::str::FromStr for LoessTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "loess" => Ok(Self::Loess),
             _ => Err("invalid value"),
@@ -10927,14 +10911,14 @@ impl std::str::FromStr for LoessTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for LoessTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LoessTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11015,7 +10999,7 @@ impl ToString for LookupTransformType {
 }
 impl std::str::FromStr for LookupTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "lookup" => Ok(Self::Lookup),
             _ => Err("invalid value"),
@@ -11023,14 +11007,14 @@ impl std::str::FromStr for LookupTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for LookupTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LookupTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11107,7 +11091,7 @@ impl ToString for MarkGroupType {
 }
 impl std::str::FromStr for MarkGroupType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "group" => Ok(Self::Group),
             _ => Err("invalid value"),
@@ -11115,14 +11099,14 @@ impl std::str::FromStr for MarkGroupType {
     }
 }
 impl std::convert::TryFrom<&str> for MarkGroupType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarkGroupType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11139,13 +11123,13 @@ pub struct MarkVisual {
 pub struct MarkVisualType(String);
 impl std::ops::Deref for MarkVisualType {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::convert::TryFrom<String> for MarkVisualType {
     type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, &'static str> {
         if ["group".to_string()].contains(&value) {
             Err("invalid value")
         } else {
@@ -11164,7 +11148,7 @@ pub enum Markclip {
 pub struct Marktype(pub String);
 impl std::ops::Deref for Marktype {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -11213,7 +11197,7 @@ impl ToString for NestTransformType {
 }
 impl std::str::FromStr for NestTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "nest" => Ok(Self::Nest),
             _ => Err("invalid value"),
@@ -11221,14 +11205,14 @@ impl std::str::FromStr for NestTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for NestTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NestTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11384,7 +11368,7 @@ pub struct NumberValueVariant1Subtype1Subtype3 {}
 pub struct OnEvents(pub Vec<OnEventsItem>);
 impl std::ops::Deref for OnEvents {
     type Target = Vec<OnEventsItem>;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &Vec<OnEventsItem> {
         &self.0
     }
 }
@@ -11427,7 +11411,7 @@ pub enum OnEventsItemSubtype1Update {
 pub struct OnMarkTrigger(pub Vec<OnMarkTriggerItem>);
 impl std::ops::Deref for OnMarkTrigger {
     type Target = Vec<OnMarkTriggerItem>;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &Vec<OnMarkTriggerItem> {
         &self.0
     }
 }
@@ -11444,7 +11428,7 @@ pub struct OnMarkTriggerItem {
 pub struct OnTrigger(pub Vec<OnTriggerItem>);
 impl std::ops::Deref for OnTrigger {
     type Target = Vec<OnTriggerItem>;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &Vec<OnTriggerItem> {
         &self.0
     }
 }
@@ -11537,7 +11521,7 @@ impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -11548,16 +11532,16 @@ impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Varian
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11628,7 +11612,7 @@ impl ToString for OrientValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for OrientValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -11639,14 +11623,14 @@ impl std::str::FromStr for OrientValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11746,7 +11730,7 @@ impl ToString for PackTransformType {
 }
 impl std::str::FromStr for PackTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pack" => Ok(Self::Pack),
             _ => Err("invalid value"),
@@ -11754,14 +11738,14 @@ impl std::str::FromStr for PackTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for PackTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11875,7 +11859,7 @@ impl ToString for PartitionTransformType {
 }
 impl std::str::FromStr for PartitionTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "partition" => Ok(Self::Partition),
             _ => Err("invalid value"),
@@ -11883,14 +11867,14 @@ impl std::str::FromStr for PartitionTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for PartitionTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PartitionTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -11967,7 +11951,7 @@ impl ToString for PieTransformType {
 }
 impl std::str::FromStr for PieTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pie" => Ok(Self::Pie),
             _ => Err("invalid value"),
@@ -11975,14 +11959,14 @@ impl std::str::FromStr for PieTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for PieTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PieTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12126,7 +12110,7 @@ impl ToString for PivotTransformOpVariant0 {
 }
 impl std::str::FromStr for PivotTransformOpVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -12157,14 +12141,14 @@ impl std::str::FromStr for PivotTransformOpVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for PivotTransformOpVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PivotTransformOpVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12182,7 +12166,7 @@ impl ToString for PivotTransformType {
 }
 impl std::str::FromStr for PivotTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pivot" => Ok(Self::Pivot),
             _ => Err("invalid value"),
@@ -12190,14 +12174,14 @@ impl std::str::FromStr for PivotTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for PivotTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PivotTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12260,7 +12244,7 @@ impl ToString for ProjectTransformType {
 }
 impl std::str::FromStr for ProjectTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "project" => Ok(Self::Project),
             _ => Err("invalid value"),
@@ -12268,14 +12252,14 @@ impl std::str::FromStr for ProjectTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ProjectTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12458,7 +12442,7 @@ impl ToString for QuantileTransformType {
 }
 impl std::str::FromStr for QuantileTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "quantile" => Ok(Self::Quantile),
             _ => Err("invalid value"),
@@ -12466,14 +12450,14 @@ impl std::str::FromStr for QuantileTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for QuantileTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for QuantileTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12511,7 +12495,7 @@ impl ToString for RadialGradientGradient {
 }
 impl std::str::FromStr for RadialGradientGradient {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "radial" => Ok(Self::Radial),
             _ => Err("invalid value"),
@@ -12519,14 +12503,14 @@ impl std::str::FromStr for RadialGradientGradient {
     }
 }
 impl std::convert::TryFrom<&str> for RadialGradientGradient {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RadialGradientGradient {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12624,7 +12608,7 @@ impl ToString for RegressionTransformType {
 }
 impl std::str::FromStr for RegressionTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "regression" => Ok(Self::Regression),
             _ => Err("invalid value"),
@@ -12632,14 +12616,14 @@ impl std::str::FromStr for RegressionTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for RegressionTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RegressionTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12687,7 +12671,7 @@ impl ToString for ResolvefilterTransformType {
 }
 impl std::str::FromStr for ResolvefilterTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "resolvefilter" => Ok(Self::Resolvefilter),
             _ => Err("invalid value"),
@@ -12695,14 +12679,14 @@ impl std::str::FromStr for ResolvefilterTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for ResolvefilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ResolvefilterTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -12741,7 +12725,7 @@ impl ToString for SampleTransformType {
 }
 impl std::str::FromStr for SampleTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "sample" => Ok(Self::Sample),
             _ => Err("invalid value"),
@@ -12749,14 +12733,14 @@ impl std::str::FromStr for SampleTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for SampleTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SampleTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13204,7 +13188,7 @@ impl ToString for ScaleDataVariant1SortVariant1Op {
 }
 impl std::str::FromStr for ScaleDataVariant1SortVariant1Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             _ => Err("invalid value"),
@@ -13212,14 +13196,14 @@ impl std::str::FromStr for ScaleDataVariant1SortVariant1Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13243,7 +13227,7 @@ impl ToString for ScaleDataVariant1SortVariant2Op {
 }
 impl std::str::FromStr for ScaleDataVariant1SortVariant2Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
@@ -13253,14 +13237,14 @@ impl std::str::FromStr for ScaleDataVariant1SortVariant2Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13309,7 +13293,7 @@ impl ToString for ScaleDataVariant2SortVariant1Op {
 }
 impl std::str::FromStr for ScaleDataVariant2SortVariant1Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             _ => Err("invalid value"),
@@ -13317,14 +13301,14 @@ impl std::str::FromStr for ScaleDataVariant2SortVariant1Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13348,7 +13332,7 @@ impl ToString for ScaleDataVariant2SortVariant2Op {
 }
 impl std::str::FromStr for ScaleDataVariant2SortVariant2Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
@@ -13358,14 +13342,14 @@ impl std::str::FromStr for ScaleDataVariant2SortVariant2Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13373,7 +13357,7 @@ impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant2Op {
 pub struct ScaleField(pub StringOrSignal);
 impl std::ops::Deref for ScaleField {
     type Target = StringOrSignal;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &StringOrSignal {
         &self.0
     }
 }
@@ -13427,7 +13411,7 @@ impl ToString for ScaleVariant0Type {
 }
 impl std::str::FromStr for ScaleVariant0Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "identity" => Ok(Self::Identity),
             _ => Err("invalid value"),
@@ -13435,14 +13419,14 @@ impl std::str::FromStr for ScaleVariant0Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant0Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13526,7 +13510,7 @@ impl ToString for ScaleVariant10RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant10RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -13541,14 +13525,14 @@ impl std::str::FromStr for ScaleVariant10RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant10RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant10RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13595,7 +13579,7 @@ impl ToString for ScaleVariant10Type {
 }
 impl std::str::FromStr for ScaleVariant10Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "pow" => Ok(Self::Pow),
             _ => Err("invalid value"),
@@ -13603,14 +13587,14 @@ impl std::str::FromStr for ScaleVariant10Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant10Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant10Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13694,7 +13678,7 @@ impl ToString for ScaleVariant11RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant11RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -13709,14 +13693,14 @@ impl std::str::FromStr for ScaleVariant11RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant11RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant11RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13763,7 +13747,7 @@ impl ToString for ScaleVariant11Type {
 }
 impl std::str::FromStr for ScaleVariant11Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "symlog" => Ok(Self::Symlog),
             _ => Err("invalid value"),
@@ -13771,14 +13755,14 @@ impl std::str::FromStr for ScaleVariant11Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant11Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant11Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13856,7 +13840,7 @@ impl ToString for ScaleVariant1RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -13871,14 +13855,14 @@ impl std::str::FromStr for ScaleVariant1RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -13976,7 +13960,7 @@ impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             _ => Err("invalid value"),
@@ -13984,14 +13968,14 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14015,7 +13999,7 @@ impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
@@ -14025,14 +14009,14 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14081,7 +14065,7 @@ impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             _ => Err("invalid value"),
@@ -14089,14 +14073,14 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14120,7 +14104,7 @@ impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
@@ -14130,14 +14114,14 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14155,7 +14139,7 @@ impl ToString for ScaleVariant1Type {
 }
 impl std::str::FromStr for ScaleVariant1Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "ordinal" => Ok(Self::Ordinal),
             _ => Err("invalid value"),
@@ -14163,14 +14147,14 @@ impl std::str::FromStr for ScaleVariant1Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14241,7 +14225,7 @@ impl ToString for ScaleVariant2RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant2RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -14256,14 +14240,14 @@ impl std::str::FromStr for ScaleVariant2RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant2RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant2RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14291,7 +14275,7 @@ impl ToString for ScaleVariant2Type {
 }
 impl std::str::FromStr for ScaleVariant2Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "band" => Ok(Self::Band),
             _ => Err("invalid value"),
@@ -14299,14 +14283,14 @@ impl std::str::FromStr for ScaleVariant2Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant2Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14377,7 +14361,7 @@ impl ToString for ScaleVariant3RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant3RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -14392,14 +14376,14 @@ impl std::str::FromStr for ScaleVariant3RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant3RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant3RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14427,7 +14411,7 @@ impl ToString for ScaleVariant3Type {
 }
 impl std::str::FromStr for ScaleVariant3Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "point" => Ok(Self::Point),
             _ => Err("invalid value"),
@@ -14435,14 +14419,14 @@ impl std::str::FromStr for ScaleVariant3Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant3Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14526,7 +14510,7 @@ impl ToString for ScaleVariant4RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant4RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -14541,14 +14525,14 @@ impl std::str::FromStr for ScaleVariant4RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant4RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant4RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14598,7 +14582,7 @@ impl ToString for ScaleVariant4Type {
 }
 impl std::str::FromStr for ScaleVariant4Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "quantize" => Ok(Self::Quantize),
             "threshold" => Ok(Self::Threshold),
@@ -14607,14 +14591,14 @@ impl std::str::FromStr for ScaleVariant4Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant4Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant4Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14691,7 +14675,7 @@ impl ToString for ScaleVariant5RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant5RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -14706,14 +14690,14 @@ impl std::str::FromStr for ScaleVariant5RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant5RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant5RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14760,7 +14744,7 @@ impl ToString for ScaleVariant5Type {
 }
 impl std::str::FromStr for ScaleVariant5Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "quantile" => Ok(Self::Quantile),
             _ => Err("invalid value"),
@@ -14768,14 +14752,14 @@ impl std::str::FromStr for ScaleVariant5Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant5Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant5Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14852,7 +14836,7 @@ impl ToString for ScaleVariant6RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant6RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -14867,14 +14851,14 @@ impl std::str::FromStr for ScaleVariant6RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant6RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant6RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -14921,7 +14905,7 @@ impl ToString for ScaleVariant6Type {
 }
 impl std::str::FromStr for ScaleVariant6Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "bin-ordinal" => Ok(Self::BinOrdinal),
             _ => Err("invalid value"),
@@ -14929,14 +14913,14 @@ impl std::str::FromStr for ScaleVariant6Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant6Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant6Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15010,7 +14994,7 @@ impl ToString for ScaleVariant7NiceVariant1 {
 }
 impl std::str::FromStr for ScaleVariant7NiceVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -15025,14 +15009,14 @@ impl std::str::FromStr for ScaleVariant7NiceVariant1 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15077,7 +15061,7 @@ impl ToString for ScaleVariant7NiceVariant2IntervalVariant0 {
 }
 impl std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -15092,14 +15076,14 @@ impl std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15152,7 +15136,7 @@ impl ToString for ScaleVariant7RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant7RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -15167,14 +15151,14 @@ impl std::str::FromStr for ScaleVariant7RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15224,7 +15208,7 @@ impl ToString for ScaleVariant7Type {
 }
 impl std::str::FromStr for ScaleVariant7Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
@@ -15233,14 +15217,14 @@ impl std::str::FromStr for ScaleVariant7Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15324,7 +15308,7 @@ impl ToString for ScaleVariant8RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant8RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -15339,14 +15323,14 @@ impl std::str::FromStr for ScaleVariant8RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant8RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant8RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15399,7 +15383,7 @@ impl ToString for ScaleVariant8Type {
 }
 impl std::str::FromStr for ScaleVariant8Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "linear" => Ok(Self::Linear),
             "sqrt" => Ok(Self::Sqrt),
@@ -15409,14 +15393,14 @@ impl std::str::FromStr for ScaleVariant8Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant8Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant8Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15500,7 +15484,7 @@ impl ToString for ScaleVariant9RangeVariant0 {
 }
 impl std::str::FromStr for ScaleVariant9RangeVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -15515,14 +15499,14 @@ impl std::str::FromStr for ScaleVariant9RangeVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant9RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant9RangeVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15569,7 +15553,7 @@ impl ToString for ScaleVariant9Type {
 }
 impl std::str::FromStr for ScaleVariant9Type {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "log" => Ok(Self::Log),
             _ => Err("invalid value"),
@@ -15577,14 +15561,14 @@ impl std::str::FromStr for ScaleVariant9Type {
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant9Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant9Type {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15623,7 +15607,7 @@ pub enum ScopeMarksItem {
 pub struct Selector(pub String);
 impl std::ops::Deref for Selector {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -15679,7 +15663,7 @@ impl ToString for SequenceTransformType {
 }
 impl std::str::FromStr for SequenceTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "sequence" => Ok(Self::Sequence),
             _ => Err("invalid value"),
@@ -15687,14 +15671,14 @@ impl std::str::FromStr for SequenceTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for SequenceTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SequenceTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15741,13 +15725,13 @@ pub enum Signal {
 pub struct SignalName(String);
 impl std::ops::Deref for SignalName {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::convert::TryFrom<String> for SignalName {
     type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, &'static str> {
         if [
             "parent".to_string(),
             "datum".to_string(),
@@ -15780,7 +15764,7 @@ impl ToString for SignalVariant0Push {
 }
 impl std::str::FromStr for SignalVariant0Push {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "outer" => Ok(Self::Outer),
             _ => Err("invalid value"),
@@ -15788,14 +15772,14 @@ impl std::str::FromStr for SignalVariant0Push {
     }
 }
 impl std::convert::TryFrom<&str> for SignalVariant0Push {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SignalVariant0Push {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15822,7 +15806,7 @@ impl ToString for SortOrderVariant0 {
 }
 impl std::str::FromStr for SortOrderVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "ascending" => Ok(Self::Ascending),
             "descending" => Ok(Self::Descending),
@@ -15831,14 +15815,14 @@ impl std::str::FromStr for SortOrderVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for SortOrderVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SortOrderVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15918,7 +15902,7 @@ impl ToString for StackTransformOffsetVariant0 {
 }
 impl std::str::FromStr for StackTransformOffsetVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "zero" => Ok(Self::Zero),
             "center" => Ok(Self::Center),
@@ -15928,14 +15912,14 @@ impl std::str::FromStr for StackTransformOffsetVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for StackTransformOffsetVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StackTransformOffsetVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -15953,7 +15937,7 @@ impl ToString for StackTransformType {
 }
 impl std::str::FromStr for StackTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "stack" => Ok(Self::Stack),
             _ => Err("invalid value"),
@@ -15961,14 +15945,14 @@ impl std::str::FromStr for StackTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for StackTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StackTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16011,7 +15995,7 @@ impl ToString for StratifyTransformType {
 }
 impl std::str::FromStr for StratifyTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "stratify" => Ok(Self::Stratify),
             _ => Err("invalid value"),
@@ -16019,14 +16003,14 @@ impl std::str::FromStr for StratifyTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for StratifyTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StratifyTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16253,7 +16237,7 @@ impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Valu
 }
 impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "butt" => Ok(Self::Butt),
             "round" => Ok(Self::Round),
@@ -16265,16 +16249,16 @@ impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Var
 impl std::convert::TryFrom<&str>
     for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16342,7 +16326,7 @@ impl ToString for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "butt" => Ok(Self::Butt),
             "round" => Ok(Self::Round),
@@ -16352,14 +16336,14 @@ impl std::str::FromStr for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
     }
 }
 impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16440,7 +16424,7 @@ impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Val
 }
 impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "miter" => Ok(Self::Miter),
             "round" => Ok(Self::Round),
@@ -16452,16 +16436,16 @@ impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Va
 impl std::convert::TryFrom<&str>
     for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16529,7 +16513,7 @@ impl ToString for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
 }
 impl std::str::FromStr for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "miter" => Ok(Self::Miter),
             "round" => Ok(Self::Round),
@@ -16539,14 +16523,14 @@ impl std::str::FromStr for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value 
     }
 }
 impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16716,7 +16700,7 @@ impl ToString for TickBandVariant0 {
 }
 impl std::str::FromStr for TickBandVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "center" => Ok(Self::Center),
             "extent" => Ok(Self::Extent),
@@ -16725,14 +16709,14 @@ impl std::str::FromStr for TickBandVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TickBandVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickBandVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16783,7 +16767,7 @@ impl ToString for TickCountVariant1 {
 }
 impl std::str::FromStr for TickCountVariant1 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -16798,14 +16782,14 @@ impl std::str::FromStr for TickCountVariant1 {
     }
 }
 impl std::convert::TryFrom<&str> for TickCountVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickCountVariant1 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16850,7 +16834,7 @@ impl ToString for TickCountVariant2IntervalVariant0 {
 }
 impl std::str::FromStr for TickCountVariant2IntervalVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -16865,14 +16849,14 @@ impl std::str::FromStr for TickCountVariant2IntervalVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TickCountVariant2IntervalVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickCountVariant2IntervalVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -16971,7 +16955,7 @@ impl ToString for TimeunitTransformTimezoneVariant0 {
 }
 impl std::str::FromStr for TimeunitTransformTimezoneVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "local" => Ok(Self::Local),
             "utc" => Ok(Self::Utc),
@@ -16980,14 +16964,14 @@ impl std::str::FromStr for TimeunitTransformTimezoneVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformTimezoneVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformTimezoneVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17005,7 +16989,7 @@ impl ToString for TimeunitTransformType {
 }
 impl std::str::FromStr for TimeunitTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "timeunit" => Ok(Self::Timeunit),
             _ => Err("invalid value"),
@@ -17013,14 +16997,14 @@ impl std::str::FromStr for TimeunitTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17080,7 +17064,7 @@ impl ToString for TimeunitTransformUnitsVariant0ItemVariant0 {
 }
 impl std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "year" => Ok(Self::Year),
             "quarter" => Ok(Self::Quarter),
@@ -17098,14 +17082,14 @@ impl std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17240,7 +17224,7 @@ impl ToString for TitleVariant1AlignVariant0 {
 }
 impl std::str::FromStr for TitleVariant1AlignVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
@@ -17250,14 +17234,14 @@ impl std::str::FromStr for TitleVariant1AlignVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1AlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1AlignVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17287,7 +17271,7 @@ impl ToString for TitleVariant1AnchorVariant0 {
 }
 impl std::str::FromStr for TitleVariant1AnchorVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -17297,14 +17281,14 @@ impl std::str::FromStr for TitleVariant1AnchorVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1AnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1AnchorVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17349,7 +17333,7 @@ impl ToString for TitleVariant1BaselineVariant0 {
 }
 impl std::str::FromStr for TitleVariant1BaselineVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -17362,14 +17346,14 @@ impl std::str::FromStr for TitleVariant1BaselineVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1BaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1BaselineVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17459,7 +17443,7 @@ impl ToString for TitleVariant1FrameVariant0 {
 }
 impl std::str::FromStr for TitleVariant1FrameVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "group" => Ok(Self::Group),
             "bounds" => Ok(Self::Bounds),
@@ -17468,14 +17452,14 @@ impl std::str::FromStr for TitleVariant1FrameVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1FrameVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1FrameVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17529,7 +17513,7 @@ impl ToString for TitleVariant1OrientVariant0 {
 }
 impl std::str::FromStr for TitleVariant1OrientVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -17541,14 +17525,14 @@ impl std::str::FromStr for TitleVariant1OrientVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1OrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1OrientVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17747,7 +17731,7 @@ impl ToString for TreeTransformMethodVariant0 {
 }
 impl std::str::FromStr for TreeTransformMethodVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "tidy" => Ok(Self::Tidy),
             "cluster" => Ok(Self::Cluster),
@@ -17756,14 +17740,14 @@ impl std::str::FromStr for TreeTransformMethodVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TreeTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreeTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17811,7 +17795,7 @@ impl ToString for TreeTransformType {
 }
 impl std::str::FromStr for TreeTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "tree" => Ok(Self::Tree),
             _ => Err("invalid value"),
@@ -17819,14 +17803,14 @@ impl std::str::FromStr for TreeTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for TreeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreeTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17852,7 +17836,7 @@ impl ToString for TreelinksTransformType {
 }
 impl std::str::FromStr for TreelinksTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "treelinks" => Ok(Self::Treelinks),
             _ => Err("invalid value"),
@@ -17860,14 +17844,14 @@ impl std::str::FromStr for TreelinksTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for TreelinksTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreelinksTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -17992,7 +17976,7 @@ impl ToString for TreemapTransformMethodVariant0 {
 }
 impl std::str::FromStr for TreemapTransformMethodVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "squarify" => Ok(Self::Squarify),
             "resquarify" => Ok(Self::Resquarify),
@@ -18005,14 +17989,14 @@ impl std::str::FromStr for TreemapTransformMethodVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for TreemapTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreemapTransformMethodVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18096,7 +18080,7 @@ impl ToString for TreemapTransformType {
 }
 impl std::str::FromStr for TreemapTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "treemap" => Ok(Self::Treemap),
             _ => Err("invalid value"),
@@ -18104,14 +18088,14 @@ impl std::str::FromStr for TreemapTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for TreemapTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreemapTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18169,7 +18153,7 @@ impl ToString for VoronoiTransformType {
 }
 impl std::str::FromStr for VoronoiTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "voronoi" => Ok(Self::Voronoi),
             _ => Err("invalid value"),
@@ -18177,14 +18161,14 @@ impl std::str::FromStr for VoronoiTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for VoronoiTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for VoronoiTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18423,7 +18407,7 @@ impl ToString for WindowTransformOpsVariant0ItemVariant0 {
 }
 impl std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "row_number" => Ok(Self::RowNumber),
             "rank" => Ok(Self::Rank),
@@ -18467,14 +18451,14 @@ impl std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::convert::TryFrom<&str> for WindowTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WindowTransformOpsVariant0ItemVariant0 {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18505,7 +18489,7 @@ impl ToString for WindowTransformType {
 }
 impl std::str::FromStr for WindowTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "window" => Ok(Self::Window),
             _ => Err("invalid value"),
@@ -18513,14 +18497,14 @@ impl std::str::FromStr for WindowTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for WindowTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WindowTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -18689,7 +18673,7 @@ impl ToString for WordcloudTransformType {
 }
 impl std::str::FromStr for WordcloudTransformType {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "wordcloud" => Ok(Self::Wordcloud),
             _ => Err("invalid value"),
@@ -18697,14 +18681,14 @@ impl std::str::FromStr for WordcloudTransformType {
     }
 }
 impl std::convert::TryFrom<&str> for WordcloudTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WordcloudTransformType {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -204,6 +204,18 @@ impl std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AggregateTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AggregateTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AggregateTransformType {
     #[serde(rename = "aggregate")]
@@ -223,6 +235,18 @@ impl std::str::FromStr for AggregateTransformType {
             "aggregate" => Ok(Self::Aggregate),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AggregateTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AggregateTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -299,6 +323,20 @@ impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
+impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -370,6 +408,18 @@ impl std::str::FromStr for AlignValueVariant1Subtype1Subtype0Variant1Value {
             "center" => Ok(Self::Center),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -458,6 +508,20 @@ impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
+impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -529,6 +593,18 @@ impl std::str::FromStr for AnchorValueVariant1Subtype1Subtype0Variant1Value {
             "end" => Ok(Self::End),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -802,6 +878,18 @@ impl std::str::FromStr for AutosizeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AutosizeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AutosizeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AutosizeVariant1Contains {
     #[serde(rename = "content")]
@@ -825,6 +913,18 @@ impl std::str::FromStr for AutosizeVariant1Contains {
             "padding" => Ok(Self::Padding),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AutosizeVariant1Contains {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AutosizeVariant1Contains {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -862,6 +962,18 @@ impl std::str::FromStr for AutosizeVariant1Type {
             "none" => Ok(Self::None),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AutosizeVariant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AutosizeVariant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1314,6 +1426,18 @@ impl std::str::FromStr for AxisFormatTypeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AxisFormatTypeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisFormatTypeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisGridCap {
@@ -1386,6 +1510,18 @@ impl std::str::FromStr for AxisLabelAlignVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AxisLabelAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisLabelAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelAngle {
@@ -1437,6 +1573,18 @@ impl std::str::FromStr for AxisLabelBaselineVariant0 {
             "line-bottom" => Ok(Self::LineBottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AxisLabelBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisLabelBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1571,6 +1719,18 @@ impl std::str::FromStr for AxisOrientVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AxisOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisPosition {
@@ -1667,6 +1827,18 @@ impl std::str::FromStr for AxisTitleAlignVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for AxisTitleAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisTitleAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleAnchor {
@@ -1700,6 +1872,18 @@ impl std::str::FromStr for AxisTitleAnchorVariant0 {
             "end" => Ok(Self::End),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AxisTitleAnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisTitleAnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1753,6 +1937,18 @@ impl std::str::FromStr for AxisTitleBaselineVariant0 {
             "line-bottom" => Ok(Self::LineBottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for AxisTitleBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AxisTitleBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1989,6 +2185,22 @@ impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Vari
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -2064,6 +2276,18 @@ impl std::str::FromStr for BaselineValueVariant1Subtype1Subtype0Variant1Value {
             "alphabetic" => Ok(Self::Alphabetic),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2242,6 +2466,18 @@ impl std::str::FromStr for BinTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for BinTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BinTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Bind {
@@ -2319,6 +2555,18 @@ impl std::str::FromStr for BindVariant0Input {
         }
     }
 }
+impl std::convert::TryFrom<&str> for BindVariant0Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BindVariant0Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BindVariant1Input {
     #[serde(rename = "radio")]
@@ -2344,6 +2592,18 @@ impl std::str::FromStr for BindVariant1Input {
         }
     }
 }
+impl std::convert::TryFrom<&str> for BindVariant1Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BindVariant1Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BindVariant2Input {
     #[serde(rename = "range")]
@@ -2363,6 +2623,18 @@ impl std::str::FromStr for BindVariant2Input {
             "range" => Ok(Self::Range),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BindVariant2Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BindVariant2Input {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2512,6 +2784,20 @@ impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
+impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -2631,6 +2917,18 @@ impl std::str::FromStr for BlendValueVariant1Subtype1Subtype0Variant1Value {
             "luminosity" => Ok(Self::Luminosity),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2781,6 +3079,18 @@ impl std::str::FromStr for CollectTransformType {
             "collect" => Ok(Self::Collect),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CollectTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CollectTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2952,6 +3262,18 @@ impl std::str::FromStr for ContourTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ContourTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ContourTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformValues {
@@ -3052,6 +3374,18 @@ impl std::str::FromStr for CountpatternTransformCaseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for CountpatternTransformCaseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CountpatternTransformCaseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformField {
@@ -3090,6 +3424,18 @@ impl std::str::FromStr for CountpatternTransformType {
             "countpattern" => Ok(Self::Countpattern),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CountpatternTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CountpatternTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3135,6 +3481,18 @@ impl std::str::FromStr for CrossTransformType {
             "cross" => Ok(Self::Cross),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CrossTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CrossTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3185,6 +3543,18 @@ impl std::str::FromStr for CrossfilterTransformType {
             "crossfilter" => Ok(Self::Crossfilter),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for CrossfilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CrossfilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3296,6 +3666,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtra {
@@ -3335,6 +3717,22 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
@@ -3343,11 +3741,9 @@ impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3358,20 +3754,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -3381,8 +3777,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3431,6 +3830,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtra {
@@ -3470,6 +3881,22 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
@@ -3478,11 +3905,9 @@ impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3493,20 +3918,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -3516,8 +3941,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3539,6 +3967,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1Type {
             "json" => Ok(Self::Json),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3585,6 +4025,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtra {
@@ -3624,6 +4076,22 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
@@ -3632,11 +4100,9 @@ impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3647,20 +4113,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -3670,8 +4136,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3697,6 +4166,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2Type {
             "tsv" => Ok(Self::Tsv),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3744,6 +4225,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtra {
@@ -3783,6 +4276,22 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
@@ -3791,11 +4300,9 @@ impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -3806,20 +4313,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -3829,8 +4336,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3852,6 +4362,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3Type {
             "dsv" => Ok(Self::Dsv),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3895,6 +4417,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant0Type {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "interior")]
@@ -3920,6 +4454,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Filter {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Filter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Filter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
@@ -3939,6 +4485,18 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Type {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4001,6 +4559,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtra {
@@ -4040,6 +4610,22 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
@@ -4048,11 +4634,9 @@ impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4063,20 +4647,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -4086,8 +4670,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4136,6 +4723,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtra {
@@ -4175,6 +4774,22 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
@@ -4183,11 +4798,9 @@ impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4198,20 +4811,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -4221,8 +4834,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4244,6 +4860,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1Type {
             "json" => Ok(Self::Json),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4290,6 +4918,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtra {
@@ -4329,6 +4969,22 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
@@ -4337,11 +4993,9 @@ impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4352,20 +5006,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -4375,8 +5029,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4402,6 +5059,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2Type {
             "tsv" => Ok(Self::Tsv),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4449,6 +5118,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtra {
@@ -4488,6 +5169,22 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraE
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
@@ -4496,11 +5193,9 @@ impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExt
         &self.0
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
@@ -4511,20 +5206,20 @@ impl std::convert::TryFrom<&str>
         Ok(Self(value.to_string()))
     }
 }
+impl std::convert::TryFrom<&str>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
 {
-    type Error = &'static str;
+    type Error = <Self as std::str::FromStr>::Err;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1
-{
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
@@ -4534,8 +5229,11 @@ impl<'de> serde::Deserialize<'de>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
-            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4557,6 +5255,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3Type {
             "dsv" => Ok(Self::Dsv),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4600,6 +5310,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant0Type {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "interior")]
@@ -4625,6 +5347,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Filter {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Filter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Filter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
@@ -4644,6 +5378,18 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Type {
             "topojson" => Ok(Self::Topojson),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4747,6 +5493,18 @@ impl std::str::FromStr for DensityTransformDistributionVariant0Function {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant0Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant0Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant0Mean {
@@ -4780,6 +5538,18 @@ impl std::str::FromStr for DensityTransformDistributionVariant1Function {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant1Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant1Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant1Mean {
@@ -4811,6 +5581,18 @@ impl std::str::FromStr for DensityTransformDistributionVariant2Function {
             "uniform" => Ok(Self::Uniform),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant2Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant2Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4859,6 +5641,18 @@ impl std::str::FromStr for DensityTransformDistributionVariant3Function {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant3Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant3Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant4Distributions {
@@ -4884,6 +5678,18 @@ impl std::str::FromStr for DensityTransformDistributionVariant4Function {
             "mixture" => Ok(Self::Mixture),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant4Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant4Function {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4958,6 +5764,18 @@ impl std::str::FromStr for DensityTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for DensityTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DensityTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DirectionValue {
@@ -5028,6 +5846,22 @@ impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -5095,6 +5929,18 @@ impl std::str::FromStr for DirectionValueVariant1Subtype1Subtype0Variant1Value {
             "vertical" => Ok(Self::Vertical),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5183,6 +6029,18 @@ impl std::str::FromStr for DotbinTransformType {
             "dotbin" => Ok(Self::Dotbin),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for DotbinTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DotbinTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5496,6 +6354,18 @@ impl std::str::FromStr for ExtentTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ExtentTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ExtentTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Facet {
@@ -5586,6 +6456,18 @@ impl std::str::FromStr for FilterTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for FilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FlattenTransform {
@@ -5651,6 +6533,18 @@ impl std::str::FromStr for FlattenTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for FlattenTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FlattenTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FoldTransform {
@@ -5706,6 +6600,18 @@ impl std::str::FromStr for FoldTransformType {
             "fold" => Ok(Self::Fold),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for FoldTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FoldTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5958,6 +6864,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant0Force {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant0Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant0Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant0X {
@@ -5989,6 +6907,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant1Force {
             "collide" => Ok(Self::Collide),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant1Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant1Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6044,6 +6974,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant2Force {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant2Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant2Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2Strength {
@@ -6083,6 +7025,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant3Force {
             "link" => Ok(Self::Link),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant3Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant3Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6127,6 +7081,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant4Force {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant4Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant4Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant4Strength {
@@ -6159,6 +7125,18 @@ impl std::str::FromStr for ForceTransformForcesItemVariant5Force {
             "y" => Ok(Self::Y),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant5Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant5Force {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6213,6 +7191,18 @@ impl std::str::FromStr for ForceTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ForceTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForceTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformVelocityDecay {
@@ -6263,6 +7253,18 @@ impl std::str::FromStr for FormulaTransformType {
             "formula" => Ok(Self::Formula),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for FormulaTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FormulaTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6327,6 +7329,18 @@ impl std::str::FromStr for GeojsonTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for GeojsonTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GeojsonTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeopathTransform {
@@ -6387,6 +7401,18 @@ impl std::str::FromStr for GeopathTransformType {
             "geopath" => Ok(Self::Geopath),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for GeopathTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GeopathTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6450,6 +7476,18 @@ impl std::str::FromStr for GeopointTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for GeopointTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GeopointTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeoshapeTransform {
@@ -6510,6 +7548,18 @@ impl std::str::FromStr for GeoshapeTransformType {
             "geoshape" => Ok(Self::Geoshape),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for GeoshapeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GeoshapeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6652,6 +7702,18 @@ impl std::str::FromStr for GraticuleTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for GraticuleTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for GraticuleTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GuideEncode {
@@ -6740,6 +7802,18 @@ impl std::str::FromStr for HeatmapTransformResolveVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for HeatmapTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for HeatmapTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum HeatmapTransformType {
     #[serde(rename = "heatmap")]
@@ -6759,6 +7833,18 @@ impl std::str::FromStr for HeatmapTransformType {
             "heatmap" => Ok(Self::Heatmap),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for HeatmapTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for HeatmapTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6796,6 +7882,18 @@ impl std::str::FromStr for IdentifierTransformType {
             "identifier" => Ok(Self::Identifier),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IdentifierTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IdentifierTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6892,6 +7990,18 @@ impl std::str::FromStr for ImputeTransformMethodVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ImputeTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ImputeTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ImputeTransformType {
     #[serde(rename = "impute")]
@@ -6911,6 +8021,18 @@ impl std::str::FromStr for ImputeTransformType {
             "impute" => Ok(Self::Impute),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ImputeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ImputeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6998,6 +8120,18 @@ impl std::str::FromStr for IsocontourTransformResolveVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for IsocontourTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IsocontourTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformScale {
@@ -7057,6 +8191,18 @@ impl std::str::FromStr for IsocontourTransformType {
             "isocontour" => Ok(Self::Isocontour),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for IsocontourTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IsocontourTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7255,6 +8401,18 @@ impl std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for JoinaggregateTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for JoinaggregateTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum JoinaggregateTransformType {
     #[serde(rename = "joinaggregate")]
@@ -7274,6 +8432,18 @@ impl std::str::FromStr for JoinaggregateTransformType {
             "joinaggregate" => Ok(Self::Joinaggregate),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for JoinaggregateTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for JoinaggregateTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7376,6 +8546,18 @@ impl std::str::FromStr for Kde2dTransformType {
             "kde2d" => Ok(Self::Kde2d),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for Kde2dTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for Kde2dTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7533,6 +8715,18 @@ impl std::str::FromStr for KdeTransformResolveVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for KdeTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for KdeTransformResolveVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformSteps {
@@ -7558,6 +8752,18 @@ impl std::str::FromStr for KdeTransformType {
             "kde" => Ok(Self::Kde),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for KdeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for KdeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7590,6 +8796,18 @@ impl std::str::FromStr for LabelOverlapVariant1 {
             "greedy" => Ok(Self::Greedy),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LabelOverlapVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LabelOverlapVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7743,6 +8961,18 @@ impl std::str::FromStr for LabelTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LabelTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LabelTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Layout {
@@ -7828,6 +9058,18 @@ impl std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant0Variant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant0Variant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant1Column {
@@ -7861,6 +9103,18 @@ impl std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
             "none" => Ok(Self::None),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1ColumnVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1ColumnVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7898,6 +9152,18 @@ impl std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1RowVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1RowVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0Bounds {
@@ -7927,6 +9193,18 @@ impl std::str::FromStr for LayoutVariant0BoundsVariant0 {
             "flush" => Ok(Self::Flush),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LayoutVariant0BoundsVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0BoundsVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8051,6 +9329,18 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant0Variant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant0Variant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Column {
@@ -8082,6 +9372,18 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Row {
@@ -8111,6 +9413,18 @@ impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
             "end" => Ok(Self::End),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8499,6 +9813,18 @@ impl std::str::FromStr for LegendSubtype0Direction {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0Direction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0Direction {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendSubtype0Encode {
@@ -8585,6 +9911,18 @@ impl std::str::FromStr for LegendSubtype0FormatTypeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0FormatTypeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0FormatTypeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0GradientOpacity {
@@ -8639,6 +9977,18 @@ impl std::str::FromStr for LegendSubtype0GridAlignVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0GridAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0GridAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelAlign {
@@ -8672,6 +10022,18 @@ impl std::str::FromStr for LegendSubtype0LabelAlignVariant0 {
             "center" => Ok(Self::Center),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype0LabelAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0LabelAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8719,6 +10081,18 @@ impl std::str::FromStr for LegendSubtype0LabelBaselineVariant0 {
             "line-bottom" => Ok(Self::LineBottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype0LabelBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0LabelBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8847,6 +10221,18 @@ impl std::str::FromStr for LegendSubtype0OrientVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0OrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0OrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0Padding {
@@ -8951,6 +10337,18 @@ impl std::str::FromStr for LegendSubtype0TitleAlignVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0TitleAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0TitleAlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleAnchor {
@@ -8984,6 +10382,18 @@ impl std::str::FromStr for LegendSubtype0TitleAnchorVariant0 {
             "end" => Ok(Self::End),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype0TitleAnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0TitleAnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9031,6 +10441,18 @@ impl std::str::FromStr for LegendSubtype0TitleBaselineVariant0 {
             "line-bottom" => Ok(Self::LineBottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype0TitleBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0TitleBaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9121,6 +10543,18 @@ impl std::str::FromStr for LegendSubtype0TitleOrientVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LegendSubtype0TitleOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0TitleOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitlePadding {
@@ -9150,6 +10584,18 @@ impl std::str::FromStr for LegendSubtype0Type {
             "symbol" => Ok(Self::Symbol),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9198,6 +10644,18 @@ impl std::str::FromStr for LinearGradientGradient {
             "linear" => Ok(Self::Linear),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LinearGradientGradient {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LinearGradientGradient {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9265,6 +10723,18 @@ impl std::str::FromStr for LinkpathTransformOrientVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LinkpathTransformOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LinkpathTransformOrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformShape {
@@ -9306,6 +10776,18 @@ impl std::str::FromStr for LinkpathTransformShapeVariant0 {
             "orthogonal" => Ok(Self::Orthogonal),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LinkpathTransformShapeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LinkpathTransformShapeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9355,6 +10837,18 @@ impl std::str::FromStr for LinkpathTransformType {
             "linkpath" => Ok(Self::Linkpath),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LinkpathTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LinkpathTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9430,6 +10924,18 @@ impl std::str::FromStr for LoessTransformType {
             "loess" => Ok(Self::Loess),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for LoessTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LoessTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9516,6 +11022,18 @@ impl std::str::FromStr for LookupTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LookupTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LookupTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformValues {
@@ -9594,6 +11112,18 @@ impl std::str::FromStr for MarkGroupType {
             "group" => Ok(Self::Group),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for MarkGroupType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MarkGroupType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9688,6 +11218,18 @@ impl std::str::FromStr for NestTransformType {
             "nest" => Ok(Self::Nest),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for NestTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NestTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10005,6 +11547,20 @@ impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
+impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -10080,6 +11636,18 @@ impl std::str::FromStr for OrientValueVariant1Subtype1Subtype0Variant1Value {
             "bottom" => Ok(Self::Bottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10183,6 +11751,18 @@ impl std::str::FromStr for PackTransformType {
             "pack" => Ok(Self::Pack),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PackTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PackTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10302,6 +11882,18 @@ impl std::str::FromStr for PartitionTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PartitionTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PartitionTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PieTransform {
@@ -10380,6 +11972,18 @@ impl std::str::FromStr for PieTransformType {
             "pie" => Ok(Self::Pie),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PieTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PieTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10552,6 +12156,18 @@ impl std::str::FromStr for PivotTransformOpVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for PivotTransformOpVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PivotTransformOpVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PivotTransformType {
     #[serde(rename = "pivot")]
@@ -10571,6 +12187,18 @@ impl std::str::FromStr for PivotTransformType {
             "pivot" => Ok(Self::Pivot),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for PivotTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PivotTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10637,6 +12265,18 @@ impl std::str::FromStr for ProjectTransformType {
             "project" => Ok(Self::Project),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ProjectTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ProjectTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10825,6 +12465,18 @@ impl std::str::FromStr for QuantileTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for QuantileTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for QuantileTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RadialGradient {
@@ -10864,6 +12516,18 @@ impl std::str::FromStr for RadialGradientGradient {
             "radial" => Ok(Self::Radial),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for RadialGradientGradient {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RadialGradientGradient {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10967,6 +12631,18 @@ impl std::str::FromStr for RegressionTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for RegressionTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RegressionTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformX {
@@ -11018,6 +12694,18 @@ impl std::str::FromStr for ResolvefilterTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ResolvefilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ResolvefilterTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11058,6 +12746,18 @@ impl std::str::FromStr for SampleTransformType {
             "sample" => Ok(Self::Sample),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SampleTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SampleTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11511,6 +13211,18 @@ impl std::str::FromStr for ScaleDataVariant1SortVariant1Op {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleDataVariant1SortVariant2Op {
     #[serde(rename = "count")]
@@ -11538,6 +13250,18 @@ impl std::str::FromStr for ScaleDataVariant1SortVariant2Op {
             "max" => Ok(Self::Max),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11592,6 +13316,18 @@ impl std::str::FromStr for ScaleDataVariant2SortVariant1Op {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleDataVariant2SortVariant2Op {
     #[serde(rename = "count")]
@@ -11619,6 +13355,18 @@ impl std::str::FromStr for ScaleDataVariant2SortVariant2Op {
             "max" => Ok(Self::Max),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11684,6 +13432,18 @@ impl std::str::FromStr for ScaleVariant0Type {
             "identity" => Ok(Self::Identity),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant0Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11780,6 +13540,18 @@ impl std::str::FromStr for ScaleVariant10RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant10RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant10RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant1Item {
@@ -11828,6 +13600,18 @@ impl std::str::FromStr for ScaleVariant10Type {
             "pow" => Ok(Self::Pow),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant10Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant10Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11924,6 +13708,18 @@ impl std::str::FromStr for ScaleVariant11RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant11RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant11RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant1Item {
@@ -11972,6 +13768,18 @@ impl std::str::FromStr for ScaleVariant11Type {
             "symlog" => Ok(Self::Symlog),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant11Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant11Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12060,6 +13868,18 @@ impl std::str::FromStr for ScaleVariant1RangeVariant0 {
             "heatmap" => Ok(Self::Heatmap),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12163,6 +13983,18 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     #[serde(rename = "count")]
@@ -12190,6 +14022,18 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
             "max" => Ok(Self::Max),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12244,6 +14088,18 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     #[serde(rename = "count")]
@@ -12273,6 +14129,18 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant1Type {
     #[serde(rename = "ordinal")]
@@ -12292,6 +14160,18 @@ impl std::str::FromStr for ScaleVariant1Type {
             "ordinal" => Ok(Self::Ordinal),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant1Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12375,6 +14255,18 @@ impl std::str::FromStr for ScaleVariant2RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant2RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant2RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2RangeVariant1Item {
@@ -12404,6 +14296,18 @@ impl std::str::FromStr for ScaleVariant2Type {
             "band" => Ok(Self::Band),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant2Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12487,6 +14391,18 @@ impl std::str::FromStr for ScaleVariant3RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant3RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant3RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3RangeVariant1Item {
@@ -12516,6 +14432,18 @@ impl std::str::FromStr for ScaleVariant3Type {
             "point" => Ok(Self::Point),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant3Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12612,6 +14540,18 @@ impl std::str::FromStr for ScaleVariant4RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant4RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant4RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant1Item {
@@ -12664,6 +14604,18 @@ impl std::str::FromStr for ScaleVariant4Type {
             "threshold" => Ok(Self::Threshold),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant4Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant4Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12753,6 +14705,18 @@ impl std::str::FromStr for ScaleVariant5RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant5RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant5RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant1Item {
@@ -12801,6 +14765,18 @@ impl std::str::FromStr for ScaleVariant5Type {
             "quantile" => Ok(Self::Quantile),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant5Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant5Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12890,6 +14866,18 @@ impl std::str::FromStr for ScaleVariant6RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant6RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant6RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant1Item {
@@ -12938,6 +14926,18 @@ impl std::str::FromStr for ScaleVariant6Type {
             "bin-ordinal" => Ok(Self::BinOrdinal),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant6Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant6Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13024,6 +15024,18 @@ impl std::str::FromStr for ScaleVariant7NiceVariant1 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7NiceVariant2Interval {
@@ -13077,6 +15089,18 @@ impl std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
             "year" => Ok(Self::Year),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant2IntervalVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant2IntervalVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13142,6 +15166,18 @@ impl std::str::FromStr for ScaleVariant7RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant7RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant7RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant1Item {
@@ -13194,6 +15230,18 @@ impl std::str::FromStr for ScaleVariant7Type {
             "utc" => Ok(Self::Utc),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant7Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant7Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13290,6 +15338,18 @@ impl std::str::FromStr for ScaleVariant8RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant8RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant8RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant1Item {
@@ -13346,6 +15406,18 @@ impl std::str::FromStr for ScaleVariant8Type {
             "sequential" => Ok(Self::Sequential),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant8Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant8Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13442,6 +15514,18 @@ impl std::str::FromStr for ScaleVariant9RangeVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for ScaleVariant9RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant9RangeVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant1Item {
@@ -13490,6 +15574,18 @@ impl std::str::FromStr for ScaleVariant9Type {
             "log" => Ok(Self::Log),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for ScaleVariant9Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ScaleVariant9Type {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13590,6 +15686,18 @@ impl std::str::FromStr for SequenceTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SequenceTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SequenceTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Signal {
@@ -13679,6 +15787,18 @@ impl std::str::FromStr for SignalVariant0Push {
         }
     }
 }
+impl std::convert::TryFrom<&str> for SignalVariant0Push {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SignalVariant0Push {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SortOrder {
@@ -13708,6 +15828,18 @@ impl std::str::FromStr for SortOrderVariant0 {
             "descending" => Ok(Self::Descending),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for SortOrderVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for SortOrderVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13795,6 +15927,18 @@ impl std::str::FromStr for StackTransformOffsetVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for StackTransformOffsetVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StackTransformOffsetVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StackTransformType {
     #[serde(rename = "stack")]
@@ -13814,6 +15958,18 @@ impl std::str::FromStr for StackTransformType {
             "stack" => Ok(Self::Stack),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StackTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StackTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13860,6 +16016,18 @@ impl std::str::FromStr for StratifyTransformType {
             "stratify" => Ok(Self::Stratify),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StratifyTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StratifyTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14094,6 +16262,22 @@ impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -14165,6 +16349,18 @@ impl std::str::FromStr for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
             "square" => Ok(Self::Square),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14253,6 +16449,22 @@ impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Va
         }
     }
 }
+impl std::convert::TryFrom<&str>
+    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+{
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -14324,6 +16536,18 @@ impl std::str::FromStr for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value 
             "bevel" => Ok(Self::Bevel),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14500,6 +16724,18 @@ impl std::str::FromStr for TickBandVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TickBandVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TickBandVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum TickCount {
@@ -14561,6 +16797,18 @@ impl std::str::FromStr for TickCountVariant1 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TickCountVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TickCountVariant1 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TickCountVariant2Interval {
@@ -14614,6 +16862,18 @@ impl std::str::FromStr for TickCountVariant2IntervalVariant0 {
             "year" => Ok(Self::Year),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TickCountVariant2IntervalVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TickCountVariant2IntervalVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14719,6 +16979,18 @@ impl std::str::FromStr for TimeunitTransformTimezoneVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TimeunitTransformTimezoneVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TimeunitTransformTimezoneVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TimeunitTransformType {
     #[serde(rename = "timeunit")]
@@ -14738,6 +17010,18 @@ impl std::str::FromStr for TimeunitTransformType {
             "timeunit" => Ok(Self::Timeunit),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TimeunitTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TimeunitTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14811,6 +17095,18 @@ impl std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
             "milliseconds" => Ok(Self::Milliseconds),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TimeunitTransformUnitsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TimeunitTransformUnitsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14953,6 +17249,18 @@ impl std::str::FromStr for TitleVariant1AlignVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TitleVariant1AlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TitleVariant1AlignVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Anchor {
@@ -14986,6 +17294,18 @@ impl std::str::FromStr for TitleVariant1AnchorVariant0 {
             "end" => Ok(Self::End),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TitleVariant1AnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TitleVariant1AnchorVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15039,6 +17359,18 @@ impl std::str::FromStr for TitleVariant1BaselineVariant0 {
             "line-bottom" => Ok(Self::LineBottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TitleVariant1BaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TitleVariant1BaselineVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15135,6 +17467,18 @@ impl std::str::FromStr for TitleVariant1FrameVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TitleVariant1FrameVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TitleVariant1FrameVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Limit {
@@ -15194,6 +17538,18 @@ impl std::str::FromStr for TitleVariant1OrientVariant0 {
             "bottom" => Ok(Self::Bottom),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TitleVariant1OrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TitleVariant1OrientVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15399,6 +17755,18 @@ impl std::str::FromStr for TreeTransformMethodVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TreeTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TreeTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSize {
@@ -15450,6 +17818,18 @@ impl std::str::FromStr for TreeTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TreeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TreeTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreelinksTransform {
@@ -15477,6 +17857,18 @@ impl std::str::FromStr for TreelinksTransformType {
             "treelinks" => Ok(Self::Treelinks),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for TreelinksTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TreelinksTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15612,6 +18004,18 @@ impl std::str::FromStr for TreemapTransformMethodVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TreemapTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TreemapTransformMethodVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPadding {
@@ -15699,6 +18103,18 @@ impl std::str::FromStr for TreemapTransformType {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TreemapTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TreemapTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct VoronoiTransform {
@@ -15758,6 +18174,18 @@ impl std::str::FromStr for VoronoiTransformType {
             "voronoi" => Ok(Self::Voronoi),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for VoronoiTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for VoronoiTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16038,6 +18466,18 @@ impl std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
         }
     }
 }
+impl std::convert::TryFrom<&str> for WindowTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WindowTransformOpsVariant0ItemVariant0 {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformParams {
@@ -16070,6 +18510,18 @@ impl std::str::FromStr for WindowTransformType {
             "window" => Ok(Self::Window),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WindowTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WindowTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16242,6 +18694,18 @@ impl std::str::FromStr for WordcloudTransformType {
             "wordcloud" => Ok(Self::Wordcloud),
             _ => Err("invalid value"),
         }
+    }
+}
+impl std::convert::TryFrom<&str> for WordcloudTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WordcloudTransformType {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 mod defaults {

--- a/typify-test/build.rs
+++ b/typify-test/build.rs
@@ -106,7 +106,7 @@ fn main() {
     UnknownFormat::add(&mut type_space);
     ipnetwork::IpNetwork::add(&mut type_space);
 
-    let content = format!(
+    let contents = format!(
         "{}\n{}",
         "use serde::{Deserialize, Serialize};",
         type_space.to_string()
@@ -114,7 +114,7 @@ fn main() {
 
     let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
     out_file.push("codegen.rs");
-    fs::write(out_file, &content).unwrap();
+    fs::write(out_file, contents).unwrap();
 }
 
 trait AddType {

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -8,13 +8,13 @@ pub struct TestType {
 pub struct TestTypeWhereNot(String);
 impl std::ops::Deref for TestTypeWhereNot {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::convert::TryFrom<String> for TestTypeWhereNot {
     type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, &'static str> {
         if ["start".to_string(), "middle".to_string(), "end".to_string()].contains(&value) {
             Err("invalid value")
         } else {
@@ -26,13 +26,13 @@ impl std::convert::TryFrom<String> for TestTypeWhereNot {
 pub struct TestTypeWhyNot(String);
 impl std::ops::Deref for TestTypeWhyNot {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::convert::TryFrom<String> for TestTypeWhyNot {
     type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, &'static str> {
         if ["because".to_string()].contains(&value) {
             Err("invalid value")
         } else {

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -29,4 +29,16 @@ impl std::str::FromStr for LetterBoxLetter {
         }
     }
 }
+impl std::convert::TryFrom<&str> for LetterBoxLetter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LetterBoxLetter {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 fn main() {}

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -21,7 +21,7 @@ impl ToString for LetterBoxLetter {
 }
 impl std::str::FromStr for LetterBoxLetter {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "a" => Ok(Self::A),
             "b" => Ok(Self::B),
@@ -30,14 +30,14 @@ impl std::str::FromStr for LetterBoxLetter {
     }
 }
 impl std::convert::TryFrom<&str> for LetterBoxLetter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LetterBoxLetter {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -18,13 +18,13 @@ impl ToString for IdOrName {
 pub struct Name(String);
 impl std::ops::Deref for Name {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for Name {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if value.len() > 63usize {
             return Err("longer than 63 characters");
         }
@@ -33,14 +33,14 @@ impl std::str::FromStr for Name {
     }
 }
 impl std::convert::TryFrom<&str> for Name {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Name {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -51,9 +51,7 @@ impl<'de> serde::Deserialize<'de> for Name {
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 fn main() {}

--- a/typify/tests/schemas/multiple-instance-types.json
+++ b/typify/tests/schemas/multiple-instance-types.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "seriously-anything": {
+      "type": [
+        "null",
+        "boolean",
+        "object",
+        "array",
+        "number",
+        "string",
+        "integer"
+      ]
+    },
+    "one-of-several": {
+      "type": [
+        "null",
+        "boolean",
+        "object",
+        "array",
+        "string",
+        "integer"
+      ]
+    },
+    "int-or-str": {
+      "type": [
+        "string",
+        "integer"
+      ]
+    }
+  }
+}

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IntOrStr {
+    String(String),
+    Integer(i64),
+}
+impl std::str::FromStr for IntOrStr {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::String(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Integer(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IntOrStr {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IntOrStr {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl ToString for IntOrStr {
+    fn to_string(&self) -> String {
+        match self {
+            Self::String(x) => x.to_string(),
+            Self::Integer(x) => x.to_string(),
+        }
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OneOfSeveral {
+    Null,
+    Boolean(bool),
+    Object(std::collections::HashMap<String, serde_json::Value>),
+    Array(Vec<serde_json::Value>),
+    String(String),
+    Integer(i64),
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SeriouslyAnything(pub serde_json::Value);
+impl std::ops::Deref for SeriouslyAnything {
+    type Target = serde_json::Value;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -7,7 +7,7 @@ pub enum IntOrStr {
 }
 impl std::str::FromStr for IntOrStr {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
             Ok(Self::String(v))
         } else if let Ok(v) = value.parse() {
@@ -18,14 +18,14 @@ impl std::str::FromStr for IntOrStr {
     }
 }
 impl std::convert::TryFrom<&str> for IntOrStr {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IntOrStr {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -51,7 +51,7 @@ pub enum OneOfSeveral {
 pub struct SeriouslyAnything(pub serde_json::Value);
 impl std::ops::Deref for SeriouslyAnything {
     type Target = serde_json::Value;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &serde_json::Value {
         &self.0
     }
 }

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -19,7 +19,7 @@ impl ToString for TestEnum {
 }
 impl std::str::FromStr for TestEnum {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "failure" => Ok(Self::Failure),
             "skipped" => Ok(Self::Skipped),
@@ -29,14 +29,14 @@ impl std::str::FromStr for TestEnum {
     }
 }
 impl std::convert::TryFrom<&str> for TestEnum {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TestEnum {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -28,6 +28,18 @@ impl std::str::FromStr for TestEnum {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TestEnum {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TestEnum {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 impl Default for TestEnum {
     fn default() -> Self {
         TestEnum::Failure

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -9,7 +9,7 @@ pub struct TestType {
 pub struct TypeThatHasMoreDerives(pub std::collections::HashMap<String, String>);
 impl std::ops::Deref for TypeThatHasMoreDerives {
     type Target = std::collections::HashMap<String, String>;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &std::collections::HashMap<String, String> {
         &self.0
     }
 }

--- a/typify/tests/schemas/types-with-more-impls.json
+++ b/typify/tests/schemas/types-with-more-impls.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "PatternString": {
+      "type": "string",
+      "pattern": "xx"
+    },
+    "Sub10Primes": {
+      "type": "integer",
+      "format": "uint",
+      "enum": [
+        2,
+        3,
+        5,
+        7
+      ]
+    }
+  }
+}

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 pub struct PatternString(String);
 impl std::ops::Deref for PatternString {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
 impl std::str::FromStr for PatternString {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("xx").unwrap().find(value).is_none() {
             return Err("doesn't match pattern \"xx\"");
         }
@@ -17,14 +17,14 @@ impl std::str::FromStr for PatternString {
     }
 }
 impl std::convert::TryFrom<&str> for PatternString {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PatternString {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
@@ -35,22 +35,20 @@ impl<'de> serde::Deserialize<'de> for PatternString {
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: <Self as std::str::FromStr>::Err| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Sub10Primes(u32);
 impl std::ops::Deref for Sub10Primes {
     type Target = u32;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &u32 {
         &self.0
     }
 }
 impl std::convert::TryFrom<u32> for Sub10Primes {
     type Error = &'static str;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, &'static str> {
         if ![2_u32, 3_u32, 5_u32, 7_u32].contains(&value) {
             Err("invalid value")
         } else {

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Serialize)]
+pub struct PatternString(String);
+impl std::ops::Deref for PatternString {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::str::FromStr for PatternString {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if regress::Regex::new("xx").unwrap().find(value).is_none() {
+            return Err("doesn't match pattern \"xx\"");
+        }
+        Ok(Self(value.to_string()))
+    }
+}
+impl std::convert::TryFrom<&str> for PatternString {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PatternString {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PatternString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: <Self as std::str::FromStr>::Err| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Sub10Primes(u32);
+impl std::ops::Deref for Sub10Primes {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::convert::TryFrom<u32> for Sub10Primes {
+    type Error = &'static str;
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        if ![2_u32, 3_u32, 5_u32, 7_u32].contains(&value) {
+            Err("invalid value")
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -23,7 +23,7 @@ impl ToString for TestTypeValue {
 }
 impl std::str::FromStr for TestTypeValue {
     type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
@@ -33,14 +33,14 @@ impl std::str::FromStr for TestTypeValue {
     }
 }
 impl std::convert::TryFrom<&str> for TestTypeValue {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TestTypeValue {
-    type Error = <Self as std::str::FromStr>::Err;
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -32,4 +32,16 @@ impl std::str::FromStr for TestTypeValue {
         }
     }
 }
+impl std::convert::TryFrom<&str> for TestTypeValue {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TestTypeValue {
+    type Error = <Self as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
 fn main() {}

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -9,7 +9,7 @@ pub enum IpNet {
 pub struct Ipv4Net(pub String);
 impl std::ops::Deref for Ipv4Net {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -17,7 +17,7 @@ impl std::ops::Deref for Ipv4Net {
 pub struct Ipv6Net(pub String);
 impl std::ops::Deref for Ipv6Net {
     type Target = String;
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }


### PR DESCRIPTION
Brings consistency to use of `FromStr` and `TryFrom<String-ish>` impls.

Simplifies the code generation for `FromStr` for untagged enum variants.

Removes use of `Self::...` syntax except for variants because of potential conflicts between associated types and variant names.

Adds support for some limited schemas with multiple types specified in a `type` array.

Moves some legacy tests to the new generate+compile mechanism.