### PR TITLE
make dependency on typify-macro optional

### DIFF
--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -10,8 +10,12 @@ readme = "../README.md"
 keywords = ["json", "schema", "proc_macro"]
 categories = ["api-bindings", "compilers"]
 
+[features]
+default = ["macro"]
+macro = ["typify-macro"]
+
 [dependencies]
-typify-macro = { version = "0.0.11-dev", path = "../typify-macro" }
+typify-macro = { version = "0.0.11-dev", path = "../typify-macro", optional = true }
 typify-impl = { version = "0.0.11-dev", path = "../typify-impl" }
 
 [dev-dependencies]

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -167,5 +167,5 @@ pub use typify_impl::TypeSpacePatch;
 pub use typify_impl::TypeSpaceSettings;
 pub use typify_impl::TypeStruct;
 pub use typify_impl::TypeStructPropInfo;
-
+#[cfg(feature = "macro")]
 pub use typify_macro::import_types;


### PR DESCRIPTION
c.f. https://github.com/oxidecomputer/progenitor/pull/345

happy to create a feature "macro" or "macros" if you prefer.