### PR TITLE
serde_json::from_string -> serde_json::from_str

### DIFF
--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -130,7 +130,7 @@ impl TypeEntry {
                 // unfortunate, but unavoidable without getting in the
                 // underpants of the serialized form of these built-in types.
                 quote! {
-                    serde_json::from_string::< #( #type_path )::* >(#text).unwrap()
+                    serde_json::from_str::< #( #type_path )::* >(#text).unwrap()
                 }
             }
             TypeEntryDetails::Boolean => {
@@ -518,7 +518,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    serde_json::from_string::<uuid::Uuid>("\"not-a-uuid\"").unwrap()
+                    serde_json::from_str::<uuid::Uuid>("\"not-a-uuid\"").unwrap()
                 }
                 .to_string()
             ),

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -19102,8 +19102,8 @@ mod defaults {
     }
     pub(super) fn voronoi_transform_extent() -> super::VoronoiTransformExtent {
         super::VoronoiTransformExtent::Variant0(
-            serde_json::from_string::<serde_json::Value>("[-100000,-100000]").unwrap(),
-            serde_json::from_string::<serde_json::Value>("[100000,100000]").unwrap(),
+            serde_json::from_str::<serde_json::Value>("[-100000,-100000]").unwrap(),
+            serde_json::from_str::<serde_json::Value>("[100000,100000]").unwrap(),
         )
     }
     pub(super) fn window_transform_frame() -> super::WindowTransformFrame {


### PR DESCRIPTION
I believe this was meant to be `from_str`, unless you meant [this `from_string`](https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html#method.from_string)?

I still have to update tests (though I'm not fully sure how the outfiles are generated right now).