### PR TITLE
Misc clippy fixes

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -940,7 +940,7 @@ impl TypeSpace {
         let type_id = self
             .ref_to_id
             .get(key)
-            .expect(format!("key {} is missing", key).as_str());
+            .unwrap_or_else(|| panic!("key {} is missing", key));
         Ok((
             TypeEntryDetails::Reference(type_id.clone()).into(),
             metadata,
@@ -1422,11 +1422,11 @@ impl TypeSpace {
         }
     }
 
-    pub(crate) fn convert_option<'a, 'b>(
+    pub(crate) fn convert_option<'a>(
         &mut self,
         type_name: Name,
         metadata: &'a Option<Box<Metadata>>,
-        schema: &'b Schema,
+        schema: &Schema,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
         let (ty, _) = self.convert_schema(type_name, schema)?;
         let ty = self.type_to_option(ty);

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -139,24 +139,24 @@ impl TypeEntry {
             }) => match tag_type {
                 EnumTagType::External => {
                     validate_default_for_external_enum(type_space, variants, default)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Internal { tag } => {
                     validate_default_for_internal_enum(type_space, variants, default, tag)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Adjacent { tag, content } => {
                     validate_default_for_adjacent_enum(type_space, variants, default, tag, content)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Untagged => {
                     validate_default_for_untagged_enum(type_space, variants, default)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
             },
             TypeEntryDetails::Struct(TypeEntryStruct { properties, .. }) => {
                 validate_default_struct_props(properties, type_space, default)
-                    .ok_or_else(|| Error::invalid_value())
+                    .ok_or_else(Error::invalid_value)
             }
 
             TypeEntryDetails::Newtype(TypeEntryNewtype { type_id, .. }) => {
@@ -225,8 +225,9 @@ impl TypeEntry {
                     Err(Error::invalid_value())
                 }
             }
-            TypeEntryDetails::Tuple(ids) => validate_default_tuple(ids, type_space, default)
-                .ok_or_else(|| Error::invalid_value()),
+            TypeEntryDetails::Tuple(ids) => {
+                validate_default_tuple(ids, type_space, default).ok_or_else(Error::invalid_value)
+            }
             TypeEntryDetails::Unit => {
                 if let serde_json::Value::Null = default {
                     Ok(DefaultKind::Intrinsic)
@@ -341,7 +342,7 @@ pub(crate) fn validate_default_for_external_enum(
         Some(DefaultKind::Specific)
     } else {
         let map = default.as_object()?;
-        (map.len() == 1).then(|| ())?;
+        (map.len() == 1).then_some(())?;
 
         let (name, value) = map.iter().next()?;
 

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -659,7 +659,7 @@ mod tests {
 
         let mut type_space = TypeSpace::default();
         let (ty, _) = type_space.convert_schema(Name::Unknown, &schema).unwrap();
-        let output = ty.type_name(&type_space).replace(" ", "");
+        let output = ty.type_name(&type_space).replace(' ', "");
         assert_eq!(
             output,
             "std::collections::HashMap<String,serde_json::Value>"

--- a/typify-impl/src/test_util.rs
+++ b/typify-impl/src/test_util.rs
@@ -91,7 +91,7 @@ fn validate_output_impl<T: JsonSchema + Schema>(ignore_variant_names: bool) {
 #[macro_export]
 macro_rules! validate_builtin {
     ($t:ty) => {
-        crate::test_util::validate_builtin_impl::<$t>(stringify!($t))
+        $crate::test_util::validate_builtin_impl::<$t>(stringify!($t))
     };
 }
 

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -228,7 +228,7 @@ impl TypeEntryEnum {
                     .variants
                     .iter()
                     .all(|variant| matches!(variant.details, VariantDetails::Simple)))
-            .then(|| TypeEntryEnumImpl::AllSimpleVariants),
+            .then_some(TypeEntryEnumImpl::AllSimpleVariants),
             // Untagged and all variants impl FromStr
             untagged_newtype_variants(
                 type_space,
@@ -236,7 +236,7 @@ impl TypeEntryEnum {
                 &self.variants,
                 TypeSpaceImpl::FromStr,
             )
-            .then(|| TypeEntryEnumImpl::UntaggedFromStr),
+            .then_some(TypeEntryEnumImpl::UntaggedFromStr),
             // Untagged and all variants impl Display
             untagged_newtype_variants(
                 type_space,
@@ -244,7 +244,7 @@ impl TypeEntryEnum {
                 &self.variants,
                 TypeSpaceImpl::Display,
             )
-            .then(|| TypeEntryEnumImpl::UntaggedDisplay),
+            .then_some(TypeEntryEnumImpl::UntaggedDisplay),
         ]
         .into_iter()
         .flatten()

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -604,7 +604,11 @@ pub(crate) fn sanitize(input: &str, case: Case) -> String {
         "async" => "async_".to_string(), // TODO syn should handle this case...
         "+1" => "plus1".to_string(),
         "-1" => "minus1".to_string(),
-        _ => to_case(&input.replace("'", "").replace(|c| !is_xid_continue(c), "-")),
+        _ => to_case(
+            &input
+                .replace('\'', "")
+                .replace(|c| !is_xid_continue(c), "-"),
+        ),
     };
 
     let out = match out.chars().next() {

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -138,7 +138,7 @@ impl TypeEntry {
                 quote! { #v }
             }
             TypeEntryDetails::Integer(type_name) | TypeEntryDetails::Float(type_name) => {
-                value.is_number().then(|| ())?;
+                value.is_number().then_some(())?;
                 let val = match proc_macro2::Literal::from_str(&format!("{}_{}", value, type_name))
                 {
                     Ok(v) => v,
@@ -174,7 +174,7 @@ fn value_for_external_enum(
         Some(quote! { #scope #type_ident::#var_ident })
     } else {
         let map = value.as_object()?;
-        (map.len() == 1).then(|| ())?;
+        (map.len() == 1).then_some(())?;
 
         let (name, var_value) = map.iter().next()?;
 
@@ -328,7 +328,7 @@ fn value_for_tuple(
     scope: &TokenStream,
 ) -> Option<Vec<TokenStream>> {
     let arr = value.as_array()?;
-    (arr.len() == types.len()).then(|| ())?;
+    (arr.len() == types.len()).then_some(())?;
     types
         .iter()
         .zip(arr)

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -25,7 +25,7 @@ fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {
     let mut out_path = path.clone();
     out_path.set_extension("rs");
 
-    let file = File::open(path.clone())?;
+    let file = File::open(path)?;
     let reader = BufReader::new(file);
 
     // Read the JSON contents of the file as an instance of `User`.


### PR DESCRIPTION
Includes fairly clear and simple fixes for stable default enabled lints
- https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure - pre 1.29.0
- https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations - 1.48.0
- https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern - pre 1.29.0
- https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call - pre 1.29.0
- https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes - pre 1.29.0

This change has been tested with progenitor and https://github.com/substrait-io/substrait-rs as well.

I have left out https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args which is added in 1.66.0 , as that may be too recent .  If so, we should add a `clippy.toml` to silence specific lints which are not wanted on this project.  Then developers can use clippy and not be drowned in warnings not related to the changes they have made.  And I am happy to set up CI to enforce the local clippy settings on changes within PRs, so there is a consistent approach .  A simpler approach is to use https://deepsource.io/ , free for OSS, which loosely enforces various Rust lints, meaning the project admins can set expected quality levels, and DeepSource can also track code coverage for Rust - not many of the SaaS can do that.