### PR TITLE
WIP: Add Default where there is no explicit default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,15 +49,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
+name = "educe"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "enum-ordinalize"
+version = "3.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bb1df8b45ecb7ffa78dca1c17a438fb193eb083db0b1b494d2a61bcb5096a"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "example-build"
 version = "0.0.0"
 dependencies = [
+ "educe",
  "schemars",
  "serde",
  "serde_json",
@@ -62,6 +95,7 @@ dependencies = [
 name = "example-macro"
 version = "0.0.0"
 dependencies = [
+ "educe",
  "serde",
  "serde_json",
  "typify",
@@ -170,6 +204,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.16",
 ]
 
 [[package]]
@@ -337,6 +410,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
@@ -478,7 +557,7 @@ dependencies = [
  "home",
  "lazy_static",
  "regex",
- "semver",
+ "semver 0.11.0",
  "walkdir",
 ]
 
@@ -501,6 +580,7 @@ dependencies = [
 name = "typify"
 version = "0.0.11-dev"
 dependencies = [
+ "educe",
  "expectorate",
  "glob",
  "quote",
@@ -519,6 +599,7 @@ dependencies = [
 name = "typify-impl"
 version = "0.0.11-dev"
 dependencies = [
+ "educe",
  "expectorate",
  "heck",
  "log",
@@ -541,6 +622,7 @@ dependencies = [
 name = "typify-macro"
 version = "0.0.11-dev"
 dependencies = [
+ "educe",
  "proc-macro2",
  "quote",
  "schemars",
@@ -555,6 +637,7 @@ dependencies = [
 name = "typify-test"
 version = "0.0.0"
 dependencies = [
+ "educe",
  "ipnetwork",
  "regress",
  "schemars",

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2021"
 
 [dependencies]
+educe = "0.4.20"
 serde = "1.0"
 serde_json = "1.0.91"
 

--- a/example-macro/Cargo.toml
+++ b/example-macro/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2021"
 
 [dependencies]
+educe = "0.4.20"
 typify = { path = "../typify" }
 serde = "1.0"
 serde_json = "1.0"

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 unicode-ident = "1.0.6"
 
 [dev-dependencies]
+educe = "0.4.20"
 expectorate = "1.0"
 paste = "1.0"
 schema = "0.0.1"

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -551,13 +551,19 @@ impl TypeSpace {
 
             Some("uuid") => {
                 self.uses_uuid = true;
-                Ok((TypeEntry::new_builtin("uuid::Uuid", &["Display"]), metadata))
+                Ok((
+                    TypeEntry::new_builtin("uuid::Uuid", &["Default", "Display"]),
+                    metadata,
+                ))
             }
 
             Some("date") => {
                 self.uses_chrono = true;
                 Ok((
-                    TypeEntry::new_builtin("chrono::Date<chrono::offset::Utc>", &["Display"]),
+                    TypeEntry::new_builtin(
+                        "chrono::Date<chrono::offset::Utc>",
+                        &["Default", "Display"],
+                    ),
                     metadata,
                 ))
             }
@@ -565,21 +571,24 @@ impl TypeSpace {
             Some("date-time") => {
                 self.uses_chrono = true;
                 Ok((
-                    TypeEntry::new_builtin("chrono::DateTime<chrono::offset::Utc>", &["Display"]),
+                    TypeEntry::new_builtin(
+                        "chrono::DateTime<chrono::offset::Utc>",
+                        &["Default", "Display"],
+                    ),
                     metadata,
                 ))
             }
 
             Some("ip") => Ok((
-                TypeEntry::new_builtin("std::net::IpAddr", &["Display"]),
+                TypeEntry::new_builtin("std::net::IpAddr", &["Default", "Display"]),
                 metadata,
             )),
             Some("ipv4") => Ok((
-                TypeEntry::new_builtin("std::net::Ipv4Addr", &["Display"]),
+                TypeEntry::new_builtin("std::net::Ipv4Addr", &["Default", "Display"]),
                 metadata,
             )),
             Some("ipv6") => Ok((
-                TypeEntry::new_builtin("std::net::Ipv6Addr", &["Display"]),
+                TypeEntry::new_builtin("std::net::Ipv6Addr", &["Default", "Display"]),
                 metadata,
             )),
             Some(unhandled) => {

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1605,8 +1605,10 @@ mod tests {
         type_entry.output(&type_space, &mut output);
         let actual = output.into_stream();
         let expected = quote! {
-            #[derive(Clone, Debug, Deserialize, Serialize)]
+            #[derive(Clone, Debug, Deserialize, Serialize, educe::Educe)]
+            #[educe(Default)]
             pub enum ResultX {
+                #[educe(Default)]
                 Ok(u32),
                 Err(String),
             }
@@ -1632,8 +1634,10 @@ mod tests {
         type_entry.output(&type_space, &mut output);
         let actual = output.into_stream();
         let expected = quote! {
-            #[derive(A, B, C, Clone, D, Debug, Deserialize, Serialize)]
+            #[derive(A, B, C, Clone, D, Debug, Deserialize, Serialize, educe::Educe)]
+            #[educe(Default)]
             pub enum ResultX {
+                #[educe(Default)]
                 Ok(u32),
                 Err(String),
             }

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -188,7 +188,7 @@ fn value_for_external_enum(
             VariantDetails::Simple => None,
             VariantDetails::Item(type_id) => {
                 let item = value_for_item(type_space, var_value, type_id, scope);
-                Some(quote! { #scope #type_ident::#var_ident ( #item ) })
+                Some(quote! { #scope #type_ident::#var_ident ( #item ::default() ) })
             }
             VariantDetails::Tuple(types) => {
                 let tup = value_for_tuple(type_space, var_value, types, scope)?;

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,6 +1,16 @@
 mod types {
     #[derive(
-        Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+        Clone,
+        Debug,
+        Default,
+        Deserialize,
+        Eq,
+        Hash,
+        JsonSchema,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
     )]
     pub struct AllTheTraits {
         pub ok: String,
@@ -10,7 +20,7 @@ mod types {
             builder::AllTheTraits::default()
         }
     }
-    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
     pub struct CompoundType {
         pub value1: String,
         pub value2: u64,
@@ -20,7 +30,7 @@ mod types {
             builder::CompoundType::default()
         }
     }
-    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
     pub struct Pair {
         #[serde(default = "defaults::pair_a")]
         pub a: StringEnum,
@@ -33,9 +43,22 @@ mod types {
         }
     }
     #[derive(
-        Clone, Copy, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Deserialize,
+        Eq,
+        Hash,
+        JsonSchema,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        educe :: Educe,
     )]
+    #[educe(Default)]
     pub enum StringEnum {
+        #[educe(Default)]
         One,
         Two,
         BuckleMyShoe,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstance {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -19,7 +19,7 @@ pub struct AlertInstance {
     #[doc = "State of a code scanning alert."]
     pub state: AlertInstanceState,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -33,15 +33,19 @@ pub struct AlertInstanceLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_line: Option<i64>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AlertInstanceState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
@@ -82,7 +86,7 @@ impl std::convert::TryFrom<&String> for AlertInstanceState {
     }
 }
 #[doc = "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct App {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -105,8 +109,12 @@ pub struct App {
     pub slug: Option<String>,
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppEventsItem {
+    #[educe(Default)]
     #[serde(rename = "check_run")]
     CheckRun,
     #[serde(rename = "check_suite")]
@@ -311,7 +319,7 @@ impl std::convert::TryFrom<&String> for AppEventsItem {
     }
 }
 #[doc = "The set of permissions for the GitHub app"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -383,8 +391,12 @@ pub struct AppPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflows: Option<AppPermissionsWorkflows>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsActions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -420,8 +432,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsActions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsAdministration {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -457,8 +473,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsAdministration {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsChecks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -494,8 +514,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsChecks {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsContentReferences {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -531,8 +555,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsContentReferences {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsContents {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -568,8 +596,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsContents {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsDeployments {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -605,8 +637,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsDeployments {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsDiscussions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -642,8 +678,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsDiscussions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsEmails {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -679,8 +719,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsEmails {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsEnvironments {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -716,8 +760,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsEnvironments {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsIssues {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -753,8 +801,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsIssues {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsMembers {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -790,8 +842,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsMembers {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsMetadata {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -827,8 +883,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsMetadata {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationAdministration {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -864,8 +924,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationAdministration
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationHooks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -901,8 +965,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationHooks {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationPackages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -938,8 +1006,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPackages {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationPlan {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -975,8 +1047,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPlan {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationProjects {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1012,8 +1088,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationProjects {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationSecrets {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1049,8 +1129,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSecrets {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationSelfHostedRunners {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1086,8 +1170,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSelfHostedRunn
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsOrganizationUserBlocking {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1123,8 +1211,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsOrganizationUserBlocking {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsPackages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1160,8 +1252,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsPackages {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsPages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1197,8 +1293,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsPages {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsPullRequests {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1234,8 +1334,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsPullRequests {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsRepositoryHooks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1271,8 +1375,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsRepositoryHooks {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsRepositoryProjects {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1308,8 +1416,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsRepositoryProjects {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsSecretScanningAlerts {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1345,8 +1457,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsSecretScanningAlerts {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsSecrets {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1382,8 +1498,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsSecrets {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsSecurityEvents {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1419,8 +1539,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsSecurityEvents {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsSecurityScanningAlert {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1456,8 +1580,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsSecurityScanningAlert {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsSingleFile {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1493,8 +1621,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsSingleFile {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsStatuses {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1530,8 +1662,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsStatuses {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsTeamDiscussions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1567,8 +1703,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsTeamDiscussions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsVulnerabilityAlerts {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1604,8 +1744,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsVulnerabilityAlerts {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AppPermissionsWorkflows {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -1642,8 +1786,12 @@ impl std::convert::TryFrom<&String> for AppPermissionsWorkflows {
     }
 }
 #[doc = "How the author is associated with the repository."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AuthorAssociation {
+    #[educe(Default)]
     #[serde(rename = "COLLABORATOR")]
     Collaborator,
     #[serde(rename = "CONTRIBUTOR")]
@@ -1704,7 +1852,7 @@ impl std::convert::TryFrom<&String> for AuthorAssociation {
     }
 }
 #[doc = "The branch protection rule. Includes a `name` and all the [branch protection settings](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-settings) applied to branches that match the name. Binary settings are boolean. Multi-level configurations are one of `off`, `non_admins`, or `everyone`. Actor and build lists are arrays of strings."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRule {
     pub admin_enforced: bool,
@@ -1738,8 +1886,12 @@ pub struct BranchProtectionRule {
     pub strict_required_status_checks_policy: bool,
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleAllowDeletionsEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -1779,8 +1931,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowDeletionsEnforc
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleAllowForcePushesEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -1821,7 +1977,7 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowForcePushesEnfo
     }
 }
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleCreated {
     pub action: BranchProtectionRuleCreatedAction,
@@ -1833,8 +1989,12 @@ pub struct BranchProtectionRuleCreated {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -1867,7 +2027,7 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleCreatedAction {
     }
 }
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleDeleted {
     pub action: BranchProtectionRuleDeletedAction,
@@ -1879,8 +2039,12 @@ pub struct BranchProtectionRuleDeleted {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -1913,7 +2077,7 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleDeletedAction {
     }
 }
 #[doc = "Activity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEdited {
     pub action: BranchProtectionRuleEditedAction,
@@ -1926,8 +2090,12 @@ pub struct BranchProtectionRuleEdited {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -1960,7 +2128,7 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleEditedAction {
     }
 }
 #[doc = "If the action was `edited`, the changes to the rule."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1968,19 +2136,21 @@ pub struct BranchProtectionRuleEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authorized_actors_only: Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorNames {
     pub from: Vec<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorsOnly {
     pub from: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum BranchProtectionRuleEvent {
+    #[educe(Default)]
     #[doc = "branch protection rule created event\n\nActivity related to a branch protection rule. For more information, see \"[About branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules).\""]
     #[serde(rename = "created")]
     Created {
@@ -2016,8 +2186,12 @@ pub enum BranchProtectionRuleEvent {
         sender: User,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2059,8 +2233,12 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleMergeQueueEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2100,8 +2278,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleMergeQueueEnforcemen
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRulePullRequestReviewsEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2141,8 +2323,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRulePullRequestReviewsEn
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleRequiredConversationResolutionLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2182,8 +2368,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredConversation
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2223,8 +2413,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredDeploymentsE
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2264,8 +2458,12 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredStatusChecks
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BranchProtectionRuleSignatureRequirementEnforcementLevel {
+    #[educe(Default)]
     #[serde(rename = "off")]
     Off,
     #[serde(rename = "non_admins")]
@@ -2305,7 +2503,7 @@ impl std::convert::TryFrom<&String> for BranchProtectionRuleSignatureRequirement
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompleted {
     pub action: CheckRunCompletedAction,
@@ -2320,8 +2518,12 @@ pub struct CheckRunCompleted {
     pub requested_action: Option<CheckRunCompletedRequestedAction>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCompletedAction {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -2354,7 +2556,7 @@ impl std::convert::TryFrom<&String> for CheckRunCompletedAction {
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRun {
     pub app: App,
@@ -2383,7 +2585,7 @@ pub struct CheckRunCompletedCheckRun {
     pub status: CheckRunCompletedCheckRunStatus,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -2406,8 +2608,12 @@ pub struct CheckRunCompletedCheckRunCheckSuite {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCompletedCheckRunCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -2463,8 +2669,12 @@ impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteConcl
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCompletedCheckRunCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "in_progress")]
     InProgress,
     #[serde(rename = "completed")]
@@ -2505,8 +2715,12 @@ impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteStatu
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCompletedCheckRunConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -2566,7 +2780,7 @@ impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunOutput {
     pub annotations_count: i64,
@@ -2577,8 +2791,12 @@ pub struct CheckRunCompletedCheckRunOutput {
     pub title: Option<String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCompletedCheckRunStatus {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -2611,14 +2829,14 @@ impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunStatus {
     }
 }
 #[doc = "The action requested by the user."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreated {
     pub action: CheckRunCreatedAction,
@@ -2633,8 +2851,12 @@ pub struct CheckRunCreated {
     pub requested_action: Option<CheckRunCreatedRequestedAction>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -2667,7 +2889,7 @@ impl std::convert::TryFrom<&String> for CheckRunCreatedAction {
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRun {
     pub app: App,
@@ -2696,7 +2918,7 @@ pub struct CheckRunCreatedCheckRun {
     pub status: CheckRunCreatedCheckRunStatus,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -2719,8 +2941,12 @@ pub struct CheckRunCreatedCheckRunCheckSuite {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCreatedCheckRunCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -2776,8 +3002,12 @@ impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteConclus
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCreatedCheckRunCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
     #[serde(rename = "in_progress")]
@@ -2818,8 +3048,12 @@ impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteStatus 
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCreatedCheckRunConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -2879,7 +3113,7 @@ impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunOutput {
     pub annotations_count: i64,
@@ -2890,8 +3124,12 @@ pub struct CheckRunCreatedCheckRunOutput {
     pub title: Option<String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunCreatedCheckRunStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
     #[serde(rename = "in_progress")]
@@ -2932,7 +3170,7 @@ impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunStatus {
     }
 }
 #[doc = "The action requested by the user."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
@@ -2940,7 +3178,7 @@ pub struct CheckRunCreatedRequestedAction {
     pub identifier: Option<String>,
 }
 #[doc = "A deployment to a repository environment. This will only be populated if the check run was created by a GitHub Actions workflow job that references an environment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunDeployment {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -2955,9 +3193,11 @@ pub struct CheckRunDeployment {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum CheckRunEvent {
+    #[educe(Default)]
     #[doc = "check_run completed event"]
     #[serde(rename = "completed")]
     Completed {
@@ -3013,7 +3253,7 @@ pub enum CheckRunEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequest {
     pub base: CheckRunPullRequestBase,
@@ -3022,7 +3262,7 @@ pub struct CheckRunPullRequest {
     pub number: i64,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequestBase {
     #[serde(rename = "ref")]
@@ -3030,7 +3270,7 @@ pub struct CheckRunPullRequestBase {
     pub repo: RepoRef,
     pub sha: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequestHead {
     #[serde(rename = "ref")]
@@ -3038,7 +3278,7 @@ pub struct CheckRunPullRequestHead {
     pub repo: RepoRef,
     pub sha: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedAction {
     pub action: CheckRunRequestedActionAction,
@@ -3051,8 +3291,12 @@ pub struct CheckRunRequestedAction {
     pub requested_action: CheckRunRequestedActionRequestedAction,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRequestedActionAction {
+    #[educe(Default)]
     #[serde(rename = "requested_action")]
     RequestedAction,
 }
@@ -3085,7 +3329,7 @@ impl std::convert::TryFrom<&String> for CheckRunRequestedActionAction {
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRun {
     pub app: App,
@@ -3114,7 +3358,7 @@ pub struct CheckRunRequestedActionCheckRun {
     pub status: CheckRunRequestedActionCheckRunStatus,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunCheckSuite {
     pub after: Option<String>,
@@ -3137,8 +3381,12 @@ pub struct CheckRunRequestedActionCheckRunCheckSuite {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -3194,8 +3442,12 @@ impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuit
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
     #[serde(rename = "in_progress")]
@@ -3236,8 +3488,12 @@ impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuit
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRequestedActionCheckRunConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -3297,7 +3553,7 @@ impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunConclusio
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunOutput {
     pub annotations_count: i64,
@@ -3308,8 +3564,12 @@ pub struct CheckRunRequestedActionCheckRunOutput {
     pub title: Option<String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRequestedActionCheckRunStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
     #[serde(rename = "in_progress")]
@@ -3350,14 +3610,14 @@ impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunStatus {
     }
 }
 #[doc = "The action requested by the user."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequested {
     pub action: CheckRunRerequestedAction,
@@ -3372,8 +3632,12 @@ pub struct CheckRunRerequested {
     pub requested_action: Option<CheckRunRerequestedRequestedAction>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRerequestedAction {
+    #[educe(Default)]
     #[serde(rename = "rerequested")]
     Rerequested,
 }
@@ -3406,7 +3670,7 @@ impl std::convert::TryFrom<&String> for CheckRunRerequestedAction {
     }
 }
 #[doc = "The [check_run](https://docs.github.com/en/rest/reference/checks#get-a-check-run)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRun {
     pub app: App,
@@ -3435,7 +3699,7 @@ pub struct CheckRunRerequestedCheckRun {
     pub status: CheckRunRerequestedCheckRunStatus,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -3458,8 +3722,12 @@ pub struct CheckRunRerequestedCheckRunCheckSuite {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -3515,8 +3783,12 @@ impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteCon
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -3549,8 +3821,12 @@ impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteSta
     }
 }
 #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRerequestedCheckRunConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -3610,7 +3886,7 @@ impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunOutput {
     pub annotations_count: i64,
@@ -3621,8 +3897,12 @@ pub struct CheckRunRerequestedCheckRunOutput {
     pub title: Option<String>,
 }
 #[doc = "The phase of the lifecycle that the check is currently in."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckRunRerequestedCheckRunStatus {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -3655,14 +3935,14 @@ impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunStatus {
     }
 }
 #[doc = "The action requested by the user."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteCompleted {
     pub action: CheckSuiteCompletedAction,
@@ -3674,8 +3954,12 @@ pub struct CheckSuiteCompleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteCompletedAction {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -3708,7 +3992,7 @@ impl std::convert::TryFrom<&String> for CheckSuiteCompletedAction {
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteCompletedCheckSuite {
     pub after: String,
@@ -3735,8 +4019,12 @@ pub struct CheckSuiteCompletedCheckSuite {
     pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteCompletedCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -3793,8 +4081,12 @@ impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteConclusion 
     }
 }
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteCompletedCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
     #[serde(rename = "in_progress")]
@@ -3838,9 +4130,11 @@ impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum CheckSuiteEvent {
+    #[educe(Default)]
     #[doc = "check_suite completed event"]
     #[serde(rename = "completed")]
     Completed {
@@ -3875,7 +4169,7 @@ pub enum CheckSuiteEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRequested {
     pub action: CheckSuiteRequestedAction,
@@ -3887,8 +4181,12 @@ pub struct CheckSuiteRequested {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRequestedAction {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
 }
@@ -3921,7 +4219,7 @@ impl std::convert::TryFrom<&String> for CheckSuiteRequestedAction {
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRequestedCheckSuite {
     pub after: String,
@@ -3948,8 +4246,12 @@ pub struct CheckSuiteRequestedCheckSuite {
     pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRequestedCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -4006,8 +4308,12 @@ impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteConclusion 
     }
 }
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRequestedCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
     #[serde(rename = "in_progress")]
@@ -4051,7 +4357,7 @@ impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRerequested {
     pub action: CheckSuiteRerequestedAction,
@@ -4063,8 +4369,12 @@ pub struct CheckSuiteRerequested {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRerequestedAction {
+    #[educe(Default)]
     #[serde(rename = "rerequested")]
     Rerequested,
 }
@@ -4097,7 +4407,7 @@ impl std::convert::TryFrom<&String> for CheckSuiteRerequestedAction {
     }
 }
 #[doc = "The [check_suite](https://docs.github.com/en/rest/reference/checks#suites)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRerequestedCheckSuite {
     pub after: String,
@@ -4124,8 +4434,12 @@ pub struct CheckSuiteRerequestedCheckSuite {
     pub url: String,
 }
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRerequestedCheckSuiteConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -4182,8 +4496,12 @@ impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteConclusio
     }
 }
 #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CheckSuiteRerequestedCheckSuiteStatus {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
     #[serde(rename = "in_progress")]
@@ -4227,7 +4545,7 @@ impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranch {
     pub action: CodeScanningAlertAppearedInBranchAction,
@@ -4244,8 +4562,12 @@ pub struct CodeScanningAlertAppearedInBranch {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertAppearedInBranchAction {
+    #[educe(Default)]
     #[serde(rename = "appeared_in_branch")]
     AppearedInBranch,
 }
@@ -4278,7 +4600,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAction 
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -4302,8 +4624,12 @@ pub struct CodeScanningAlertAppearedInBranchAlert {
     pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertAppearedInBranchAlertDismissedReason {
+    #[educe(Default)]
     #[serde(rename = "false positive")]
     FalsePositive,
     #[serde(rename = "won't fix")]
@@ -4343,7 +4669,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertDi
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -4354,8 +4680,12 @@ pub struct CodeScanningAlertAppearedInBranchAlertRule {
     pub severity: Option<CodeScanningAlertAppearedInBranchAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertAppearedInBranchAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -4400,8 +4730,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertRu
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertAppearedInBranchAlertState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
@@ -4441,7 +4775,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertSt
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
@@ -4449,7 +4783,7 @@ pub struct CodeScanningAlertAppearedInBranchAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUser {
     pub action: CodeScanningAlertClosedByUserAction,
@@ -4466,8 +4800,12 @@ pub struct CodeScanningAlertClosedByUser {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertClosedByUserAction {
+    #[educe(Default)]
     #[serde(rename = "closed_by_user")]
     ClosedByUser,
 }
@@ -4500,7 +4838,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAction {
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -4524,8 +4862,12 @@ pub struct CodeScanningAlertClosedByUserAlert {
     pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertClosedByUserAlertDismissedReason {
+    #[educe(Default)]
     #[serde(rename = "false positive")]
     FalsePositive,
     #[serde(rename = "won't fix")]
@@ -4565,7 +4907,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertDismis
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -4584,8 +4926,12 @@ pub struct CodeScanningAlertClosedByUserAlertRule {
     pub tags: (),
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertClosedByUserAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -4630,8 +4976,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertRuleSe
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertClosedByUserAlertState {
+    #[educe(Default)]
     #[serde(rename = "dismissed")]
     Dismissed,
 }
@@ -4663,7 +5013,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertState 
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4673,7 +5023,7 @@ pub struct CodeScanningAlertClosedByUserAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreated {
     pub action: CodeScanningAlertCreatedAction,
@@ -4690,8 +5040,12 @@ pub struct CodeScanningAlertCreated {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -4724,7 +5078,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAction {
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -4747,7 +5101,7 @@ pub struct CodeScanningAlertCreatedAlert {
     pub tool: CodeScanningAlertCreatedAlertTool,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -4766,8 +5120,12 @@ pub struct CodeScanningAlertCreatedAlertRule {
     pub tags: (),
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertCreatedAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -4812,8 +5170,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertRuleSeverit
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertCreatedAlertState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
@@ -4849,7 +5211,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4859,9 +5221,11 @@ pub struct CodeScanningAlertCreatedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum CodeScanningAlertEvent {
+    #[educe(Default)]
     #[doc = "code_scanning_alert appeared_in_branch event"]
     #[serde(rename = "appeared_in_branch")]
     AppearedInBranch {
@@ -4959,7 +5323,7 @@ pub enum CodeScanningAlertEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixed {
     pub action: CodeScanningAlertFixedAction,
@@ -4976,8 +5340,12 @@ pub struct CodeScanningAlertFixed {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertFixedAction {
+    #[educe(Default)]
     #[serde(rename = "fixed")]
     Fixed,
 }
@@ -5010,7 +5378,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAction {
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -5036,8 +5404,12 @@ pub struct CodeScanningAlertFixedAlert {
     pub url: String,
 }
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertFixedAlertDismissedReason {
+    #[educe(Default)]
     #[serde(rename = "false positive")]
     FalsePositive,
     #[serde(rename = "won't fix")]
@@ -5077,7 +5449,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertDismissedReas
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -5096,8 +5468,12 @@ pub struct CodeScanningAlertFixedAlertRule {
     pub tags: (),
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertFixedAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -5142,8 +5518,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertRuleSeverity 
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertFixedAlertState {
+    #[educe(Default)]
     #[serde(rename = "fixed")]
     Fixed,
 }
@@ -5175,7 +5555,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5185,7 +5565,7 @@ pub struct CodeScanningAlertFixedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopened {
     pub action: CodeScanningAlertReopenedAction,
@@ -5202,8 +5582,12 @@ pub struct CodeScanningAlertReopened {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedAction {
+    #[educe(Default)]
     #[serde(rename = "reopened")]
     Reopened,
 }
@@ -5236,7 +5620,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAction {
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -5259,7 +5643,7 @@ pub struct CodeScanningAlertReopenedAlert {
     pub tool: CodeScanningAlertReopenedAlertTool,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -5278,8 +5662,12 @@ pub struct CodeScanningAlertReopenedAlertRule {
     pub tags: (),
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -5324,8 +5712,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertRuleSeveri
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedAlertState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "dismissed")]
@@ -5365,7 +5757,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5375,7 +5767,7 @@ pub struct CodeScanningAlertReopenedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUser {
     pub action: CodeScanningAlertReopenedByUserAction,
@@ -5392,8 +5784,12 @@ pub struct CodeScanningAlertReopenedByUser {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedByUserAction {
+    #[educe(Default)]
     #[serde(rename = "reopened_by_user")]
     ReopenedByUser,
 }
@@ -5426,7 +5822,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAction {
     }
 }
 #[doc = "The code scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -5449,7 +5845,7 @@ pub struct CodeScanningAlertReopenedByUserAlert {
     pub tool: CodeScanningAlertReopenedByUserAlertTool,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -5460,8 +5856,12 @@ pub struct CodeScanningAlertReopenedByUserAlertRule {
     pub severity: Option<CodeScanningAlertReopenedByUserAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedByUserAlertRuleSeverity {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "note")]
@@ -5506,8 +5906,12 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertRule
     }
 }
 #[doc = "State of a code scanning alert."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CodeScanningAlertReopenedByUserAlertState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
 }
@@ -5539,7 +5943,7 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertStat
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
@@ -5547,7 +5951,7 @@ pub struct CodeScanningAlertReopenedByUserAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Commit {
     #[doc = "An array of files added in the commit."]
@@ -5570,7 +5974,7 @@ pub struct Commit {
     pub url: String,
 }
 #[doc = "A commit comment is created. The type of activity is specified in the `action` property. "]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitCommentCreated {
     #[doc = "The action performed. Can be `created`."]
@@ -5584,8 +5988,12 @@ pub struct CommitCommentCreated {
     pub sender: User,
 }
 #[doc = "The action performed. Can be `created`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CommitCommentCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -5618,7 +6026,7 @@ impl std::convert::TryFrom<&String> for CommitCommentCreatedAction {
     }
 }
 #[doc = "The [commit comment](https://docs.github.com/en/rest/reference/repos#get-a-commit-comment) resource."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitCommentCreatedComment {
     pub author_association: AuthorAssociation,
@@ -5642,9 +6050,11 @@ pub struct CommitCommentCreatedComment {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum CommitCommentEvent {
+    #[educe(Default)]
     #[doc = "commit_comment created event\n\nA commit comment is created. The type of activity is specified in the `action` property. "]
     #[serde(rename = "created")]
     Created {
@@ -5657,7 +6067,7 @@ pub enum CommitCommentEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitSimple {
     pub author: Committer,
@@ -5668,7 +6078,7 @@ pub struct CommitSimple {
     pub tree_id: String,
 }
 #[doc = "Metaproperties for Git author/committer information."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Committer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5680,7 +6090,7 @@ pub struct Committer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContentReferenceCreated {
     pub action: ContentReferenceCreatedAction,
@@ -5691,8 +6101,12 @@ pub struct ContentReferenceCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ContentReferenceCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -5724,16 +6138,18 @@ impl std::convert::TryFrom<&String> for ContentReferenceCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContentReferenceCreatedContentReference {
     pub id: i64,
     pub node_id: String,
     pub reference: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum ContentReferenceEvent {
+    #[educe(Default)]
     #[doc = "content_reference created event"]
     #[serde(rename = "created")]
     Created {
@@ -5746,7 +6162,7 @@ pub enum ContentReferenceEvent {
     },
 }
 #[doc = "A Git branch or tag is created."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CreateEvent {
     #[doc = "The repository's current description."]
@@ -5768,8 +6184,12 @@ pub struct CreateEvent {
     pub sender: User,
 }
 #[doc = "The type of Git ref object created in the repository. Can be either `branch` or `tag`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CreateEventRefType {
+    #[educe(Default)]
     #[serde(rename = "tag")]
     Tag,
     #[serde(rename = "branch")]
@@ -5806,7 +6226,7 @@ impl std::convert::TryFrom<&String> for CreateEventRefType {
     }
 }
 #[doc = "A Git branch or tag is deleted."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5824,8 +6244,12 @@ pub struct DeleteEvent {
     pub sender: User,
 }
 #[doc = "The type of Git ref object deleted in the repository. Can be either `branch` or `tag`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DeleteEventRefType {
+    #[educe(Default)]
     #[serde(rename = "tag")]
     Tag,
     #[serde(rename = "branch")]
@@ -5861,7 +6285,7 @@ impl std::convert::TryFrom<&String> for DeleteEventRefType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreated {
     pub action: DeployKeyCreatedAction,
@@ -5873,8 +6297,12 @@ pub struct DeployKeyCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DeployKeyCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -5907,7 +6335,7 @@ impl std::convert::TryFrom<&String> for DeployKeyCreatedAction {
     }
 }
 #[doc = "The [`deploy key`](https://docs.github.com/en/rest/reference/repos#get-a-deploy-key) resource."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreatedKey {
     pub created_at: String,
@@ -5918,7 +6346,7 @@ pub struct DeployKeyCreatedKey {
     pub url: String,
     pub verified: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyDeleted {
     pub action: DeployKeyDeletedAction,
@@ -5930,8 +6358,12 @@ pub struct DeployKeyDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DeployKeyDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -5964,7 +6396,7 @@ impl std::convert::TryFrom<&String> for DeployKeyDeletedAction {
     }
 }
 #[doc = "The [`deploy key`](https://docs.github.com/en/rest/reference/repos#get-a-deploy-key) resource."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyDeletedKey {
     pub created_at: String,
@@ -5975,9 +6407,11 @@ pub struct DeployKeyDeletedKey {
     pub url: String,
     pub verified: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum DeployKeyEvent {
+    #[educe(Default)]
     #[doc = "deploy_key created event"]
     #[serde(rename = "created")]
     Created {
@@ -6001,7 +6435,7 @@ pub enum DeployKeyEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreated {
     pub action: DeploymentCreatedAction,
@@ -6015,8 +6449,12 @@ pub struct DeploymentCreated {
     pub workflow: (),
     pub workflow_run: (),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DeploymentCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -6049,7 +6487,7 @@ impl std::convert::TryFrom<&String> for DeploymentCreatedAction {
     }
 }
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeployment {
     pub created_at: String,
@@ -6071,12 +6509,14 @@ pub struct DeploymentCreatedDeployment {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeploymentPayload {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum DeploymentEvent {
+    #[educe(Default)]
     #[doc = "deployment created event"]
     #[serde(rename = "created")]
     Created {
@@ -6091,7 +6531,7 @@ pub enum DeploymentEvent {
         workflow_run: (),
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreated {
     pub action: DeploymentStatusCreatedAction,
@@ -6104,8 +6544,12 @@ pub struct DeploymentStatusCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DeploymentStatusCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -6138,7 +6582,7 @@ impl std::convert::TryFrom<&String> for DeploymentStatusCreatedAction {
     }
 }
 #[doc = "The [deployment](https://docs.github.com/en/rest/reference/repos#list-deployments) that this status is associated with."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeployment {
     pub created_at: String,
@@ -6159,11 +6603,11 @@ pub struct DeploymentStatusCreatedDeployment {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentPayload {}
 #[doc = "The [deployment status](https://docs.github.com/en/rest/reference/repos#list-deployment-statuses)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentStatus {
     pub created_at: String,
@@ -6184,9 +6628,11 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum DeploymentStatusEvent {
+    #[educe(Default)]
     #[doc = "deployment_status created event"]
     #[serde(rename = "created")]
     Created {
@@ -6200,7 +6646,7 @@ pub enum DeploymentStatusEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Discussion {
     pub active_lock_reason: Option<String>,
@@ -6223,7 +6669,7 @@ pub struct Discussion {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnswered {
     pub action: DiscussionAnsweredAction,
@@ -6236,8 +6682,12 @@ pub struct DiscussionAnswered {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionAnsweredAction {
+    #[educe(Default)]
     #[serde(rename = "answered")]
     Answered,
 }
@@ -6269,7 +6719,7 @@ impl std::convert::TryFrom<&String> for DiscussionAnsweredAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredAnswer {
     pub author_association: AuthorAssociation,
@@ -6285,7 +6735,7 @@ pub struct DiscussionAnsweredAnswer {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -6298,7 +6748,7 @@ pub struct DiscussionCategory {
     pub slug: String,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChanged {
     pub action: DiscussionCategoryChangedAction,
@@ -6311,8 +6761,12 @@ pub struct DiscussionCategoryChanged {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionCategoryChangedAction {
+    #[educe(Default)]
     #[serde(rename = "category_changed")]
     CategoryChanged,
 }
@@ -6344,17 +6798,17 @@ impl std::convert::TryFrom<&String> for DiscussionCategoryChangedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChanges {
     pub category: DiscussionCategoryChangedChangesCategory,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChangesCategory {
     pub from: DiscussionCategoryChangedChangesCategoryFrom,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChangesCategoryFrom {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -6367,7 +6821,7 @@ pub struct DiscussionCategoryChangedChangesCategoryFrom {
     pub slug: String,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentCreated {
     pub action: DiscussionCommentCreatedAction,
@@ -6379,8 +6833,12 @@ pub struct DiscussionCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionCommentCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -6412,7 +6870,7 @@ impl std::convert::TryFrom<&String> for DiscussionCommentCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentCreatedComment {
     pub author_association: AuthorAssociation,
@@ -6428,7 +6886,7 @@ pub struct DiscussionCommentCreatedComment {
     pub updated_at: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentDeleted {
     pub action: DiscussionCommentDeletedAction,
@@ -6440,8 +6898,12 @@ pub struct DiscussionCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionCommentDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -6473,7 +6935,7 @@ impl std::convert::TryFrom<&String> for DiscussionCommentDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentDeletedComment {
     pub author_association: AuthorAssociation,
@@ -6489,7 +6951,7 @@ pub struct DiscussionCommentDeletedComment {
     pub updated_at: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEdited {
     pub action: DiscussionCommentEditedAction,
@@ -6502,8 +6964,12 @@ pub struct DiscussionCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionCommentEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -6535,17 +7001,17 @@ impl std::convert::TryFrom<&String> for DiscussionCommentEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedChanges {
     pub body: DiscussionCommentEditedChangesBody,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedChangesBody {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedComment {
     pub author_association: AuthorAssociation,
@@ -6561,9 +7027,11 @@ pub struct DiscussionCommentEditedComment {
     pub updated_at: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum DiscussionCommentEvent {
+    #[educe(Default)]
     #[doc = "discussion_comment created event"]
     #[serde(rename = "created")]
     Created {
@@ -6599,7 +7067,7 @@ pub enum DiscussionCommentEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreated {
     pub action: DiscussionCreatedAction,
@@ -6611,8 +7079,12 @@ pub struct DiscussionCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -6644,7 +7116,7 @@ impl std::convert::TryFrom<&String> for DiscussionCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionDeleted {
     pub action: DiscussionDeletedAction,
@@ -6656,8 +7128,12 @@ pub struct DiscussionDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -6689,7 +7165,7 @@ impl std::convert::TryFrom<&String> for DiscussionDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEdited {
     pub action: DiscussionEditedAction,
@@ -6703,8 +7179,12 @@ pub struct DiscussionEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -6736,7 +7216,7 @@ impl std::convert::TryFrom<&String> for DiscussionEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6744,19 +7224,21 @@ pub struct DiscussionEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<DiscussionEditedChangesTitle>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChangesBody {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChangesTitle {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum DiscussionEvent {
+    #[educe(Default)]
     #[doc = "discussion answered event"]
     #[serde(rename = "answered")]
     Answered {
@@ -6909,7 +7391,7 @@ pub enum DiscussionEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLabeled {
     pub action: DiscussionLabeledAction,
@@ -6922,8 +7404,12 @@ pub struct DiscussionLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionLabeledAction {
+    #[educe(Default)]
     #[serde(rename = "labeled")]
     Labeled,
 }
@@ -6955,7 +7441,7 @@ impl std::convert::TryFrom<&String> for DiscussionLabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLocked {
     pub action: DiscussionLockedAction,
@@ -6967,8 +7453,12 @@ pub struct DiscussionLocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionLockedAction {
+    #[educe(Default)]
     #[serde(rename = "locked")]
     Locked,
 }
@@ -7000,7 +7490,7 @@ impl std::convert::TryFrom<&String> for DiscussionLockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionPinned {
     pub action: DiscussionPinnedAction,
@@ -7012,8 +7502,12 @@ pub struct DiscussionPinned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionPinnedAction {
+    #[educe(Default)]
     #[serde(rename = "pinned")]
     Pinned,
 }
@@ -7045,8 +7539,12 @@ impl std::convert::TryFrom<&String> for DiscussionPinnedAction {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "locked")]
@@ -7086,7 +7584,7 @@ impl std::convert::TryFrom<&String> for DiscussionState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionTransferred {
     pub action: DiscussionTransferredAction,
@@ -7099,8 +7597,12 @@ pub struct DiscussionTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionTransferredAction {
+    #[educe(Default)]
     #[serde(rename = "transferred")]
     Transferred,
 }
@@ -7132,13 +7634,13 @@ impl std::convert::TryFrom<&String> for DiscussionTransferredAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionTransferredChanges {
     pub new_discussion: Discussion,
     pub new_repository: Repository,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnanswered {
     pub action: DiscussionUnansweredAction,
@@ -7151,8 +7653,12 @@ pub struct DiscussionUnanswered {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionUnansweredAction {
+    #[educe(Default)]
     #[serde(rename = "unanswered")]
     Unanswered,
 }
@@ -7184,7 +7690,7 @@ impl std::convert::TryFrom<&String> for DiscussionUnansweredAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnansweredOldAnswer {
     pub author_association: AuthorAssociation,
@@ -7200,7 +7706,7 @@ pub struct DiscussionUnansweredOldAnswer {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlabeled {
     pub action: DiscussionUnlabeledAction,
@@ -7213,8 +7719,12 @@ pub struct DiscussionUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionUnlabeledAction {
+    #[educe(Default)]
     #[serde(rename = "unlabeled")]
     Unlabeled,
 }
@@ -7246,7 +7756,7 @@ impl std::convert::TryFrom<&String> for DiscussionUnlabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlocked {
     pub action: DiscussionUnlockedAction,
@@ -7258,8 +7768,12 @@ pub struct DiscussionUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionUnlockedAction {
+    #[educe(Default)]
     #[serde(rename = "unlocked")]
     Unlocked,
 }
@@ -7291,7 +7805,7 @@ impl std::convert::TryFrom<&String> for DiscussionUnlockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnpinned {
     pub action: DiscussionUnpinnedAction,
@@ -7303,8 +7817,12 @@ pub struct DiscussionUnpinned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DiscussionUnpinnedAction {
+    #[educe(Default)]
     #[serde(rename = "unpinned")]
     Unpinned,
 }
@@ -7336,9 +7854,11 @@ impl std::convert::TryFrom<&String> for DiscussionUnpinnedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Everything {
+    #[educe(Default)]
     BranchProtectionRuleEvent(BranchProtectionRuleEvent),
     CheckRunEvent(CheckRunEvent),
     CheckSuiteEvent(CheckSuiteEvent),
@@ -7396,7 +7916,7 @@ pub enum Everything {
     WorkflowRunEvent(WorkflowRunEvent),
 }
 #[doc = "A user forks a repository."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForkEvent {
     #[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
@@ -7408,21 +7928,27 @@ pub struct ForkEvent {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", content = "sender")]
 pub enum GithubAppAuthorizationEvent {
+    #[educe(Default)]
     #[doc = "github_app_authorization revoked event"]
     #[serde(rename = "revoked")]
     Revoked(User),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubAppAuthorizationRevoked {
     pub action: GithubAppAuthorizationRevokedAction,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GithubAppAuthorizationRevokedAction {
+    #[educe(Default)]
     #[serde(rename = "revoked")]
     Revoked,
 }
@@ -7454,7 +7980,7 @@ impl std::convert::TryFrom<&String> for GithubAppAuthorizationRevokedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubOrg {
     pub avatar_url: String,
@@ -7482,7 +8008,7 @@ pub struct GithubOrg {
     pub url: String,
 }
 #[doc = "A wiki page is created or updated."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GollumEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7494,7 +8020,7 @@ pub struct GollumEvent {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GollumEventPagesItem {
     #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
@@ -7510,8 +8036,12 @@ pub struct GollumEventPagesItem {
     pub title: String,
 }
 #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GollumEventPagesItemAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
     #[serde(rename = "edited")]
@@ -7548,7 +8078,7 @@ impl std::convert::TryFrom<&String> for GollumEventPagesItemAction {
     }
 }
 #[doc = "The GitHub App installation."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Installation {
     pub access_tokens_url: String,
@@ -7577,7 +8107,7 @@ pub struct Installation {
     pub target_type: InstallationTargetType,
     pub updated_at: InstallationUpdatedAt,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationCreated {
     pub action: InstallationCreatedAction,
@@ -7589,8 +8119,12 @@ pub struct InstallationCreated {
     pub requester: Option<User>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -7622,9 +8156,11 @@ impl std::convert::TryFrom<&String> for InstallationCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum InstallationCreatedAt {
+    #[educe(Default)]
     Variant0(chrono::DateTime<chrono::offset::Utc>),
     Variant1(i64),
 }
@@ -7636,7 +8172,7 @@ impl ToString for InstallationCreatedAt {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationCreatedRepositoriesItem {
     pub full_name: String,
@@ -7648,7 +8184,7 @@ pub struct InstallationCreatedRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationDeleted {
     pub action: InstallationDeletedAction,
@@ -7660,8 +8196,12 @@ pub struct InstallationDeleted {
     pub requester: (),
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -7693,7 +8233,7 @@ impl std::convert::TryFrom<&String> for InstallationDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationDeletedRepositoriesItem {
     pub full_name: String,
@@ -7705,9 +8245,11 @@ pub struct InstallationDeletedRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum InstallationEvent {
+    #[educe(Default)]
     #[doc = "installation created event"]
     #[serde(rename = "created")]
     Created {
@@ -7764,8 +8306,12 @@ pub enum InstallationEvent {
         sender: User,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationEventsItem {
+    #[educe(Default)]
     #[serde(rename = "check_run")]
     CheckRun,
     #[serde(rename = "check_suite")]
@@ -7974,14 +8520,14 @@ impl std::convert::TryFrom<&String> for InstallationEventsItem {
     }
 }
 #[doc = "Installation"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationLite {
     #[doc = "The ID of the installation."]
     pub id: i64,
     pub node_id: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationNewPermissionsAccepted {
     pub action: InstallationNewPermissionsAcceptedAction,
@@ -7993,8 +8539,12 @@ pub struct InstallationNewPermissionsAccepted {
     pub requester: (),
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationNewPermissionsAcceptedAction {
+    #[educe(Default)]
     #[serde(rename = "new_permissions_accepted")]
     NewPermissionsAccepted,
 }
@@ -8026,7 +8576,7 @@ impl std::convert::TryFrom<&String> for InstallationNewPermissionsAcceptedAction
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
     pub full_name: String,
@@ -8038,7 +8588,7 @@ pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8113,8 +8663,12 @@ pub struct InstallationPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflows: Option<InstallationPermissionsWorkflows>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsActions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8150,8 +8704,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsActions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsAdministration {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8187,8 +8745,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsAdministration {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsChecks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8224,8 +8786,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsChecks {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsContentReferences {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8261,8 +8827,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsContentReferences
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsContents {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8298,8 +8868,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsContents {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsDeployments {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8335,8 +8909,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsDeployments {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsDiscussions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8372,8 +8950,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsDiscussions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsEmails {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8409,8 +8991,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsEmails {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsEnvironments {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8446,8 +9032,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsEnvironments {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsIssues {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8483,8 +9073,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsIssues {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsMembers {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8520,8 +9114,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsMembers {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsMetadata {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8557,8 +9155,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsMetadata {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationAdministration {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8594,8 +9196,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationAdmin
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationEvents {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8631,8 +9237,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationEvent
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationHooks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8668,8 +9278,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationHooks
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationPackages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8705,8 +9319,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPacka
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationPlan {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8742,8 +9360,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPlan 
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationProjects {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8779,8 +9401,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationProje
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationSecrets {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8816,8 +9442,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSecre
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationSelfHostedRunners {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8853,8 +9483,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSelfH
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsOrganizationUserBlocking {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8890,8 +9524,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationUserB
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsPackages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8927,8 +9565,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsPackages {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsPages {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -8964,8 +9606,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsPages {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsPullRequests {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9001,8 +9647,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsPullRequests {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsRepositoryHooks {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9038,8 +9688,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryHooks {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsRepositoryProjects {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9075,8 +9729,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryProject
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsSecretScanningAlerts {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9112,8 +9770,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsSecretScanningAle
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsSecrets {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9149,8 +9811,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsSecrets {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsSecurityEvents {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9186,8 +9852,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityEvents {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsSecurityScanningAlert {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9223,8 +9893,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityScanningA
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsSingleFile {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9260,8 +9934,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsSingleFile {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsStatuses {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9297,8 +9975,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsStatuses {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsTeamDiscussions {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9334,8 +10016,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsTeamDiscussions {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsVulnerabilityAlerts {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9371,8 +10057,12 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsVulnerabilityAler
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationPermissionsWorkflows {
+    #[educe(Default)]
     #[serde(rename = "read")]
     Read,
     #[serde(rename = "write")]
@@ -9408,7 +10098,7 @@ impl std::convert::TryFrom<&String> for InstallationPermissionsWorkflows {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAdded {
     pub action: InstallationRepositoriesAddedAction,
@@ -9422,8 +10112,12 @@ pub struct InstallationRepositoriesAdded {
     pub requester: Option<User>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationRepositoriesAddedAction {
+    #[educe(Default)]
     #[serde(rename = "added")]
     Added,
 }
@@ -9455,7 +10149,7 @@ impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
     pub full_name: String,
@@ -9467,7 +10161,7 @@ pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9485,8 +10179,12 @@ pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     pub private: Option<bool>,
 }
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationRepositoriesAddedRepositorySelection {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "selected")]
@@ -9522,9 +10220,11 @@ impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedRepositoryS
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum InstallationRepositoriesEvent {
+    #[educe(Default)]
     #[doc = "installation_repositories added event"]
     #[serde(rename = "added")]
     Added {
@@ -9552,7 +10252,7 @@ pub enum InstallationRepositoriesEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemoved {
     pub action: InstallationRepositoriesRemovedAction,
@@ -9566,8 +10266,12 @@ pub struct InstallationRepositoriesRemoved {
     pub requester: Option<User>,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationRepositoriesRemovedAction {
+    #[educe(Default)]
     #[serde(rename = "removed")]
     Removed,
 }
@@ -9599,7 +10303,7 @@ impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemovedRepositoriesAddedItem {
     pub full_name: String,
@@ -9611,7 +10315,7 @@ pub struct InstallationRepositoriesRemovedRepositoriesAddedItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemovedRepositoriesRemovedItem {
     pub full_name: String,
@@ -9624,8 +10328,12 @@ pub struct InstallationRepositoriesRemovedRepositoriesRemovedItem {
     pub private: bool,
 }
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationRepositoriesRemovedRepositorySelection {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "selected")]
@@ -9662,8 +10370,12 @@ impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedRepositor
     }
 }
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationRepositorySelection {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "selected")]
@@ -9699,7 +10411,7 @@ impl std::convert::TryFrom<&String> for InstallationRepositorySelection {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspend {
     pub action: InstallationSuspendAction,
@@ -9711,8 +10423,12 @@ pub struct InstallationSuspend {
     pub requester: (),
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationSuspendAction {
+    #[educe(Default)]
     #[serde(rename = "suspend")]
     Suspend,
 }
@@ -9744,7 +10460,7 @@ impl std::convert::TryFrom<&String> for InstallationSuspendAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendRepositoriesItem {
     pub full_name: String,
@@ -9756,8 +10472,12 @@ pub struct InstallationSuspendRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationTargetType {
+    #[educe(Default)]
     User,
     Organization,
 }
@@ -9791,7 +10511,7 @@ impl std::convert::TryFrom<&String> for InstallationTargetType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspend {
     pub action: InstallationUnsuspendAction,
@@ -9803,8 +10523,12 @@ pub struct InstallationUnsuspend {
     pub requester: (),
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum InstallationUnsuspendAction {
+    #[educe(Default)]
     #[serde(rename = "unsuspend")]
     Unsuspend,
 }
@@ -9836,7 +10560,7 @@ impl std::convert::TryFrom<&String> for InstallationUnsuspendAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendRepositoriesItem {
     pub full_name: String,
@@ -9848,9 +10572,11 @@ pub struct InstallationUnsuspendRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum InstallationUpdatedAt {
+    #[educe(Default)]
     Variant0(chrono::DateTime<chrono::offset::Utc>),
     Variant1(i64),
 }
@@ -9863,7 +10589,7 @@ impl ToString for InstallationUpdatedAt {
     }
 }
 #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Issue {
     pub active_lock_reason: Option<IssueActiveLockReason>,
@@ -9903,8 +10629,12 @@ pub struct Issue {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssueActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -9949,7 +10679,7 @@ impl std::convert::TryFrom<&String> for IssueActiveLockReason {
     }
 }
 #[doc = "The [comment](https://docs.github.com/en/rest/reference/issues#comments) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueComment {
     pub author_association: AuthorAssociation,
@@ -9967,7 +10697,7 @@ pub struct IssueComment {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreated {
     pub action: IssueCommentCreatedAction,
@@ -9981,8 +10711,12 @@ pub struct IssueCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssueCommentCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -10014,7 +10748,7 @@ impl std::convert::TryFrom<&String> for IssueCommentCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeleted {
     pub action: IssueCommentDeletedAction,
@@ -10028,8 +10762,12 @@ pub struct IssueCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssueCommentDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -10061,7 +10799,7 @@ impl std::convert::TryFrom<&String> for IssueCommentDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEdited {
     pub action: IssueCommentEditedAction,
@@ -10076,8 +10814,12 @@ pub struct IssueCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssueCommentEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -10110,21 +10852,23 @@ impl std::convert::TryFrom<&String> for IssueCommentEditedAction {
     }
 }
 #[doc = "The changes to the comment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<IssueCommentEditedChangesBody>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum IssueCommentEvent {
+    #[educe(Default)]
     #[doc = "issue_comment created event"]
     #[serde(rename = "created")]
     Created {
@@ -10166,7 +10910,7 @@ pub enum IssueCommentEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -10179,8 +10923,12 @@ pub struct IssuePullRequest {
     pub url: Option<String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssueState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -10217,7 +10965,7 @@ impl std::convert::TryFrom<&String> for IssueState {
     }
 }
 #[doc = "Activity related to an issue. The type of activity is specified in the action property."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesAssigned {
     #[doc = "The action that was performed."]
@@ -10234,8 +10982,12 @@ pub struct IssuesAssigned {
     pub sender: User,
 }
 #[doc = "The action that was performed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesAssignedAction {
+    #[educe(Default)]
     #[serde(rename = "assigned")]
     Assigned,
 }
@@ -10267,7 +11019,7 @@ impl std::convert::TryFrom<&String> for IssuesAssignedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosed {
     #[doc = "The action that was performed."]
@@ -10282,8 +11034,12 @@ pub struct IssuesClosed {
     pub sender: User,
 }
 #[doc = "The action that was performed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesClosedAction {
+    #[educe(Default)]
     #[serde(rename = "closed")]
     Closed,
 }
@@ -10315,7 +11071,7 @@ impl std::convert::TryFrom<&String> for IssuesClosedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDeleted {
     pub action: IssuesDeletedAction,
@@ -10327,8 +11083,12 @@ pub struct IssuesDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -10360,7 +11120,7 @@ impl std::convert::TryFrom<&String> for IssuesDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestoned {
     pub action: IssuesDemilestonedAction,
@@ -10373,8 +11133,12 @@ pub struct IssuesDemilestoned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesDemilestonedAction {
+    #[educe(Default)]
     #[serde(rename = "demilestoned")]
     Demilestoned,
 }
@@ -10406,7 +11170,7 @@ impl std::convert::TryFrom<&String> for IssuesDemilestonedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEdited {
     pub action: IssuesEditedAction,
@@ -10421,8 +11185,12 @@ pub struct IssuesEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -10455,7 +11223,7 @@ impl std::convert::TryFrom<&String> for IssuesEditedAction {
     }
 }
 #[doc = "The changes to the issue."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -10463,21 +11231,23 @@ pub struct IssuesEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<IssuesEditedChangesTitle>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChangesTitle {
     #[doc = "The previous version of the title."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum IssuesEvent {
+    #[educe(Default)]
     #[doc = "issues assigned event\n\nActivity related to an issue. The type of activity is specified in the action property."]
     #[serde(rename = "assigned")]
     Assigned {
@@ -10676,7 +11446,7 @@ pub enum IssuesEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLabeled {
     pub action: IssuesLabeledAction,
@@ -10691,8 +11461,12 @@ pub struct IssuesLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesLabeledAction {
+    #[educe(Default)]
     #[serde(rename = "labeled")]
     Labeled,
 }
@@ -10724,7 +11498,7 @@ impl std::convert::TryFrom<&String> for IssuesLabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLocked {
     pub action: IssuesLockedAction,
@@ -10736,8 +11510,12 @@ pub struct IssuesLocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesLockedAction {
+    #[educe(Default)]
     #[serde(rename = "locked")]
     Locked,
 }
@@ -10769,7 +11547,7 @@ impl std::convert::TryFrom<&String> for IssuesLockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestoned {
     pub action: IssuesMilestonedAction,
@@ -10782,8 +11560,12 @@ pub struct IssuesMilestoned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesMilestonedAction {
+    #[educe(Default)]
     #[serde(rename = "milestoned")]
     Milestoned,
 }
@@ -10815,7 +11597,7 @@ impl std::convert::TryFrom<&String> for IssuesMilestonedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpened {
     pub action: IssuesOpenedAction,
@@ -10829,8 +11611,12 @@ pub struct IssuesOpened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesOpenedAction {
+    #[educe(Default)]
     #[serde(rename = "opened")]
     Opened,
 }
@@ -10862,13 +11648,13 @@ impl std::convert::TryFrom<&String> for IssuesOpenedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedChanges {
     pub old_issue: Issue,
     pub old_repository: Repository,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesPinned {
     pub action: IssuesPinnedAction,
@@ -10880,8 +11666,12 @@ pub struct IssuesPinned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesPinnedAction {
+    #[educe(Default)]
     #[serde(rename = "pinned")]
     Pinned,
 }
@@ -10913,7 +11703,7 @@ impl std::convert::TryFrom<&String> for IssuesPinnedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopened {
     pub action: IssuesReopenedAction,
@@ -10925,8 +11715,12 @@ pub struct IssuesReopened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesReopenedAction {
+    #[educe(Default)]
     #[serde(rename = "reopened")]
     Reopened,
 }
@@ -10958,7 +11752,7 @@ impl std::convert::TryFrom<&String> for IssuesReopenedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesTransferred {
     pub action: IssuesTransferredAction,
@@ -10971,8 +11765,12 @@ pub struct IssuesTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesTransferredAction {
+    #[educe(Default)]
     #[serde(rename = "transferred")]
     Transferred,
 }
@@ -11004,13 +11802,13 @@ impl std::convert::TryFrom<&String> for IssuesTransferredAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesTransferredChanges {
     pub new_issue: Issue,
     pub new_repository: Repository,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnassigned {
     #[doc = "The action that was performed."]
@@ -11027,8 +11825,12 @@ pub struct IssuesUnassigned {
     pub sender: User,
 }
 #[doc = "The action that was performed."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesUnassignedAction {
+    #[educe(Default)]
     #[serde(rename = "unassigned")]
     Unassigned,
 }
@@ -11060,7 +11862,7 @@ impl std::convert::TryFrom<&String> for IssuesUnassignedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlabeled {
     pub action: IssuesUnlabeledAction,
@@ -11075,8 +11877,12 @@ pub struct IssuesUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesUnlabeledAction {
+    #[educe(Default)]
     #[serde(rename = "unlabeled")]
     Unlabeled,
 }
@@ -11108,7 +11914,7 @@ impl std::convert::TryFrom<&String> for IssuesUnlabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlocked {
     pub action: IssuesUnlockedAction,
@@ -11120,8 +11926,12 @@ pub struct IssuesUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesUnlockedAction {
+    #[educe(Default)]
     #[serde(rename = "unlocked")]
     Unlocked,
 }
@@ -11153,7 +11963,7 @@ impl std::convert::TryFrom<&String> for IssuesUnlockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnpinned {
     pub action: IssuesUnpinnedAction,
@@ -11165,8 +11975,12 @@ pub struct IssuesUnpinned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IssuesUnpinnedAction {
+    #[educe(Default)]
     #[serde(rename = "unpinned")]
     Unpinned,
 }
@@ -11198,7 +12012,7 @@ impl std::convert::TryFrom<&String> for IssuesUnpinnedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Label {
     #[doc = "6-character hex code, without the leading #, identifying the color"]
@@ -11212,7 +12026,7 @@ pub struct Label {
     #[doc = "URL for the label"]
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelCreated {
     pub action: LabelCreatedAction,
@@ -11225,8 +12039,12 @@ pub struct LabelCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LabelCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -11258,7 +12076,7 @@ impl std::convert::TryFrom<&String> for LabelCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelDeleted {
     pub action: LabelDeletedAction,
@@ -11271,8 +12089,12 @@ pub struct LabelDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LabelDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -11304,7 +12126,7 @@ impl std::convert::TryFrom<&String> for LabelDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEdited {
     pub action: LabelEditedAction,
@@ -11319,8 +12141,12 @@ pub struct LabelEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LabelEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -11353,7 +12179,7 @@ impl std::convert::TryFrom<&String> for LabelEditedAction {
     }
 }
 #[doc = "The changes to the label if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11363,27 +12189,29 @@ pub struct LabelEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<LabelEditedChangesName>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesColor {
     #[doc = "The previous version of the color if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum LabelEvent {
+    #[educe(Default)]
     #[doc = "label created event"]
     #[serde(rename = "created")]
     Created {
@@ -11423,7 +12251,7 @@ pub enum LabelEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct License {
     pub key: String,
@@ -11432,12 +12260,12 @@ pub struct License {
     pub spdx_id: String,
     pub url: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Link {
     pub href: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchase {
     pub account: MarketplacePurchaseAccount,
@@ -11449,7 +12277,7 @@ pub struct MarketplacePurchase {
     pub plan: MarketplacePurchasePlan,
     pub unit_count: i64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseAccount {
     pub id: i64,
@@ -11459,7 +12287,7 @@ pub struct MarketplacePurchaseAccount {
     #[serde(rename = "type")]
     pub type_: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelled {
     pub action: MarketplacePurchaseCancelledAction,
@@ -11469,8 +12297,12 @@ pub struct MarketplacePurchaseCancelled {
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseCancelledSender,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarketplacePurchaseCancelledAction {
+    #[educe(Default)]
     #[serde(rename = "cancelled")]
     Cancelled,
 }
@@ -11502,7 +12334,7 @@ impl std::convert::TryFrom<&String> for MarketplacePurchaseCancelledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledSender {
     pub avatar_url: String,
@@ -11525,7 +12357,7 @@ pub struct MarketplacePurchaseCancelledSender {
     pub type_: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChanged {
     pub action: MarketplacePurchaseChangedAction,
@@ -11535,8 +12367,12 @@ pub struct MarketplacePurchaseChanged {
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseChangedSender,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarketplacePurchaseChangedAction {
+    #[educe(Default)]
     #[serde(rename = "changed")]
     Changed,
 }
@@ -11568,7 +12404,7 @@ impl std::convert::TryFrom<&String> for MarketplacePurchaseChangedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChangedSender {
     pub avatar_url: String,
@@ -11591,9 +12427,11 @@ pub struct MarketplacePurchaseChangedSender {
     pub type_: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum MarketplacePurchaseEvent {
+    #[educe(Default)]
     #[doc = "marketplace_purchase cancelled event"]
     #[serde(rename = "cancelled")]
     Cancelled {
@@ -11640,7 +12478,7 @@ pub enum MarketplacePurchaseEvent {
         sender: MarketplacePurchasePurchasedSender,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChange {
     pub action: MarketplacePurchasePendingChangeAction,
@@ -11650,8 +12488,12 @@ pub struct MarketplacePurchasePendingChange {
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeSender,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarketplacePurchasePendingChangeAction {
+    #[educe(Default)]
     #[serde(rename = "pending_change")]
     PendingChange,
 }
@@ -11683,7 +12525,7 @@ impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelled {
     pub action: MarketplacePurchasePendingChangeCancelledAction,
@@ -11693,8 +12535,12 @@ pub struct MarketplacePurchasePendingChangeCancelled {
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeCancelledSender,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarketplacePurchasePendingChangeCancelledAction {
+    #[educe(Default)]
     #[serde(rename = "pending_change_cancelled")]
     PendingChangeCancelled,
 }
@@ -11726,7 +12572,7 @@ impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeCancelle
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub avatar_url: String,
@@ -11749,7 +12595,7 @@ pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub type_: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeSender {
     pub avatar_url: String,
@@ -11772,7 +12618,7 @@ pub struct MarketplacePurchasePendingChangeSender {
     pub type_: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -11785,7 +12631,7 @@ pub struct MarketplacePurchasePlan {
     pub unit_name: Option<String>,
     pub yearly_price_in_cents: i64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchased {
     pub action: MarketplacePurchasePurchasedAction,
@@ -11795,8 +12641,12 @@ pub struct MarketplacePurchasePurchased {
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePurchasedSender,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarketplacePurchasePurchasedAction {
+    #[educe(Default)]
     #[serde(rename = "purchased")]
     Purchased,
 }
@@ -11828,7 +12678,7 @@ impl std::convert::TryFrom<&String> for MarketplacePurchasePurchasedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedSender {
     pub avatar_url: String,
@@ -11852,7 +12702,7 @@ pub struct MarketplacePurchasePurchasedSender {
     pub url: String,
 }
 #[doc = "Activity related to repository collaborators. The type of activity is specified in the action property."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAdded {
     pub action: MemberAddedAction,
@@ -11865,8 +12715,12 @@ pub struct MemberAdded {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MemberAddedAction {
+    #[educe(Default)]
     #[serde(rename = "added")]
     Added,
 }
@@ -11898,19 +12752,23 @@ impl std::convert::TryFrom<&String> for MemberAddedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission: Option<MemberAddedChangesPermission>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChangesPermission {
     pub to: MemberAddedChangesPermissionTo,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MemberAddedChangesPermissionTo {
+    #[educe(Default)]
     #[serde(rename = "write")]
     Write,
     #[serde(rename = "admin")]
@@ -11946,7 +12804,7 @@ impl std::convert::TryFrom<&String> for MemberAddedChangesPermissionTo {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEdited {
     pub action: MemberEditedAction,
@@ -11958,8 +12816,12 @@ pub struct MemberEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MemberEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -11992,20 +12854,22 @@ impl std::convert::TryFrom<&String> for MemberEditedAction {
     }
 }
 #[doc = "The changes to the collaborator permissions"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEditedChanges {
     pub old_permission: MemberEditedChangesOldPermission,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEditedChangesOldPermission {
     #[doc = "The previous permissions of the collaborator if the action was edited."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum MemberEvent {
+    #[educe(Default)]
     #[doc = "member added event\n\nActivity related to repository collaborators. The type of activity is specified in the action property."]
     #[serde(rename = "added")]
     Added {
@@ -12040,7 +12904,7 @@ pub enum MemberEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberRemoved {
     pub action: MemberRemovedAction,
@@ -12051,8 +12915,12 @@ pub struct MemberRemoved {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MemberRemovedAction {
+    #[educe(Default)]
     #[serde(rename = "removed")]
     Removed,
 }
@@ -12085,7 +12953,7 @@ impl std::convert::TryFrom<&String> for MemberRemovedAction {
     }
 }
 #[doc = "The membership between the user and the organization. Not present when the action is `member_invited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Membership {
     pub organization_url: String,
@@ -12094,7 +12962,7 @@ pub struct Membership {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MembershipAdded {
     pub action: MembershipAddedAction,
@@ -12109,8 +12977,12 @@ pub struct MembershipAdded {
     #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MembershipAddedAction {
+    #[educe(Default)]
     #[serde(rename = "added")]
     Added,
 }
@@ -12143,8 +13015,12 @@ impl std::convert::TryFrom<&String> for MembershipAddedAction {
     }
 }
 #[doc = "The scope of the membership. Currently, can only be `team`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MembershipAddedScope {
+    #[educe(Default)]
     #[serde(rename = "team")]
     Team,
 }
@@ -12176,9 +13052,11 @@ impl std::convert::TryFrom<&String> for MembershipAddedScope {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum MembershipEvent {
+    #[educe(Default)]
     #[doc = "membership added event"]
     #[serde(rename = "added")]
     Added {
@@ -12208,7 +13086,7 @@ pub enum MembershipEvent {
         team: MembershipRemovedTeam,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MembershipRemoved {
     pub action: MembershipRemovedAction,
@@ -12223,8 +13101,12 @@ pub struct MembershipRemoved {
     #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
     pub team: MembershipRemovedTeam,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MembershipRemovedAction {
+    #[educe(Default)]
     #[serde(rename = "removed")]
     Removed,
 }
@@ -12257,8 +13139,12 @@ impl std::convert::TryFrom<&String> for MembershipRemovedAction {
     }
 }
 #[doc = "The scope of the membership. Currently, can only be `team`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MembershipRemovedScope {
+    #[educe(Default)]
     #[serde(rename = "team")]
     Team,
     #[serde(rename = "organization")]
@@ -12295,9 +13181,11 @@ impl std::convert::TryFrom<&String> for MembershipRemovedScope {
     }
 }
 #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum MembershipRemovedTeam {
+    #[educe(Default)]
     Variant0(Team),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12306,7 +13194,7 @@ pub enum MembershipRemovedTeam {
         name: String,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeleted {
     pub action: MetaDeletedAction,
@@ -12316,8 +13204,12 @@ pub struct MetaDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MetaDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -12350,7 +13242,7 @@ impl std::convert::TryFrom<&String> for MetaDeletedAction {
     }
 }
 #[doc = "The modified webhook. This will contain different keys based on the type of webhook it is: repository, organization, business, app, or GitHub Marketplace."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeletedHook {
     pub active: bool,
@@ -12363,15 +13255,19 @@ pub struct MetaDeletedHook {
     pub type_: String,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeletedHookConfig {
     pub content_type: MetaDeletedHookConfigContentType,
     pub insecure_ssl: String,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MetaDeletedHookConfigContentType {
+    #[educe(Default)]
     #[serde(rename = "json")]
     Json,
     #[serde(rename = "form")]
@@ -12407,9 +13303,11 @@ impl std::convert::TryFrom<&String> for MetaDeletedHookConfigContentType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum MetaEvent {
+    #[educe(Default)]
     #[doc = "meta deleted event"]
     #[serde(rename = "deleted")]
     Deleted {
@@ -12421,7 +13319,7 @@ pub enum MetaEvent {
     },
 }
 #[doc = "A collection of related issues and pull requests."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Milestone {
     pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
@@ -12444,7 +13342,7 @@ pub struct Milestone {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneClosed {
     pub action: MilestoneClosedAction,
@@ -12456,8 +13354,12 @@ pub struct MilestoneClosed {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneClosedAction {
+    #[educe(Default)]
     #[serde(rename = "closed")]
     Closed,
 }
@@ -12489,7 +13391,7 @@ impl std::convert::TryFrom<&String> for MilestoneClosedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneCreated {
     pub action: MilestoneCreatedAction,
@@ -12501,8 +13403,12 @@ pub struct MilestoneCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -12534,7 +13440,7 @@ impl std::convert::TryFrom<&String> for MilestoneCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneDeleted {
     pub action: MilestoneDeletedAction,
@@ -12546,8 +13452,12 @@ pub struct MilestoneDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -12579,7 +13489,7 @@ impl std::convert::TryFrom<&String> for MilestoneDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEdited {
     pub action: MilestoneEditedAction,
@@ -12592,8 +13502,12 @@ pub struct MilestoneEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -12626,7 +13540,7 @@ impl std::convert::TryFrom<&String> for MilestoneEditedAction {
     }
 }
 #[doc = "The changes to the milestone if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12636,27 +13550,29 @@ pub struct MilestoneEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<MilestoneEditedChangesTitle>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesDueOn {
     #[doc = "The previous version of the due date if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum MilestoneEvent {
+    #[educe(Default)]
     #[doc = "milestone closed event"]
     #[serde(rename = "closed")]
     Closed {
@@ -12714,7 +13630,7 @@ pub enum MilestoneEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneOpened {
     pub action: MilestoneOpenedAction,
@@ -12726,8 +13642,12 @@ pub struct MilestoneOpened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneOpenedAction {
+    #[educe(Default)]
     #[serde(rename = "opened")]
     Opened,
 }
@@ -12760,8 +13680,12 @@ impl std::convert::TryFrom<&String> for MilestoneOpenedAction {
     }
 }
 #[doc = "The state of the milestone."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MilestoneState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -12797,7 +13721,7 @@ impl std::convert::TryFrom<&String> for MilestoneState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrgBlockBlocked {
     pub action: OrgBlockBlockedAction,
@@ -12808,8 +13732,12 @@ pub struct OrgBlockBlocked {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrgBlockBlockedAction {
+    #[educe(Default)]
     #[serde(rename = "blocked")]
     Blocked,
 }
@@ -12841,9 +13769,11 @@ impl std::convert::TryFrom<&String> for OrgBlockBlockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum OrgBlockEvent {
+    #[educe(Default)]
     #[doc = "org_block blocked event"]
     #[serde(rename = "blocked")]
     Blocked {
@@ -12865,7 +13795,7 @@ pub enum OrgBlockEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrgBlockUnblocked {
     pub action: OrgBlockUnblockedAction,
@@ -12876,8 +13806,12 @@ pub struct OrgBlockUnblocked {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrgBlockUnblockedAction {
+    #[educe(Default)]
     #[serde(rename = "unblocked")]
     Unblocked,
 }
@@ -12909,7 +13843,7 @@ impl std::convert::TryFrom<&String> for OrgBlockUnblockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Organization {
     pub avatar_url: String,
@@ -12927,7 +13861,7 @@ pub struct Organization {
     pub repos_url: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationDeleted {
     pub action: OrganizationDeletedAction,
@@ -12937,8 +13871,12 @@ pub struct OrganizationDeleted {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrganizationDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -12970,9 +13908,11 @@ impl std::convert::TryFrom<&String> for OrganizationDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum OrganizationEvent {
+    #[educe(Default)]
     #[doc = "organization deleted event"]
     #[serde(rename = "deleted")]
     Deleted {
@@ -13020,7 +13960,7 @@ pub enum OrganizationEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberAdded {
     pub action: OrganizationMemberAddedAction,
@@ -13030,8 +13970,12 @@ pub struct OrganizationMemberAdded {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrganizationMemberAddedAction {
+    #[educe(Default)]
     #[serde(rename = "member_added")]
     MemberAdded,
 }
@@ -13063,7 +14007,7 @@ impl std::convert::TryFrom<&String> for OrganizationMemberAddedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvited {
     pub action: OrganizationMemberInvitedAction,
@@ -13074,8 +14018,12 @@ pub struct OrganizationMemberInvited {
     pub sender: User,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrganizationMemberInvitedAction {
+    #[educe(Default)]
     #[serde(rename = "member_invited")]
     MemberInvited,
 }
@@ -13108,7 +14056,7 @@ impl std::convert::TryFrom<&String> for OrganizationMemberInvitedAction {
     }
 }
 #[doc = "The invitation for the user or email if the action is `member_invited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvitedInvitation {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -13123,7 +14071,7 @@ pub struct OrganizationMemberInvitedInvitation {
     pub role: String,
     pub team_count: f64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberRemoved {
     pub action: OrganizationMemberRemovedAction,
@@ -13133,8 +14081,12 @@ pub struct OrganizationMemberRemoved {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrganizationMemberRemovedAction {
+    #[educe(Default)]
     #[serde(rename = "member_removed")]
     MemberRemoved,
 }
@@ -13166,7 +14118,7 @@ impl std::convert::TryFrom<&String> for OrganizationMemberRemovedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationRenamed {
     pub action: OrganizationRenamedAction,
@@ -13176,8 +14128,12 @@ pub struct OrganizationRenamed {
     pub organization: Organization,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrganizationRenamedAction {
+    #[educe(Default)]
     #[serde(rename = "renamed")]
     Renamed,
 }
@@ -13209,9 +14165,11 @@ impl std::convert::TryFrom<&String> for OrganizationRenamedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum PackageEvent {
+    #[educe(Default)]
     #[doc = "package published event"]
     #[serde(rename = "published")]
     Published {
@@ -13231,7 +14189,7 @@ pub enum PackageEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublished {
     pub action: PackagePublishedAction,
@@ -13241,8 +14199,12 @@ pub struct PackagePublished {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PackagePublishedAction {
+    #[educe(Default)]
     #[serde(rename = "published")]
     Published,
 }
@@ -13275,7 +14237,7 @@ impl std::convert::TryFrom<&String> for PackagePublishedAction {
     }
 }
 #[doc = "Information about the package."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackage {
     pub created_at: String,
@@ -13291,7 +14253,7 @@ pub struct PackagePublishedPackage {
     pub registry: PackagePublishedPackageRegistry,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersion {
     pub author: User,
@@ -13318,7 +14280,7 @@ pub struct PackagePublishedPackagePackageVersion {
     pub updated_at: String,
     pub version: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersionPackageFilesItem {
     pub content_type: String,
@@ -13333,7 +14295,7 @@ pub struct PackagePublishedPackagePackageVersionPackageFilesItem {
     pub state: String,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersionRelease {
     pub author: User,
@@ -13348,7 +14310,7 @@ pub struct PackagePublishedPackagePackageVersionRelease {
     pub target_commitish: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackageRegistry {
     pub about_url: String,
@@ -13358,7 +14320,7 @@ pub struct PackagePublishedPackageRegistry {
     pub url: String,
     pub vendor: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdated {
     pub action: PackageUpdatedAction,
@@ -13368,8 +14330,12 @@ pub struct PackageUpdated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PackageUpdatedAction {
+    #[educe(Default)]
     #[serde(rename = "updated")]
     Updated,
 }
@@ -13402,7 +14368,7 @@ impl std::convert::TryFrom<&String> for PackageUpdatedAction {
     }
 }
 #[doc = "Information about the package."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackage {
     pub created_at: String,
@@ -13418,7 +14384,7 @@ pub struct PackageUpdatedPackage {
     pub registry: PackageUpdatedPackageRegistry,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersion {
     pub author: User,
@@ -13445,7 +14411,7 @@ pub struct PackageUpdatedPackagePackageVersion {
     pub updated_at: String,
     pub version: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub content_type: String,
@@ -13460,7 +14426,7 @@ pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub state: String,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersionRelease {
     pub author: User,
@@ -13475,7 +14441,7 @@ pub struct PackageUpdatedPackagePackageVersionRelease {
     pub target_commitish: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackageRegistry {
     pub about_url: String,
@@ -13486,7 +14452,7 @@ pub struct PackageUpdatedPackageRegistry {
     pub vendor: String,
 }
 #[doc = "Page Build"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEvent {
     pub build: PageBuildEventBuild,
@@ -13499,7 +14465,7 @@ pub struct PageBuildEvent {
     pub sender: User,
 }
 #[doc = "The [List GitHub Pages builds](https://docs.github.com/en/rest/reference/repos#list-github-pages-builds) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuild {
     pub commit: String,
@@ -13511,12 +14477,12 @@ pub struct PageBuildEventBuild {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuildError {
     pub message: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEvent {
     pub hook: PingEventHook,
@@ -13531,7 +14497,7 @@ pub struct PingEvent {
     pub zen: String,
 }
 #[doc = "The [webhook configuration](https://docs.github.com/en/rest/reference/repos#get-a-repository-webhook)."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHook {
     pub active: bool,
@@ -13553,7 +14519,7 @@ pub struct PingEventHook {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHookConfig {
     pub content_type: PingEventHookConfigContentType,
@@ -13562,8 +14528,12 @@ pub struct PingEventHookConfig {
     pub secret: Option<String>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PingEventHookConfigContentType {
+    #[educe(Default)]
     #[serde(rename = "json")]
     Json,
     #[serde(rename = "form")]
@@ -13599,14 +14569,14 @@ impl std::convert::TryFrom<&String> for PingEventHookConfigContentType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHookLastResponse {
     pub code: (),
     pub message: (),
     pub status: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Project {
     #[doc = "Body of the project"]
@@ -13626,7 +14596,7 @@ pub struct Project {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCard {
     #[serde(default)]
@@ -13647,7 +14617,7 @@ pub struct ProjectCard {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConverted {
     pub action: ProjectCardConvertedAction,
@@ -13660,8 +14630,12 @@ pub struct ProjectCardConverted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCardConvertedAction {
+    #[educe(Default)]
     #[serde(rename = "converted")]
     Converted,
 }
@@ -13693,17 +14667,17 @@ impl std::convert::TryFrom<&String> for ProjectCardConvertedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChanges {
     pub note: ProjectCardConvertedChangesNote,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChangesNote {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardCreated {
     pub action: ProjectCardCreatedAction,
@@ -13715,8 +14689,12 @@ pub struct ProjectCardCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCardCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -13748,7 +14726,7 @@ impl std::convert::TryFrom<&String> for ProjectCardCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardDeleted {
     pub action: ProjectCardDeletedAction,
@@ -13760,8 +14738,12 @@ pub struct ProjectCardDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCardDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -13793,7 +14775,7 @@ impl std::convert::TryFrom<&String> for ProjectCardDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEdited {
     pub action: ProjectCardEditedAction,
@@ -13806,8 +14788,12 @@ pub struct ProjectCardEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCardEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -13839,19 +14825,21 @@ impl std::convert::TryFrom<&String> for ProjectCardEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEditedChanges {
     pub note: ProjectCardEditedChangesNote,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEditedChangesNote {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum ProjectCardEvent {
+    #[educe(Default)]
     #[doc = "project_card converted event"]
     #[serde(rename = "converted")]
     Converted {
@@ -13911,7 +14899,7 @@ pub enum ProjectCardEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMoved {
     pub action: ProjectCardMovedAction,
@@ -13924,8 +14912,12 @@ pub struct ProjectCardMoved {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCardMovedAction {
+    #[educe(Default)]
     #[serde(rename = "moved")]
     Moved,
 }
@@ -13957,17 +14949,17 @@ impl std::convert::TryFrom<&String> for ProjectCardMovedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChanges {
     pub column_id: ProjectCardMovedChangesColumnId,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChangesColumnId {
     pub from: i64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectClosed {
     pub action: ProjectClosedAction,
@@ -13979,8 +14971,12 @@ pub struct ProjectClosed {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectClosedAction {
+    #[educe(Default)]
     #[serde(rename = "closed")]
     Closed,
 }
@@ -14012,7 +15008,7 @@ impl std::convert::TryFrom<&String> for ProjectClosedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumn {
     pub cards_url: String,
@@ -14026,7 +15022,7 @@ pub struct ProjectColumn {
     pub updated_at: chrono::DateTime<chrono::offset::Utc>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnCreated {
     pub action: ProjectColumnCreatedAction,
@@ -14038,8 +15034,12 @@ pub struct ProjectColumnCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectColumnCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -14071,7 +15071,7 @@ impl std::convert::TryFrom<&String> for ProjectColumnCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnDeleted {
     pub action: ProjectColumnDeletedAction,
@@ -14083,8 +15083,12 @@ pub struct ProjectColumnDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectColumnDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -14116,7 +15120,7 @@ impl std::convert::TryFrom<&String> for ProjectColumnDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEdited {
     pub action: ProjectColumnEditedAction,
@@ -14129,8 +15133,12 @@ pub struct ProjectColumnEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectColumnEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -14162,20 +15170,22 @@ impl std::convert::TryFrom<&String> for ProjectColumnEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<ProjectColumnEditedChangesName>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChangesName {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum ProjectColumnEvent {
+    #[educe(Default)]
     #[doc = "project_column created event"]
     #[serde(rename = "created")]
     Created {
@@ -14222,7 +15232,7 @@ pub enum ProjectColumnEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnMoved {
     pub action: ProjectColumnMovedAction,
@@ -14234,8 +15244,12 @@ pub struct ProjectColumnMoved {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectColumnMovedAction {
+    #[educe(Default)]
     #[serde(rename = "moved")]
     Moved,
 }
@@ -14267,7 +15281,7 @@ impl std::convert::TryFrom<&String> for ProjectColumnMovedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCreated {
     pub action: ProjectCreatedAction,
@@ -14279,8 +15293,12 @@ pub struct ProjectCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -14312,7 +15330,7 @@ impl std::convert::TryFrom<&String> for ProjectCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectDeleted {
     pub action: ProjectDeletedAction,
@@ -14324,8 +15342,12 @@ pub struct ProjectDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -14357,7 +15379,7 @@ impl std::convert::TryFrom<&String> for ProjectDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEdited {
     pub action: ProjectEditedAction,
@@ -14370,8 +15392,12 @@ pub struct ProjectEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -14404,7 +15430,7 @@ impl std::convert::TryFrom<&String> for ProjectEditedAction {
     }
 }
 #[doc = "The changes to the project if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14412,21 +15438,23 @@ pub struct ProjectEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<ProjectEditedChangesName>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChangesName {
     #[doc = "The changes to the project if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum ProjectEvent {
+    #[educe(Default)]
     #[doc = "project closed event"]
     #[serde(rename = "closed")]
     Closed {
@@ -14484,7 +15512,7 @@ pub enum ProjectEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectReopened {
     pub action: ProjectReopenedAction,
@@ -14496,8 +15524,12 @@ pub struct ProjectReopened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectReopenedAction {
+    #[educe(Default)]
     #[serde(rename = "reopened")]
     Reopened,
 }
@@ -14530,8 +15562,12 @@ impl std::convert::TryFrom<&String> for ProjectReopenedAction {
     }
 }
 #[doc = "State of the project; either 'open' or 'closed'"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -14568,7 +15604,7 @@ impl std::convert::TryFrom<&String> for ProjectState {
     }
 }
 #[doc = "When a private repository is made public."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PublicEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14578,7 +15614,7 @@ pub struct PublicEvent {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequest {
     pub active_lock_reason: Option<PullRequestActiveLockReason>,
@@ -14636,8 +15672,12 @@ pub struct PullRequest {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -14681,7 +15721,7 @@ impl std::convert::TryFrom<&String> for PullRequestActiveLockReason {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAssigned {
     pub action: PullRequestAssignedAction,
@@ -14696,8 +15736,12 @@ pub struct PullRequestAssigned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestAssignedAction {
+    #[educe(Default)]
     #[serde(rename = "assigned")]
     Assigned,
 }
@@ -14729,7 +15773,7 @@ impl std::convert::TryFrom<&String> for PullRequestAssignedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeDisabled {
     pub action: PullRequestAutoMergeDisabledAction,
@@ -14742,8 +15786,12 @@ pub struct PullRequestAutoMergeDisabled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestAutoMergeDisabledAction {
+    #[educe(Default)]
     #[serde(rename = "auto_merge_disabled")]
     AutoMergeDisabled,
 }
@@ -14775,7 +15823,7 @@ impl std::convert::TryFrom<&String> for PullRequestAutoMergeDisabledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeEnabled {
     pub action: PullRequestAutoMergeEnabledAction,
@@ -14788,8 +15836,12 @@ pub struct PullRequestAutoMergeEnabled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestAutoMergeEnabledAction {
+    #[educe(Default)]
     #[serde(rename = "auto_merge_enabled")]
     AutoMergeEnabled,
 }
@@ -14821,7 +15873,7 @@ impl std::convert::TryFrom<&String> for PullRequestAutoMergeEnabledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestBase {
     pub label: String,
@@ -14831,7 +15883,7 @@ pub struct PullRequestBase {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosed {
     pub action: PullRequestClosedAction,
@@ -14845,8 +15897,12 @@ pub struct PullRequestClosed {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestClosedAction {
+    #[educe(Default)]
     #[serde(rename = "closed")]
     Closed,
 }
@@ -14878,7 +15934,7 @@ impl std::convert::TryFrom<&String> for PullRequestClosedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraft {
     pub action: PullRequestConvertedToDraftAction,
@@ -14892,8 +15948,12 @@ pub struct PullRequestConvertedToDraft {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestConvertedToDraftAction {
+    #[educe(Default)]
     #[serde(rename = "converted_to_draft")]
     ConvertedToDraft,
 }
@@ -14925,7 +15985,7 @@ impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEdited {
     pub action: PullRequestEditedAction,
@@ -14940,8 +16000,12 @@ pub struct PullRequestEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -14974,7 +16038,7 @@ impl std::convert::TryFrom<&String> for PullRequestEditedAction {
     }
 }
 #[doc = "The changes to the comment if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14982,21 +16046,23 @@ pub struct PullRequestEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<PullRequestEditedChangesTitle>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PullRequestEvent {
+    #[educe(Default)]
     Assigned(PullRequestAssigned),
     AutoMergeDisabled(PullRequestAutoMergeDisabled),
     AutoMergeEnabled(PullRequestAutoMergeEnabled),
@@ -15015,7 +16081,7 @@ pub enum PullRequestEvent {
     Unlabeled(PullRequestUnlabeled),
     Unlocked(PullRequestUnlocked),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestHead {
     pub label: String,
@@ -15025,7 +16091,7 @@ pub struct PullRequestHead {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLabeled {
     pub action: PullRequestLabeledAction,
@@ -15040,8 +16106,12 @@ pub struct PullRequestLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestLabeledAction {
+    #[educe(Default)]
     #[serde(rename = "labeled")]
     Labeled,
 }
@@ -15073,7 +16143,7 @@ impl std::convert::TryFrom<&String> for PullRequestLabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLinks {
     pub comments: Link,
@@ -15086,7 +16156,7 @@ pub struct PullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLocked {
     pub action: PullRequestLockedAction,
@@ -15100,8 +16170,12 @@ pub struct PullRequestLocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestLockedAction {
+    #[educe(Default)]
     #[serde(rename = "locked")]
     Locked,
 }
@@ -15133,7 +16207,7 @@ impl std::convert::TryFrom<&String> for PullRequestLockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpened {
     pub action: PullRequestOpenedAction,
@@ -15147,8 +16221,12 @@ pub struct PullRequestOpened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestOpenedAction {
+    #[educe(Default)]
     #[serde(rename = "opened")]
     Opened,
 }
@@ -15180,7 +16258,7 @@ impl std::convert::TryFrom<&String> for PullRequestOpenedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReview {
     pub action: PullRequestReadyForReviewAction,
@@ -15194,8 +16272,12 @@ pub struct PullRequestReadyForReview {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReadyForReviewAction {
+    #[educe(Default)]
     #[serde(rename = "ready_for_review")]
     ReadyForReview,
 }
@@ -15227,7 +16309,7 @@ impl std::convert::TryFrom<&String> for PullRequestReadyForReviewAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopened {
     pub action: PullRequestReopenedAction,
@@ -15241,8 +16323,12 @@ pub struct PullRequestReopened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReopenedAction {
+    #[educe(Default)]
     #[serde(rename = "reopened")]
     Reopened,
 }
@@ -15274,14 +16360,16 @@ impl std::convert::TryFrom<&String> for PullRequestReopenedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PullRequestRequestedReviewersItem {
+    #[educe(Default)]
     User(User),
     Team(Team),
 }
 #[doc = "The [comment](https://docs.github.com/en/rest/reference/pulls#comments) itself."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewComment {
     pub author_association: AuthorAssociation,
@@ -15332,7 +16420,7 @@ pub struct PullRequestReviewComment {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreated {
     pub action: PullRequestReviewCommentCreatedAction,
@@ -15345,8 +16433,12 @@ pub struct PullRequestReviewCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -15378,7 +16470,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
@@ -15421,8 +16513,12 @@ pub struct PullRequestReviewCommentCreatedPullRequest {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -15466,7 +16562,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullReque
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestBase {
     pub label: String,
@@ -15476,7 +16572,7 @@ pub struct PullRequestReviewCommentCreatedPullRequestBase {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestHead {
     pub label: String,
@@ -15486,7 +16582,7 @@ pub struct PullRequestReviewCommentCreatedPullRequestHead {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestLinks {
     pub comments: Link,
@@ -15499,14 +16595,20 @@ pub struct PullRequestReviewCommentCreatedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
+    #[educe(Default)]
     User(User),
     Team(Team),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentCreatedPullRequestState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -15542,7 +16644,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullReque
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeleted {
     pub action: PullRequestReviewCommentDeletedAction,
@@ -15555,8 +16657,12 @@ pub struct PullRequestReviewCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -15588,7 +16694,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
@@ -15631,8 +16737,12 @@ pub struct PullRequestReviewCommentDeletedPullRequest {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -15676,7 +16786,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullReque
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestBase {
     pub label: String,
@@ -15686,7 +16796,7 @@ pub struct PullRequestReviewCommentDeletedPullRequestBase {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestHead {
     pub label: String,
@@ -15696,7 +16806,7 @@ pub struct PullRequestReviewCommentDeletedPullRequestHead {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestLinks {
     pub comments: Link,
@@ -15709,14 +16819,20 @@ pub struct PullRequestReviewCommentDeletedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
+    #[educe(Default)]
     User(User),
     Team(Team),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentDeletedPullRequestState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -15752,7 +16868,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullReque
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEdited {
     pub action: PullRequestReviewCommentEditedAction,
@@ -15766,8 +16882,12 @@ pub struct PullRequestReviewCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -15800,19 +16920,19 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedAction {
     }
 }
 #[doc = "The changes to the comment."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<PullRequestReviewCommentEditedChangesBody>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
@@ -15855,8 +16975,12 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -15900,7 +17024,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullReques
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestBase {
     pub label: String,
@@ -15910,7 +17034,7 @@ pub struct PullRequestReviewCommentEditedPullRequestBase {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestHead {
     pub label: String,
@@ -15920,7 +17044,7 @@ pub struct PullRequestReviewCommentEditedPullRequestHead {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestLinks {
     pub comments: Link,
@@ -15933,14 +17057,20 @@ pub struct PullRequestReviewCommentEditedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
+    #[educe(Default)]
     User(User),
     Team(Team),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentEditedPullRequestState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -15976,9 +17106,11 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullReques
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum PullRequestReviewCommentEvent {
+    #[educe(Default)]
     #[doc = "pull_request_review_comment created event"]
     #[serde(rename = "created")]
     Created {
@@ -16017,7 +17149,7 @@ pub enum PullRequestReviewCommentEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentLinks {
     pub html: Link,
@@ -16026,8 +17158,12 @@ pub struct PullRequestReviewCommentLinks {
     pub self_: Link,
 }
 #[doc = "The side of the first line of the range for a multi-line comment."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentSide {
+    #[educe(Default)]
     #[serde(rename = "LEFT")]
     Left,
     #[serde(rename = "RIGHT")]
@@ -16064,8 +17200,12 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentSide {
     }
 }
 #[doc = "The side of the first line of the range for a multi-line comment."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewCommentStartSide {
+    #[educe(Default)]
     #[serde(rename = "LEFT")]
     Left,
     #[serde(rename = "RIGHT")]
@@ -16101,7 +17241,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewCommentStartSide {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissed {
     pub action: PullRequestReviewDismissedAction,
@@ -16114,8 +17254,12 @@ pub struct PullRequestReviewDismissed {
     pub review: PullRequestReviewDismissedReview,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewDismissedAction {
+    #[educe(Default)]
     #[serde(rename = "dismissed")]
     Dismissed,
 }
@@ -16148,7 +17292,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewDismissedAction {
     }
 }
 #[doc = "The review that was affected."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissedReview {
     pub author_association: AuthorAssociation,
@@ -16167,14 +17311,18 @@ pub struct PullRequestReviewDismissedReview {
     pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewDismissedReviewState {
+    #[educe(Default)]
     #[serde(rename = "dismissed")]
     Dismissed,
 }
@@ -16206,7 +17354,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewDismissedReviewState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEdited {
     pub action: PullRequestReviewEditedAction,
@@ -16220,8 +17368,12 @@ pub struct PullRequestReviewEdited {
     pub review: PullRequestReviewEditedReview,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -16253,20 +17405,20 @@ impl std::convert::TryFrom<&String> for PullRequestReviewEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<PullRequestReviewEditedChangesBody>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: String,
 }
 #[doc = "The review that was affected."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedReview {
     pub author_association: AuthorAssociation,
@@ -16285,15 +17437,17 @@ pub struct PullRequestReviewEditedReview {
     pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum PullRequestReviewEvent {
+    #[educe(Default)]
     #[doc = "pull_request_review dismissed event"]
     #[serde(rename = "dismissed")]
     Dismissed {
@@ -16332,9 +17486,11 @@ pub enum PullRequestReviewEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PullRequestReviewRequestRemoved {
+    #[educe(Default)]
     Variant0 {
         action: PullRequestReviewRequestRemovedVariant0Action,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -16362,8 +17518,12 @@ pub enum PullRequestReviewRequestRemoved {
         sender: User,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewRequestRemovedVariant0Action {
+    #[educe(Default)]
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
 }
@@ -16395,8 +17555,12 @@ impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant0A
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewRequestRemovedVariant1Action {
+    #[educe(Default)]
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
 }
@@ -16428,9 +17592,11 @@ impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant1A
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PullRequestReviewRequested {
+    #[educe(Default)]
     Variant0 {
         action: PullRequestReviewRequestedVariant0Action,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -16458,8 +17624,12 @@ pub enum PullRequestReviewRequested {
         sender: User,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewRequestedVariant0Action {
+    #[educe(Default)]
     #[serde(rename = "review_requested")]
     ReviewRequested,
 }
@@ -16491,8 +17661,12 @@ impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant0Action
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewRequestedVariant1Action {
+    #[educe(Default)]
     #[serde(rename = "review_requested")]
     ReviewRequested,
 }
@@ -16524,7 +17698,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant1Action
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmitted {
     pub action: PullRequestReviewSubmittedAction,
@@ -16537,8 +17711,12 @@ pub struct PullRequestReviewSubmitted {
     pub review: PullRequestReviewSubmittedReview,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestReviewSubmittedAction {
+    #[educe(Default)]
     #[serde(rename = "submitted")]
     Submitted,
 }
@@ -16571,7 +17749,7 @@ impl std::convert::TryFrom<&String> for PullRequestReviewSubmittedAction {
     }
 }
 #[doc = "The review that was affected."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmittedReview {
     pub author_association: AuthorAssociation,
@@ -16590,15 +17768,19 @@ pub struct PullRequestReviewSubmittedReview {
     pub submitted_at: chrono::DateTime<chrono::offset::Utc>,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmittedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
 }
 #[doc = "State of this Pull Request. Either `open` or `closed`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -16634,7 +17816,7 @@ impl std::convert::TryFrom<&String> for PullRequestState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestSynchronize {
     pub action: PullRequestSynchronizeAction,
@@ -16650,8 +17832,12 @@ pub struct PullRequestSynchronize {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestSynchronizeAction {
+    #[educe(Default)]
     #[serde(rename = "synchronize")]
     Synchronize,
 }
@@ -16683,7 +17869,7 @@ impl std::convert::TryFrom<&String> for PullRequestSynchronizeAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnassigned {
     pub action: PullRequestUnassignedAction,
@@ -16698,8 +17884,12 @@ pub struct PullRequestUnassigned {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestUnassignedAction {
+    #[educe(Default)]
     #[serde(rename = "unassigned")]
     Unassigned,
 }
@@ -16731,7 +17921,7 @@ impl std::convert::TryFrom<&String> for PullRequestUnassignedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlabeled {
     pub action: PullRequestUnlabeledAction,
@@ -16746,8 +17936,12 @@ pub struct PullRequestUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestUnlabeledAction {
+    #[educe(Default)]
     #[serde(rename = "unlabeled")]
     Unlabeled,
 }
@@ -16779,7 +17973,7 @@ impl std::convert::TryFrom<&String> for PullRequestUnlabeledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlocked {
     pub action: PullRequestUnlockedAction,
@@ -16793,8 +17987,12 @@ pub struct PullRequestUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PullRequestUnlockedAction {
+    #[educe(Default)]
     #[serde(rename = "unlocked")]
     Unlocked,
 }
@@ -16826,7 +18024,7 @@ impl std::convert::TryFrom<&String> for PullRequestUnlockedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PushEvent {
     #[doc = "The SHA of the most recent commit on `ref` after the push."]
@@ -16853,7 +18051,7 @@ pub struct PushEvent {
     pub sender: User,
 }
 #[doc = "The [release](https://docs.github.com/en/rest/reference/repos/#get-a-release) object."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Release {
     pub assets: Vec<ReleaseAsset>,
@@ -16880,7 +18078,7 @@ pub struct Release {
     pub zipball_url: Option<String>,
 }
 #[doc = "Data related to a release."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseAsset {
     pub browser_download_url: String,
@@ -16901,8 +18099,12 @@ pub struct ReleaseAsset {
     pub url: String,
 }
 #[doc = "State of the release asset."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseAssetState {
+    #[educe(Default)]
     #[serde(rename = "uploaded")]
     Uploaded,
 }
@@ -16934,7 +18136,7 @@ impl std::convert::TryFrom<&String> for ReleaseAssetState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseCreated {
     pub action: ReleaseCreatedAction,
@@ -16946,8 +18148,12 @@ pub struct ReleaseCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -16979,7 +18185,7 @@ impl std::convert::TryFrom<&String> for ReleaseCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseDeleted {
     pub action: ReleaseDeletedAction,
@@ -16991,8 +18197,12 @@ pub struct ReleaseDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -17024,7 +18234,7 @@ impl std::convert::TryFrom<&String> for ReleaseDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEdited {
     pub action: ReleaseEditedAction,
@@ -17037,8 +18247,12 @@ pub struct ReleaseEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -17070,7 +18284,7 @@ impl std::convert::TryFrom<&String> for ReleaseEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17078,21 +18292,23 @@ pub struct ReleaseEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<ReleaseEditedChangesName>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum ReleaseEvent {
+    #[educe(Default)]
     #[doc = "release created event"]
     #[serde(rename = "created")]
     Created {
@@ -17172,7 +18388,7 @@ pub enum ReleaseEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePrereleased {
     pub action: ReleasePrereleasedAction,
@@ -17184,8 +18400,12 @@ pub struct ReleasePrereleased {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleasePrereleasedAction {
+    #[educe(Default)]
     #[serde(rename = "prereleased")]
     Prereleased,
 }
@@ -17217,7 +18437,7 @@ impl std::convert::TryFrom<&String> for ReleasePrereleasedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePublished {
     pub action: ReleasePublishedAction,
@@ -17229,8 +18449,12 @@ pub struct ReleasePublished {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleasePublishedAction {
+    #[educe(Default)]
     #[serde(rename = "published")]
     Published,
 }
@@ -17262,7 +18486,7 @@ impl std::convert::TryFrom<&String> for ReleasePublishedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseReleased {
     pub action: ReleaseReleasedAction,
@@ -17274,8 +18498,12 @@ pub struct ReleaseReleased {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseReleasedAction {
+    #[educe(Default)]
     #[serde(rename = "released")]
     Released,
 }
@@ -17307,7 +18535,7 @@ impl std::convert::TryFrom<&String> for ReleaseReleasedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseUnpublished {
     pub action: ReleaseUnpublishedAction,
@@ -17319,8 +18547,12 @@ pub struct ReleaseUnpublished {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ReleaseUnpublishedAction {
+    #[educe(Default)]
     #[serde(rename = "unpublished")]
     Unpublished,
 }
@@ -17352,7 +18584,7 @@ impl std::convert::TryFrom<&String> for ReleaseUnpublishedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepoRef {
     pub id: i64,
@@ -17360,7 +18592,7 @@ pub struct RepoRef {
     pub url: String,
 }
 #[doc = "A git repository"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Repository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -17476,7 +18708,7 @@ pub struct Repository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchived {
     pub action: RepositoryArchivedAction,
@@ -17487,8 +18719,12 @@ pub struct RepositoryArchived {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryArchivedAction {
+    #[educe(Default)]
     #[serde(rename = "archived")]
     Archived,
 }
@@ -17520,7 +18756,7 @@ impl std::convert::TryFrom<&String> for RepositoryArchivedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryCreated {
     pub action: RepositoryCreatedAction,
@@ -17531,8 +18767,12 @@ pub struct RepositoryCreated {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -17564,9 +18804,11 @@ impl std::convert::TryFrom<&String> for RepositoryCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RepositoryCreatedAt {
+    #[educe(Default)]
     Variant0(i64),
     Variant1(chrono::DateTime<chrono::offset::Utc>),
 }
@@ -17578,7 +18820,7 @@ impl ToString for RepositoryCreatedAt {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDeleted {
     pub action: RepositoryDeletedAction,
@@ -17589,8 +18831,12 @@ pub struct RepositoryDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -17622,9 +18868,11 @@ impl std::convert::TryFrom<&String> for RepositoryDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum RepositoryDispatchEvent {
+    #[educe(Default)]
     #[doc = "repository_dispatch on-demand-test event"]
     #[serde(rename = "on-demand-test")]
     OnDemandTest {
@@ -17637,7 +18885,7 @@ pub enum RepositoryDispatchEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDispatchOnDemandTest {
     pub action: RepositoryDispatchOnDemandTestAction,
@@ -17649,8 +18897,12 @@ pub struct RepositoryDispatchOnDemandTest {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryDispatchOnDemandTestAction {
+    #[educe(Default)]
     #[serde(rename = "on-demand-test")]
     OnDemandTest,
 }
@@ -17682,7 +18934,7 @@ impl std::convert::TryFrom<&String> for RepositoryDispatchOnDemandTestAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEdited {
     pub action: RepositoryEditedAction,
@@ -17694,8 +18946,12 @@ pub struct RepositoryEdited {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -17727,7 +18983,7 @@ impl std::convert::TryFrom<&String> for RepositoryEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17737,24 +18993,26 @@ pub struct RepositoryEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<RepositoryEditedChangesHomepage>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDefaultBranch {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDescription {
     pub from: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesHomepage {
     pub from: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum RepositoryEvent {
+    #[educe(Default)]
     #[doc = "repository archived event"]
     #[serde(rename = "archived")]
     Archived {
@@ -17849,7 +19107,7 @@ pub enum RepositoryEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryImportEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17860,8 +19118,12 @@ pub struct RepositoryImportEvent {
     pub sender: User,
     pub status: RepositoryImportEventStatus,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryImportEventStatus {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "cancelled")]
@@ -17901,7 +19163,7 @@ impl std::convert::TryFrom<&String> for RepositoryImportEventStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryLite {
     pub archive_url: String,
@@ -17954,7 +19216,7 @@ pub struct RepositoryLite {
     pub trees_url: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPermissions {
     pub admin: bool,
@@ -17965,7 +19227,7 @@ pub struct RepositoryPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triage: Option<bool>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatized {
     pub action: RepositoryPrivatizedAction,
@@ -17976,8 +19238,12 @@ pub struct RepositoryPrivatized {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryPrivatizedAction {
+    #[educe(Default)]
     #[serde(rename = "privatized")]
     Privatized,
 }
@@ -18009,7 +19275,7 @@ impl std::convert::TryFrom<&String> for RepositoryPrivatizedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicized {
     pub action: RepositoryPublicizedAction,
@@ -18020,8 +19286,12 @@ pub struct RepositoryPublicized {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryPublicizedAction {
+    #[educe(Default)]
     #[serde(rename = "publicized")]
     Publicized,
 }
@@ -18053,14 +19323,16 @@ impl std::convert::TryFrom<&String> for RepositoryPublicizedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RepositoryPushedAt {
+    #[educe(Default)]
     Variant0(i64),
     Variant1(chrono::DateTime<chrono::offset::Utc>),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamed {
     pub action: RepositoryRenamedAction,
@@ -18072,8 +19344,12 @@ pub struct RepositoryRenamed {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryRenamedAction {
+    #[educe(Default)]
     #[serde(rename = "renamed")]
     Renamed,
 }
@@ -18105,22 +19381,22 @@ impl std::convert::TryFrom<&String> for RepositoryRenamedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChanges {
     pub repository: RepositoryRenamedChangesRepository,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChangesRepository {
     pub name: RepositoryRenamedChangesRepositoryName,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChangesRepositoryName {
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferred {
     pub action: RepositoryTransferredAction,
@@ -18132,8 +19408,12 @@ pub struct RepositoryTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryTransferredAction {
+    #[educe(Default)]
     #[serde(rename = "transferred")]
     Transferred,
 }
@@ -18165,23 +19445,23 @@ impl std::convert::TryFrom<&String> for RepositoryTransferredAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChanges {
     pub owner: RepositoryTransferredChangesOwner,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwner {
     pub from: RepositoryTransferredChangesOwnerFrom,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwnerFrom {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchived {
     pub action: RepositoryUnarchivedAction,
@@ -18192,8 +19472,12 @@ pub struct RepositoryUnarchived {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryUnarchivedAction {
+    #[educe(Default)]
     #[serde(rename = "unarchived")]
     Unarchived,
 }
@@ -18225,7 +19509,7 @@ impl std::convert::TryFrom<&String> for RepositoryUnarchivedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertCreate {
     pub action: RepositoryVulnerabilityAlertCreateAction,
@@ -18235,8 +19519,12 @@ pub struct RepositoryVulnerabilityAlertCreate {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryVulnerabilityAlertCreateAction {
+    #[educe(Default)]
     #[serde(rename = "create")]
     Create,
 }
@@ -18269,7 +19557,7 @@ impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertCreateAction
     }
 }
 #[doc = "The security alert of the vulnerable dependency."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertCreateAlert {
     pub affected_package_name: String,
@@ -18291,7 +19579,7 @@ pub struct RepositoryVulnerabilityAlertCreateAlert {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertDismiss {
     pub action: RepositoryVulnerabilityAlertDismissAction,
@@ -18301,8 +19589,12 @@ pub struct RepositoryVulnerabilityAlertDismiss {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryVulnerabilityAlertDismissAction {
+    #[educe(Default)]
     #[serde(rename = "dismiss")]
     Dismiss,
 }
@@ -18335,7 +19627,7 @@ impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertDismissActio
     }
 }
 #[doc = "The security alert of the vulnerable dependency."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertDismissAlert {
     pub affected_package_name: String,
@@ -18354,9 +19646,11 @@ pub struct RepositoryVulnerabilityAlertDismissAlert {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum RepositoryVulnerabilityAlertEvent {
+    #[educe(Default)]
     #[doc = "repository_vulnerability_alert create event"]
     #[serde(rename = "create")]
     Create {
@@ -18385,7 +19679,7 @@ pub enum RepositoryVulnerabilityAlertEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertResolve {
     pub action: RepositoryVulnerabilityAlertResolveAction,
@@ -18395,8 +19689,12 @@ pub struct RepositoryVulnerabilityAlertResolve {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RepositoryVulnerabilityAlertResolveAction {
+    #[educe(Default)]
     #[serde(rename = "resolve")]
     Resolve,
 }
@@ -18429,7 +19727,7 @@ impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertResolveActio
     }
 }
 #[doc = "The security alert of the vulnerable dependency."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertResolveAlert {
     pub affected_package_name: String,
@@ -18451,7 +19749,7 @@ pub struct RepositoryVulnerabilityAlertResolveAlert {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertCreated {
     pub action: SecretScanningAlertCreatedAction,
@@ -18462,8 +19760,12 @@ pub struct SecretScanningAlertCreated {
     pub organization: Option<Organization>,
     pub repository: Repository,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecretScanningAlertCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -18496,7 +19798,7 @@ impl std::convert::TryFrom<&String> for SecretScanningAlertCreatedAction {
     }
 }
 #[doc = "The secret scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertCreatedAlert {
     pub number: i64,
@@ -18505,9 +19807,11 @@ pub struct SecretScanningAlertCreatedAlert {
     pub resolved_by: (),
     pub secret_type: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum SecretScanningAlertEvent {
+    #[educe(Default)]
     #[doc = "secret_scanning_alert created event"]
     #[serde(rename = "created")]
     Created {
@@ -18541,7 +19845,7 @@ pub enum SecretScanningAlertEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertReopened {
     pub action: SecretScanningAlertReopenedAction,
@@ -18553,8 +19857,12 @@ pub struct SecretScanningAlertReopened {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecretScanningAlertReopenedAction {
+    #[educe(Default)]
     #[serde(rename = "reopened")]
     Reopened,
 }
@@ -18587,7 +19895,7 @@ impl std::convert::TryFrom<&String> for SecretScanningAlertReopenedAction {
     }
 }
 #[doc = "The secret scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertReopenedAlert {
     pub number: i64,
@@ -18596,7 +19904,7 @@ pub struct SecretScanningAlertReopenedAlert {
     pub resolved_by: (),
     pub secret_type: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertResolved {
     pub action: SecretScanningAlertResolvedAction,
@@ -18608,8 +19916,12 @@ pub struct SecretScanningAlertResolved {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecretScanningAlertResolvedAction {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
 }
@@ -18642,7 +19954,7 @@ impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAction {
     }
 }
 #[doc = "The secret scanning alert involved in the event."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertResolvedAlert {
     pub number: i64,
@@ -18651,8 +19963,12 @@ pub struct SecretScanningAlertResolvedAlert {
     pub resolved_by: User,
     pub secret_type: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecretScanningAlertResolvedAlertResolution {
+    #[educe(Default)]
     #[serde(rename = "false_positive")]
     FalsePositive,
     #[serde(rename = "wontfix")]
@@ -18696,9 +20012,11 @@ impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAlertResoluti
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", content = "security_advisory")]
 pub enum SecurityAdvisoryEvent {
+    #[educe(Default)]
     #[doc = "security_advisory performed event"]
     #[serde(rename = "performed")]
     Performed(SecurityAdvisoryPerformedSecurityAdvisory),
@@ -18712,14 +20030,18 @@ pub enum SecurityAdvisoryEvent {
     #[serde(rename = "withdrawn")]
     Withdrawn(SecurityAdvisoryWithdrawnSecurityAdvisory),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformed {
     pub action: SecurityAdvisoryPerformedAction,
     pub security_advisory: SecurityAdvisoryPerformedSecurityAdvisory,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecurityAdvisoryPerformedAction {
+    #[educe(Default)]
     #[serde(rename = "performed")]
     Performed,
 }
@@ -18752,7 +20074,7 @@ impl std::convert::TryFrom<&String> for SecurityAdvisoryPerformedAction {
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisory {
     pub cvss: SecurityAdvisoryPerformedSecurityAdvisoryCvss,
@@ -18768,31 +20090,31 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisory {
     pub vulnerabilities: Vec<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
     pub type_: String,
     pub value: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem {
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -18801,25 +20123,29 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: String,
     pub vulnerable_version_range: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublished {
     pub action: SecurityAdvisoryPublishedAction,
     pub security_advisory: SecurityAdvisoryPublishedSecurityAdvisory,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecurityAdvisoryPublishedAction {
+    #[educe(Default)]
     #[serde(rename = "published")]
     Published,
 }
@@ -18852,7 +20178,7 @@ impl std::convert::TryFrom<&String> for SecurityAdvisoryPublishedAction {
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisory {
     pub cvss: SecurityAdvisoryPublishedSecurityAdvisoryCvss,
@@ -18868,31 +20194,31 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisory {
     pub vulnerabilities: Vec<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
     pub type_: String,
     pub value: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem {
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -18901,25 +20227,29 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: String,
     pub vulnerable_version_range: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdated {
     pub action: SecurityAdvisoryUpdatedAction,
     pub security_advisory: SecurityAdvisoryUpdatedSecurityAdvisory,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecurityAdvisoryUpdatedAction {
+    #[educe(Default)]
     #[serde(rename = "updated")]
     Updated,
 }
@@ -18952,7 +20282,7 @@ impl std::convert::TryFrom<&String> for SecurityAdvisoryUpdatedAction {
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
     pub cvss: SecurityAdvisoryUpdatedSecurityAdvisoryCvss,
@@ -18968,31 +20298,31 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
     pub vulnerabilities: Vec<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
     pub type_: String,
     pub value: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem {
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -19001,25 +20331,29 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: String,
     pub vulnerable_version_range: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawn {
     pub action: SecurityAdvisoryWithdrawnAction,
     pub security_advisory: SecurityAdvisoryWithdrawnSecurityAdvisory,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SecurityAdvisoryWithdrawnAction {
+    #[educe(Default)]
     #[serde(rename = "withdrawn")]
     Withdrawn,
 }
@@ -19052,7 +20386,7 @@ impl std::convert::TryFrom<&String> for SecurityAdvisoryWithdrawnAction {
     }
 }
 #[doc = "The details of the security advisory, including summary, description, and severity."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
     pub cvss: SecurityAdvisoryWithdrawnSecurityAdvisoryCvss,
@@ -19068,31 +20402,31 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
     pub vulnerabilities: Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem {
     pub cwe_id: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
     pub type_: String,
     pub value: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem {
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -19101,18 +20435,18 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
     pub severity: String,
     pub vulnerable_version_range: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
     pub name: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequest {
     pub active_lock_reason: Option<SimplePullRequestActiveLockReason>,
@@ -19153,8 +20487,12 @@ pub struct SimplePullRequest {
     pub url: String,
     pub user: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SimplePullRequestActiveLockReason {
+    #[educe(Default)]
     #[serde(rename = "resolved")]
     Resolved,
     #[serde(rename = "off-topic")]
@@ -19198,7 +20536,7 @@ impl std::convert::TryFrom<&String> for SimplePullRequestActiveLockReason {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestBase {
     pub label: String,
@@ -19208,7 +20546,7 @@ pub struct SimplePullRequestBase {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestHead {
     pub label: String,
@@ -19218,7 +20556,7 @@ pub struct SimplePullRequestHead {
     pub sha: String,
     pub user: User,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestLinks {
     pub comments: Link,
@@ -19231,14 +20569,20 @@ pub struct SimplePullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SimplePullRequestRequestedReviewersItem {
+    #[educe(Default)]
     User(User),
     Team(Team),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SimplePullRequestState {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -19274,15 +20618,19 @@ impl std::convert::TryFrom<&String> for SimplePullRequestState {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCancelled {
     pub action: SponsorshipCancelledAction,
     pub sender: User,
     pub sponsorship: SponsorshipCancelledSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipCancelledAction {
+    #[educe(Default)]
     #[serde(rename = "cancelled")]
     Cancelled,
 }
@@ -19314,7 +20662,7 @@ impl std::convert::TryFrom<&String> for SponsorshipCancelledAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCancelledSponsorship {
     pub created_at: String,
@@ -19324,15 +20672,19 @@ pub struct SponsorshipCancelledSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCreated {
     pub action: SponsorshipCreatedAction,
     pub sender: User,
     pub sponsorship: SponsorshipCreatedSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -19364,7 +20716,7 @@ impl std::convert::TryFrom<&String> for SponsorshipCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCreatedSponsorship {
     pub created_at: String,
@@ -19374,7 +20726,7 @@ pub struct SponsorshipCreatedSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEdited {
     pub action: SponsorshipEditedAction,
@@ -19382,8 +20734,12 @@ pub struct SponsorshipEdited {
     pub sender: User,
     pub sponsorship: SponsorshipEditedSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -19415,19 +20771,19 @@ impl std::convert::TryFrom<&String> for SponsorshipEditedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub privacy_level: Option<SponsorshipEditedChangesPrivacyLevel>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChangesPrivacyLevel {
     #[doc = "The `edited` event types include the details about the change when someone edits a sponsorship to change the privacy."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedSponsorship {
     pub created_at: String,
@@ -19437,9 +20793,11 @@ pub struct SponsorshipEditedSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum SponsorshipEvent {
+    #[educe(Default)]
     #[doc = "sponsorship cancelled event"]
     #[serde(rename = "cancelled")]
     Cancelled {
@@ -19486,7 +20844,7 @@ pub enum SponsorshipEvent {
         sponsorship: SponsorshipTierChangedSponsorship,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingCancellation {
     pub action: SponsorshipPendingCancellationAction,
@@ -19496,8 +20854,12 @@ pub struct SponsorshipPendingCancellation {
     pub sender: User,
     pub sponsorship: SponsorshipPendingCancellationSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipPendingCancellationAction {
+    #[educe(Default)]
     #[serde(rename = "pending_cancellation")]
     PendingCancellation,
 }
@@ -19529,7 +20891,7 @@ impl std::convert::TryFrom<&String> for SponsorshipPendingCancellationAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingCancellationSponsorship {
     pub created_at: String,
@@ -19539,7 +20901,7 @@ pub struct SponsorshipPendingCancellationSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChange {
     pub action: SponsorshipPendingTierChangeAction,
@@ -19550,8 +20912,12 @@ pub struct SponsorshipPendingTierChange {
     pub sender: User,
     pub sponsorship: SponsorshipPendingTierChangeSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipPendingTierChangeAction {
+    #[educe(Default)]
     #[serde(rename = "pending_tier_change")]
     PendingTierChange,
 }
@@ -19583,17 +20949,17 @@ impl std::convert::TryFrom<&String> for SponsorshipPendingTierChangeAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeChanges {
     pub tier: SponsorshipPendingTierChangeChangesTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeChangesTier {
     pub from: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeSponsorship {
     pub created_at: String,
@@ -19604,7 +20970,7 @@ pub struct SponsorshipPendingTierChangeSponsorship {
     pub tier: SponsorshipTier,
 }
 #[doc = "The `tier_changed` and `pending_tier_change` will include the original tier before the change or pending change. For more information, see the pending tier change payload."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTier {
     pub created_at: String,
@@ -19616,7 +20982,7 @@ pub struct SponsorshipTier {
     pub name: String,
     pub node_id: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChanged {
     pub action: SponsorshipTierChangedAction,
@@ -19624,8 +20990,12 @@ pub struct SponsorshipTierChanged {
     pub sender: User,
     pub sponsorship: SponsorshipTierChangedSponsorship,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SponsorshipTierChangedAction {
+    #[educe(Default)]
     #[serde(rename = "tier_changed")]
     TierChanged,
 }
@@ -19657,17 +21027,17 @@ impl std::convert::TryFrom<&String> for SponsorshipTierChangedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChanges {
     pub tier: SponsorshipTierChangedChangesTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChangesTier {
     pub from: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedSponsorship {
     pub created_at: String,
@@ -19677,7 +21047,7 @@ pub struct SponsorshipTierChangedSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StarCreated {
     pub action: StarCreatedAction,
@@ -19690,8 +21060,12 @@ pub struct StarCreated {
     #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
     pub starred_at: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StarCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -19723,7 +21097,7 @@ impl std::convert::TryFrom<&String> for StarCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StarDeleted {
     pub action: StarDeletedAction,
@@ -19736,8 +21110,12 @@ pub struct StarDeleted {
     #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
     pub starred_at: (),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StarDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -19769,9 +21147,11 @@ impl std::convert::TryFrom<&String> for StarDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum StarEvent {
+    #[educe(Default)]
     #[doc = "star created event"]
     #[serde(rename = "created")]
     Created {
@@ -19797,7 +21177,7 @@ pub enum StarEvent {
         starred_at: (),
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -19826,20 +21206,20 @@ pub struct StatusEvent {
     pub target_url: Option<String>,
     pub updated_at: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventBranchesItem {
     pub commit: StatusEventBranchesItemCommit,
     pub name: String,
     pub protected: bool,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventBranchesItemCommit {
     pub sha: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommit {
     pub author: Option<User>,
@@ -19852,7 +21232,7 @@ pub struct StatusEventCommit {
     pub sha: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommit {
     pub author: Committer,
@@ -19863,13 +21243,13 @@ pub struct StatusEventCommitCommit {
     pub url: String,
     pub verification: StatusEventCommitCommitVerification,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitTree {
     pub sha: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitVerification {
     pub payload: Option<String>,
@@ -19877,8 +21257,12 @@ pub struct StatusEventCommitCommitVerification {
     pub signature: Option<String>,
     pub verified: bool,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StatusEventCommitCommitVerificationReason {
+    #[educe(Default)]
     #[serde(rename = "expired_key")]
     ExpiredKey,
     #[serde(rename = "not_signing_key")]
@@ -19958,7 +21342,7 @@ impl std::convert::TryFrom<&String> for StatusEventCommitCommitVerificationReaso
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitParentsItem {
     pub html_url: String,
@@ -19966,8 +21350,12 @@ pub struct StatusEventCommitParentsItem {
     pub url: String,
 }
 #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StatusEventState {
+    #[educe(Default)]
     #[serde(rename = "pending")]
     Pending,
     #[serde(rename = "success")]
@@ -20012,7 +21400,7 @@ impl std::convert::TryFrom<&String> for StatusEventState {
     }
 }
 #[doc = "Groups of organization members that gives permissions on specified repositories."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Team {
     #[doc = "Description of the team"]
@@ -20034,7 +21422,7 @@ pub struct Team {
     #[doc = "URL for the team"]
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamAddEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -20044,7 +21432,7 @@ pub struct TeamAddEvent {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamAddedToRepository {
     pub action: TeamAddedToRepositoryAction,
@@ -20056,8 +21444,12 @@ pub struct TeamAddedToRepository {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamAddedToRepositoryAction {
+    #[educe(Default)]
     #[serde(rename = "added_to_repository")]
     AddedToRepository,
 }
@@ -20089,7 +21481,7 @@ impl std::convert::TryFrom<&String> for TeamAddedToRepositoryAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamCreated {
     pub action: TeamCreatedAction,
@@ -20101,8 +21493,12 @@ pub struct TeamCreated {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamCreatedAction {
+    #[educe(Default)]
     #[serde(rename = "created")]
     Created,
 }
@@ -20134,7 +21530,7 @@ impl std::convert::TryFrom<&String> for TeamCreatedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamDeleted {
     pub action: TeamDeletedAction,
@@ -20146,8 +21542,12 @@ pub struct TeamDeleted {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamDeletedAction {
+    #[educe(Default)]
     #[serde(rename = "deleted")]
     Deleted,
 }
@@ -20179,7 +21579,7 @@ impl std::convert::TryFrom<&String> for TeamDeletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEdited {
     pub action: TeamEditedAction,
@@ -20192,8 +21592,12 @@ pub struct TeamEdited {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamEditedAction {
+    #[educe(Default)]
     #[serde(rename = "edited")]
     Edited,
 }
@@ -20226,7 +21630,7 @@ impl std::convert::TryFrom<&String> for TeamEditedAction {
     }
 }
 #[doc = "The changes to the team if the action was `edited`."]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -20238,35 +21642,35 @@ pub struct TeamEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<TeamEditedChangesRepository>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesPrivacy {
     #[doc = "The previous version of the team's privacy if the action was `edited`."]
     pub from: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepository {
     pub permissions: TeamEditedChangesRepositoryPermissions,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissions {
     pub from: TeamEditedChangesRepositoryPermissionsFrom,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
@@ -20279,9 +21683,11 @@ pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub push: Option<bool>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum TeamEvent {
+    #[educe(Default)]
     #[doc = "team added_to_repository event"]
     #[serde(rename = "added_to_repository")]
     AddedToRepository {
@@ -20339,7 +21745,7 @@ pub enum TeamEvent {
         team: Team,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamParent {
     #[doc = "Description of the team"]
@@ -20359,8 +21765,12 @@ pub struct TeamParent {
     #[doc = "URL for the team"]
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamParentPrivacy {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -20400,8 +21810,12 @@ impl std::convert::TryFrom<&String> for TeamParentPrivacy {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamPrivacy {
+    #[educe(Default)]
     #[serde(rename = "open")]
     Open,
     #[serde(rename = "closed")]
@@ -20441,7 +21855,7 @@ impl std::convert::TryFrom<&String> for TeamPrivacy {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamRemovedFromRepository {
     pub action: TeamRemovedFromRepositoryAction,
@@ -20453,8 +21867,12 @@ pub struct TeamRemovedFromRepository {
     pub sender: User,
     pub team: Team,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TeamRemovedFromRepositoryAction {
+    #[educe(Default)]
     #[serde(rename = "removed_from_repository")]
     RemovedFromRepository,
 }
@@ -20486,7 +21904,7 @@ impl std::convert::TryFrom<&String> for TeamRemovedFromRepositoryAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct User {
     pub avatar_url: String,
@@ -20513,8 +21931,12 @@ pub struct User {
     pub type_: UserType,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum UserType {
+    #[educe(Default)]
     Bot,
     User,
     Organization,
@@ -20551,9 +21973,11 @@ impl std::convert::TryFrom<&String> for UserType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum WatchEvent {
+    #[educe(Default)]
     #[doc = "watch started event"]
     #[serde(rename = "started")]
     Started {
@@ -20565,7 +21989,7 @@ pub enum WatchEvent {
         sender: User,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WatchStarted {
     pub action: WatchStartedAction,
@@ -20576,8 +22000,12 @@ pub struct WatchStarted {
     pub repository: Repository,
     pub sender: User,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WatchStartedAction {
+    #[educe(Default)]
     #[serde(rename = "started")]
     Started,
 }
@@ -20609,14 +22037,20 @@ impl std::convert::TryFrom<&String> for WatchStartedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WebhookEvents {
+    #[educe(Default)]
     Variant0(Vec<WebhookEventsVariant0Item>),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WebhookEventsVariant0Item {
+    #[educe(Default)]
     #[serde(rename = "check_run")]
     CheckRun,
     #[serde(rename = "check_suite")]
@@ -20832,7 +22266,7 @@ impl std::convert::TryFrom<&String> for WebhookEventsVariant0Item {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Workflow {
     pub badge_url: String,
@@ -20846,7 +22280,7 @@ pub struct Workflow {
     pub updated_at: String,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowDispatchEvent {
     pub inputs: Option<std::collections::HashMap<String, serde_json::Value>>,
@@ -20860,7 +22294,7 @@ pub struct WorkflowDispatchEvent {
     pub sender: User,
     pub workflow: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJob {
     pub check_run_url: String,
@@ -20879,7 +22313,7 @@ pub struct WorkflowJob {
     pub steps: Vec<WorkflowStep>,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobCompleted {
     pub action: WorkflowJobCompletedAction,
@@ -20891,8 +22325,12 @@ pub struct WorkflowJobCompleted {
     pub sender: User,
     pub workflow_job: WorkflowJob,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobCompletedAction {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -20924,8 +22362,12 @@ impl std::convert::TryFrom<&String> for WorkflowJobCompletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -20961,9 +22403,11 @@ impl std::convert::TryFrom<&String> for WorkflowJobConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum WorkflowJobEvent {
+    #[educe(Default)]
     #[doc = "workflow_job completed event"]
     #[serde(rename = "completed")]
     Completed {
@@ -20998,7 +22442,7 @@ pub enum WorkflowJobEvent {
         workflow_job: WorkflowJob,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueued {
     pub action: WorkflowJobQueuedAction,
@@ -21010,8 +22454,12 @@ pub struct WorkflowJobQueued {
     pub sender: User,
     pub workflow_job: WorkflowJobQueuedWorkflowJob,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobQueuedAction {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
 }
@@ -21043,7 +22491,7 @@ impl std::convert::TryFrom<&String> for WorkflowJobQueuedAction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueuedWorkflowJob {
     pub check_run_url: String,
@@ -21062,8 +22510,12 @@ pub struct WorkflowJobQueuedWorkflowJob {
     pub steps: Vec<WorkflowStep>,
     pub url: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobQueuedWorkflowJobStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
 }
@@ -21095,7 +22547,7 @@ impl std::convert::TryFrom<&String> for WorkflowJobQueuedWorkflowJobStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobStarted {
     pub action: WorkflowJobStartedAction,
@@ -21107,8 +22559,12 @@ pub struct WorkflowJobStarted {
     pub sender: User,
     pub workflow_job: WorkflowJob,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobStartedAction {
+    #[educe(Default)]
     #[serde(rename = "started")]
     Started,
 }
@@ -21140,8 +22596,12 @@ impl std::convert::TryFrom<&String> for WorkflowJobStartedAction {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowJobStatus {
+    #[educe(Default)]
     #[serde(rename = "queued")]
     Queued,
     #[serde(rename = "in_progress")]
@@ -21181,7 +22641,7 @@ impl std::convert::TryFrom<&String> for WorkflowJobStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRun {
     pub artifacts_url: String,
@@ -21212,7 +22672,7 @@ pub struct WorkflowRun {
     pub workflow_id: i64,
     pub workflow_url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompleted {
     pub action: WorkflowRunCompletedAction,
@@ -21225,8 +22685,12 @@ pub struct WorkflowRunCompleted {
     pub workflow: Workflow,
     pub workflow_run: WorkflowRun,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowRunCompletedAction {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -21258,8 +22722,12 @@ impl std::convert::TryFrom<&String> for WorkflowRunCompletedAction {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowRunConclusion {
+    #[educe(Default)]
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
@@ -21315,9 +22783,11 @@ impl std::convert::TryFrom<&String> for WorkflowRunConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "action", deny_unknown_fields)]
 pub enum WorkflowRunEvent {
+    #[educe(Default)]
     #[doc = "workflow_run completed event"]
     #[serde(rename = "completed")]
     Completed {
@@ -21343,7 +22813,7 @@ pub enum WorkflowRunEvent {
         workflow_run: WorkflowRun,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItem {
     pub base: WorkflowRunPullRequestsItemBase,
@@ -21352,7 +22822,7 @@ pub struct WorkflowRunPullRequestsItem {
     pub number: f64,
     pub url: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItemBase {
     #[serde(rename = "ref")]
@@ -21360,7 +22830,7 @@ pub struct WorkflowRunPullRequestsItemBase {
     pub repo: RepoRef,
     pub sha: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItemHead {
     #[serde(rename = "ref")]
@@ -21368,7 +22838,7 @@ pub struct WorkflowRunPullRequestsItemHead {
     pub repo: RepoRef,
     pub sha: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunRequested {
     pub action: WorkflowRunRequestedAction,
@@ -21381,8 +22851,12 @@ pub struct WorkflowRunRequested {
     pub workflow: Workflow,
     pub workflow_run: WorkflowRun,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowRunRequestedAction {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
 }
@@ -21414,8 +22888,12 @@ impl std::convert::TryFrom<&String> for WorkflowRunRequestedAction {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowRunStatus {
+    #[educe(Default)]
     #[serde(rename = "requested")]
     Requested,
     #[serde(rename = "in_progress")]
@@ -21459,9 +22937,11 @@ impl std::convert::TryFrom<&String> for WorkflowRunStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(tag = "status", deny_unknown_fields)]
 pub enum WorkflowStep {
+    #[educe(Default)]
     #[doc = "Workflow Step (In Progress)"]
     #[serde(rename = "in_progress")]
     InProgress {
@@ -21481,7 +22961,7 @@ pub enum WorkflowStep {
         started_at: String,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowStepCompleted {
     pub completed_at: String,
@@ -21491,8 +22971,12 @@ pub struct WorkflowStepCompleted {
     pub started_at: String,
     pub status: WorkflowStepCompletedStatus,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowStepCompletedConclusion {
+    #[educe(Default)]
     #[serde(rename = "failure")]
     Failure,
     #[serde(rename = "skipped")]
@@ -21532,8 +23016,12 @@ impl std::convert::TryFrom<&String> for WorkflowStepCompletedConclusion {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowStepCompletedStatus {
+    #[educe(Default)]
     #[serde(rename = "completed")]
     Completed,
 }
@@ -21565,7 +23053,7 @@ impl std::convert::TryFrom<&String> for WorkflowStepCompletedStatus {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowStepInProgress {
     pub completed_at: (),
@@ -21575,8 +23063,12 @@ pub struct WorkflowStepInProgress {
     pub started_at: String,
     pub status: WorkflowStepInProgressStatus,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WorkflowStepInProgressStatus {
+    #[educe(Default)]
     #[serde(rename = "in_progress")]
     InProgress,
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregateTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -20,79 +20,105 @@ pub struct AggregateTransform {
     #[serde(rename = "type")]
     pub type_: AggregateTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformAs {
+    #[educe(Default)]
     Variant0(Vec<AggregateTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformCross {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformDrop {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformFields {
+    #[educe(Default)]
     Variant0(Vec<AggregateTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformFieldsVariant0Item {
+    #[educe(Default)]
     Variant0(ScaleField),
     Variant1(ParamField),
     Variant2(Expr),
     Variant3,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<AggregateTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformOps {
+    #[educe(Default)]
     Variant0(Vec<AggregateTransformOpsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AggregateTransformOpsVariant0Item {
+    #[educe(Default)]
     Variant0(AggregateTransformOpsVariant0ItemVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AggregateTransformOpsVariant0ItemVariant0 {
+    #[educe(Default)]
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
@@ -216,8 +242,12 @@ impl std::convert::TryFrom<&String> for AggregateTransformOpsVariant0ItemVariant
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AggregateTransformType {
+    #[educe(Default)]
     #[serde(rename = "aggregate")]
     Aggregate,
 }
@@ -249,27 +279,29 @@ impl std::convert::TryFrom<&String> for AggregateTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AlignValue {
+    #[educe(Default)]
     Variant0(Vec<AlignValueVariant0Item>),
     Variant1(AlignValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: AlignValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AlignValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -280,9 +312,11 @@ pub struct AlignValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -294,8 +328,12 @@ pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -337,26 +375,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AlignValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AlignValueVariant1Subtype1Subtype0>,
@@ -367,9 +407,11 @@ pub struct AlignValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AlignValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AlignValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: AlignValueVariant1Subtype1Subtype0Variant1Value,
@@ -381,8 +423,12 @@ pub enum AlignValueVariant1Subtype1Subtype0 {
         range: AlignValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AlignValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -422,39 +468,43 @@ impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype1Subtype0Varian
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AlignValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnchorValue {
+    #[educe(Default)]
     Variant0(Vec<AnchorValueVariant0Item>),
     Variant1(AnchorValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: AnchorValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AnchorValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -465,9 +515,11 @@ pub struct AnchorValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -479,8 +531,12 @@ pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -522,26 +578,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AnchorValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnchorValueVariant1Subtype1Subtype0>,
@@ -552,9 +610,11 @@ pub struct AnchorValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AnchorValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: AnchorValueVariant1Subtype1Subtype0Variant1Value,
@@ -566,8 +626,12 @@ pub enum AnchorValueVariant1Subtype1Subtype0 {
         range: AnchorValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AnchorValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -607,39 +671,43 @@ impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype1Subtype0Varia
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnyValue {
+    #[educe(Default)]
     Variant0(Vec<AnyValueVariant0Item>),
     Variant1(AnyValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: AnyValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AnyValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -650,9 +718,11 @@ pub struct AnyValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: serde_json::Value,
@@ -664,26 +734,28 @@ pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: AnyValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnyValueVariant1Subtype1Subtype0>,
@@ -694,9 +766,11 @@ pub struct AnyValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<AnyValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: serde_json::Value,
@@ -708,45 +782,51 @@ pub enum AnyValueVariant1Subtype1Subtype0 {
         range: AnyValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayOrSignal {
+    #[educe(Default)]
     Variant0(Vec<serde_json::Value>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayValue {
+    #[educe(Default)]
     Variant0(Vec<ArrayValueVariant0Item>),
     Variant1(ArrayValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: ArrayValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: ArrayValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -757,9 +837,11 @@ pub struct ArrayValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: Vec<serde_json::Value>,
@@ -771,26 +853,28 @@ pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: ArrayValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<ArrayValueVariant1Subtype1Subtype0>,
@@ -801,9 +885,11 @@ pub struct ArrayValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<ArrayValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: Vec<serde_json::Value>,
@@ -815,21 +901,25 @@ pub enum ArrayValueVariant1Subtype1Subtype0 {
         range: ArrayValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Autosize {
+    #[educe(Default)]
     Variant0(AutosizeVariant0),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -841,8 +931,12 @@ pub enum Autosize {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AutosizeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "pad")]
     Pad,
     #[serde(rename = "fit")]
@@ -890,8 +984,12 @@ impl std::convert::TryFrom<&String> for AutosizeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AutosizeVariant1Contains {
+    #[educe(Default)]
     #[serde(rename = "content")]
     Content,
     #[serde(rename = "padding")]
@@ -927,8 +1025,12 @@ impl std::convert::TryFrom<&String> for AutosizeVariant1Contains {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AutosizeVariant1Type {
+    #[educe(Default)]
     #[serde(rename = "pad")]
     Pad,
     #[serde(rename = "fit")]
@@ -976,7 +1078,7 @@ impl std::convert::TryFrom<&String> for AutosizeVariant1Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Axis {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1304,50 +1406,64 @@ pub struct Axis {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zindex: Option<f64>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisBandPosition {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainCap {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainDash {
+    #[educe(Default)]
     Variant0(Vec<f64>),
     Variant1(ArrayValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainDashOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisDomainWidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AxisEncode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1363,9 +1479,11 @@ pub struct AxisEncode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<GuideEncode>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum AxisFormat {
+    #[educe(Default)]
     Variant0(String),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1391,14 +1509,20 @@ pub enum AxisFormat {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisFormatType {
+    #[educe(Default)]
     Variant0(AxisFormatTypeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisFormatTypeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "number")]
     Number,
     #[serde(rename = "time")]
@@ -1438,51 +1562,69 @@ impl std::convert::TryFrom<&String> for AxisFormatTypeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridCap {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridDash {
+    #[educe(Default)]
     Variant0(Vec<f64>),
     Variant1(ArrayValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridDashOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisGridWidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelAlign {
+    #[educe(Default)]
     Variant0(AxisLabelAlignVariant0),
     Variant1(AlignValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisLabelAlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -1522,20 +1664,28 @@ impl std::convert::TryFrom<&String> for AxisLabelAlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelAngle {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelBaseline {
+    #[educe(Default)]
     Variant0(AxisLabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisLabelBaselineVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -1587,107 +1737,143 @@ impl std::convert::TryFrom<&String> for AxisLabelBaselineVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelBound {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelFlush {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelFontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelLimit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelLineHeight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisLabelPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisMaxExtent {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisMinExtent {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisOrient {
+    #[educe(Default)]
     Variant0(AxisOrientVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisOrientVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "bottom")]
@@ -1731,75 +1917,101 @@ impl std::convert::TryFrom<&String> for AxisOrientVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisPosition {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickCap {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickDash {
+    #[educe(Default)]
     Variant0(Vec<f64>),
     Variant1(ArrayValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickDashOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickRound {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(BooleanValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTickWidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleAlign {
+    #[educe(Default)]
     Variant0(AxisTitleAlignVariant0),
     Variant1(AlignValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisTitleAlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -1839,14 +2051,20 @@ impl std::convert::TryFrom<&String> for AxisTitleAlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleAnchor {
+    #[educe(Default)]
     Variant0(Option<AxisTitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisTitleAnchorVariant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -1886,20 +2104,28 @@ impl std::convert::TryFrom<&String> for AxisTitleAnchorVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleAngle {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleBaseline {
+    #[educe(Default)]
     Variant0(AxisTitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum AxisTitleBaselineVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -1951,80 +2177,104 @@ impl std::convert::TryFrom<&String> for AxisTitleBaselineVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleFontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleLimit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleLineHeight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitlePadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleX {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTitleY {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum AxisTranslate {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Background(pub StringOrSignal);
 impl std::ops::Deref for Background {
     type Target = StringOrSignal;
@@ -2032,9 +2282,11 @@ impl std::ops::Deref for Background {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum BaseColorValue {
+    #[educe(Default)]
     Variant0(BaseColorValueVariant0),
     Variant1 {
         value: LinearGradient,
@@ -2055,14 +2307,14 @@ pub enum BaseColorValue {
         color: BaseColorValueVariant4Color,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BaseColorValueVariant0Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BaseColorValueVariant0Subtype1Subtype0>,
@@ -2073,9 +2325,11 @@ pub struct BaseColorValueVariant0Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BaseColorValueVariant0Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: Option<String>,
@@ -2087,47 +2341,53 @@ pub enum BaseColorValueVariant0Subtype1Subtype0 {
         range: BaseColorValueVariant0Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant4Color {
+    #[educe(Default)]
     Rgb(ColorRgb),
     Hsl(ColorHsl),
     Lab(ColorLab),
     Hcl(ColorHcl),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaselineValue {
+    #[educe(Default)]
     Variant0(Vec<BaselineValueVariant0Item>),
     Variant1(BaselineValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: BaselineValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BaselineValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -2138,9 +2398,11 @@ pub struct BaselineValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -2152,8 +2414,12 @@ pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -2201,26 +2467,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BaselineValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BaselineValueVariant1Subtype1Subtype0>,
@@ -2231,9 +2499,11 @@ pub struct BaselineValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BaselineValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: BaselineValueVariant1Subtype1Subtype0Variant1Value,
@@ -2245,8 +2515,12 @@ pub enum BaselineValueVariant1Subtype1Subtype0 {
         range: BaselineValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BaselineValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -2290,19 +2564,21 @@ impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype1Subtype0Var
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BinTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2336,117 +2612,157 @@ pub struct BinTransform {
     #[serde(rename = "type")]
     pub type_: BinTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformAnchor {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformAs {
+    #[educe(Default)]
     Variant0(BinTransformAsVariant0, BinTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformBase {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformDivide {
+    #[educe(Default)]
     Variant0(Vec<BinTransformDivideVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformDivideVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformExtent {
+    #[educe(Default)]
     Variant0(BinTransformExtentVariant0, BinTransformExtentVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformExtentVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformInterval {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformMaxbins {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformMinstep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformName {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformNice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformSpan {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformStep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformSteps {
+    #[educe(Default)]
     Variant0(Vec<BinTransformStepsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BinTransformStepsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BinTransformType {
+    #[educe(Default)]
     #[serde(rename = "bin")]
     Bin,
 }
@@ -2478,9 +2794,11 @@ impl std::convert::TryFrom<&String> for BinTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Bind {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         debounce: Option<f64>,
@@ -2534,8 +2852,12 @@ pub enum Bind {
         event: Option<String>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BindVariant0Input {
+    #[educe(Default)]
     #[serde(rename = "checkbox")]
     Checkbox,
 }
@@ -2567,8 +2889,12 @@ impl std::convert::TryFrom<&String> for BindVariant0Input {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BindVariant1Input {
+    #[educe(Default)]
     #[serde(rename = "radio")]
     Radio,
     #[serde(rename = "select")]
@@ -2604,8 +2930,12 @@ impl std::convert::TryFrom<&String> for BindVariant1Input {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BindVariant2Input {
+    #[educe(Default)]
     #[serde(rename = "range")]
     Range,
 }
@@ -2637,7 +2967,7 @@ impl std::convert::TryFrom<&String> for BindVariant2Input {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BindVariant3Input(String);
 impl std::ops::Deref for BindVariant3Input {
     type Target = String;
@@ -2662,27 +2992,29 @@ impl std::convert::TryFrom<String> for BindVariant3Input {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BlendValue {
+    #[educe(Default)]
     Variant0(Vec<BlendValueVariant0Item>),
     Variant1(BlendValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: BlendValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BlendValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -2693,9 +3025,11 @@ pub struct BlendValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>,
@@ -2707,8 +3041,12 @@ pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "multiply")]
     Multiply,
     #[serde(rename = "screen")]
@@ -2798,26 +3136,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BlendValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BlendValueVariant1Subtype1Subtype0>,
@@ -2828,9 +3168,11 @@ pub struct BlendValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BlendValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BlendValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: Option<BlendValueVariant1Subtype1Subtype0Variant1Value>,
@@ -2842,8 +3184,12 @@ pub enum BlendValueVariant1Subtype1Subtype0 {
         range: BlendValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum BlendValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "multiply")]
     Multiply,
     #[serde(rename = "screen")]
@@ -2931,45 +3277,51 @@ impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype1Subtype0Varian
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BlendValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanOrSignal {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanValue {
+    #[educe(Default)]
     Variant0(Vec<BooleanValueVariant0Item>),
     Variant1(BooleanValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: BooleanValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BooleanValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -2980,9 +3332,11 @@ pub struct BooleanValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: bool,
@@ -2994,26 +3348,28 @@ pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: BooleanValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BooleanValueVariant1Subtype1Subtype0>,
@@ -3024,9 +3380,11 @@ pub struct BooleanValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<BooleanValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: bool,
@@ -3038,19 +3396,21 @@ pub enum BooleanValueVariant1Subtype1Subtype0 {
         range: BooleanValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BooleanValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CollectTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3060,8 +3420,12 @@ pub struct CollectTransform {
     #[serde(rename = "type")]
     pub type_: CollectTransformType,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CollectTransformType {
+    #[educe(Default)]
     #[serde(rename = "collect")]
     Collect,
 }
@@ -3093,46 +3457,50 @@ impl std::convert::TryFrom<&String> for CollectTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColorHcl {
     pub c: NumberValue,
     pub h: NumberValue,
     pub l: NumberValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColorHsl {
     pub h: NumberValue,
     pub l: NumberValue,
     pub s: NumberValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColorLab {
     pub a: NumberValue,
     pub b: NumberValue,
     pub l: NumberValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColorRgb {
     pub b: NumberValue,
     pub g: NumberValue,
     pub r: NumberValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ColorValue {
+    #[educe(Default)]
     Variant0(Vec<ColorValueVariant0Item>),
     Variant1(BaseColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ColorValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: BaseColorValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Compare {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         field: Option<CompareVariant0Field>,
@@ -3146,19 +3514,23 @@ pub enum Compare {
         order: Vec<SortOrder>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CompareVariant0Field {
+    #[educe(Default)]
     ScaleField(ScaleField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CompareVariant1FieldItem {
+    #[educe(Default)]
     ScaleField(ScaleField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContourTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3187,62 +3559,84 @@ pub struct ContourTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub y: Option<ContourTransformY>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformBandwidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformCellSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformCount {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformNice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformSize {
+    #[educe(Default)]
     Variant0(ContourTransformSizeVariant0, ContourTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformSmooth {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformThresholds {
+    #[educe(Default)]
     Variant0(Vec<ContourTransformThresholdsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformThresholdsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ContourTransformType {
+    #[educe(Default)]
     #[serde(rename = "contour")]
     Contour,
 }
@@ -3274,40 +3668,50 @@ impl std::convert::TryFrom<&String> for ContourTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformValues {
+    #[educe(Default)]
     Variant0(Vec<ContourTransformValuesVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformValuesVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformWeight {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ContourTransformY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CountpatternTransform {
     #[serde(rename = "as", default = "defaults::countpattern_transform_as")]
@@ -3324,29 +3728,39 @@ pub struct CountpatternTransform {
     #[serde(rename = "type")]
     pub type_: CountpatternTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformAs {
+    #[educe(Default)]
     Variant0(
         CountpatternTransformAsVariant0,
         CountpatternTransformAsVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformCase {
+    #[educe(Default)]
     Variant0(CountpatternTransformCaseVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CountpatternTransformCaseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "upper")]
     Upper,
     #[serde(rename = "lower")]
@@ -3386,27 +3800,37 @@ impl std::convert::TryFrom<&String> for CountpatternTransformCaseVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformPattern {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CountpatternTransformStopwords {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CountpatternTransformType {
+    #[educe(Default)]
     #[serde(rename = "countpattern")]
     Countpattern,
 }
@@ -3438,7 +3862,7 @@ impl std::convert::TryFrom<&String> for CountpatternTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CrossTransform {
     #[serde(rename = "as", default = "defaults::cross_transform_as")]
@@ -3450,20 +3874,28 @@ pub struct CrossTransform {
     #[serde(rename = "type")]
     pub type_: CrossTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CrossTransformAs {
+    #[educe(Default)]
     Variant0(CrossTransformAsVariant0, CrossTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CrossTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CrossTransformType {
+    #[educe(Default)]
     #[serde(rename = "cross")]
     Cross,
 }
@@ -3495,7 +3927,7 @@ impl std::convert::TryFrom<&String> for CrossTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CrossfilterTransform {
     pub fields: CrossfilterTransformFields,
@@ -3505,27 +3937,37 @@ pub struct CrossfilterTransform {
     #[serde(rename = "type")]
     pub type_: CrossfilterTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFields {
+    #[educe(Default)]
     Variant0(Vec<CrossfilterTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFieldsVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum CrossfilterTransformQuery {
+    #[educe(Default)]
     Variant0(Vec<serde_json::Value>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum CrossfilterTransformType {
+    #[educe(Default)]
     #[serde(rename = "crossfilter")]
     Crossfilter,
 }
@@ -3557,9 +3999,11 @@ impl std::convert::TryFrom<&String> for CrossfilterTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Data {
+    #[educe(Default)]
     Variant0 {
         name: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3600,19 +4044,23 @@ pub enum Data {
         values: DataVariant3Values,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant1Source {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant2Format {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DataVariant2FormatVariant0 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<DataVariant2FormatVariant0Subtype0>,
@@ -3625,16 +4073,18 @@ pub struct DataVariant2FormatVariant0 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_4: Option<DataVariant2FormatVariant0Subtype4>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parse: Option<DataVariant2FormatVariant0Subtype0Parse>,
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<StringOrSignal>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype0Parse {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -3645,8 +4095,12 @@ pub enum DataVariant2FormatVariant0Subtype0Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -3678,14 +4132,20 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -3733,7 +4193,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -3782,7 +4242,7 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3794,9 +4254,11 @@ pub struct DataVariant2FormatVariant0Subtype1 {
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<DataVariant2FormatVariant0Subtype1Type>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype1Parse {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -3807,8 +4269,12 @@ pub enum DataVariant2FormatVariant0Subtype1Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -3840,14 +4306,20 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -3895,7 +4367,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -3944,8 +4416,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype1Type {
+    #[educe(Default)]
     #[serde(rename = "json")]
     Json,
 }
@@ -3977,7 +4453,7 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -3987,9 +4463,11 @@ pub struct DataVariant2FormatVariant0Subtype2 {
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype2Type,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype2Parse {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -4000,8 +4478,12 @@ pub enum DataVariant2FormatVariant0Subtype2Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -4033,14 +4515,20 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -4088,7 +4576,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -4137,8 +4625,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype2Type {
+    #[educe(Default)]
     #[serde(rename = "csv")]
     Csv,
     #[serde(rename = "tsv")]
@@ -4174,7 +4666,7 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype3 {
     pub delimiter: String,
@@ -4185,9 +4677,11 @@ pub struct DataVariant2FormatVariant0Subtype3 {
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype3Type,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype3Parse {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -4198,8 +4692,12 @@ pub enum DataVariant2FormatVariant0Subtype3Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -4231,14 +4729,20 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -4286,7 +4790,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -4335,8 +4839,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype3Type {
+    #[educe(Default)]
     #[serde(rename = "dsv")]
     Dsv,
 }
@@ -4368,9 +4876,11 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype4 {
+    #[educe(Default)]
     Variant0 {
         feature: StringOrSignal,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4388,8 +4898,12 @@ pub enum DataVariant2FormatVariant0Subtype4 {
         type_: DataVariant2FormatVariant0Subtype4Variant1Type,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype4Variant0Type {
+    #[educe(Default)]
     #[serde(rename = "topojson")]
     Topojson,
 }
@@ -4421,8 +4935,12 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Filter {
+    #[educe(Default)]
     #[serde(rename = "interior")]
     Interior,
     #[serde(rename = "exterior")]
@@ -4458,8 +4976,12 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Type {
+    #[educe(Default)]
     #[serde(rename = "topojson")]
     Topojson,
 }
@@ -4491,13 +5013,15 @@ impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3Format {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DataVariant3FormatVariant0 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<DataVariant3FormatVariant0Subtype0>,
@@ -4510,16 +5034,18 @@ pub struct DataVariant3FormatVariant0 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_4: Option<DataVariant3FormatVariant0Subtype4>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parse: Option<DataVariant3FormatVariant0Subtype0Parse>,
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<StringOrSignal>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype0Parse {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -4530,8 +5056,12 @@ pub enum DataVariant3FormatVariant0Subtype0Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -4563,14 +5093,20 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -4618,7 +5154,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -4667,7 +5203,7 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4679,9 +5215,11 @@ pub struct DataVariant3FormatVariant0Subtype1 {
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<DataVariant3FormatVariant0Subtype1Type>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype1Parse {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -4692,8 +5230,12 @@ pub enum DataVariant3FormatVariant0Subtype1Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -4725,14 +5267,20 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -4780,7 +5328,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -4829,8 +5377,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype1Type {
+    #[educe(Default)]
     #[serde(rename = "json")]
     Json,
 }
@@ -4862,7 +5414,7 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -4872,9 +5424,11 @@ pub struct DataVariant3FormatVariant0Subtype2 {
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype2Type,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype2Parse {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -4885,8 +5439,12 @@ pub enum DataVariant3FormatVariant0Subtype2Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -4918,14 +5476,20 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -4973,7 +5537,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -5022,8 +5586,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype2Type {
+    #[educe(Default)]
     #[serde(rename = "csv")]
     Csv,
     #[serde(rename = "tsv")]
@@ -5059,7 +5627,7 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype3 {
     pub delimiter: String,
@@ -5070,9 +5638,11 @@ pub struct DataVariant3FormatVariant0Subtype3 {
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype3Type,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype3Parse {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant0),
     Variant1 {
         #[serde(flatten)]
@@ -5083,8 +5653,12 @@ pub enum DataVariant3FormatVariant0Subtype3Parse {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant0 {
+    #[educe(Default)]
     #[serde(rename = "auto")]
     Auto,
 }
@@ -5116,14 +5690,20 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtra {
+    #[educe(Default)]
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0),
     Variant1(DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0 {
+    #[educe(Default)]
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -5171,7 +5751,7 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1 {
     type Target = String;
@@ -5220,8 +5800,12 @@ impl<'de> serde::Deserialize<'de>
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype3Type {
+    #[educe(Default)]
     #[serde(rename = "dsv")]
     Dsv,
 }
@@ -5253,9 +5837,11 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype4 {
+    #[educe(Default)]
     Variant0 {
         feature: StringOrSignal,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5273,8 +5859,12 @@ pub enum DataVariant3FormatVariant0Subtype4 {
         type_: DataVariant3FormatVariant0Subtype4Variant1Type,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype4Variant0Type {
+    #[educe(Default)]
     #[serde(rename = "topojson")]
     Topojson,
 }
@@ -5306,8 +5896,12 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Filter {
+    #[educe(Default)]
     #[serde(rename = "interior")]
     Interior,
     #[serde(rename = "exterior")]
@@ -5343,8 +5937,12 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Type {
+    #[educe(Default)]
     #[serde(rename = "topojson")]
     Topojson,
 }
@@ -5376,13 +5974,15 @@ impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Varian
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DataVariant3Values {
+    #[educe(Default)]
     Variant0(serde_json::Value),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DensityTransform {
     #[serde(rename = "as", default = "defaults::density_transform_as")]
@@ -5404,21 +6004,27 @@ pub struct DensityTransform {
     #[serde(rename = "type")]
     pub type_: DensityTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformAs {
+    #[educe(Default)]
     Variant0(Vec<DensityTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DensityTransformDistribution {
+    #[educe(Default)]
     Variant0 {
         function: DensityTransformDistributionVariant0Function,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5456,8 +6062,12 @@ pub enum DensityTransformDistribution {
         weights: Option<DensityTransformDistributionVariant4Weights>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformDistributionVariant0Function {
+    #[educe(Default)]
     #[serde(rename = "normal")]
     Normal,
 }
@@ -5489,20 +6099,28 @@ impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant0Func
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant0Mean {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant0Stdev {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformDistributionVariant1Function {
+    #[educe(Default)]
     #[serde(rename = "lognormal")]
     Lognormal,
 }
@@ -5534,20 +6152,28 @@ impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant1Func
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant1Mean {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant1Stdev {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformDistributionVariant2Function {
+    #[educe(Default)]
     #[serde(rename = "uniform")]
     Uniform,
 }
@@ -5579,33 +6205,45 @@ impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant2Func
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant2Max {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant2Min {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant3Bandwidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant3Field {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformDistributionVariant3Function {
+    #[educe(Default)]
     #[serde(rename = "kde")]
     Kde,
 }
@@ -5637,14 +6275,20 @@ impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant3Func
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant4Distributions {
+    #[educe(Default)]
     Variant0(Vec<serde_json::Value>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformDistributionVariant4Function {
+    #[educe(Default)]
     #[serde(rename = "mixture")]
     Mixture,
 }
@@ -5676,59 +6320,79 @@ impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant4Func
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant4Weights {
+    #[educe(Default)]
     Variant0(Vec<DensityTransformDistributionVariant4WeightsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant4WeightsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformExtent {
+    #[educe(Default)]
     Variant0(
         DensityTransformExtentVariant0,
         DensityTransformExtentVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformExtentVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformMaxsteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformMethod {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformMinsteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DensityTransformSteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DensityTransformType {
+    #[educe(Default)]
     #[serde(rename = "density")]
     Density,
 }
@@ -5760,27 +6424,29 @@ impl std::convert::TryFrom<&String> for DensityTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DirectionValue {
+    #[educe(Default)]
     Variant0(Vec<DirectionValueVariant0Item>),
     Variant1(DirectionValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: DirectionValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: DirectionValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -5791,9 +6457,11 @@ pub struct DirectionValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -5805,8 +6473,12 @@ pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "horizontal")]
     Horizontal,
     #[serde(rename = "vertical")]
@@ -5846,26 +6518,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: DirectionValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<DirectionValueVariant1Subtype1Subtype0>,
@@ -5876,9 +6550,11 @@ pub struct DirectionValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<DirectionValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: DirectionValueVariant1Subtype1Subtype0Variant1Value,
@@ -5890,8 +6566,12 @@ pub enum DirectionValueVariant1Subtype1Subtype0 {
         range: DirectionValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DirectionValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "horizontal")]
     Horizontal,
     #[serde(rename = "vertical")]
@@ -5927,19 +6607,21 @@ impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype1Subtype0Va
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DotbinTransform {
     #[serde(rename = "as", default = "defaults::dotbin_transform_as")]
@@ -5956,46 +6638,62 @@ pub struct DotbinTransform {
     #[serde(rename = "type")]
     pub type_: DotbinTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<DotbinTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformSmooth {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum DotbinTransformStep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum DotbinTransformType {
+    #[educe(Default)]
     #[serde(rename = "dotbin")]
     Dotbin,
 }
@@ -6027,7 +6725,7 @@ impl std::convert::TryFrom<&String> for DotbinTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Element(pub String);
 impl std::ops::Deref for Element {
     type Target = String;
@@ -6035,10 +6733,10 @@ impl std::ops::Deref for Element {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Encode {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub align: Option<AlignValue>,
@@ -6259,14 +6957,14 @@ pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zindex: Option<NumberValue>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Everything {
     #[serde(flatten)]
     pub subtype_0: Scope,
     #[serde(flatten)]
     pub subtype_1: EverythingSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct EverythingSubtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autosize: Option<Autosize>,
@@ -6287,13 +6985,13 @@ pub struct EverythingSubtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub width: Option<NumberOrSignal>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Expr {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
     pub as_: Option<String>,
     pub expr: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ExprString(pub String);
 impl std::ops::Deref for ExprString {
     type Target = String;
@@ -6301,7 +6999,7 @@ impl std::ops::Deref for ExprString {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExtentTransform {
     pub field: ExtentTransformField,
@@ -6310,15 +7008,21 @@ pub struct ExtentTransform {
     #[serde(rename = "type")]
     pub type_: ExtentTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ExtentTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ExtentTransformType {
+    #[educe(Default)]
     #[serde(rename = "extent")]
     Extent,
 }
@@ -6350,16 +7054,18 @@ impl std::convert::TryFrom<&String> for ExtentTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Facet {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
     pub facet: FacetFacet,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum FacetFacet {
+    #[educe(Default)]
     Variant0 {
         data: String,
         field: String,
@@ -6373,7 +7079,7 @@ pub enum FacetFacet {
         name: String,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FacetFacetVariant1Aggregate {
     #[serde(rename = "as", default, skip_serializing_if = "Vec::is_empty")]
@@ -6385,15 +7091,19 @@ pub struct FacetFacetVariant1Aggregate {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ops: Vec<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FacetFacetVariant1Groupby {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Field {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2 {
@@ -6410,7 +7120,7 @@ pub enum Field {
         parent: Box<Field>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FilterTransform {
     pub expr: ExprString,
@@ -6419,8 +7129,12 @@ pub struct FilterTransform {
     #[serde(rename = "type")]
     pub type_: FilterTransformType,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum FilterTransformType {
+    #[educe(Default)]
     #[serde(rename = "filter")]
     Filter,
 }
@@ -6452,7 +7166,7 @@ impl std::convert::TryFrom<&String> for FilterTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FlattenTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -6465,39 +7179,53 @@ pub struct FlattenTransform {
     #[serde(rename = "type")]
     pub type_: FlattenTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FlattenTransformAs {
+    #[educe(Default)]
     Variant0(Vec<FlattenTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FlattenTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FlattenTransformFields {
+    #[educe(Default)]
     Variant0(Vec<FlattenTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FlattenTransformFieldsVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FlattenTransformIndex {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum FlattenTransformType {
+    #[educe(Default)]
     #[serde(rename = "flatten")]
     Flatten,
 }
@@ -6529,7 +7257,7 @@ impl std::convert::TryFrom<&String> for FlattenTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FoldTransform {
     #[serde(rename = "as", default = "defaults::fold_transform_as")]
@@ -6540,33 +7268,45 @@ pub struct FoldTransform {
     #[serde(rename = "type")]
     pub type_: FoldTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FoldTransformAs {
+    #[educe(Default)]
     Variant0(FoldTransformAsVariant0, FoldTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FoldTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FoldTransformFields {
+    #[educe(Default)]
     Variant0(Vec<FoldTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FoldTransformFieldsVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum FoldTransformType {
+    #[educe(Default)]
     #[serde(rename = "fold")]
     Fold,
 }
@@ -6598,27 +7338,29 @@ impl std::convert::TryFrom<&String> for FoldTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FontWeightValue {
+    #[educe(Default)]
     Variant0(Vec<FontWeightValueVariant0Item>),
     Variant1(FontWeightValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: FontWeightValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: FontWeightValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -6629,9 +7371,11 @@ pub struct FontWeightValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: MyEnum,
@@ -6643,26 +7387,28 @@ pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: FontWeightValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<FontWeightValueVariant1Subtype1Subtype0>,
@@ -6673,9 +7419,11 @@ pub struct FontWeightValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<FontWeightValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: MyEnum,
@@ -6687,19 +7435,21 @@ pub enum FontWeightValueVariant1Subtype1Subtype0 {
         range: FontWeightValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForceTransform {
     #[serde(default = "defaults::force_transform_alpha")]
@@ -6732,39 +7482,51 @@ pub struct ForceTransform {
     )]
     pub velocity_decay: ForceTransformVelocityDecay,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformAlpha {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaMin {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaTarget {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformAs {
+    #[educe(Default)]
     Variant0(Vec<ForceTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ForceTransformForcesItem {
+    #[educe(Default)]
     Variant0 {
         force: ForceTransformForcesItemVariant0Force,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6827,8 +7589,12 @@ pub enum ForceTransformForcesItem {
         y: Option<ForceTransformForcesItemVariant5Y>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant0Force {
+    #[educe(Default)]
     #[serde(rename = "center")]
     Center,
 }
@@ -6860,20 +7626,28 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant0Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant0X {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant0Y {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant1Force {
+    #[educe(Default)]
     #[serde(rename = "collide")]
     Collide,
 }
@@ -6905,40 +7679,54 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant1Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant1Iterations {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant1Radius {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant1Strength {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2DistanceMax {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2DistanceMin {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant2Force {
+    #[educe(Default)]
     #[serde(rename = "nbody")]
     Nbody,
 }
@@ -6970,28 +7758,38 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant2Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2Strength {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2Theta {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Distance {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant3Force {
+    #[educe(Default)]
     #[serde(rename = "link")]
     Link,
 }
@@ -7023,29 +7821,39 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant3Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Id {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Iterations {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Strength {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant4Force {
+    #[educe(Default)]
     #[serde(rename = "x")]
     X,
 }
@@ -7077,21 +7885,29 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant4Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant4Strength {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant4X {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformForcesItemVariant5Force {
+    #[educe(Default)]
     #[serde(rename = "y")]
     Y,
 }
@@ -7123,39 +7939,53 @@ impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant5Force {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant5Strength {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant5Y {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformIterations {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformRestart {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformStatic {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ForceTransformType {
+    #[educe(Default)]
     #[serde(rename = "force")]
     Force,
 }
@@ -7187,13 +8017,15 @@ impl std::convert::TryFrom<&String> for ForceTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ForceTransformVelocityDecay {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FormulaTransform {
     #[serde(rename = "as")]
@@ -7206,20 +8038,28 @@ pub struct FormulaTransform {
     #[serde(rename = "type")]
     pub type_: FormulaTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FormulaTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum FormulaTransformInitonly {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum FormulaTransformType {
+    #[educe(Default)]
     #[serde(rename = "formula")]
     Formula,
 }
@@ -7251,13 +8091,13 @@ impl std::convert::TryFrom<&String> for FormulaTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct From {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeojsonTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7269,31 +8109,41 @@ pub struct GeojsonTransform {
     #[serde(rename = "type")]
     pub type_: GeojsonTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeojsonTransformFields {
+    #[educe(Default)]
     Variant0(
         GeojsonTransformFieldsVariant0,
         GeojsonTransformFieldsVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeojsonTransformFieldsVariant0 {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeojsonTransformGeojson {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GeojsonTransformType {
+    #[educe(Default)]
     #[serde(rename = "geojson")]
     Geojson,
 }
@@ -7325,7 +8175,7 @@ impl std::convert::TryFrom<&String> for GeojsonTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeopathTransform {
     #[serde(rename = "as", default = "defaults::geopath_transform_as")]
@@ -7345,29 +8195,39 @@ pub struct GeopathTransform {
     #[serde(rename = "type")]
     pub type_: GeopathTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopathTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopathTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopathTransformPointRadius {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GeopathTransformType {
+    #[educe(Default)]
     #[serde(rename = "geopath")]
     Geopath,
 }
@@ -7399,7 +8259,7 @@ impl std::convert::TryFrom<&String> for GeopathTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeopointTransform {
     #[serde(rename = "as", default = "defaults::geopoint_transform_as")]
@@ -7411,36 +8271,48 @@ pub struct GeopointTransform {
     #[serde(rename = "type")]
     pub type_: GeopointTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopointTransformAs {
+    #[educe(Default)]
     Variant0(GeopointTransformAsVariant0, GeopointTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopointTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopointTransformFields {
+    #[educe(Default)]
     Variant0(
         GeopointTransformFieldsVariant0,
         GeopointTransformFieldsVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeopointTransformFieldsVariant0 {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GeopointTransformType {
+    #[educe(Default)]
     #[serde(rename = "geopoint")]
     Geopoint,
 }
@@ -7472,7 +8344,7 @@ impl std::convert::TryFrom<&String> for GeopointTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeoshapeTransform {
     #[serde(rename = "as", default = "defaults::geoshape_transform_as")]
@@ -7492,29 +8364,39 @@ pub struct GeoshapeTransform {
     #[serde(rename = "type")]
     pub type_: GeoshapeTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeoshapeTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeoshapeTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GeoshapeTransformPointRadius {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GeoshapeTransformType {
+    #[educe(Default)]
     #[serde(rename = "geoshape")]
     Geoshape,
 }
@@ -7546,7 +8428,7 @@ impl std::convert::TryFrom<&String> for GeoshapeTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct GradientStops(pub Vec<GradientStopsItem>);
 impl std::ops::Deref for GradientStops {
     type Target = Vec<GradientStopsItem>;
@@ -7554,13 +8436,13 @@ impl std::ops::Deref for GradientStops {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GradientStopsItem {
     pub color: String,
     pub offset: f64,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GraticuleTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7596,77 +8478,101 @@ pub struct GraticuleTransform {
     #[serde(rename = "type")]
     pub type_: GraticuleTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtent {
+    #[educe(Default)]
     Variant0(serde_json::Value, serde_json::Value),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMajor {
+    #[educe(Default)]
     Variant0(serde_json::Value, serde_json::Value),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMinor {
+    #[educe(Default)]
     Variant0(serde_json::Value, serde_json::Value),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformPrecision {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStep {
+    #[educe(Default)]
     Variant0(
         GraticuleTransformStepVariant0,
         GraticuleTransformStepVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajor {
+    #[educe(Default)]
     Variant0(
         GraticuleTransformStepMajorVariant0,
         GraticuleTransformStepMajorVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajorVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinor {
+    #[educe(Default)]
     Variant0(
         GraticuleTransformStepMinorVariant0,
         GraticuleTransformStepMinorVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinorVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum GraticuleTransformType {
+    #[educe(Default)]
     #[serde(rename = "graticule")]
     Graticule,
 }
@@ -7698,7 +8604,7 @@ impl std::convert::TryFrom<&String> for GraticuleTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GuideEncode {
     #[serde(default)]
@@ -7708,7 +8614,7 @@ pub struct GuideEncode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub style: Option<Style>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HeatmapTransform {
     #[serde(rename = "as", default = "defaults::heatmap_transform_as")]
@@ -7726,43 +8632,57 @@ pub struct HeatmapTransform {
     #[serde(rename = "type")]
     pub type_: HeatmapTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum HeatmapTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum HeatmapTransformColor {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum HeatmapTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum HeatmapTransformOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum HeatmapTransformResolve {
+    #[educe(Default)]
     Variant0(HeatmapTransformResolveVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum HeatmapTransformResolveVariant0 {
+    #[educe(Default)]
     #[serde(rename = "shared")]
     Shared,
     #[serde(rename = "independent")]
@@ -7798,8 +8718,12 @@ impl std::convert::TryFrom<&String> for HeatmapTransformResolveVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum HeatmapTransformType {
+    #[educe(Default)]
     #[serde(rename = "heatmap")]
     Heatmap,
 }
@@ -7831,7 +8755,7 @@ impl std::convert::TryFrom<&String> for HeatmapTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IdentifierTransform {
     #[serde(rename = "as")]
@@ -7841,14 +8765,20 @@ pub struct IdentifierTransform {
     #[serde(rename = "type")]
     pub type_: IdentifierTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IdentifierTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IdentifierTransformType {
+    #[educe(Default)]
     #[serde(rename = "identifier")]
     Identifier,
 }
@@ -7880,7 +8810,7 @@ impl std::convert::TryFrom<&String> for IdentifierTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImputeTransform {
     pub field: ImputeTransformField,
@@ -7898,47 +8828,63 @@ pub struct ImputeTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<ImputeTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformKeyvals {
+    #[educe(Default)]
     Variant0(Vec<serde_json::Value>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ImputeTransformMethod {
+    #[educe(Default)]
     Variant0(ImputeTransformMethodVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ImputeTransformMethodVariant0 {
+    #[educe(Default)]
     #[serde(rename = "value")]
     Value,
     #[serde(rename = "mean")]
@@ -7986,8 +8932,12 @@ impl std::convert::TryFrom<&String> for ImputeTransformMethodVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ImputeTransformType {
+    #[educe(Default)]
     #[serde(rename = "impute")]
     Impute,
 }
@@ -8019,7 +8969,7 @@ impl std::convert::TryFrom<&String> for ImputeTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IsocontourTransform {
     #[serde(rename = "as", default = "defaults::isocontour_transform_as")]
@@ -8047,40 +8997,54 @@ pub struct IsocontourTransform {
     #[serde(default = "defaults::isocontour_transform_zero")]
     pub zero: IsocontourTransformZero,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformLevels {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformNice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformResolve {
+    #[educe(Default)]
     Variant0(IsocontourTransformResolveVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IsocontourTransformResolveVariant0 {
+    #[educe(Default)]
     #[serde(rename = "shared")]
     Shared,
     #[serde(rename = "independent")]
@@ -8116,48 +9080,64 @@ impl std::convert::TryFrom<&String> for IsocontourTransformResolveVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformScale {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformSmooth {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholds {
+    #[educe(Default)]
     Variant0(Vec<IsocontourTransformThresholdsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholdsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslate {
+    #[educe(Default)]
     Variant0(Vec<IsocontourTransformTranslateVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslateVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum IsocontourTransformType {
+    #[educe(Default)]
     #[serde(rename = "isocontour")]
     Isocontour,
 }
@@ -8189,13 +9169,15 @@ impl std::convert::TryFrom<&String> for IsocontourTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IsocontourTransformZero {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JoinaggregateTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -8213,67 +9195,89 @@ pub struct JoinaggregateTransform {
     #[serde(rename = "type")]
     pub type_: JoinaggregateTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAs {
+    #[educe(Default)]
     Variant0(Vec<JoinaggregateTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFields {
+    #[educe(Default)]
     Variant0(Vec<JoinaggregateTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFieldsVariant0Item {
+    #[educe(Default)]
     Variant0(ScaleField),
     Variant1(ParamField),
     Variant2(Expr),
     Variant3,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<JoinaggregateTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOps {
+    #[educe(Default)]
     Variant0(Vec<JoinaggregateTransformOpsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOpsVariant0Item {
+    #[educe(Default)]
     Variant0(JoinaggregateTransformOpsVariant0ItemVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum JoinaggregateTransformOpsVariant0ItemVariant0 {
+    #[educe(Default)]
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
@@ -8397,8 +9401,12 @@ impl std::convert::TryFrom<&String> for JoinaggregateTransformOpsVariant0ItemVar
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum JoinaggregateTransformType {
+    #[educe(Default)]
     #[serde(rename = "joinaggregate")]
     Joinaggregate,
 }
@@ -8430,7 +9438,7 @@ impl std::convert::TryFrom<&String> for JoinaggregateTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Kde2dTransform {
     #[serde(rename = "as", default = "defaults::kde2d_transform_as")]
@@ -8453,66 +9461,88 @@ pub struct Kde2dTransform {
     pub x: Kde2dTransformX,
     pub y: Kde2dTransformY,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidth {
+    #[educe(Default)]
     Variant0(
         Kde2dTransformBandwidthVariant0,
         Kde2dTransformBandwidthVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidthVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformCellSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformCounts {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<Kde2dTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformSize {
+    #[educe(Default)]
     Variant0(Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum Kde2dTransformType {
+    #[educe(Default)]
     #[serde(rename = "kde2d")]
     Kde2d,
 }
@@ -8544,28 +9574,34 @@ impl std::convert::TryFrom<&String> for Kde2dTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformWeight {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Kde2dTransformY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct KdeTransform {
     #[serde(rename = "as", default = "defaults::kde_transform_as")]
@@ -8594,88 +9630,118 @@ pub struct KdeTransform {
     #[serde(rename = "type")]
     pub type_: KdeTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformAs {
+    #[educe(Default)]
     Variant0(Vec<KdeTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformBandwidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformCounts {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformCumulative {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformExtent {
+    #[educe(Default)]
     Variant0(KdeTransformExtentVariant0, KdeTransformExtentVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformExtentVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<KdeTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformMaxsteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformMinsteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformResolve {
+    #[educe(Default)]
     Variant0(KdeTransformResolveVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum KdeTransformResolveVariant0 {
+    #[educe(Default)]
     #[serde(rename = "shared")]
     Shared,
     #[serde(rename = "independent")]
@@ -8711,14 +9777,20 @@ impl std::convert::TryFrom<&String> for KdeTransformResolveVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum KdeTransformSteps {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum KdeTransformType {
+    #[educe(Default)]
     #[serde(rename = "kde")]
     Kde,
 }
@@ -8750,15 +9822,21 @@ impl std::convert::TryFrom<&String> for KdeTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelOverlap {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(LabelOverlapVariant1),
     Variant2(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LabelOverlapVariant1 {
+    #[educe(Default)]
     #[serde(rename = "parity")]
     Parity,
     #[serde(rename = "greedy")]
@@ -8794,7 +9872,7 @@ impl std::convert::TryFrom<&String> for LabelOverlapVariant1 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelTransform {
     #[serde(default = "defaults::label_transform_anchor")]
@@ -8833,21 +9911,27 @@ pub struct LabelTransform {
     #[serde(rename = "type")]
     pub type_: LabelTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAnchor {
+    #[educe(Default)]
     Variant0(Vec<LabelTransformAnchorVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAnchorVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAs {
+    #[educe(Default)]
     Variant0(
         LabelTransformAsVariant0,
         LabelTransformAsVariant0,
@@ -8857,75 +9941,101 @@ pub enum LabelTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidBaseMark {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidMarks {
+    #[educe(Default)]
     Variant0(Vec<String>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformLineAnchor {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformMarkIndex {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformMethod {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformOffset {
+    #[educe(Default)]
     Variant0(Vec<LabelTransformOffsetVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformOffsetVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformSize {
+    #[educe(Default)]
     Variant0(LabelTransformSizeVariant0, LabelTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LabelTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LabelTransformType {
+    #[educe(Default)]
     #[serde(rename = "label")]
     Label,
 }
@@ -8957,9 +10067,11 @@ impl std::convert::TryFrom<&String> for LabelTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Layout {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         align: Option<LayoutVariant0Align>,
@@ -8996,9 +10108,11 @@ pub enum Layout {
     },
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Align {
+    #[educe(Default)]
     Variant0(LayoutVariant0AlignVariant0),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9007,14 +10121,20 @@ pub enum LayoutVariant0Align {
         row: Option<LayoutVariant0AlignVariant1Row>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant0 {
+    #[educe(Default)]
     Variant0(LayoutVariant0AlignVariant0Variant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0AlignVariant0Variant0 {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -9054,14 +10174,20 @@ impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant0Variant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant1Column {
+    #[educe(Default)]
     Variant0(LayoutVariant0AlignVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0AlignVariant1ColumnVariant0 {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -9101,14 +10227,20 @@ impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1ColumnVariant
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant1Row {
+    #[educe(Default)]
     Variant0(LayoutVariant0AlignVariant1RowVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0AlignVariant1RowVariant0 {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -9148,14 +10280,20 @@ impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1RowVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0Bounds {
+    #[educe(Default)]
     Variant0(LayoutVariant0BoundsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0BoundsVariant0 {
+    #[educe(Default)]
     #[serde(rename = "full")]
     Full,
     #[serde(rename = "flush")]
@@ -9191,9 +10329,11 @@ impl std::convert::TryFrom<&String> for LayoutVariant0BoundsVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Center {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
     Variant2 {
@@ -9203,9 +10343,11 @@ pub enum LayoutVariant0Center {
         row: Option<BooleanOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0FooterBand {
+    #[educe(Default)]
     Variant0(NumberOrSignal),
     Variant1,
     Variant2 {
@@ -9215,9 +10357,11 @@ pub enum LayoutVariant0FooterBand {
         row: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0HeaderBand {
+    #[educe(Default)]
     Variant0(NumberOrSignal),
     Variant1,
     Variant2 {
@@ -9227,9 +10371,11 @@ pub enum LayoutVariant0HeaderBand {
         row: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Offset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2 {
@@ -9259,9 +10405,11 @@ pub enum LayoutVariant0Offset {
         row_title: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Padding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2 {
@@ -9271,9 +10419,11 @@ pub enum LayoutVariant0Padding {
         row: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0TitleAnchor {
+    #[educe(Default)]
     Variant0(LayoutVariant0TitleAnchorVariant0),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9282,14 +10432,20 @@ pub enum LayoutVariant0TitleAnchor {
         row: Option<LayoutVariant0TitleAnchorVariant1Row>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant0 {
+    #[educe(Default)]
     Variant0(LayoutVariant0TitleAnchorVariant0Variant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0TitleAnchorVariant0Variant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
@@ -9325,14 +10481,20 @@ impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant0Variant
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Column {
+    #[educe(Default)]
     Variant0(LayoutVariant0TitleAnchorVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
@@ -9368,14 +10530,20 @@ impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1ColumnV
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Row {
+    #[educe(Default)]
     Variant0(LayoutVariant0TitleAnchorVariant1RowVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LayoutVariant0TitleAnchorVariant1RowVariant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
@@ -9411,9 +10579,11 @@ impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1RowVari
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0TitleBand {
+    #[educe(Default)]
     Variant0(NumberOrSignal),
     Variant1,
     Variant2 {
@@ -9423,14 +10593,14 @@ pub enum LayoutVariant0TitleBand {
         row: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Legend {
     #[serde(flatten)]
     pub subtype_0: LegendSubtype0,
     #[serde(flatten)]
     pub subtype_1: LegendSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendSubtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9766,14 +10936,20 @@ pub struct LegendSubtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zindex: Option<f64>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0CornerRadius {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0Direction {
+    #[educe(Default)]
     #[serde(rename = "vertical")]
     Vertical,
     #[serde(rename = "horizontal")]
@@ -9809,7 +10985,7 @@ impl std::convert::TryFrom<&String> for LegendSubtype0Direction {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendSubtype0Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9825,16 +11001,20 @@ pub struct LegendSubtype0Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<GuideEncode>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0FillColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendSubtype0Format {
+    #[educe(Default)]
     Variant0(String),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9860,14 +11040,20 @@ pub enum LegendSubtype0Format {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0FormatType {
+    #[educe(Default)]
     Variant0(LegendSubtype0FormatTypeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0FormatTypeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "number")]
     Number,
     #[serde(rename = "time")]
@@ -9907,33 +11093,45 @@ impl std::convert::TryFrom<&String> for LegendSubtype0FormatTypeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0GradientOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0GradientStrokeColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0GradientStrokeWidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0GridAlign {
+    #[educe(Default)]
     Variant0(LegendSubtype0GridAlignVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0GridAlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -9973,14 +11171,20 @@ impl std::convert::TryFrom<&String> for LegendSubtype0GridAlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelAlign {
+    #[educe(Default)]
     Variant0(LegendSubtype0LabelAlignVariant0),
     Variant1(AlignValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0LabelAlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -10020,14 +11224,20 @@ impl std::convert::TryFrom<&String> for LegendSubtype0LabelAlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelBaseline {
+    #[educe(Default)]
     Variant0(LegendSubtype0LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0LabelBaselineVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -10079,81 +11289,109 @@ impl std::convert::TryFrom<&String> for LegendSubtype0LabelBaselineVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelLimit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LegendX {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0LegendY {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0Offset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0Orient {
+    #[educe(Default)]
     Variant0(LegendSubtype0OrientVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0OrientVariant0 {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "left")]
@@ -10217,83 +11455,111 @@ impl std::convert::TryFrom<&String> for LegendSubtype0OrientVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0Padding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0StrokeColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolDash {
+    #[educe(Default)]
     Variant0(Vec<f64>),
     Variant1(ArrayValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolDashOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolFillColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolStrokeColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolStrokeWidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolType {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleAlign {
+    #[educe(Default)]
     Variant0(LegendSubtype0TitleAlignVariant0),
     Variant1(AlignValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0TitleAlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -10333,14 +11599,20 @@ impl std::convert::TryFrom<&String> for LegendSubtype0TitleAlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleAnchor {
+    #[educe(Default)]
     Variant0(Option<LegendSubtype0TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0TitleAnchorVariant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -10380,14 +11652,20 @@ impl std::convert::TryFrom<&String> for LegendSubtype0TitleAnchorVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleBaseline {
+    #[educe(Default)]
     Variant0(LegendSubtype0TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0TitleBaselineVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -10439,63 +11717,85 @@ impl std::convert::TryFrom<&String> for LegendSubtype0TitleBaselineVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleLimit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleLineHeight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleOpacity {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleOrient {
+    #[educe(Default)]
     Variant0(LegendSubtype0TitleOrientVariant0),
     Variant1(OrientValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0TitleOrientVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -10539,14 +11839,20 @@ impl std::convert::TryFrom<&String> for LegendSubtype0TitleOrientVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitlePadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LegendSubtype0Type {
+    #[educe(Default)]
     #[serde(rename = "gradient")]
     Gradient,
     #[serde(rename = "symbol")]
@@ -10582,9 +11888,11 @@ impl std::convert::TryFrom<&String> for LegendSubtype0Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LegendSubtype1 {
+    #[educe(Default)]
     Variant0 {},
     Variant1 {},
     Variant2 {},
@@ -10593,7 +11901,7 @@ pub enum LegendSubtype1 {
     Variant5 {},
     Variant6 {},
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LinearGradient {
     pub gradient: LinearGradientGradient,
@@ -10609,8 +11917,12 @@ pub struct LinearGradient {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub y2: Option<f64>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LinearGradientGradient {
+    #[educe(Default)]
     #[serde(rename = "linear")]
     Linear,
 }
@@ -10642,7 +11954,7 @@ impl std::convert::TryFrom<&String> for LinearGradientGradient {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LinkpathTransform {
     #[serde(rename = "as", default = "defaults::linkpath_transform_as")]
@@ -10666,20 +11978,28 @@ pub struct LinkpathTransform {
     #[serde(rename = "type")]
     pub type_: LinkpathTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformOrient {
+    #[educe(Default)]
     Variant0(LinkpathTransformOrientVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LinkpathTransformOrientVariant0 {
+    #[educe(Default)]
     #[serde(rename = "horizontal")]
     Horizontal,
     #[serde(rename = "vertical")]
@@ -10719,14 +12039,20 @@ impl std::convert::TryFrom<&String> for LinkpathTransformOrientVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformShape {
+    #[educe(Default)]
     Variant0(LinkpathTransformShapeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LinkpathTransformShapeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "line")]
     Line,
     #[serde(rename = "arc")]
@@ -10774,36 +12100,48 @@ impl std::convert::TryFrom<&String> for LinkpathTransformShapeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformSourceX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformSourceY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformTargetX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LinkpathTransformTargetY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LinkpathTransformType {
+    #[educe(Default)]
     #[serde(rename = "linkpath")]
     Linkpath,
 }
@@ -10835,14 +12173,18 @@ impl std::convert::TryFrom<&String> for LinkpathTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Listener {
+    #[educe(Default)]
     Variant0(SignalRef),
-    Variant1 { scale: String },
+    Variant1 {
+        scale: String,
+    },
     Variant2(Stream),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LoessTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -10858,39 +12200,53 @@ pub struct LoessTransform {
     pub x: LoessTransformX,
     pub y: LoessTransformY,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformAs {
+    #[educe(Default)]
     Variant0(Vec<LoessTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformBandwidth {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<LoessTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LoessTransformType {
+    #[educe(Default)]
     #[serde(rename = "loess")]
     Loess,
 }
@@ -10922,21 +12278,25 @@ impl std::convert::TryFrom<&String> for LoessTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LoessTransformY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LookupTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -10953,40 +12313,54 @@ pub struct LookupTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<LookupTransformValues>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformAs {
+    #[educe(Default)]
     Variant0(Vec<LookupTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformFields {
+    #[educe(Default)]
     Variant0(Vec<LookupTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformFieldsVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LookupTransformType {
+    #[educe(Default)]
     #[serde(rename = "lookup")]
     Lookup,
 }
@@ -11018,20 +12392,24 @@ impl std::convert::TryFrom<&String> for LookupTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformValues {
+    #[educe(Default)]
     Variant0(Vec<LookupTransformValuesVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum LookupTransformValuesVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Mark {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aria: Option<bool>,
@@ -11060,7 +12438,7 @@ pub struct Mark {
     #[serde(rename = "type")]
     pub type_: Marktype,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MarkGroup {
     #[serde(flatten)]
     pub mark: Mark,
@@ -11071,14 +12449,20 @@ pub struct MarkGroup {
     #[serde(rename = "type")]
     pub type_: MarkGroupType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum MarkGroupFrom {
+    #[educe(Default)]
     From(From),
     Facet(Facet),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum MarkGroupType {
+    #[educe(Default)]
     #[serde(rename = "group")]
     Group,
 }
@@ -11110,7 +12494,7 @@ impl std::convert::TryFrom<&String> for MarkGroupType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MarkVisual {
     #[serde(flatten)]
     pub mark: Mark,
@@ -11119,7 +12503,7 @@ pub struct MarkVisual {
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<MarkVisualType>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MarkVisualType(String);
 impl std::ops::Deref for MarkVisualType {
     type Target = String;
@@ -11137,14 +12521,20 @@ impl std::convert::TryFrom<String> for MarkVisualType {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Markclip {
+    #[educe(Default)]
     Variant0(BooleanOrSignal),
-    Variant1 { path: StringOrSignal },
-    Variant2 { sphere: StringOrSignal },
+    Variant1 {
+        path: StringOrSignal,
+    },
+    Variant2 {
+        sphere: StringOrSignal,
+    },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Marktype(pub String);
 impl std::ops::Deref for Marktype {
     type Target = String;
@@ -11152,7 +12542,7 @@ impl std::ops::Deref for Marktype {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NestTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11164,27 +12554,37 @@ pub struct NestTransform {
     #[serde(rename = "type")]
     pub type_: NestTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NestTransformGenerate {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NestTransformKeys {
+    #[educe(Default)]
     Variant0(Vec<NestTransformKeysVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NestTransformKeysVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum NestTransformType {
+    #[educe(Default)]
     #[serde(rename = "nest")]
     Nest,
 }
@@ -11216,7 +12616,7 @@ impl std::convert::TryFrom<&String> for NestTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberModifiers {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub band: Option<NumberModifiersBand>,
@@ -11233,57 +12633,69 @@ pub struct NumberModifiers {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberModifiersBand {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberModifiersExponent {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberModifiersMult {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberModifiersOffset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberOrSignal {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberValue {
+    #[educe(Default)]
     Variant0(Vec<NumberValueVariant0Item>),
     Variant1(NumberValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: NumberValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: NumberModifiers,
     #[serde(flatten)]
     pub subtype_1: NumberValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -11294,9 +12706,11 @@ pub struct NumberValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: f64,
@@ -11308,26 +12722,28 @@ pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: NumberModifiers,
     #[serde(flatten)]
     pub subtype_1: NumberValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<NumberValueVariant1Subtype1Subtype0>,
@@ -11338,9 +12754,11 @@ pub struct NumberValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<NumberValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: f64,
@@ -11352,19 +12770,21 @@ pub enum NumberValueVariant1Subtype1Subtype0 {
         range: NumberValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NumberValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OnEvents(pub Vec<OnEventsItem>);
 impl std::ops::Deref for OnEvents {
     type Target = Vec<OnEventsItem>;
@@ -11372,42 +12792,50 @@ impl std::ops::Deref for OnEvents {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OnEventsItem {
     #[serde(flatten)]
     pub subtype_0: OnEventsItemSubtype0,
     #[serde(flatten)]
     pub subtype_1: OnEventsItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OnEventsItemSubtype0 {
     pub events: OnEventsItemSubtype0Events,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OnEventsItemSubtype0Events {
+    #[educe(Default)]
     Variant0(Selector),
     Variant1(Listener),
     Variant2(Vec<Listener>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 pub enum OnEventsItemSubtype1 {
+    #[educe(Default)]
     #[serde(rename = "encode")]
     Encode(String),
     #[serde(rename = "update")]
     Update(OnEventsItemSubtype1Update),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OnEventsItemSubtype1Update {
+    #[educe(Default)]
     Variant0(ExprString),
     Variant1(Expr),
     Variant2(SignalRef),
-    Variant3 { value: serde_json::Value },
+    Variant3 {
+        value: serde_json::Value,
+    },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OnMarkTrigger(pub Vec<OnMarkTriggerItem>);
 impl std::ops::Deref for OnMarkTrigger {
     type Target = Vec<OnMarkTriggerItem>;
@@ -11415,7 +12843,7 @@ impl std::ops::Deref for OnMarkTrigger {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OnMarkTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11424,7 +12852,7 @@ pub struct OnMarkTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<ExprString>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OnTrigger(pub Vec<OnTriggerItem>);
 impl std::ops::Deref for OnTrigger {
     type Target = Vec<OnTriggerItem>;
@@ -11432,7 +12860,7 @@ impl std::ops::Deref for OnTrigger {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OnTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11447,33 +12875,37 @@ pub struct OnTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<ExprString>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OnTriggerItemRemove {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(ExprString),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OrientValue {
+    #[educe(Default)]
     Variant0(Vec<OrientValueVariant0Item>),
     Variant1(OrientValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: OrientValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: OrientValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -11484,9 +12916,11 @@ pub struct OrientValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -11498,8 +12932,12 @@ pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -11545,26 +12983,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: OrientValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<OrientValueVariant1Subtype1Subtype0>,
@@ -11575,9 +13015,11 @@ pub struct OrientValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<OrientValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OrientValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: OrientValueVariant1Subtype1Subtype0Variant1Value,
@@ -11589,8 +13031,12 @@ pub enum OrientValueVariant1Subtype1Subtype0 {
         range: OrientValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum OrientValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -11634,19 +13080,21 @@ impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype1Subtype0Varia
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OrientValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackTransform {
     #[serde(rename = "as", default = "defaults::pack_transform_as")]
@@ -11666,9 +13114,11 @@ pub struct PackTransform {
     #[serde(rename = "type")]
     pub type_: PackTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformAs {
+    #[educe(Default)]
     Variant0(
         PackTransformAsVariant0,
         PackTransformAsVariant0,
@@ -11678,46 +13128,62 @@ pub enum PackTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformRadius {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformSize {
+    #[educe(Default)]
     Variant0(PackTransformSizeVariant0, PackTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PackTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PackTransformType {
+    #[educe(Default)]
     #[serde(rename = "pack")]
     Pack,
 }
@@ -11749,9 +13215,11 @@ impl std::convert::TryFrom<&String> for PackTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Padding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11765,14 +13233,14 @@ pub enum Padding {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ParamField {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
     pub as_: Option<String>,
     pub field: String,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PartitionTransform {
     #[serde(rename = "as", default = "defaults::partition_transform_as")]
@@ -11792,9 +13260,11 @@ pub struct PartitionTransform {
     #[serde(rename = "type")]
     pub type_: PartitionTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformAs {
+    #[educe(Default)]
     Variant0(
         PartitionTransformAsVariant0,
         PartitionTransformAsVariant0,
@@ -11805,48 +13275,64 @@ pub enum PartitionTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformRound {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformSize {
+    #[educe(Default)]
     Variant0(
         PartitionTransformSizeVariant0,
         PartitionTransformSizeVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PartitionTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PartitionTransformType {
+    #[educe(Default)]
     #[serde(rename = "partition")]
     Partition,
 }
@@ -11878,7 +13364,7 @@ impl std::convert::TryFrom<&String> for PartitionTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PieTransform {
     #[serde(rename = "as", default = "defaults::pie_transform_as")]
@@ -11900,45 +13386,61 @@ pub struct PieTransform {
     #[serde(rename = "type")]
     pub type_: PieTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformAs {
+    #[educe(Default)]
     Variant0(PieTransformAsVariant0, PieTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformEndAngle {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformSort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PieTransformStartAngle {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PieTransformType {
+    #[educe(Default)]
     #[serde(rename = "pie")]
     Pie,
 }
@@ -11970,7 +13472,7 @@ impl std::convert::TryFrom<&String> for PieTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PivotTransform {
     pub field: PivotTransformField,
@@ -11988,47 +13490,63 @@ pub struct PivotTransform {
     pub type_: PivotTransformType,
     pub value: PivotTransformValue,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<PivotTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformLimit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformOp {
+    #[educe(Default)]
     Variant0(PivotTransformOpVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PivotTransformOpVariant0 {
+    #[educe(Default)]
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
@@ -12152,8 +13670,12 @@ impl std::convert::TryFrom<&String> for PivotTransformOpVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum PivotTransformType {
+    #[educe(Default)]
     #[serde(rename = "pivot")]
     Pivot,
 }
@@ -12185,14 +13707,16 @@ impl std::convert::TryFrom<&String> for PivotTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum PivotTransformValue {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -12204,34 +13728,46 @@ pub struct ProjectTransform {
     #[serde(rename = "type")]
     pub type_: ProjectTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectTransformAs {
+    #[educe(Default)]
     Variant0(Vec<ProjectTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectTransformFields {
+    #[educe(Default)]
     Variant0(Vec<ProjectTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectTransformFieldsVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ProjectTransformType {
+    #[educe(Default)]
     #[serde(rename = "project")]
     Project,
 }
@@ -12263,7 +13799,7 @@ impl std::convert::TryFrom<&String> for ProjectTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Projection {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub center: Option<ProjectionCenter>,
@@ -12301,67 +13837,87 @@ pub struct Projection {
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<StringOrSignal>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionCenter {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionClipExtent {
+    #[educe(Default)]
     Variant0(ProjectionClipExtentVariant0, ProjectionClipExtentVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionClipExtentVariant0 {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionExtent {
+    #[educe(Default)]
     Variant0(ProjectionExtentVariant0, ProjectionExtentVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionExtentVariant0 {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionFit {
+    #[educe(Default)]
     Variant0(std::collections::HashMap<String, serde_json::Value>),
     Variant1(Vec<serde_json::Value>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionParallels {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionRotate {
+    #[educe(Default)]
     Variant0(Vec<NumberOrSignal>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionSize {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ProjectionTranslate {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct QuantileTransform {
     #[serde(rename = "as", default = "defaults::quantile_transform_as")]
@@ -12378,58 +13934,78 @@ pub struct QuantileTransform {
     #[serde(rename = "type")]
     pub type_: QuantileTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformAs {
+    #[educe(Default)]
     Variant0(Vec<QuantileTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<QuantileTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformProbs {
+    #[educe(Default)]
     Variant0(Vec<QuantileTransformProbsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformProbsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum QuantileTransformStep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum QuantileTransformType {
+    #[educe(Default)]
     #[serde(rename = "quantile")]
     Quantile,
 }
@@ -12461,7 +14037,7 @@ impl std::convert::TryFrom<&String> for QuantileTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RadialGradient {
     pub gradient: RadialGradientGradient,
@@ -12481,8 +14057,12 @@ pub struct RadialGradient {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub y2: Option<f64>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RadialGradientGradient {
+    #[educe(Default)]
     #[serde(rename = "radial")]
     Radial,
 }
@@ -12514,7 +14094,7 @@ impl std::convert::TryFrom<&String> for RadialGradientGradient {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RegressionTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -12536,66 +14116,88 @@ pub struct RegressionTransform {
     pub x: RegressionTransformX,
     pub y: RegressionTransformY,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformAs {
+    #[educe(Default)]
     Variant0(Vec<RegressionTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformExtent {
+    #[educe(Default)]
     Variant0(
         RegressionTransformExtentVariant0,
         RegressionTransformExtentVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformExtentVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<RegressionTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformMethod {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformOrder {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformParams {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum RegressionTransformType {
+    #[educe(Default)]
     #[serde(rename = "regression")]
     Regression,
 }
@@ -12627,21 +14229,25 @@ impl std::convert::TryFrom<&String> for RegressionTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum RegressionTransformY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResolvefilterTransform {
     pub filter: serde_json::Value,
@@ -12651,14 +14257,20 @@ pub struct ResolvefilterTransform {
     #[serde(rename = "type")]
     pub type_: ResolvefilterTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ResolvefilterTransformIgnore {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ResolvefilterTransformType {
+    #[educe(Default)]
     #[serde(rename = "resolvefilter")]
     Resolvefilter,
 }
@@ -12690,12 +14302,12 @@ impl std::convert::TryFrom<&String> for ResolvefilterTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Rule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub test: Option<String>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SampleTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12705,14 +14317,20 @@ pub struct SampleTransform {
     #[serde(rename = "type")]
     pub type_: SampleTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SampleTransformSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SampleTransformType {
+    #[educe(Default)]
     #[serde(rename = "sample")]
     Sample,
 }
@@ -12744,9 +14362,11 @@ impl std::convert::TryFrom<&String> for SampleTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Scale {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         domain: Option<ScaleVariant0Domain>,
@@ -13110,9 +14730,11 @@ pub enum Scale {
         zero: Option<BooleanOrSignal>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleBins {
+    #[educe(Default)]
     Variant0(Vec<NumberOrSignal>),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13123,9 +14745,11 @@ pub enum ScaleBins {
     },
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleData {
+    #[educe(Default)]
     Variant0 {
         data: String,
         field: StringOrSignal,
@@ -13144,9 +14768,11 @@ pub enum ScaleData {
         sort: Option<ScaleDataVariant2Sort>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant0Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13157,9 +14783,11 @@ pub enum ScaleDataVariant0Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant1Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13174,8 +14802,12 @@ pub enum ScaleDataVariant1Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleDataVariant1SortVariant1Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
 }
@@ -13207,8 +14839,12 @@ impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant1Op {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleDataVariant1SortVariant2Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "min")]
@@ -13248,23 +14884,32 @@ impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant2Op {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2FieldsItem {
-    Variant0 { data: String, field: StringOrSignal },
+    #[educe(Default)]
+    Variant0 {
+        data: String,
+        field: StringOrSignal,
+    },
     Variant1(Vec<ScaleDataVariant2FieldsItemVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleDataVariant2FieldsItemVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(f64),
     Variant2(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13279,8 +14924,12 @@ pub enum ScaleDataVariant2Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleDataVariant2SortVariant1Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
 }
@@ -13312,8 +14961,12 @@ impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant1Op {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleDataVariant2SortVariant2Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "min")]
@@ -13353,7 +15006,7 @@ impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant2Op {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ScaleField(pub StringOrSignal);
 impl std::ops::Deref for ScaleField {
     type Target = StringOrSignal;
@@ -13361,9 +15014,11 @@ impl std::ops::Deref for ScaleField {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleInterpolate {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2 {
@@ -13373,23 +15028,29 @@ pub enum ScaleInterpolate {
         type_: StringOrSignal,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant0Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant0DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant0DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant0DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13397,8 +15058,12 @@ pub enum ScaleVariant0DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant0Type {
+    #[educe(Default)]
     #[serde(rename = "identity")]
     Identity,
 }
@@ -13430,23 +15095,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant0Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant10DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13454,16 +15125,20 @@ pub enum ScaleVariant10DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant10Range {
+    #[educe(Default)]
     Variant0(ScaleVariant10RangeVariant0),
     Variant1(Vec<ScaleVariant10RangeVariant1Item>),
     Variant2 {
@@ -13475,8 +15150,12 @@ pub enum ScaleVariant10Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant10RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -13536,9 +15215,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant10RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13546,27 +15227,37 @@ pub enum ScaleVariant10RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant10Type {
+    #[educe(Default)]
     #[serde(rename = "pow")]
     Pow,
 }
@@ -13598,23 +15289,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant10Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant11DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13622,16 +15319,20 @@ pub enum ScaleVariant11DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant11Range {
+    #[educe(Default)]
     Variant0(ScaleVariant11RangeVariant0),
     Variant1(Vec<ScaleVariant11RangeVariant1Item>),
     Variant2 {
@@ -13643,8 +15344,12 @@ pub enum ScaleVariant11Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant11RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -13704,9 +15409,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant11RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13714,27 +15421,37 @@ pub enum ScaleVariant11RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant11Type {
+    #[educe(Default)]
     #[serde(rename = "symlog")]
     Symlog,
 }
@@ -13766,23 +15483,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant11Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant1DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13790,9 +15513,11 @@ pub enum ScaleVariant1DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1Range {
+    #[educe(Default)]
     Variant0(ScaleVariant1RangeVariant0),
     Variant1(Vec<ScaleVariant1RangeVariant1Item>),
     Variant2 {
@@ -13805,8 +15530,12 @@ pub enum ScaleVariant1Range {
     Variant3(ScaleVariant1RangeVariant3),
     Variant4(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -13866,9 +15595,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -13876,28 +15607,36 @@ pub enum ScaleVariant1RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3 {
+    #[educe(Default)]
     Variant0 {
         data: String,
         field: StringOrSignal,
@@ -13916,9 +15655,11 @@ pub enum ScaleVariant1RangeVariant3 {
         sort: Option<ScaleVariant1RangeVariant3Variant2Sort>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant0Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13929,9 +15670,11 @@ pub enum ScaleVariant1RangeVariant3Variant0Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant1Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13946,8 +15689,12 @@ pub enum ScaleVariant1RangeVariant3Variant1Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant1Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
 }
@@ -13979,8 +15726,12 @@ impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVa
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant2Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "min")]
@@ -14020,23 +15771,32 @@ impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVa
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItem {
-    Variant0 { data: String, field: StringOrSignal },
+    #[educe(Default)]
+    Variant0 {
+        data: String,
+        field: StringOrSignal,
+    },
     Variant1(Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(f64),
     Variant2(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2Sort {
+    #[educe(Default)]
     Variant0(bool),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14051,8 +15811,12 @@ pub enum ScaleVariant1RangeVariant3Variant2Sort {
         order: Option<SortOrder>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant1Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
 }
@@ -14084,8 +15848,12 @@ impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVa
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant2Op {
+    #[educe(Default)]
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "min")]
@@ -14125,8 +15893,12 @@ impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVa
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant1Type {
+    #[educe(Default)]
     #[serde(rename = "ordinal")]
     Ordinal,
 }
@@ -14158,23 +15930,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant1Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant2Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant2DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant2DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant2DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14182,16 +15960,24 @@ pub enum ScaleVariant2DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant2Range {
+    #[educe(Default)]
     Variant0(ScaleVariant2RangeVariant0),
     Variant1(Vec<ScaleVariant2RangeVariant1Item>),
-    Variant2 { step: NumberOrSignal },
+    Variant2 {
+        step: NumberOrSignal,
+    },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant2RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -14251,9 +16037,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant2RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant2RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14261,8 +16049,12 @@ pub enum ScaleVariant2RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant2Type {
+    #[educe(Default)]
     #[serde(rename = "band")]
     Band,
 }
@@ -14294,23 +16086,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant2Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant3Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant3DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant3DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant3DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14318,16 +16116,24 @@ pub enum ScaleVariant3DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant3Range {
+    #[educe(Default)]
     Variant0(ScaleVariant3RangeVariant0),
     Variant1(Vec<ScaleVariant3RangeVariant1Item>),
-    Variant2 { step: NumberOrSignal },
+    Variant2 {
+        step: NumberOrSignal,
+    },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant3RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -14387,9 +16193,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant3RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant3RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14397,8 +16205,12 @@ pub enum ScaleVariant3RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant3Type {
+    #[educe(Default)]
     #[serde(rename = "point")]
     Point,
 }
@@ -14430,23 +16242,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant3Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant4DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14454,16 +16272,20 @@ pub enum ScaleVariant4DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant4Range {
+    #[educe(Default)]
     Variant0(ScaleVariant4RangeVariant0),
     Variant1(Vec<ScaleVariant4RangeVariant1Item>),
     Variant2 {
@@ -14475,8 +16297,12 @@ pub enum ScaleVariant4Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant4RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -14536,9 +16362,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant4RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14546,27 +16374,37 @@ pub enum ScaleVariant4RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant4Type {
+    #[educe(Default)]
     #[serde(rename = "quantize")]
     Quantize,
     #[serde(rename = "threshold")]
@@ -14602,23 +16440,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant4Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant5DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14626,9 +16470,11 @@ pub enum ScaleVariant5DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant5Range {
+    #[educe(Default)]
     Variant0(ScaleVariant5RangeVariant0),
     Variant1(Vec<ScaleVariant5RangeVariant1Item>),
     Variant2 {
@@ -14640,8 +16486,12 @@ pub enum ScaleVariant5Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant5RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -14701,9 +16551,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant5RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14711,27 +16563,37 @@ pub enum ScaleVariant5RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant5Type {
+    #[educe(Default)]
     #[serde(rename = "quantile")]
     Quantile,
 }
@@ -14763,23 +16625,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant5Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant6DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14787,9 +16655,11 @@ pub enum ScaleVariant6DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant6Range {
+    #[educe(Default)]
     Variant0(ScaleVariant6RangeVariant0),
     Variant1(Vec<ScaleVariant6RangeVariant1Item>),
     Variant2 {
@@ -14801,8 +16671,12 @@ pub enum ScaleVariant6Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant6RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -14862,9 +16736,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant6RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14872,27 +16748,37 @@ pub enum ScaleVariant6RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant6Type {
+    #[educe(Default)]
     #[serde(rename = "bin-ordinal")]
     BinOrdinal,
 }
@@ -14924,23 +16810,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant6Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant7DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -14948,9 +16840,11 @@ pub enum ScaleVariant7DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant7Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(ScaleVariant7NiceVariant1),
     Variant2 {
@@ -14959,8 +16853,12 @@ pub enum ScaleVariant7Nice {
         step: Option<NumberOrSignal>,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant7NiceVariant1 {
+    #[educe(Default)]
     #[serde(rename = "millisecond")]
     Millisecond,
     #[serde(rename = "second")]
@@ -15020,14 +16918,20 @@ impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant1 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7NiceVariant2Interval {
+    #[educe(Default)]
     Variant0(ScaleVariant7NiceVariant2IntervalVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant7NiceVariant2IntervalVariant0 {
+    #[educe(Default)]
     #[serde(rename = "millisecond")]
     Millisecond,
     #[serde(rename = "second")]
@@ -15087,9 +16991,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant2IntervalVariant
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant7Range {
+    #[educe(Default)]
     Variant0(ScaleVariant7RangeVariant0),
     Variant1(Vec<ScaleVariant7RangeVariant1Item>),
     Variant2 {
@@ -15101,8 +17007,12 @@ pub enum ScaleVariant7Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant7RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -15162,9 +17072,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant7RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -15172,27 +17084,37 @@ pub enum ScaleVariant7RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant7Type {
+    #[educe(Default)]
     #[serde(rename = "time")]
     Time,
     #[serde(rename = "utc")]
@@ -15228,23 +17150,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant7Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant8DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -15252,16 +17180,20 @@ pub enum ScaleVariant8DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant8Range {
+    #[educe(Default)]
     Variant0(ScaleVariant8RangeVariant0),
     Variant1(Vec<ScaleVariant8RangeVariant1Item>),
     Variant2 {
@@ -15273,8 +17205,12 @@ pub enum ScaleVariant8Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant8RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -15334,9 +17270,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant8RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -15344,27 +17282,37 @@ pub enum ScaleVariant8RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant8Type {
+    #[educe(Default)]
     #[serde(rename = "linear")]
     Linear,
     #[serde(rename = "sqrt")]
@@ -15404,23 +17352,29 @@ impl std::convert::TryFrom<&String> for ScaleVariant8Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9Domain {
+    #[educe(Default)]
     Variant0(Vec<ScaleVariant9DomainVariant0Item>),
     Variant1(ScaleData),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9DomainRaw {
+    #[educe(Default)]
     Variant0,
     Variant1(Vec<serde_json::Value>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9DomainVariant0Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -15428,16 +17382,20 @@ pub enum ScaleVariant9DomainVariant0Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9Nice {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(f64),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant9Range {
+    #[educe(Default)]
     Variant0(ScaleVariant9RangeVariant0),
     Variant1(Vec<ScaleVariant9RangeVariant1Item>),
     Variant2 {
@@ -15449,8 +17407,12 @@ pub enum ScaleVariant9Range {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant9RangeVariant0 {
+    #[educe(Default)]
     #[serde(rename = "width")]
     Width,
     #[serde(rename = "height")]
@@ -15510,9 +17472,11 @@ impl std::convert::TryFrom<&String> for ScaleVariant9RangeVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant1Item {
+    #[educe(Default)]
     Variant0,
     Variant1(bool),
     Variant2(String),
@@ -15520,27 +17484,37 @@ pub enum ScaleVariant9RangeVariant1Item {
     Variant4(SignalRef),
     Variant5(Vec<NumberOrSignal>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Extent {
+    #[educe(Default)]
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Scheme {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>),
     Variant2(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2SchemeVariant1Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum ScaleVariant9Type {
+    #[educe(Default)]
     #[serde(rename = "log")]
     Log,
 }
@@ -15572,7 +17546,7 @@ impl std::convert::TryFrom<&String> for ScaleVariant9Type {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Scope {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub axes: Vec<Axis>,
@@ -15597,13 +17571,15 @@ pub struct Scope {
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub usermeta: std::collections::HashMap<String, serde_json::Value>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum ScopeMarksItem {
+    #[educe(Default)]
     Group(MarkGroup),
     Visual(MarkVisual),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Selector(pub String);
 impl std::ops::Deref for Selector {
     type Target = String;
@@ -15611,7 +17587,7 @@ impl std::ops::Deref for Selector {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SequenceTransform {
     #[serde(rename = "as", default = "defaults::sequence_transform_as")]
@@ -15625,32 +17601,44 @@ pub struct SequenceTransform {
     #[serde(rename = "type")]
     pub type_: SequenceTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SequenceTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SequenceTransformStart {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SequenceTransformStep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SequenceTransformStop {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SequenceTransformType {
+    #[educe(Default)]
     #[serde(rename = "sequence")]
     Sequence,
 }
@@ -15682,9 +17670,11 @@ impl std::convert::TryFrom<&String> for SequenceTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Signal {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
@@ -15721,7 +17711,7 @@ pub enum Signal {
         value: Option<serde_json::Value>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SignalName(String);
 impl std::ops::Deref for SignalName {
     type Target = String;
@@ -15746,12 +17736,16 @@ impl std::convert::TryFrom<String> for SignalName {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SignalRef {
     pub signal: String,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SignalVariant0Push {
+    #[educe(Default)]
     #[serde(rename = "outer")]
     Outer,
 }
@@ -15783,14 +17777,20 @@ impl std::convert::TryFrom<&String> for SignalVariant0Push {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum SortOrder {
+    #[educe(Default)]
     Variant0(SortOrderVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum SortOrderVariant0 {
+    #[educe(Default)]
     #[serde(rename = "ascending")]
     Ascending,
     #[serde(rename = "descending")]
@@ -15826,7 +17826,7 @@ impl std::convert::TryFrom<&String> for SortOrderVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StackTransform {
     #[serde(rename = "as", default = "defaults::stack_transform_as")]
@@ -15844,46 +17844,62 @@ pub struct StackTransform {
     #[serde(rename = "type")]
     pub type_: StackTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformAs {
+    #[educe(Default)]
     Variant0(StackTransformAsVariant0, StackTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<StackTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StackTransformOffset {
+    #[educe(Default)]
     Variant0(StackTransformOffsetVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StackTransformOffsetVariant0 {
+    #[educe(Default)]
     #[serde(rename = "zero")]
     Zero,
     #[serde(rename = "center")]
@@ -15923,8 +17939,12 @@ impl std::convert::TryFrom<&String> for StackTransformOffsetVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StackTransformType {
+    #[educe(Default)]
     #[serde(rename = "stack")]
     Stack,
 }
@@ -15956,7 +17976,7 @@ impl std::convert::TryFrom<&String> for StackTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StratifyTransform {
     pub key: StratifyTransformKey,
@@ -15967,22 +17987,30 @@ pub struct StratifyTransform {
     #[serde(rename = "type")]
     pub type_: StratifyTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StratifyTransformKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StratifyTransformParentKey {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StratifyTransformType {
+    #[educe(Default)]
     #[serde(rename = "stratify")]
     Stratify,
 }
@@ -16014,14 +18042,14 @@ impl std::convert::TryFrom<&String> for StratifyTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Stream {
     #[serde(flatten)]
     pub subtype_0: StreamSubtype0,
     #[serde(flatten)]
     pub subtype_1: StreamSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StreamSubtype0 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub between: Vec<Stream>,
@@ -16038,15 +18066,19 @@ pub struct StreamSubtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub throttle: Option<f64>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StreamSubtype0Filter {
+    #[educe(Default)]
     Variant0(ExprString),
     Variant1(Vec<ExprString>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StreamSubtype1 {
+    #[educe(Default)]
     Variant0 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
@@ -16060,38 +18092,42 @@ pub enum StreamSubtype1 {
         merge: Vec<Stream>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringModifiers {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringOrSignal {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringValue {
+    #[educe(Default)]
     Variant0(Vec<StringValueVariant0Item>),
     Variant1(StringValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: StringValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StringValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StringValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -16102,9 +18138,11 @@ pub struct StringValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StringValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: String,
@@ -16116,26 +18154,28 @@ pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StringValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StringValueVariant1Subtype1Subtype0>,
@@ -16146,9 +18186,11 @@ pub struct StringValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StringValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: String,
@@ -16160,39 +18202,43 @@ pub enum StringValueVariant1Subtype1Subtype0 {
         range: StringValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StringValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeCapValue {
+    #[educe(Default)]
     Variant0(Vec<StrokeCapValueVariant0Item>),
     Variant1(StrokeCapValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: StrokeCapValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StrokeCapValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -16203,9 +18249,11 @@ pub struct StrokeCapValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -16217,8 +18265,12 @@ pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "butt")]
     Butt,
     #[serde(rename = "round")]
@@ -16262,26 +18314,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StrokeCapValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StrokeCapValueVariant1Subtype1Subtype0>,
@@ -16292,9 +18346,11 @@ pub struct StrokeCapValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StrokeCapValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: StrokeCapValueVariant1Subtype1Subtype0Variant1Value,
@@ -16306,8 +18362,12 @@ pub enum StrokeCapValueVariant1Subtype1Subtype0 {
         range: StrokeCapValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "butt")]
     Butt,
     #[serde(rename = "round")]
@@ -16347,39 +18407,43 @@ impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype1Subtype0Va
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeJoinValue {
+    #[educe(Default)]
     Variant0(Vec<StrokeJoinValueVariant0Item>),
     Variant1(StrokeJoinValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: StrokeJoinValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StrokeJoinValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -16390,9 +18454,11 @@ pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -16404,8 +18470,12 @@ pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "miter")]
     Miter,
     #[serde(rename = "round")]
@@ -16449,26 +18519,28 @@ impl std::convert::TryFrom<&String>
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: StrokeJoinValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StrokeJoinValueVariant1Subtype1Subtype0>,
@@ -16479,9 +18551,11 @@ pub struct StrokeJoinValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<StrokeJoinValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: StrokeJoinValueVariant1Subtype1Subtype0Variant1Value,
@@ -16493,8 +18567,12 @@ pub enum StrokeJoinValueVariant1Subtype1Subtype0 {
         range: StrokeJoinValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     #[serde(rename = "miter")]
     Miter,
     #[serde(rename = "round")]
@@ -16534,57 +18612,67 @@ impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype1Subtype0V
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Style {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextOrSignal {
+    #[educe(Default)]
     Variant0(TextOrSignalVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextOrSignalVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValue {
+    #[educe(Default)]
     Variant0(Vec<TextValueVariant0Item>),
     Variant1(TextValueVariant1),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0Item {
     #[serde(flatten)]
     pub subtype_0: Rule,
     #[serde(flatten)]
     pub subtype_1: TextValueVariant0ItemSubtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: TextValueVariant0ItemSubtype1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<TextValueVariant0ItemSubtype1Subtype1Subtype0>,
@@ -16595,9 +18683,11 @@ pub struct TextValueVariant0ItemSubtype1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<TextValueVariant0ItemSubtype1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
@@ -16609,32 +18699,36 @@ pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0 {
         range: TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant1 {
     #[serde(flatten)]
     pub subtype_0: StringModifiers,
     #[serde(flatten)]
     pub subtype_1: TextValueVariant1Subtype1,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<TextValueVariant1Subtype1Subtype0>,
@@ -16645,9 +18739,11 @@ pub struct TextValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_3: Option<TextValueVariant1Subtype1Subtype3>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant1Subtype1Subtype0 {
+    #[educe(Default)]
     Variant0(SignalRef),
     Variant1 {
         value: TextValueVariant1Subtype1Subtype0Variant1Value,
@@ -16659,32 +18755,42 @@ pub enum TextValueVariant1Subtype1Subtype0 {
         range: TextValueVariant1Subtype1Subtype0Variant3Range,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant1Subtype1Subtype0Variant1Value {
+    #[educe(Default)]
     Variant0(String),
     Variant1(Vec<String>),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TextValueVariant1Subtype1Subtype0Variant3Range {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(bool),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1Subtype1 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1Subtype2 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1Subtype3 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TickBand {
+    #[educe(Default)]
     Variant0(TickBandVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TickBandVariant0 {
+    #[educe(Default)]
     #[serde(rename = "center")]
     Center,
     #[serde(rename = "extent")]
@@ -16720,9 +18826,11 @@ impl std::convert::TryFrom<&String> for TickBandVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum TickCount {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(TickCountVariant1),
     Variant2 {
@@ -16732,8 +18840,12 @@ pub enum TickCount {
     },
     Variant3(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TickCountVariant1 {
+    #[educe(Default)]
     #[serde(rename = "millisecond")]
     Millisecond,
     #[serde(rename = "second")]
@@ -16793,14 +18905,20 @@ impl std::convert::TryFrom<&String> for TickCountVariant1 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TickCountVariant2Interval {
+    #[educe(Default)]
     Variant0(TickCountVariant2IntervalVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TickCountVariant2IntervalVariant0 {
+    #[educe(Default)]
     #[serde(rename = "millisecond")]
     Millisecond,
     #[serde(rename = "second")]
@@ -16860,7 +18978,7 @@ impl std::convert::TryFrom<&String> for TickCountVariant2IntervalVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TimeunitTransform {
     #[serde(rename = "as", default = "defaults::timeunit_transform_as")]
@@ -16883,63 +19001,85 @@ pub struct TimeunitTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub units: Option<TimeunitTransformUnits>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformAs {
+    #[educe(Default)]
     Variant0(TimeunitTransformAsVariant0, TimeunitTransformAsVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtent {
+    #[educe(Default)]
     Variant0(Vec<TimeunitTransformExtentVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtentVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformInterval {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformMaxbins {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformStep {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformTimezone {
+    #[educe(Default)]
     Variant0(TimeunitTransformTimezoneVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TimeunitTransformTimezoneVariant0 {
+    #[educe(Default)]
     #[serde(rename = "local")]
     Local,
     #[serde(rename = "utc")]
@@ -16975,8 +19115,12 @@ impl std::convert::TryFrom<&String> for TimeunitTransformTimezoneVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TimeunitTransformType {
+    #[educe(Default)]
     #[serde(rename = "timeunit")]
     Timeunit,
 }
@@ -17008,20 +19152,28 @@ impl std::convert::TryFrom<&String> for TimeunitTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnits {
+    #[educe(Default)]
     Variant0(Vec<TimeunitTransformUnitsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnitsVariant0Item {
+    #[educe(Default)]
     Variant0(TimeunitTransformUnitsVariant0ItemVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TimeunitTransformUnitsVariant0ItemVariant0 {
+    #[educe(Default)]
     #[serde(rename = "year")]
     Year,
     #[serde(rename = "quarter")]
@@ -17093,9 +19245,11 @@ impl std::convert::TryFrom<&String> for TimeunitTransformUnitsVariant0ItemVarian
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Title {
+    #[educe(Default)]
     Variant0(String),
     Variant1 {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17198,14 +19352,20 @@ pub enum Title {
         zindex: Option<f64>,
     },
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Align {
+    #[educe(Default)]
     Variant0(TitleVariant1AlignVariant0),
     Variant1(AlignValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TitleVariant1AlignVariant0 {
+    #[educe(Default)]
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -17245,14 +19405,20 @@ impl std::convert::TryFrom<&String> for TitleVariant1AlignVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Anchor {
+    #[educe(Default)]
     Variant0(Option<TitleVariant1AnchorVariant0>),
     Variant1(AnchorValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TitleVariant1AnchorVariant0 {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -17292,20 +19458,28 @@ impl std::convert::TryFrom<&String> for TitleVariant1AnchorVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Angle {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Baseline {
+    #[educe(Default)]
     Variant0(TitleVariant1BaselineVariant0),
     Variant1(BaselineValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TitleVariant1BaselineVariant0 {
+    #[educe(Default)]
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -17357,36 +19531,42 @@ impl std::convert::TryFrom<&String> for TitleVariant1BaselineVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Color {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Dx {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Dy {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TitleVariant1Encode {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<TitleVariant1EncodeSubtype0>,
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_1: Option<TitleVariant1EncodeSubtype1>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TitleVariant1EncodeSubtype0 {}
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TitleVariant1EncodeSubtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17396,38 +19576,52 @@ pub struct TitleVariant1EncodeSubtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<GuideEncode>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Font {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1FontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1FontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1FontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Frame {
+    #[educe(Default)]
     Variant0(TitleVariant1FrameVariant0),
     Variant1(StringValue),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TitleVariant1FrameVariant0 {
+    #[educe(Default)]
     #[serde(rename = "group")]
     Group,
     #[serde(rename = "bounds")]
@@ -17463,32 +19657,44 @@ impl std::convert::TryFrom<&String> for TitleVariant1FrameVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Limit {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1LineHeight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Offset {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1Orient {
+    #[educe(Default)]
     Variant0(TitleVariant1OrientVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TitleVariant1OrientVariant0 {
+    #[educe(Default)]
     #[serde(rename = "none")]
     None,
     #[serde(rename = "left")]
@@ -17536,46 +19742,60 @@ impl std::convert::TryFrom<&String> for TitleVariant1OrientVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleColor {
+    #[educe(Default)]
     Variant0,
     Variant1(String),
     Variant2(ColorValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(StringValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontWeight {
+    #[educe(Default)]
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleLineHeight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(NumberValue),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum Transform {
+    #[educe(Default)]
     CrossfilterTransform(CrossfilterTransform),
     ResolvefilterTransform(ResolvefilterTransform),
     LinkpathTransform(LinkpathTransform),
@@ -17628,9 +19848,11 @@ pub enum Transform {
     VoronoiTransform(VoronoiTransform),
     WordcloudTransform(WordcloudTransform),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TransformMark {
+    #[educe(Default)]
     CrossfilterTransform(CrossfilterTransform),
     ResolvefilterTransform(ResolvefilterTransform),
     LinkpathTransform(LinkpathTransform),
@@ -17662,7 +19884,7 @@ pub enum TransformMark {
     VoronoiTransform(VoronoiTransform),
     WordcloudTransform(WordcloudTransform),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreeTransform {
     #[serde(rename = "as", default = "defaults::tree_transform_as")]
@@ -17684,9 +19906,11 @@ pub struct TreeTransform {
     #[serde(rename = "type")]
     pub type_: TreeTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformAs {
+    #[educe(Default)]
     Variant0(
         TreeTransformAsVariant0,
         TreeTransformAsVariant0,
@@ -17695,27 +19919,37 @@ pub enum TreeTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformMethod {
+    #[educe(Default)]
     Variant0(TreeTransformMethodVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TreeTransformMethodVariant0 {
+    #[educe(Default)]
     #[serde(rename = "tidy")]
     Tidy,
     #[serde(rename = "cluster")]
@@ -17751,38 +19985,52 @@ impl std::convert::TryFrom<&String> for TreeTransformMethodVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSize {
+    #[educe(Default)]
     Variant0(TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformSeparation {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformSize {
+    #[educe(Default)]
     Variant0(TreeTransformSizeVariant0, TreeTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreeTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TreeTransformType {
+    #[educe(Default)]
     #[serde(rename = "tree")]
     Tree,
 }
@@ -17814,7 +20062,7 @@ impl std::convert::TryFrom<&String> for TreeTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreelinksTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17822,8 +20070,12 @@ pub struct TreelinksTransform {
     #[serde(rename = "type")]
     pub type_: TreelinksTransformType,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TreelinksTransformType {
+    #[educe(Default)]
     #[serde(rename = "treelinks")]
     Treelinks,
 }
@@ -17855,7 +20107,7 @@ impl std::convert::TryFrom<&String> for TreelinksTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreemapTransform {
     #[serde(rename = "as", default = "defaults::treemap_transform_as")]
@@ -17915,9 +20167,11 @@ pub struct TreemapTransform {
     #[serde(rename = "type")]
     pub type_: TreemapTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformAs {
+    #[educe(Default)]
     Variant0(
         TreemapTransformAsVariant0,
         TreemapTransformAsVariant0,
@@ -17928,27 +20182,37 @@ pub enum TreemapTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformField {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformMethod {
+    #[educe(Default)]
     Variant0(TreemapTransformMethodVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TreemapTransformMethodVariant0 {
+    #[educe(Default)]
     #[serde(rename = "squarify")]
     Squarify,
     #[serde(rename = "resquarify")]
@@ -18000,74 +20264,100 @@ impl std::convert::TryFrom<&String> for TreemapTransformMethodVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingBottom {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingInner {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingLeft {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingOuter {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingRight {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingTop {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformRatio {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformRound {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformSize {
+    #[educe(Default)]
     Variant0(TreemapTransformSizeVariant0, TreemapTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum TreemapTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TreemapTransformType {
+    #[educe(Default)]
     #[serde(rename = "treemap")]
     Treemap,
 }
@@ -18099,7 +20389,7 @@ impl std::convert::TryFrom<&String> for TreemapTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct VoronoiTransform {
     #[serde(rename = "as", default = "defaults::voronoi_transform_as")]
@@ -18115,32 +20405,44 @@ pub struct VoronoiTransform {
     pub x: VoronoiTransformX,
     pub y: VoronoiTransformY,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformAs {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformExtent {
+    #[educe(Default)]
     Variant0(serde_json::Value, serde_json::Value),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformSize {
+    #[educe(Default)]
     Variant0(VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum VoronoiTransformType {
+    #[educe(Default)]
     #[serde(rename = "voronoi")]
     Voronoi,
 }
@@ -18172,21 +20474,25 @@ impl std::convert::TryFrom<&String> for VoronoiTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformX {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum VoronoiTransformY {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WindowTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -18214,79 +20520,105 @@ pub struct WindowTransform {
     #[serde(rename = "type")]
     pub type_: WindowTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformAs {
+    #[educe(Default)]
     Variant0(Vec<WindowTransformAsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformAsVariant0Item {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformFields {
+    #[educe(Default)]
     Variant0(Vec<WindowTransformFieldsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformFieldsVariant0Item {
+    #[educe(Default)]
     Variant0(ScaleField),
     Variant1(ParamField),
     Variant2(Expr),
     Variant3,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformFrame {
+    #[educe(Default)]
     Variant0(WindowTransformFrameVariant0, WindowTransformFrameVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformFrameVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformGroupby {
+    #[educe(Default)]
     Variant0(Vec<WindowTransformGroupbyVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformGroupbyVariant0Item {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformIgnorePeers {
+    #[educe(Default)]
     Variant0(bool),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformOps {
+    #[educe(Default)]
     Variant0(Vec<WindowTransformOpsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformOpsVariant0Item {
+    #[educe(Default)]
     Variant0(WindowTransformOpsVariant0ItemVariant0),
     Variant1(SignalRef),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WindowTransformOpsVariant0ItemVariant0 {
+    #[educe(Default)]
     #[serde(rename = "row_number")]
     RowNumber,
     #[serde(rename = "rank")]
@@ -18462,21 +20794,29 @@ impl std::convert::TryFrom<&String> for WindowTransformOpsVariant0ItemVariant0 {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformParams {
+    #[educe(Default)]
     Variant0(Vec<WindowTransformParamsVariant0Item>),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WindowTransformParamsVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WindowTransformType {
+    #[educe(Default)]
     #[serde(rename = "window")]
     Window,
 }
@@ -18508,7 +20848,7 @@ impl std::convert::TryFrom<&String> for WindowTransformType {
         value.parse()
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WordcloudTransform {
     #[serde(rename = "as", default = "defaults::wordcloud_transform_as")]
@@ -18550,9 +20890,11 @@ pub struct WordcloudTransform {
     #[serde(rename = "type")]
     pub type_: WordcloudTransformType,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformAs {
+    #[educe(Default)]
     Variant0(
         WordcloudTransformAsVariant0,
         WordcloudTransformAsVariant0,
@@ -18564,103 +20906,133 @@ pub enum WordcloudTransformAs {
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformAsVariant0 {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFont {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSize {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRange {
+    #[educe(Default)]
     Variant0(Vec<WordcloudTransformFontSizeRangeVariant0Item>),
     Variant1(SignalRef),
     Variant2,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRangeVariant0Item {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontStyle {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontWeight {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformPadding {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformRotate {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
     Variant2(Expr),
     Variant3(ParamField),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformSize {
+    #[educe(Default)]
     Variant0(
         WordcloudTransformSizeVariant0,
         WordcloudTransformSizeVariant0,
     ),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformSizeVariant0 {
+    #[educe(Default)]
     Variant0(f64),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformSpiral {
+    #[educe(Default)]
     Variant0(String),
     Variant1(SignalRef),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum WordcloudTransformText {
+    #[educe(Default)]
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum WordcloudTransformType {
+    #[educe(Default)]
     #[serde(rename = "wordcloud")]
     Wordcloud,
 }

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
+educe = "0.4.20"
 proc-macro2 = "1.0"
 quote = "1.0"
 schemars = "0.8.11"

--- a/typify-test/Cargo.toml
+++ b/typify-test/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2021"
 
 [dependencies]
+educe = "0.4.20"
 regress = "0.4.1"
 serde = "1.0.152"
 serde_json = "1.0.91"

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -15,6 +15,7 @@ typify-macro = { version = "0.0.11-dev", path = "../typify-macro" }
 typify-impl = { version = "0.0.11-dev", path = "../typify-impl" }
 
 [dev-dependencies]
+educe = "0.4.20"
 expectorate = "1.0.6"
 glob = "0.3.1"
 quote = "1.0.23"

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestType {
     pub where_not: TestTypeWhereNot,
     pub why_not: TestTypeWhyNot,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestTypeWhereNot(String);
 impl std::ops::Deref for TestTypeWhereNot {
     type Target = String;
@@ -22,7 +22,7 @@ impl std::convert::TryFrom<String> for TestTypeWhereNot {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestTypeWhyNot(String);
 impl std::ops::Deref for TestTypeWhyNot {
     type Target = String;

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct LetterBox {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub letter: Option<LetterBoxLetter>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum LetterBoxLetter {
+    #[educe(Default)]
     #[serde(rename = "a")]
     A,
     #[serde(rename = "b")]

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IdOrName {
+    #[educe(Default)]
     Id(uuid::Uuid),
     Name(Name),
 }
@@ -14,7 +16,7 @@ impl ToString for IdOrName {
     }
 }
 #[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID."]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct Name(String);
 impl std::ops::Deref for Name {
     type Target = String;

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IntOrStr {
+    #[educe(Default)]
     String(String),
     Integer(i64),
 }
@@ -37,9 +39,11 @@ impl ToString for IntOrStr {
         }
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OneOfSeveral {
+    #[educe(Default)]
     Null,
     Boolean(bool),
     Object(std::collections::HashMap<String, serde_json::Value>),
@@ -47,7 +51,7 @@ pub enum OneOfSeveral {
     String(String),
     Integer(i64),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SeriouslyAnything(pub serde_json::Value);
 impl std::ops::Deref for SeriouslyAnything {
     type Target = serde_json::Value;

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestType {
     pub converted_type: serde_json::Value,
     pub patched_type: TypeThatHasMoreDerives,
     pub replaced_type: String,
 }
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TypeThatHasMoreDerives(pub std::collections::HashMap<String, String>);
 impl std::ops::Deref for TypeThatHasMoreDerives {
     type Target = std::collections::HashMap<String, String>;

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestBed {
     #[serde(default = "defaults::test_bed_any")]
     pub any: Vec<serde_json::Value>,

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct PatternString(String);
 impl std::ops::Deref for PatternString {
     type Target = String;
@@ -38,7 +38,7 @@ impl<'de> serde::Deserialize<'de> for PatternString {
             .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Sub10Primes(u32);
 impl std::ops::Deref for Sub10Primes {
     type Target = u32;

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -1,10 +1,14 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TestType {
     pub value: Option<TestTypeValue>,
 }
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, educe :: Educe,
+)]
+#[educe(Default)]
 pub enum TestTypeValue {
+    #[educe(Default)]
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum IpNet {
+    #[educe(Default)]
     V4(Ipv4Net),
     V6(Ipv4Net),
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Ipv4Net(pub String);
 impl std::ops::Deref for Ipv4Net {
     type Target = String;
@@ -13,7 +15,7 @@ impl std::ops::Deref for Ipv4Net {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Ipv6Net(pub String);
 impl std::ops::Deref for Ipv6Net {
     type Target = String;
@@ -21,10 +23,16 @@ impl std::ops::Deref for Ipv6Net {
         &self.0
     }
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, educe :: Educe)]
+#[educe(Default)]
 #[serde(untagged)]
 pub enum OneOfTypes {
-    Variant0 { bar: i64 },
-    Variant1 { foo: String },
+    #[educe(Default)]
+    Variant0 {
+        bar: i64,
+    },
+    Variant1 {
+        foo: String,
+    },
 }
 fn main() {}


### PR DESCRIPTION
Closes https://github.com/oxidecomputer/typify/issues/181

There is still one error with progenitor tests (`build_nexus`), naming that https://doc.rust-lang.org/std/net/struct.Ipv4Addr.html and friends do not implement `Default`, so any struct which uses them will fail to derive `Default`. https://github.com/magiclen/educe/issues/6 shows how this can already be fixed with `educe`, and also how an enhancement to `educe` might be able to make the implementation here less complicated.

This also highlights there are no tests here using `format: ipv4` in such a similar way to progenitor's `nexus.json`, that should causes failures here.