### PR TITLE
Convenience `From<T>` impls for variants that can be identified by type alone

### DIFF
--- a/cargo-typify/tests/integration.rs
+++ b/cargo-typify/tests/integration.rs
@@ -1,5 +1,5 @@
 use expectorate::assert_contents;
-use newline_converter::{dos2unix, unix2dos};
+use newline_converter::dos2unix;
 use tempdir::TempDir;
 
 #[test]
@@ -19,12 +19,9 @@ fn test_simple() {
         .assert()
         .success();
 
-    let content = std::fs::read_to_string(output_file).unwrap();
+    let actual = std::fs::read_to_string(output_file).unwrap();
 
-    assert_contents(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/outputs/builder.rs"),
-        &content,
-    );
+    assert_contents("tests/outputs/builder.rs", &actual);
 }
 
 #[test]
@@ -43,10 +40,7 @@ fn test_default_output() {
 
     let content = std::fs::read_to_string(output_file).unwrap();
 
-    assert_contents(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/outputs/builder.rs"),
-        &content,
-    );
+    assert_contents("tests/outputs/builder.rs", &content);
 }
 
 #[test]
@@ -57,14 +51,6 @@ fn test_positional_stdout() {
 
     let mut cmd = Command::cargo_bin("cargo-typify").unwrap();
 
-    let expected = std::fs::read_to_string(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/outputs/positional.rs"
-    ))
-    .unwrap();
-
-    let expected = dos2unix(&expected);
-
     let output = cmd
         .args(["typify", input, "--positional", "--output", "-"])
         .output()
@@ -74,7 +60,7 @@ fn test_positional_stdout() {
     let actual = dos2unix(&output_stdout);
 
     assert!(output.status.success());
-    assert_eq!(actual, expected);
+    assert_contents("tests/outputs/positional.rs", &actual);
 }
 
 #[test]
@@ -97,12 +83,9 @@ fn test_builder() {
     .assert()
     .success();
 
-    let content = std::fs::read_to_string(output_file).unwrap();
+    let actual = std::fs::read_to_string(output_file).unwrap();
 
-    assert_contents(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/outputs/builder.rs"),
-        &content,
-    );
+    assert_contents("tests/outputs/builder.rs", &actual);
 }
 
 #[test]
@@ -127,12 +110,9 @@ fn test_derive() {
     .assert()
     .success();
 
-    let content = std::fs::read_to_string(output_file).unwrap();
+    let actual = std::fs::read_to_string(output_file).unwrap();
 
-    assert_contents(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/outputs/derive.rs"),
-        &content,
-    );
+    assert_contents("tests/outputs/derive.rs", &actual);
 }
 
 #[test]
@@ -159,12 +139,9 @@ fn test_multi_derive() {
     .assert()
     .success();
 
-    let content = std::fs::read_to_string(output_file).unwrap();
+    let actual = std::fs::read_to_string(output_file).unwrap();
 
-    assert_contents(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/outputs/multi_derive.rs"),
-        &content,
-    );
+    assert_contents("tests/outputs/multi_derive.rs", &actual);
 }
 
 #[test]
@@ -173,19 +150,11 @@ fn test_help() {
 
     let mut cmd = Command::cargo_bin("cargo-typify").unwrap();
 
-    let expected = std::fs::read_to_string(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/outputs/help.txt"
-    ))
-    .unwrap();
-
-    let expected = dos2unix(&expected);
-
     let output = cmd.args(["typify", "--help"]).output().unwrap();
 
     let output_stdout = String::from_utf8(output.stdout).unwrap();
     let actual = dos2unix(&output_stdout);
 
     assert!(output.status.success());
-    assert_eq!(actual, expected);
+    assert_contents("tests/outputs/help.txt", &actual);
 }

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -39,6 +39,16 @@ impl From<&FruitOrVeg> for FruitOrVeg {
         value.clone()
     }
 }
+impl From<Veggie> for FruitOrVeg {
+    fn from(value: Veggie) -> Self {
+        Self::Veg(value)
+    }
+}
+impl From<Fruit> for FruitOrVeg {
+    fn from(value: Fruit) -> Self {
+        Self::Fruit(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -39,6 +39,16 @@ impl From<&FruitOrVeg> for FruitOrVeg {
         value.clone()
     }
 }
+impl From<Veggie> for FruitOrVeg {
+    fn from(value: Veggie) -> Self {
+        Self::Veg(value)
+    }
+}
+impl From<Fruit> for FruitOrVeg {
+    fn from(value: Fruit) -> Self {
+        Self::Fruit(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, ExtraDerive, Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -39,6 +39,16 @@ impl From<&FruitOrVeg> for FruitOrVeg {
         value.clone()
     }
 }
+impl From<Veggie> for FruitOrVeg {
+    fn from(value: Veggie) -> Self {
+        Self::Veg(value)
+    }
+}
+impl From<Fruit> for FruitOrVeg {
+    fn from(value: Fruit) -> Self {
+        Self::Fruit(value)
+    }
+}
 #[derive(AnotherDerive, Clone, Debug, Deserialize, ExtraDerive, Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]

--- a/cargo-typify/tests/outputs/positional.rs
+++ b/cargo-typify/tests/outputs/positional.rs
@@ -39,6 +39,16 @@ impl From<&FruitOrVeg> for FruitOrVeg {
         value.clone()
     }
 }
+impl From<Veggie> for FruitOrVeg {
+    fn from(value: Veggie) -> Self {
+        Self::Veg(value)
+    }
+}
+impl From<Fruit> for FruitOrVeg {
+    fn from(value: Fruit) -> Self {
+        Self::Fruit(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1623,6 +1623,12 @@ mod tests {
                     value.clone()
                 }
             }
+
+            impl From<u32> for ResultX {
+                fn from(value: u32) -> Self {
+                    Self::Ok(value)
+                }
+            }
         };
         assert_eq!(actual.to_string(), expected.to_string());
     }
@@ -1654,6 +1660,12 @@ mod tests {
             impl From<&ResultX> for ResultX {
                 fn from(value: &ResultX) -> Self {
                     value.clone()
+                }
+            }
+
+            impl From<u32> for ResultX {
+                fn from(value: u32) -> Self {
+                    Self::Ok(value)
                 }
             }
         };

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -105,7 +105,7 @@ pub struct TypeNewtype<'a> {
 }
 
 /// Type identifier returned from type creation and used to lookup types.
-#[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone, Hash)]
 pub struct TypeId(u64);
 
 #[derive(Debug, Clone, PartialEq)]

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -9481,6 +9481,281 @@ impl From<&Everything> for Everything {
         value.clone()
     }
 }
+impl From<BranchProtectionRuleEvent> for Everything {
+    fn from(value: BranchProtectionRuleEvent) -> Self {
+        Self::BranchProtectionRuleEvent(value)
+    }
+}
+impl From<CheckRunEvent> for Everything {
+    fn from(value: CheckRunEvent) -> Self {
+        Self::CheckRunEvent(value)
+    }
+}
+impl From<CheckSuiteEvent> for Everything {
+    fn from(value: CheckSuiteEvent) -> Self {
+        Self::CheckSuiteEvent(value)
+    }
+}
+impl From<CodeScanningAlertEvent> for Everything {
+    fn from(value: CodeScanningAlertEvent) -> Self {
+        Self::CodeScanningAlertEvent(value)
+    }
+}
+impl From<CommitCommentEvent> for Everything {
+    fn from(value: CommitCommentEvent) -> Self {
+        Self::CommitCommentEvent(value)
+    }
+}
+impl From<ContentReferenceEvent> for Everything {
+    fn from(value: ContentReferenceEvent) -> Self {
+        Self::ContentReferenceEvent(value)
+    }
+}
+impl From<CreateEvent> for Everything {
+    fn from(value: CreateEvent) -> Self {
+        Self::CreateEvent(value)
+    }
+}
+impl From<DeleteEvent> for Everything {
+    fn from(value: DeleteEvent) -> Self {
+        Self::DeleteEvent(value)
+    }
+}
+impl From<DeployKeyEvent> for Everything {
+    fn from(value: DeployKeyEvent) -> Self {
+        Self::DeployKeyEvent(value)
+    }
+}
+impl From<DeploymentEvent> for Everything {
+    fn from(value: DeploymentEvent) -> Self {
+        Self::DeploymentEvent(value)
+    }
+}
+impl From<DeploymentStatusEvent> for Everything {
+    fn from(value: DeploymentStatusEvent) -> Self {
+        Self::DeploymentStatusEvent(value)
+    }
+}
+impl From<DiscussionEvent> for Everything {
+    fn from(value: DiscussionEvent) -> Self {
+        Self::DiscussionEvent(value)
+    }
+}
+impl From<DiscussionCommentEvent> for Everything {
+    fn from(value: DiscussionCommentEvent) -> Self {
+        Self::DiscussionCommentEvent(value)
+    }
+}
+impl From<ForkEvent> for Everything {
+    fn from(value: ForkEvent) -> Self {
+        Self::ForkEvent(value)
+    }
+}
+impl From<GithubAppAuthorizationEvent> for Everything {
+    fn from(value: GithubAppAuthorizationEvent) -> Self {
+        Self::GithubAppAuthorizationEvent(value)
+    }
+}
+impl From<GollumEvent> for Everything {
+    fn from(value: GollumEvent) -> Self {
+        Self::GollumEvent(value)
+    }
+}
+impl From<InstallationEvent> for Everything {
+    fn from(value: InstallationEvent) -> Self {
+        Self::InstallationEvent(value)
+    }
+}
+impl From<InstallationRepositoriesEvent> for Everything {
+    fn from(value: InstallationRepositoriesEvent) -> Self {
+        Self::InstallationRepositoriesEvent(value)
+    }
+}
+impl From<IssueCommentEvent> for Everything {
+    fn from(value: IssueCommentEvent) -> Self {
+        Self::IssueCommentEvent(value)
+    }
+}
+impl From<IssuesEvent> for Everything {
+    fn from(value: IssuesEvent) -> Self {
+        Self::IssuesEvent(value)
+    }
+}
+impl From<LabelEvent> for Everything {
+    fn from(value: LabelEvent) -> Self {
+        Self::LabelEvent(value)
+    }
+}
+impl From<MarketplacePurchaseEvent> for Everything {
+    fn from(value: MarketplacePurchaseEvent) -> Self {
+        Self::MarketplacePurchaseEvent(value)
+    }
+}
+impl From<MemberEvent> for Everything {
+    fn from(value: MemberEvent) -> Self {
+        Self::MemberEvent(value)
+    }
+}
+impl From<MembershipEvent> for Everything {
+    fn from(value: MembershipEvent) -> Self {
+        Self::MembershipEvent(value)
+    }
+}
+impl From<MetaEvent> for Everything {
+    fn from(value: MetaEvent) -> Self {
+        Self::MetaEvent(value)
+    }
+}
+impl From<MilestoneEvent> for Everything {
+    fn from(value: MilestoneEvent) -> Self {
+        Self::MilestoneEvent(value)
+    }
+}
+impl From<OrgBlockEvent> for Everything {
+    fn from(value: OrgBlockEvent) -> Self {
+        Self::OrgBlockEvent(value)
+    }
+}
+impl From<OrganizationEvent> for Everything {
+    fn from(value: OrganizationEvent) -> Self {
+        Self::OrganizationEvent(value)
+    }
+}
+impl From<PackageEvent> for Everything {
+    fn from(value: PackageEvent) -> Self {
+        Self::PackageEvent(value)
+    }
+}
+impl From<PageBuildEvent> for Everything {
+    fn from(value: PageBuildEvent) -> Self {
+        Self::PageBuildEvent(value)
+    }
+}
+impl From<PingEvent> for Everything {
+    fn from(value: PingEvent) -> Self {
+        Self::PingEvent(value)
+    }
+}
+impl From<ProjectEvent> for Everything {
+    fn from(value: ProjectEvent) -> Self {
+        Self::ProjectEvent(value)
+    }
+}
+impl From<ProjectCardEvent> for Everything {
+    fn from(value: ProjectCardEvent) -> Self {
+        Self::ProjectCardEvent(value)
+    }
+}
+impl From<ProjectColumnEvent> for Everything {
+    fn from(value: ProjectColumnEvent) -> Self {
+        Self::ProjectColumnEvent(value)
+    }
+}
+impl From<PublicEvent> for Everything {
+    fn from(value: PublicEvent) -> Self {
+        Self::PublicEvent(value)
+    }
+}
+impl From<PullRequestEvent> for Everything {
+    fn from(value: PullRequestEvent) -> Self {
+        Self::PullRequestEvent(value)
+    }
+}
+impl From<PullRequestReviewEvent> for Everything {
+    fn from(value: PullRequestReviewEvent) -> Self {
+        Self::PullRequestReviewEvent(value)
+    }
+}
+impl From<PullRequestReviewCommentEvent> for Everything {
+    fn from(value: PullRequestReviewCommentEvent) -> Self {
+        Self::PullRequestReviewCommentEvent(value)
+    }
+}
+impl From<PushEvent> for Everything {
+    fn from(value: PushEvent) -> Self {
+        Self::PushEvent(value)
+    }
+}
+impl From<ReleaseEvent> for Everything {
+    fn from(value: ReleaseEvent) -> Self {
+        Self::ReleaseEvent(value)
+    }
+}
+impl From<RepositoryEvent> for Everything {
+    fn from(value: RepositoryEvent) -> Self {
+        Self::RepositoryEvent(value)
+    }
+}
+impl From<RepositoryDispatchEvent> for Everything {
+    fn from(value: RepositoryDispatchEvent) -> Self {
+        Self::RepositoryDispatchEvent(value)
+    }
+}
+impl From<RepositoryImportEvent> for Everything {
+    fn from(value: RepositoryImportEvent) -> Self {
+        Self::RepositoryImportEvent(value)
+    }
+}
+impl From<RepositoryVulnerabilityAlertEvent> for Everything {
+    fn from(value: RepositoryVulnerabilityAlertEvent) -> Self {
+        Self::RepositoryVulnerabilityAlertEvent(value)
+    }
+}
+impl From<SecretScanningAlertEvent> for Everything {
+    fn from(value: SecretScanningAlertEvent) -> Self {
+        Self::SecretScanningAlertEvent(value)
+    }
+}
+impl From<SecurityAdvisoryEvent> for Everything {
+    fn from(value: SecurityAdvisoryEvent) -> Self {
+        Self::SecurityAdvisoryEvent(value)
+    }
+}
+impl From<SponsorshipEvent> for Everything {
+    fn from(value: SponsorshipEvent) -> Self {
+        Self::SponsorshipEvent(value)
+    }
+}
+impl From<StarEvent> for Everything {
+    fn from(value: StarEvent) -> Self {
+        Self::StarEvent(value)
+    }
+}
+impl From<StatusEvent> for Everything {
+    fn from(value: StatusEvent) -> Self {
+        Self::StatusEvent(value)
+    }
+}
+impl From<TeamEvent> for Everything {
+    fn from(value: TeamEvent) -> Self {
+        Self::TeamEvent(value)
+    }
+}
+impl From<TeamAddEvent> for Everything {
+    fn from(value: TeamAddEvent) -> Self {
+        Self::TeamAddEvent(value)
+    }
+}
+impl From<WatchEvent> for Everything {
+    fn from(value: WatchEvent) -> Self {
+        Self::WatchEvent(value)
+    }
+}
+impl From<WorkflowDispatchEvent> for Everything {
+    fn from(value: WorkflowDispatchEvent) -> Self {
+        Self::WorkflowDispatchEvent(value)
+    }
+}
+impl From<WorkflowJobEvent> for Everything {
+    fn from(value: WorkflowJobEvent) -> Self {
+        Self::WorkflowJobEvent(value)
+    }
+}
+impl From<WorkflowRunEvent> for Everything {
+    fn from(value: WorkflowRunEvent) -> Self {
+        Self::WorkflowRunEvent(value)
+    }
+}
 #[doc = "A user forks a repository."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -9509,6 +9784,11 @@ pub enum GithubAppAuthorizationEvent {
 impl From<&GithubAppAuthorizationEvent> for GithubAppAuthorizationEvent {
     fn from(value: &GithubAppAuthorizationEvent) -> Self {
         value.clone()
+    }
+}
+impl From<User> for GithubAppAuthorizationEvent {
+    fn from(value: User) -> Self {
+        Self::Revoked(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9828,6 +10108,16 @@ impl ToString for InstallationCreatedAt {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12726,6 +13016,16 @@ impl ToString for InstallationUpdatedAt {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationUpdatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationUpdatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
     }
 }
 #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
@@ -15928,6 +16228,11 @@ pub enum MembershipRemovedTeam {
 impl From<&MembershipRemovedTeam> for MembershipRemovedTeam {
     fn from(value: &MembershipRemovedTeam) -> Self {
         value.clone()
+    }
+}
+impl From<Team> for MembershipRemovedTeam {
+    fn from(value: Team) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19537,6 +19842,91 @@ impl From<&PullRequestEvent> for PullRequestEvent {
         value.clone()
     }
 }
+impl From<PullRequestAssigned> for PullRequestEvent {
+    fn from(value: PullRequestAssigned) -> Self {
+        Self::Assigned(value)
+    }
+}
+impl From<PullRequestAutoMergeDisabled> for PullRequestEvent {
+    fn from(value: PullRequestAutoMergeDisabled) -> Self {
+        Self::AutoMergeDisabled(value)
+    }
+}
+impl From<PullRequestAutoMergeEnabled> for PullRequestEvent {
+    fn from(value: PullRequestAutoMergeEnabled) -> Self {
+        Self::AutoMergeEnabled(value)
+    }
+}
+impl From<PullRequestClosed> for PullRequestEvent {
+    fn from(value: PullRequestClosed) -> Self {
+        Self::Closed(value)
+    }
+}
+impl From<PullRequestConvertedToDraft> for PullRequestEvent {
+    fn from(value: PullRequestConvertedToDraft) -> Self {
+        Self::ConvertedToDraft(value)
+    }
+}
+impl From<PullRequestEdited> for PullRequestEvent {
+    fn from(value: PullRequestEdited) -> Self {
+        Self::Edited(value)
+    }
+}
+impl From<PullRequestLabeled> for PullRequestEvent {
+    fn from(value: PullRequestLabeled) -> Self {
+        Self::Labeled(value)
+    }
+}
+impl From<PullRequestLocked> for PullRequestEvent {
+    fn from(value: PullRequestLocked) -> Self {
+        Self::Locked(value)
+    }
+}
+impl From<PullRequestOpened> for PullRequestEvent {
+    fn from(value: PullRequestOpened) -> Self {
+        Self::Opened(value)
+    }
+}
+impl From<PullRequestReadyForReview> for PullRequestEvent {
+    fn from(value: PullRequestReadyForReview) -> Self {
+        Self::ReadyForReview(value)
+    }
+}
+impl From<PullRequestReopened> for PullRequestEvent {
+    fn from(value: PullRequestReopened) -> Self {
+        Self::Reopened(value)
+    }
+}
+impl From<PullRequestReviewRequestRemoved> for PullRequestEvent {
+    fn from(value: PullRequestReviewRequestRemoved) -> Self {
+        Self::ReviewRequestRemoved(value)
+    }
+}
+impl From<PullRequestReviewRequested> for PullRequestEvent {
+    fn from(value: PullRequestReviewRequested) -> Self {
+        Self::ReviewRequested(value)
+    }
+}
+impl From<PullRequestSynchronize> for PullRequestEvent {
+    fn from(value: PullRequestSynchronize) -> Self {
+        Self::Synchronize(value)
+    }
+}
+impl From<PullRequestUnassigned> for PullRequestEvent {
+    fn from(value: PullRequestUnassigned) -> Self {
+        Self::Unassigned(value)
+    }
+}
+impl From<PullRequestUnlabeled> for PullRequestEvent {
+    fn from(value: PullRequestUnlabeled) -> Self {
+        Self::Unlabeled(value)
+    }
+}
+impl From<PullRequestUnlocked> for PullRequestEvent {
+    fn from(value: PullRequestUnlocked) -> Self {
+        Self::Unlocked(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestHead {
@@ -19897,6 +20287,16 @@ impl From<&PullRequestRequestedReviewersItem> for PullRequestRequestedReviewersI
         value.clone()
     }
 }
+impl From<User> for PullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
 #[doc = "The [comment](https://docs.github.com/en/rest/reference/pulls#comments) itself."]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -20191,6 +20591,16 @@ impl From<&PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem>
         value.clone()
     }
 }
+impl From<User> for PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PullRequestReviewCommentCreatedPullRequestState {
     #[serde(rename = "open")]
@@ -20476,6 +20886,16 @@ impl From<&PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem>
 {
     fn from(value: &PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem) -> Self {
         value.clone()
+    }
+}
+impl From<User> for PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20789,6 +21209,16 @@ impl From<&PullRequestReviewCommentEditedPullRequestRequestedReviewersItem>
 {
     fn from(value: &PullRequestReviewCommentEditedPullRequestRequestedReviewersItem) -> Self {
         value.clone()
+    }
+}
+impl From<User> for PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22947,6 +23377,16 @@ impl ToString for RepositoryCreatedAt {
         }
     }
 }
+impl From<i64> for RepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDeleted {
@@ -23568,6 +24008,16 @@ pub enum RepositoryPushedAt {
 impl From<&RepositoryPushedAt> for RepositoryPushedAt {
     fn from(value: &RepositoryPushedAt) -> Self {
         value.clone()
+    }
+}
+impl From<i64> for RepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24458,6 +24908,26 @@ impl From<&SecurityAdvisoryEvent> for SecurityAdvisoryEvent {
         value.clone()
     }
 }
+impl From<SecurityAdvisoryPerformedSecurityAdvisory> for SecurityAdvisoryEvent {
+    fn from(value: SecurityAdvisoryPerformedSecurityAdvisory) -> Self {
+        Self::Performed(value)
+    }
+}
+impl From<SecurityAdvisoryPublishedSecurityAdvisory> for SecurityAdvisoryEvent {
+    fn from(value: SecurityAdvisoryPublishedSecurityAdvisory) -> Self {
+        Self::Published(value)
+    }
+}
+impl From<SecurityAdvisoryUpdatedSecurityAdvisory> for SecurityAdvisoryEvent {
+    fn from(value: SecurityAdvisoryUpdatedSecurityAdvisory) -> Self {
+        Self::Updated(value)
+    }
+}
+impl From<SecurityAdvisoryWithdrawnSecurityAdvisory> for SecurityAdvisoryEvent {
+    fn from(value: SecurityAdvisoryWithdrawnSecurityAdvisory) -> Self {
+        Self::Withdrawn(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformed {
@@ -25311,6 +25781,16 @@ pub enum SimplePullRequestRequestedReviewersItem {
 impl From<&SimplePullRequestRequestedReviewersItem> for SimplePullRequestRequestedReviewersItem {
     fn from(value: &SimplePullRequestRequestedReviewersItem) -> Self {
         value.clone()
+    }
+}
+impl From<User> for SimplePullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for SimplePullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27170,6 +27650,16 @@ pub enum WebhookEvents {
 impl From<&WebhookEvents> for WebhookEvents {
     fn from(value: &WebhookEvents) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<WebhookEventsVariant0Item>> for WebhookEvents {
+    fn from(value: Vec<WebhookEventsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<String>> for WebhookEvents {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -36,6 +36,16 @@ impl From<&AggregateTransformAs> for AggregateTransformAs {
         value.clone()
     }
 }
+impl From<Vec<AggregateTransformAsVariant0Item>> for AggregateTransformAs {
+    fn from(value: Vec<AggregateTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformAsVariant0Item {
@@ -48,6 +58,11 @@ impl From<&AggregateTransformAsVariant0Item> for AggregateTransformAsVariant0Ite
         value.clone()
     }
 }
+impl From<SignalRef> for AggregateTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformCross {
@@ -57,6 +72,16 @@ pub enum AggregateTransformCross {
 impl From<&AggregateTransformCross> for AggregateTransformCross {
     fn from(value: &AggregateTransformCross) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for AggregateTransformCross {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformCross {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -75,6 +100,16 @@ impl Default for AggregateTransformDrop {
         AggregateTransformDrop::Variant0(true)
     }
 }
+impl From<bool> for AggregateTransformDrop {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformDrop {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformFields {
@@ -84,6 +119,16 @@ pub enum AggregateTransformFields {
 impl From<&AggregateTransformFields> for AggregateTransformFields {
     fn from(value: &AggregateTransformFields) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<AggregateTransformFieldsVariant0Item>> for AggregateTransformFields {
+    fn from(value: Vec<AggregateTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -99,6 +144,21 @@ impl From<&AggregateTransformFieldsVariant0Item> for AggregateTransformFieldsVar
         value.clone()
     }
 }
+impl From<ScaleField> for AggregateTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ParamField> for AggregateTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for AggregateTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupby {
@@ -108,6 +168,16 @@ pub enum AggregateTransformGroupby {
 impl From<&AggregateTransformGroupby> for AggregateTransformGroupby {
     fn from(value: &AggregateTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<AggregateTransformGroupbyVariant0Item>> for AggregateTransformGroupby {
+    fn from(value: Vec<AggregateTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -122,6 +192,21 @@ impl From<&AggregateTransformGroupbyVariant0Item> for AggregateTransformGroupbyV
         value.clone()
     }
 }
+impl From<ScaleField> for AggregateTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for AggregateTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for AggregateTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformKey {
@@ -132,6 +217,21 @@ pub enum AggregateTransformKey {
 impl From<&AggregateTransformKey> for AggregateTransformKey {
     fn from(value: &AggregateTransformKey) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for AggregateTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for AggregateTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for AggregateTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -145,6 +245,16 @@ impl From<&AggregateTransformOps> for AggregateTransformOps {
         value.clone()
     }
 }
+impl From<Vec<AggregateTransformOpsVariant0Item>> for AggregateTransformOps {
+    fn from(value: Vec<AggregateTransformOpsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformOps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformOpsVariant0Item {
@@ -154,6 +264,16 @@ pub enum AggregateTransformOpsVariant0Item {
 impl From<&AggregateTransformOpsVariant0Item> for AggregateTransformOpsVariant0Item {
     fn from(value: &AggregateTransformOpsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<AggregateTransformOpsVariant0ItemVariant0> for AggregateTransformOpsVariant0Item {
+    fn from(value: AggregateTransformOpsVariant0ItemVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AggregateTransformOpsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -349,6 +469,16 @@ impl From<&AlignValue> for AlignValue {
         value.clone()
     }
 }
+impl From<Vec<AlignValueVariant0Item>> for AlignValue {
+    fn from(value: Vec<AlignValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValueVariant1> for AlignValue {
+    fn from(value: AlignValueVariant1) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant0Item {
     #[serde(flatten)]
@@ -408,6 +538,11 @@ impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for AlignValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -519,6 +654,16 @@ impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -591,6 +736,11 @@ pub enum AlignValueVariant1Subtype1Subtype0 {
 impl From<&AlignValueVariant1Subtype1Subtype0> for AlignValueVariant1Subtype1Subtype0 {
     fn from(value: &AlignValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for AlignValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -698,6 +848,16 @@ impl ToString for AlignValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for AlignValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AlignValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1Subtype1 {}
 impl From<&AlignValueVariant1Subtype1Subtype1> for AlignValueVariant1Subtype1Subtype1 {
@@ -728,6 +888,16 @@ pub enum AnchorValue {
 impl From<&AnchorValue> for AnchorValue {
     fn from(value: &AnchorValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<AnchorValueVariant0Item>> for AnchorValue {
+    fn from(value: Vec<AnchorValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValueVariant1> for AnchorValue {
+    fn from(value: AnchorValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -789,6 +959,11 @@ impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -904,6 +1079,16 @@ impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -976,6 +1161,11 @@ pub enum AnchorValueVariant1Subtype1Subtype0 {
 impl From<&AnchorValueVariant1Subtype1Subtype0> for AnchorValueVariant1Subtype1Subtype0 {
     fn from(value: &AnchorValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for AnchorValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -1083,6 +1273,16 @@ impl ToString for AnchorValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1Subtype1 {}
 impl From<&AnchorValueVariant1Subtype1Subtype1> for AnchorValueVariant1Subtype1Subtype1 {
@@ -1113,6 +1313,16 @@ pub enum AnyValue {
 impl From<&AnyValue> for AnyValue {
     fn from(value: &AnyValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<AnyValueVariant0Item>> for AnyValue {
+    fn from(value: Vec<AnyValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnyValueVariant1> for AnyValue {
+    fn from(value: AnyValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1176,6 +1386,11 @@ impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for AnyValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -1225,6 +1440,16 @@ impl ToString for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1301,6 +1526,11 @@ impl From<&AnyValueVariant1Subtype1Subtype0> for AnyValueVariant1Subtype1Subtype
         value.clone()
     }
 }
+impl From<SignalRef> for AnyValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Subtype1Subtype0Variant3Range {
@@ -1352,6 +1582,16 @@ impl ToString for AnyValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for AnyValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnyValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1Subtype1 {}
 impl From<&AnyValueVariant1Subtype1Subtype1> for AnyValueVariant1Subtype1Subtype1 {
@@ -1384,6 +1624,16 @@ impl From<&ArrayOrSignal> for ArrayOrSignal {
         value.clone()
     }
 }
+impl From<Vec<serde_json::Value>> for ArrayOrSignal {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ArrayOrSignal {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ArrayValue {
@@ -1393,6 +1643,16 @@ pub enum ArrayValue {
 impl From<&ArrayValue> for ArrayValue {
     fn from(value: &ArrayValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<ArrayValueVariant0Item>> for ArrayValue {
+    fn from(value: Vec<ArrayValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValueVariant1> for ArrayValue {
+    fn from(value: ArrayValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1456,6 +1716,11 @@ impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -1507,6 +1772,16 @@ impl ToString for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1583,6 +1858,11 @@ impl From<&ArrayValueVariant1Subtype1Subtype0> for ArrayValueVariant1Subtype1Sub
         value.clone()
     }
 }
+impl From<SignalRef> for ArrayValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Subtype1Subtype0Variant3Range {
@@ -1634,6 +1914,16 @@ impl ToString for ArrayValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1Subtype1 {}
 impl From<&ArrayValueVariant1Subtype1Subtype1> for ArrayValueVariant1Subtype1Subtype1 {
@@ -1672,6 +1962,16 @@ pub enum Autosize {
 impl From<&Autosize> for Autosize {
     fn from(value: &Autosize) -> Self {
         value.clone()
+    }
+}
+impl From<AutosizeVariant0> for Autosize {
+    fn from(value: AutosizeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Autosize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -2196,6 +2496,16 @@ impl From<&AxisBandPosition> for AxisBandPosition {
         value.clone()
     }
 }
+impl From<f64> for AxisBandPosition {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisBandPosition {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainCap {
@@ -2205,6 +2515,11 @@ pub enum AxisDomainCap {
 impl From<&AxisDomainCap> for AxisDomainCap {
     fn from(value: &AxisDomainCap) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisDomainCap {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2219,6 +2534,11 @@ impl From<&AxisDomainColor> for AxisDomainColor {
         value.clone()
     }
 }
+impl From<ColorValue> for AxisDomainColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainDash {
@@ -2228,6 +2548,16 @@ pub enum AxisDomainDash {
 impl From<&AxisDomainDash> for AxisDomainDash {
     fn from(value: &AxisDomainDash) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<f64>> for AxisDomainDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for AxisDomainDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2241,6 +2571,16 @@ impl From<&AxisDomainDashOffset> for AxisDomainDashOffset {
         value.clone()
     }
 }
+impl From<f64> for AxisDomainDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisDomainDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainOpacity {
@@ -2252,6 +2592,16 @@ impl From<&AxisDomainOpacity> for AxisDomainOpacity {
         value.clone()
     }
 }
+impl From<f64> for AxisDomainOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisDomainOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainWidth {
@@ -2261,6 +2611,16 @@ pub enum AxisDomainWidth {
 impl From<&AxisDomainWidth> for AxisDomainWidth {
     fn from(value: &AxisDomainWidth) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisDomainWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisDomainWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2317,6 +2677,11 @@ impl From<&AxisFormat> for AxisFormat {
         value.clone()
     }
 }
+impl From<SignalRef> for AxisFormat {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisFormatType {
@@ -2326,6 +2691,16 @@ pub enum AxisFormatType {
 impl From<&AxisFormatType> for AxisFormatType {
     fn from(value: &AxisFormatType) -> Self {
         value.clone()
+    }
+}
+impl From<AxisFormatTypeVariant0> for AxisFormatType {
+    fn from(value: AxisFormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AxisFormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -2391,6 +2766,11 @@ impl From<&AxisGridCap> for AxisGridCap {
         value.clone()
     }
 }
+impl From<StringValue> for AxisGridCap {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisGridColor {
@@ -2401,6 +2781,11 @@ pub enum AxisGridColor {
 impl From<&AxisGridColor> for AxisGridColor {
     fn from(value: &AxisGridColor) -> Self {
         value.clone()
+    }
+}
+impl From<ColorValue> for AxisGridColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2414,6 +2799,16 @@ impl From<&AxisGridDash> for AxisGridDash {
         value.clone()
     }
 }
+impl From<Vec<f64>> for AxisGridDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for AxisGridDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisGridDashOffset {
@@ -2423,6 +2818,16 @@ pub enum AxisGridDashOffset {
 impl From<&AxisGridDashOffset> for AxisGridDashOffset {
     fn from(value: &AxisGridDashOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisGridDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisGridDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2436,6 +2841,16 @@ impl From<&AxisGridOpacity> for AxisGridOpacity {
         value.clone()
     }
 }
+impl From<f64> for AxisGridOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisGridOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisGridWidth {
@@ -2447,6 +2862,16 @@ impl From<&AxisGridWidth> for AxisGridWidth {
         value.clone()
     }
 }
+impl From<f64> for AxisGridWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisGridWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelAlign {
@@ -2456,6 +2881,16 @@ pub enum AxisLabelAlign {
 impl From<&AxisLabelAlign> for AxisLabelAlign {
     fn from(value: &AxisLabelAlign) -> Self {
         value.clone()
+    }
+}
+impl From<AxisLabelAlignVariant0> for AxisLabelAlign {
+    fn from(value: AxisLabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for AxisLabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -2521,6 +2956,16 @@ impl From<&AxisLabelAngle> for AxisLabelAngle {
         value.clone()
     }
 }
+impl From<f64> for AxisLabelAngle {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelAngle {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelBaseline {
@@ -2530,6 +2975,16 @@ pub enum AxisLabelBaseline {
 impl From<&AxisLabelBaseline> for AxisLabelBaseline {
     fn from(value: &AxisLabelBaseline) -> Self {
         value.clone()
+    }
+}
+impl From<AxisLabelBaselineVariant0> for AxisLabelBaseline {
+    fn from(value: AxisLabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for AxisLabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -2608,6 +3063,21 @@ impl From<&AxisLabelBound> for AxisLabelBound {
         value.clone()
     }
 }
+impl From<bool> for AxisLabelBound {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for AxisLabelBound {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for AxisLabelBound {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelColor {
@@ -2618,6 +3088,11 @@ pub enum AxisLabelColor {
 impl From<&AxisLabelColor> for AxisLabelColor {
     fn from(value: &AxisLabelColor) -> Self {
         value.clone()
+    }
+}
+impl From<ColorValue> for AxisLabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2632,6 +3107,21 @@ impl From<&AxisLabelFlush> for AxisLabelFlush {
         value.clone()
     }
 }
+impl From<bool> for AxisLabelFlush {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for AxisLabelFlush {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for AxisLabelFlush {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFont {
@@ -2641,6 +3131,11 @@ pub enum AxisLabelFont {
 impl From<&AxisLabelFont> for AxisLabelFont {
     fn from(value: &AxisLabelFont) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisLabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2654,6 +3149,16 @@ impl From<&AxisLabelFontSize> for AxisLabelFontSize {
         value.clone()
     }
 }
+impl From<f64> for AxisLabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFontStyle {
@@ -2663,6 +3168,11 @@ pub enum AxisLabelFontStyle {
 impl From<&AxisLabelFontStyle> for AxisLabelFontStyle {
     fn from(value: &AxisLabelFontStyle) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisLabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2676,6 +3186,16 @@ impl From<&AxisLabelFontWeight> for AxisLabelFontWeight {
         value.clone()
     }
 }
+impl From<MyEnum> for AxisLabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for AxisLabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelLimit {
@@ -2685,6 +3205,16 @@ pub enum AxisLabelLimit {
 impl From<&AxisLabelLimit> for AxisLabelLimit {
     fn from(value: &AxisLabelLimit) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisLabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2698,6 +3228,16 @@ impl From<&AxisLabelLineHeight> for AxisLabelLineHeight {
         value.clone()
     }
 }
+impl From<f64> for AxisLabelLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelOffset {
@@ -2707,6 +3247,16 @@ pub enum AxisLabelOffset {
 impl From<&AxisLabelOffset> for AxisLabelOffset {
     fn from(value: &AxisLabelOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisLabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2720,6 +3270,16 @@ impl From<&AxisLabelOpacity> for AxisLabelOpacity {
         value.clone()
     }
 }
+impl From<f64> for AxisLabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelPadding {
@@ -2729,6 +3289,16 @@ pub enum AxisLabelPadding {
 impl From<&AxisLabelPadding> for AxisLabelPadding {
     fn from(value: &AxisLabelPadding) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisLabelPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisLabelPadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2742,6 +3312,16 @@ impl From<&AxisMaxExtent> for AxisMaxExtent {
         value.clone()
     }
 }
+impl From<f64> for AxisMaxExtent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisMaxExtent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisMinExtent {
@@ -2751,6 +3331,16 @@ pub enum AxisMinExtent {
 impl From<&AxisMinExtent> for AxisMinExtent {
     fn from(value: &AxisMinExtent) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisMinExtent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisMinExtent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2764,6 +3354,16 @@ impl From<&AxisOffset> for AxisOffset {
         value.clone()
     }
 }
+impl From<f64> for AxisOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisOrient {
@@ -2773,6 +3373,16 @@ pub enum AxisOrient {
 impl From<&AxisOrient> for AxisOrient {
     fn from(value: &AxisOrient) -> Self {
         value.clone()
+    }
+}
+impl From<AxisOrientVariant0> for AxisOrient {
+    fn from(value: AxisOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for AxisOrient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -2842,6 +3452,16 @@ impl From<&AxisPosition> for AxisPosition {
         value.clone()
     }
 }
+impl From<f64> for AxisPosition {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisPosition {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTickCap {
@@ -2851,6 +3471,11 @@ pub enum AxisTickCap {
 impl From<&AxisTickCap> for AxisTickCap {
     fn from(value: &AxisTickCap) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisTickCap {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2865,6 +3490,11 @@ impl From<&AxisTickColor> for AxisTickColor {
         value.clone()
     }
 }
+impl From<ColorValue> for AxisTickColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTickDash {
@@ -2874,6 +3504,16 @@ pub enum AxisTickDash {
 impl From<&AxisTickDash> for AxisTickDash {
     fn from(value: &AxisTickDash) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<f64>> for AxisTickDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for AxisTickDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2887,6 +3527,16 @@ impl From<&AxisTickDashOffset> for AxisTickDashOffset {
         value.clone()
     }
 }
+impl From<f64> for AxisTickDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTickDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTickOffset {
@@ -2896,6 +3546,16 @@ pub enum AxisTickOffset {
 impl From<&AxisTickOffset> for AxisTickOffset {
     fn from(value: &AxisTickOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisTickOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTickOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2909,6 +3569,16 @@ impl From<&AxisTickOpacity> for AxisTickOpacity {
         value.clone()
     }
 }
+impl From<f64> for AxisTickOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTickOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTickRound {
@@ -2918,6 +3588,16 @@ pub enum AxisTickRound {
 impl From<&AxisTickRound> for AxisTickRound {
     fn from(value: &AxisTickRound) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for AxisTickRound {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BooleanValue> for AxisTickRound {
+    fn from(value: BooleanValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2931,6 +3611,16 @@ impl From<&AxisTickSize> for AxisTickSize {
         value.clone()
     }
 }
+impl From<f64> for AxisTickSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTickSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTickWidth {
@@ -2942,6 +3632,16 @@ impl From<&AxisTickWidth> for AxisTickWidth {
         value.clone()
     }
 }
+impl From<f64> for AxisTickWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTickWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleAlign {
@@ -2951,6 +3651,16 @@ pub enum AxisTitleAlign {
 impl From<&AxisTitleAlign> for AxisTitleAlign {
     fn from(value: &AxisTitleAlign) -> Self {
         value.clone()
+    }
+}
+impl From<AxisTitleAlignVariant0> for AxisTitleAlign {
+    fn from(value: AxisTitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for AxisTitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3016,6 +3726,16 @@ impl From<&AxisTitleAnchor> for AxisTitleAnchor {
         value.clone()
     }
 }
+impl From<Option<AxisTitleAnchorVariant0>> for AxisTitleAnchor {
+    fn from(value: Option<AxisTitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for AxisTitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AxisTitleAnchorVariant0 {
     #[serde(rename = "start")]
@@ -3079,6 +3799,16 @@ impl From<&AxisTitleAngle> for AxisTitleAngle {
         value.clone()
     }
 }
+impl From<f64> for AxisTitleAngle {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleAngle {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleBaseline {
@@ -3088,6 +3818,16 @@ pub enum AxisTitleBaseline {
 impl From<&AxisTitleBaseline> for AxisTitleBaseline {
     fn from(value: &AxisTitleBaseline) -> Self {
         value.clone()
+    }
+}
+impl From<AxisTitleBaselineVariant0> for AxisTitleBaseline {
+    fn from(value: AxisTitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for AxisTitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3166,6 +3906,11 @@ impl From<&AxisTitleColor> for AxisTitleColor {
         value.clone()
     }
 }
+impl From<ColorValue> for AxisTitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFont {
@@ -3175,6 +3920,11 @@ pub enum AxisTitleFont {
 impl From<&AxisTitleFont> for AxisTitleFont {
     fn from(value: &AxisTitleFont) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisTitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3188,6 +3938,16 @@ impl From<&AxisTitleFontSize> for AxisTitleFontSize {
         value.clone()
     }
 }
+impl From<f64> for AxisTitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFontStyle {
@@ -3197,6 +3957,11 @@ pub enum AxisTitleFontStyle {
 impl From<&AxisTitleFontStyle> for AxisTitleFontStyle {
     fn from(value: &AxisTitleFontStyle) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for AxisTitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3210,6 +3975,16 @@ impl From<&AxisTitleFontWeight> for AxisTitleFontWeight {
         value.clone()
     }
 }
+impl From<MyEnum> for AxisTitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for AxisTitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleLimit {
@@ -3219,6 +3994,16 @@ pub enum AxisTitleLimit {
 impl From<&AxisTitleLimit> for AxisTitleLimit {
     fn from(value: &AxisTitleLimit) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisTitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3232,6 +4017,16 @@ impl From<&AxisTitleLineHeight> for AxisTitleLineHeight {
         value.clone()
     }
 }
+impl From<f64> for AxisTitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleOpacity {
@@ -3241,6 +4036,16 @@ pub enum AxisTitleOpacity {
 impl From<&AxisTitleOpacity> for AxisTitleOpacity {
     fn from(value: &AxisTitleOpacity) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisTitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3254,6 +4059,16 @@ impl From<&AxisTitlePadding> for AxisTitlePadding {
         value.clone()
     }
 }
+impl From<f64> for AxisTitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleX {
@@ -3263,6 +4078,16 @@ pub enum AxisTitleX {
 impl From<&AxisTitleX> for AxisTitleX {
     fn from(value: &AxisTitleX) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisTitleX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3276,6 +4101,16 @@ impl From<&AxisTitleY> for AxisTitleY {
         value.clone()
     }
 }
+impl From<f64> for AxisTitleY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTitleY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AxisTranslate {
@@ -3285,6 +4120,16 @@ pub enum AxisTranslate {
 impl From<&AxisTranslate> for AxisTranslate {
     fn from(value: &AxisTranslate) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for AxisTranslate {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for AxisTranslate {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3338,6 +4183,11 @@ impl From<&BaseColorValue> for BaseColorValue {
         value.clone()
     }
 }
+impl From<BaseColorValueVariant0> for BaseColorValue {
+    fn from(value: BaseColorValueVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0 {
     #[serde(flatten)]
@@ -3383,6 +4233,11 @@ pub enum BaseColorValueVariant0Subtype1Subtype0 {
 impl From<&BaseColorValueVariant0Subtype1Subtype0> for BaseColorValueVariant0Subtype1Subtype0 {
     fn from(value: &BaseColorValueVariant0Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BaseColorValueVariant0Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3436,6 +4291,16 @@ impl ToString for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaseColorValueVariant0Subtype1Subtype1 {}
 impl From<&BaseColorValueVariant0Subtype1Subtype1> for BaseColorValueVariant0Subtype1Subtype1 {
@@ -3470,6 +4335,26 @@ impl From<&BaseColorValueVariant4Color> for BaseColorValueVariant4Color {
         value.clone()
     }
 }
+impl From<ColorRgb> for BaseColorValueVariant4Color {
+    fn from(value: ColorRgb) -> Self {
+        Self::Rgb(value)
+    }
+}
+impl From<ColorHsl> for BaseColorValueVariant4Color {
+    fn from(value: ColorHsl) -> Self {
+        Self::Hsl(value)
+    }
+}
+impl From<ColorLab> for BaseColorValueVariant4Color {
+    fn from(value: ColorLab) -> Self {
+        Self::Lab(value)
+    }
+}
+impl From<ColorHcl> for BaseColorValueVariant4Color {
+    fn from(value: ColorHcl) -> Self {
+        Self::Hcl(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BaselineValue {
@@ -3479,6 +4364,16 @@ pub enum BaselineValue {
 impl From<&BaselineValue> for BaselineValue {
     fn from(value: &BaselineValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<BaselineValueVariant0Item>> for BaselineValue {
+    fn from(value: Vec<BaselineValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValueVariant1> for BaselineValue {
+    fn from(value: BaselineValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3542,6 +4437,11 @@ impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3665,6 +4565,16 @@ impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
         }
     }
 }
+impl From<f64> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -3737,6 +4647,11 @@ pub enum BaselineValueVariant1Subtype1Subtype0 {
 impl From<&BaselineValueVariant1Subtype1Subtype0> for BaselineValueVariant1Subtype1Subtype0 {
     fn from(value: &BaselineValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BaselineValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3848,6 +4763,16 @@ impl ToString for BaselineValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1Subtype1 {}
 impl From<&BaselineValueVariant1Subtype1Subtype1> for BaselineValueVariant1Subtype1Subtype1 {
@@ -3919,6 +4844,16 @@ impl From<&BinTransformAnchor> for BinTransformAnchor {
         value.clone()
     }
 }
+impl From<f64> for BinTransformAnchor {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformAnchor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAs {
@@ -3938,6 +4873,16 @@ impl Default for BinTransformAs {
         )
     }
 }
+impl From<(BinTransformAsVariant0, BinTransformAsVariant0)> for BinTransformAs {
+    fn from(value: (BinTransformAsVariant0, BinTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for BinTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAsVariant0 {
@@ -3947,6 +4892,11 @@ pub enum BinTransformAsVariant0 {
 impl From<&BinTransformAsVariant0> for BinTransformAsVariant0 {
     fn from(value: &BinTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BinTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3963,6 +4913,16 @@ impl From<&BinTransformBase> for BinTransformBase {
 impl Default for BinTransformBase {
     fn default() -> Self {
         BinTransformBase::Variant0(10_f64)
+    }
+}
+impl From<f64> for BinTransformBase {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformBase {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3984,6 +4944,16 @@ impl Default for BinTransformDivide {
         ])
     }
 }
+impl From<Vec<BinTransformDivideVariant0Item>> for BinTransformDivide {
+    fn from(value: Vec<BinTransformDivideVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformDivide {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformDivideVariant0Item {
@@ -3993,6 +4963,16 @@ pub enum BinTransformDivideVariant0Item {
 impl From<&BinTransformDivideVariant0Item> for BinTransformDivideVariant0Item {
     fn from(value: &BinTransformDivideVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for BinTransformDivideVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformDivideVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4006,6 +4986,16 @@ impl From<&BinTransformExtent> for BinTransformExtent {
         value.clone()
     }
 }
+impl From<(BinTransformExtentVariant0, BinTransformExtentVariant0)> for BinTransformExtent {
+    fn from(value: (BinTransformExtentVariant0, BinTransformExtentVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for BinTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformExtentVariant0 {
@@ -4015,6 +5005,16 @@ pub enum BinTransformExtentVariant0 {
 impl From<&BinTransformExtentVariant0> for BinTransformExtentVariant0 {
     fn from(value: &BinTransformExtentVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for BinTransformExtentVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4027,6 +5027,21 @@ pub enum BinTransformField {
 impl From<&BinTransformField> for BinTransformField {
     fn from(value: &BinTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for BinTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for BinTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for BinTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4045,6 +5060,16 @@ impl Default for BinTransformInterval {
         BinTransformInterval::Variant0(true)
     }
 }
+impl From<bool> for BinTransformInterval {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformInterval {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformMaxbins {
@@ -4061,6 +5086,16 @@ impl Default for BinTransformMaxbins {
         BinTransformMaxbins::Variant0(20_f64)
     }
 }
+impl From<f64> for BinTransformMaxbins {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformMaxbins {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformMinstep {
@@ -4072,6 +5107,16 @@ impl From<&BinTransformMinstep> for BinTransformMinstep {
         value.clone()
     }
 }
+impl From<f64> for BinTransformMinstep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformMinstep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformName {
@@ -4081,6 +5126,11 @@ pub enum BinTransformName {
 impl From<&BinTransformName> for BinTransformName {
     fn from(value: &BinTransformName) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BinTransformName {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4099,6 +5149,16 @@ impl Default for BinTransformNice {
         BinTransformNice::Variant0(true)
     }
 }
+impl From<bool> for BinTransformNice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformNice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformSpan {
@@ -4108,6 +5168,16 @@ pub enum BinTransformSpan {
 impl From<&BinTransformSpan> for BinTransformSpan {
     fn from(value: &BinTransformSpan) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for BinTransformSpan {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformSpan {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4121,6 +5191,16 @@ impl From<&BinTransformStep> for BinTransformStep {
         value.clone()
     }
 }
+impl From<f64> for BinTransformStep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformSteps {
@@ -4132,6 +5212,16 @@ impl From<&BinTransformSteps> for BinTransformSteps {
         value.clone()
     }
 }
+impl From<Vec<BinTransformStepsVariant0Item>> for BinTransformSteps {
+    fn from(value: Vec<BinTransformStepsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformSteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformStepsVariant0Item {
@@ -4141,6 +5231,16 @@ pub enum BinTransformStepsVariant0Item {
 impl From<&BinTransformStepsVariant0Item> for BinTransformStepsVariant0Item {
     fn from(value: &BinTransformStepsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for BinTransformStepsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BinTransformStepsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4439,6 +5539,16 @@ impl From<&BlendValue> for BlendValue {
         value.clone()
     }
 }
+impl From<Vec<BlendValueVariant0Item>> for BlendValue {
+    fn from(value: Vec<BlendValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BlendValueVariant1> for BlendValue {
+    fn from(value: BlendValueVariant1) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant0Item {
     #[serde(flatten)]
@@ -4498,6 +5608,11 @@ impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BlendValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4657,6 +5772,16 @@ impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -4729,6 +5854,11 @@ pub enum BlendValueVariant1Subtype1Subtype0 {
 impl From<&BlendValueVariant1Subtype1Subtype0> for BlendValueVariant1Subtype1Subtype0 {
     fn from(value: &BlendValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for BlendValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4884,6 +6014,16 @@ impl ToString for BlendValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for BlendValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BlendValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1Subtype1 {}
 impl From<&BlendValueVariant1Subtype1Subtype1> for BlendValueVariant1Subtype1Subtype1 {
@@ -4916,6 +6056,16 @@ impl From<&BooleanOrSignal> for BooleanOrSignal {
         value.clone()
     }
 }
+impl From<bool> for BooleanOrSignal {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for BooleanOrSignal {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BooleanValue {
@@ -4925,6 +6075,16 @@ pub enum BooleanValue {
 impl From<&BooleanValue> for BooleanValue {
     fn from(value: &BooleanValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<BooleanValueVariant0Item>> for BooleanValue {
+    fn from(value: Vec<BooleanValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BooleanValueVariant1> for BooleanValue {
+    fn from(value: BooleanValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4988,6 +6148,11 @@ impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -5041,6 +6206,16 @@ impl ToString for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range 
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5117,6 +6292,11 @@ impl From<&BooleanValueVariant1Subtype1Subtype0> for BooleanValueVariant1Subtype
         value.clone()
     }
 }
+impl From<SignalRef> for BooleanValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Subtype1Subtype0Variant3Range {
@@ -5166,6 +6346,16 @@ impl ToString for BooleanValueVariant1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5303,6 +6493,16 @@ impl From<&ColorValue> for ColorValue {
         value.clone()
     }
 }
+impl From<Vec<ColorValueVariant0Item>> for ColorValue {
+    fn from(value: Vec<ColorValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaseColorValue> for ColorValue {
+    fn from(value: BaseColorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ColorValueVariant0Item {
     #[serde(flatten)]
@@ -5347,6 +6547,16 @@ impl From<&CompareVariant0Field> for CompareVariant0Field {
         value.clone()
     }
 }
+impl From<ScaleField> for CompareVariant0Field {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<Expr> for CompareVariant0Field {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CompareVariant1FieldItem {
@@ -5356,6 +6566,16 @@ pub enum CompareVariant1FieldItem {
 impl From<&CompareVariant1FieldItem> for CompareVariant1FieldItem {
     fn from(value: &CompareVariant1FieldItem) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for CompareVariant1FieldItem {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<Expr> for CompareVariant1FieldItem {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5403,6 +6623,16 @@ impl From<&ContourTransformBandwidth> for ContourTransformBandwidth {
         value.clone()
     }
 }
+impl From<f64> for ContourTransformBandwidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformBandwidth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformCellSize {
@@ -5412,6 +6642,16 @@ pub enum ContourTransformCellSize {
 impl From<&ContourTransformCellSize> for ContourTransformCellSize {
     fn from(value: &ContourTransformCellSize) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ContourTransformCellSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformCellSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5425,6 +6665,16 @@ impl From<&ContourTransformCount> for ContourTransformCount {
         value.clone()
     }
 }
+impl From<f64> for ContourTransformCount {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformCount {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformNice {
@@ -5434,6 +6684,16 @@ pub enum ContourTransformNice {
 impl From<&ContourTransformNice> for ContourTransformNice {
     fn from(value: &ContourTransformNice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ContourTransformNice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformNice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5447,6 +6707,16 @@ impl From<&ContourTransformSize> for ContourTransformSize {
         value.clone()
     }
 }
+impl From<(ContourTransformSizeVariant0, ContourTransformSizeVariant0)> for ContourTransformSize {
+    fn from(value: (ContourTransformSizeVariant0, ContourTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ContourTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformSizeVariant0 {
@@ -5456,6 +6726,16 @@ pub enum ContourTransformSizeVariant0 {
 impl From<&ContourTransformSizeVariant0> for ContourTransformSizeVariant0 {
     fn from(value: &ContourTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ContourTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5474,6 +6754,16 @@ impl Default for ContourTransformSmooth {
         ContourTransformSmooth::Variant0(true)
     }
 }
+impl From<bool> for ContourTransformSmooth {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformSmooth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformThresholds {
@@ -5485,6 +6775,16 @@ impl From<&ContourTransformThresholds> for ContourTransformThresholds {
         value.clone()
     }
 }
+impl From<Vec<ContourTransformThresholdsVariant0Item>> for ContourTransformThresholds {
+    fn from(value: Vec<ContourTransformThresholdsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformThresholds {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformThresholdsVariant0Item {
@@ -5494,6 +6794,16 @@ pub enum ContourTransformThresholdsVariant0Item {
 impl From<&ContourTransformThresholdsVariant0Item> for ContourTransformThresholdsVariant0Item {
     fn from(value: &ContourTransformThresholdsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ContourTransformThresholdsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformThresholdsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5551,6 +6861,16 @@ impl From<&ContourTransformValues> for ContourTransformValues {
         value.clone()
     }
 }
+impl From<Vec<ContourTransformValuesVariant0Item>> for ContourTransformValues {
+    fn from(value: Vec<ContourTransformValuesVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformValues {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformValuesVariant0Item {
@@ -5560,6 +6880,16 @@ pub enum ContourTransformValuesVariant0Item {
 impl From<&ContourTransformValuesVariant0Item> for ContourTransformValuesVariant0Item {
     fn from(value: &ContourTransformValuesVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ContourTransformValuesVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ContourTransformValuesVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5574,6 +6904,21 @@ impl From<&ContourTransformWeight> for ContourTransformWeight {
         value.clone()
     }
 }
+impl From<ScaleField> for ContourTransformWeight {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ContourTransformWeight {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ContourTransformWeight {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformX {
@@ -5586,6 +6931,21 @@ impl From<&ContourTransformX> for ContourTransformX {
         value.clone()
     }
 }
+impl From<ScaleField> for ContourTransformX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ContourTransformX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ContourTransformX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformY {
@@ -5596,6 +6956,21 @@ pub enum ContourTransformY {
 impl From<&ContourTransformY> for ContourTransformY {
     fn from(value: &ContourTransformY) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for ContourTransformY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ContourTransformY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ContourTransformY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5642,6 +7017,26 @@ impl Default for CountpatternTransformAs {
         )
     }
 }
+impl
+    From<(
+        CountpatternTransformAsVariant0,
+        CountpatternTransformAsVariant0,
+    )> for CountpatternTransformAs
+{
+    fn from(
+        value: (
+            CountpatternTransformAsVariant0,
+            CountpatternTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for CountpatternTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformAsVariant0 {
@@ -5651,6 +7046,11 @@ pub enum CountpatternTransformAsVariant0 {
 impl From<&CountpatternTransformAsVariant0> for CountpatternTransformAsVariant0 {
     fn from(value: &CountpatternTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for CountpatternTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5667,6 +7067,16 @@ impl From<&CountpatternTransformCase> for CountpatternTransformCase {
 impl Default for CountpatternTransformCase {
     fn default() -> Self {
         CountpatternTransformCase::Variant0(CountpatternTransformCaseVariant0::Mixed)
+    }
+}
+impl From<CountpatternTransformCaseVariant0> for CountpatternTransformCase {
+    fn from(value: CountpatternTransformCaseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for CountpatternTransformCase {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5733,6 +7143,21 @@ impl From<&CountpatternTransformField> for CountpatternTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for CountpatternTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for CountpatternTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for CountpatternTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformPattern {
@@ -5749,6 +7174,11 @@ impl Default for CountpatternTransformPattern {
         CountpatternTransformPattern::Variant0("[\\w\"]+".to_string())
     }
 }
+impl From<SignalRef> for CountpatternTransformPattern {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformStopwords {
@@ -5758,6 +7188,11 @@ pub enum CountpatternTransformStopwords {
 impl From<&CountpatternTransformStopwords> for CountpatternTransformStopwords {
     fn from(value: &CountpatternTransformStopwords) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for CountpatternTransformStopwords {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5840,6 +7275,16 @@ impl Default for CrossTransformAs {
         )
     }
 }
+impl From<(CrossTransformAsVariant0, CrossTransformAsVariant0)> for CrossTransformAs {
+    fn from(value: (CrossTransformAsVariant0, CrossTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for CrossTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CrossTransformAsVariant0 {
@@ -5849,6 +7294,11 @@ pub enum CrossTransformAsVariant0 {
 impl From<&CrossTransformAsVariant0> for CrossTransformAsVariant0 {
     fn from(value: &CrossTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for CrossTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -5921,6 +7371,16 @@ impl From<&CrossfilterTransformFields> for CrossfilterTransformFields {
         value.clone()
     }
 }
+impl From<Vec<CrossfilterTransformFieldsVariant0Item>> for CrossfilterTransformFields {
+    fn from(value: Vec<CrossfilterTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for CrossfilterTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFieldsVariant0Item {
@@ -5933,6 +7393,21 @@ impl From<&CrossfilterTransformFieldsVariant0Item> for CrossfilterTransformField
         value.clone()
     }
 }
+impl From<ScaleField> for CrossfilterTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for CrossfilterTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for CrossfilterTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CrossfilterTransformQuery {
@@ -5942,6 +7417,16 @@ pub enum CrossfilterTransformQuery {
 impl From<&CrossfilterTransformQuery> for CrossfilterTransformQuery {
     fn from(value: &CrossfilterTransformQuery) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for CrossfilterTransformQuery {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for CrossfilterTransformQuery {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6047,6 +7532,11 @@ impl From<&DataVariant1Source> for DataVariant1Source {
         value.clone()
     }
 }
+impl From<Vec<String>> for DataVariant1Source {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2Format {
@@ -6056,6 +7546,16 @@ pub enum DataVariant2Format {
 impl From<&DataVariant2Format> for DataVariant2Format {
     fn from(value: &DataVariant2Format) -> Self {
         value.clone()
+    }
+}
+impl From<DataVariant2FormatVariant0> for DataVariant2Format {
+    fn from(value: DataVariant2FormatVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant2Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6104,6 +7604,18 @@ pub enum DataVariant2FormatVariant0Subtype0Parse {
 impl From<&DataVariant2FormatVariant0Subtype0Parse> for DataVariant2FormatVariant0Subtype0Parse {
     fn from(value: &DataVariant2FormatVariant0Subtype0Parse) -> Self {
         value.clone()
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant0>
+    for DataVariant2FormatVariant0Subtype0Parse
+{
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant2FormatVariant0Subtype0Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6201,6 +7713,20 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6371,6 +7897,18 @@ impl From<&DataVariant2FormatVariant0Subtype1Parse> for DataVariant2FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant0>
+    for DataVariant2FormatVariant0Subtype1Parse
+{
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant2FormatVariant0Subtype1Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
@@ -6466,6 +8004,20 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6678,6 +8230,18 @@ impl From<&DataVariant2FormatVariant0Subtype2Parse> for DataVariant2FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant0>
+    for DataVariant2FormatVariant0Subtype2Parse
+{
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant2FormatVariant0Subtype2Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
@@ -6773,6 +8337,20 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -6990,6 +8568,18 @@ impl From<&DataVariant2FormatVariant0Subtype3Parse> for DataVariant2FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant0>
+    for DataVariant2FormatVariant0Subtype3Parse
+{
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant2FormatVariant0Subtype3Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
@@ -7085,6 +8675,20 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7442,6 +9046,16 @@ impl From<&DataVariant3Format> for DataVariant3Format {
         value.clone()
     }
 }
+impl From<DataVariant3FormatVariant0> for DataVariant3Format {
+    fn from(value: DataVariant3FormatVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DataVariant3FormatVariant0 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
@@ -7488,6 +9102,18 @@ pub enum DataVariant3FormatVariant0Subtype0Parse {
 impl From<&DataVariant3FormatVariant0Subtype0Parse> for DataVariant3FormatVariant0Subtype0Parse {
     fn from(value: &DataVariant3FormatVariant0Subtype0Parse) -> Self {
         value.clone()
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant0>
+    for DataVariant3FormatVariant0Subtype0Parse
+{
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3FormatVariant0Subtype0Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7585,6 +9211,20 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -7755,6 +9395,18 @@ impl From<&DataVariant3FormatVariant0Subtype1Parse> for DataVariant3FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant0>
+    for DataVariant3FormatVariant0Subtype1Parse
+{
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3FormatVariant0Subtype1Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
@@ -7850,6 +9502,20 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8062,6 +9728,18 @@ impl From<&DataVariant3FormatVariant0Subtype2Parse> for DataVariant3FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant0>
+    for DataVariant3FormatVariant0Subtype2Parse
+{
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3FormatVariant0Subtype2Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
@@ -8157,6 +9835,20 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8374,6 +10066,18 @@ impl From<&DataVariant3FormatVariant0Subtype3Parse> for DataVariant3FormatVarian
         value.clone()
     }
 }
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant0>
+    for DataVariant3FormatVariant0Subtype3Parse
+{
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3FormatVariant0Subtype3Parse {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
@@ -8469,6 +10173,20 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtra {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtra
+{
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ExtraExtraVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -8826,6 +10544,16 @@ impl From<&DataVariant3Values> for DataVariant3Values {
         value.clone()
     }
 }
+impl From<serde_json::Value> for DataVariant3Values {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DataVariant3Values {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DensityTransform {
@@ -8872,6 +10600,16 @@ impl Default for DensityTransformAs {
         ])
     }
 }
+impl From<Vec<DensityTransformAsVariant0Item>> for DensityTransformAs {
+    fn from(value: Vec<DensityTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformAsVariant0Item {
@@ -8881,6 +10619,11 @@ pub enum DensityTransformAsVariant0Item {
 impl From<&DensityTransformAsVariant0Item> for DensityTransformAsVariant0Item {
     fn from(value: &DensityTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for DensityTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8985,6 +10728,16 @@ impl From<&DensityTransformDistributionVariant0Mean> for DensityTransformDistrib
         value.clone()
     }
 }
+impl From<f64> for DensityTransformDistributionVariant0Mean {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant0Mean {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant0Stdev {
@@ -9001,6 +10754,16 @@ impl From<&DensityTransformDistributionVariant0Stdev>
 impl Default for DensityTransformDistributionVariant0Stdev {
     fn default() -> Self {
         DensityTransformDistributionVariant0Stdev::Variant0(1_f64)
+    }
+}
+impl From<f64> for DensityTransformDistributionVariant0Stdev {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant0Stdev {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9060,6 +10823,16 @@ impl From<&DensityTransformDistributionVariant1Mean> for DensityTransformDistrib
         value.clone()
     }
 }
+impl From<f64> for DensityTransformDistributionVariant1Mean {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant1Mean {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant1Stdev {
@@ -9076,6 +10849,16 @@ impl From<&DensityTransformDistributionVariant1Stdev>
 impl Default for DensityTransformDistributionVariant1Stdev {
     fn default() -> Self {
         DensityTransformDistributionVariant1Stdev::Variant0(1_f64)
+    }
+}
+impl From<f64> for DensityTransformDistributionVariant1Stdev {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant1Stdev {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9140,6 +10923,16 @@ impl Default for DensityTransformDistributionVariant2Max {
         DensityTransformDistributionVariant2Max::Variant0(1_f64)
     }
 }
+impl From<f64> for DensityTransformDistributionVariant2Max {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant2Max {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant2Min {
@@ -9149,6 +10942,16 @@ pub enum DensityTransformDistributionVariant2Min {
 impl From<&DensityTransformDistributionVariant2Min> for DensityTransformDistributionVariant2Min {
     fn from(value: &DensityTransformDistributionVariant2Min) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for DensityTransformDistributionVariant2Min {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant2Min {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9164,6 +10967,16 @@ impl From<&DensityTransformDistributionVariant3Bandwidth>
         value.clone()
     }
 }
+impl From<f64> for DensityTransformDistributionVariant3Bandwidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant3Bandwidth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant3Field {
@@ -9176,6 +10989,21 @@ impl From<&DensityTransformDistributionVariant3Field>
 {
     fn from(value: &DensityTransformDistributionVariant3Field) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for DensityTransformDistributionVariant3Field {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for DensityTransformDistributionVariant3Field {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for DensityTransformDistributionVariant3Field {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9237,6 +11065,16 @@ impl From<&DensityTransformDistributionVariant4Distributions>
         value.clone()
     }
 }
+impl From<Vec<serde_json::Value>> for DensityTransformDistributionVariant4Distributions {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant4Distributions {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DensityTransformDistributionVariant4Function {
     #[serde(rename = "mixture")]
@@ -9296,6 +11134,18 @@ impl From<&DensityTransformDistributionVariant4Weights>
         value.clone()
     }
 }
+impl From<Vec<DensityTransformDistributionVariant4WeightsVariant0Item>>
+    for DensityTransformDistributionVariant4Weights
+{
+    fn from(value: Vec<DensityTransformDistributionVariant4WeightsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant4Weights {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionVariant4WeightsVariant0Item {
@@ -9307,6 +11157,16 @@ impl From<&DensityTransformDistributionVariant4WeightsVariant0Item>
 {
     fn from(value: &DensityTransformDistributionVariant4WeightsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for DensityTransformDistributionVariant4WeightsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformDistributionVariant4WeightsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9323,6 +11183,26 @@ impl From<&DensityTransformExtent> for DensityTransformExtent {
         value.clone()
     }
 }
+impl
+    From<(
+        DensityTransformExtentVariant0,
+        DensityTransformExtentVariant0,
+    )> for DensityTransformExtent
+{
+    fn from(
+        value: (
+            DensityTransformExtentVariant0,
+            DensityTransformExtentVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for DensityTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformExtentVariant0 {
@@ -9332,6 +11212,16 @@ pub enum DensityTransformExtentVariant0 {
 impl From<&DensityTransformExtentVariant0> for DensityTransformExtentVariant0 {
     fn from(value: &DensityTransformExtentVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for DensityTransformExtentVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9350,6 +11240,16 @@ impl Default for DensityTransformMaxsteps {
         DensityTransformMaxsteps::Variant0(200_f64)
     }
 }
+impl From<f64> for DensityTransformMaxsteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformMaxsteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformMethod {
@@ -9364,6 +11264,11 @@ impl From<&DensityTransformMethod> for DensityTransformMethod {
 impl Default for DensityTransformMethod {
     fn default() -> Self {
         DensityTransformMethod::Variant0("pdf".to_string())
+    }
+}
+impl From<SignalRef> for DensityTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9382,6 +11287,16 @@ impl Default for DensityTransformMinsteps {
         DensityTransformMinsteps::Variant0(25_f64)
     }
 }
+impl From<f64> for DensityTransformMinsteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformMinsteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformSteps {
@@ -9391,6 +11306,16 @@ pub enum DensityTransformSteps {
 impl From<&DensityTransformSteps> for DensityTransformSteps {
     fn from(value: &DensityTransformSteps) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for DensityTransformSteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DensityTransformSteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9446,6 +11371,16 @@ pub enum DirectionValue {
 impl From<&DirectionValue> for DirectionValue {
     fn from(value: &DirectionValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<DirectionValueVariant0Item>> for DirectionValue {
+    fn from(value: Vec<DirectionValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<DirectionValueVariant1> for DirectionValue {
+    fn from(value: DirectionValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9509,6 +11444,11 @@ impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9624,6 +11564,16 @@ impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Rang
         }
     }
 }
+impl From<f64> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -9696,6 +11646,11 @@ pub enum DirectionValueVariant1Subtype1Subtype0 {
 impl From<&DirectionValueVariant1Subtype1Subtype0> for DirectionValueVariant1Subtype1Subtype0 {
     fn from(value: &DirectionValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for DirectionValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -9799,6 +11754,16 @@ impl ToString for DirectionValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1Subtype1 {}
 impl From<&DirectionValueVariant1Subtype1Subtype1> for DirectionValueVariant1Subtype1Subtype1 {
@@ -9858,6 +11823,11 @@ impl Default for DotbinTransformAs {
         DotbinTransformAs::Variant0("bin".to_string())
     }
 }
+impl From<SignalRef> for DotbinTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformField {
@@ -9870,6 +11840,21 @@ impl From<&DotbinTransformField> for DotbinTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for DotbinTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for DotbinTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for DotbinTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupby {
@@ -9879,6 +11864,16 @@ pub enum DotbinTransformGroupby {
 impl From<&DotbinTransformGroupby> for DotbinTransformGroupby {
     fn from(value: &DotbinTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<DotbinTransformGroupbyVariant0Item>> for DotbinTransformGroupby {
+    fn from(value: Vec<DotbinTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DotbinTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9893,6 +11888,21 @@ impl From<&DotbinTransformGroupbyVariant0Item> for DotbinTransformGroupbyVariant
         value.clone()
     }
 }
+impl From<ScaleField> for DotbinTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for DotbinTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for DotbinTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformSmooth {
@@ -9904,6 +11914,16 @@ impl From<&DotbinTransformSmooth> for DotbinTransformSmooth {
         value.clone()
     }
 }
+impl From<bool> for DotbinTransformSmooth {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DotbinTransformSmooth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformStep {
@@ -9913,6 +11933,16 @@ pub enum DotbinTransformStep {
 impl From<&DotbinTransformStep> for DotbinTransformStep {
     fn from(value: &DotbinTransformStep) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for DotbinTransformStep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for DotbinTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -10336,6 +12366,21 @@ impl From<&ExtentTransformField> for ExtentTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for ExtentTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ExtentTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ExtentTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ExtentTransformType {
     #[serde(rename = "extent")]
@@ -10441,6 +12486,11 @@ impl From<&FacetFacetVariant1Groupby> for FacetFacetVariant1Groupby {
         value.clone()
     }
 }
+impl From<Vec<String>> for FacetFacetVariant1Groupby {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Field {
@@ -10463,6 +12513,11 @@ pub enum Field {
 impl From<&Field> for Field {
     fn from(value: &Field) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for Field {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10552,6 +12607,16 @@ impl From<&FlattenTransformAs> for FlattenTransformAs {
         value.clone()
     }
 }
+impl From<Vec<FlattenTransformAsVariant0Item>> for FlattenTransformAs {
+    fn from(value: Vec<FlattenTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for FlattenTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformAsVariant0Item {
@@ -10563,6 +12628,11 @@ impl From<&FlattenTransformAsVariant0Item> for FlattenTransformAsVariant0Item {
         value.clone()
     }
 }
+impl From<SignalRef> for FlattenTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformFields {
@@ -10572,6 +12642,16 @@ pub enum FlattenTransformFields {
 impl From<&FlattenTransformFields> for FlattenTransformFields {
     fn from(value: &FlattenTransformFields) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<FlattenTransformFieldsVariant0Item>> for FlattenTransformFields {
+    fn from(value: Vec<FlattenTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for FlattenTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10586,6 +12666,21 @@ impl From<&FlattenTransformFieldsVariant0Item> for FlattenTransformFieldsVariant
         value.clone()
     }
 }
+impl From<ScaleField> for FlattenTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for FlattenTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for FlattenTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformIndex {
@@ -10595,6 +12690,11 @@ pub enum FlattenTransformIndex {
 impl From<&FlattenTransformIndex> for FlattenTransformIndex {
     fn from(value: &FlattenTransformIndex) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for FlattenTransformIndex {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -10676,6 +12776,16 @@ impl Default for FoldTransformAs {
         )
     }
 }
+impl From<(FoldTransformAsVariant0, FoldTransformAsVariant0)> for FoldTransformAs {
+    fn from(value: (FoldTransformAsVariant0, FoldTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for FoldTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformAsVariant0 {
@@ -10685,6 +12795,11 @@ pub enum FoldTransformAsVariant0 {
 impl From<&FoldTransformAsVariant0> for FoldTransformAsVariant0 {
     fn from(value: &FoldTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for FoldTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10698,6 +12813,16 @@ impl From<&FoldTransformFields> for FoldTransformFields {
         value.clone()
     }
 }
+impl From<Vec<FoldTransformFieldsVariant0Item>> for FoldTransformFields {
+    fn from(value: Vec<FoldTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for FoldTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformFieldsVariant0Item {
@@ -10708,6 +12833,21 @@ pub enum FoldTransformFieldsVariant0Item {
 impl From<&FoldTransformFieldsVariant0Item> for FoldTransformFieldsVariant0Item {
     fn from(value: &FoldTransformFieldsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for FoldTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for FoldTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for FoldTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -10763,6 +12903,16 @@ pub enum FontWeightValue {
 impl From<&FontWeightValue> for FontWeightValue {
     fn from(value: &FontWeightValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<FontWeightValueVariant0Item>> for FontWeightValue {
+    fn from(value: Vec<FontWeightValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValueVariant1> for FontWeightValue {
+    fn from(value: FontWeightValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10828,6 +12978,11 @@ impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -10883,6 +13038,16 @@ impl ToString for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Ran
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10959,6 +13124,11 @@ impl From<&FontWeightValueVariant1Subtype1Subtype0> for FontWeightValueVariant1S
         value.clone()
     }
 }
+impl From<SignalRef> for FontWeightValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Subtype1Subtype0Variant3Range {
@@ -11008,6 +13178,16 @@ impl ToString for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11085,6 +13265,16 @@ impl Default for ForceTransformAlpha {
         ForceTransformAlpha::Variant0(1_f64)
     }
 }
+impl From<f64> for ForceTransformAlpha {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformAlpha {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaMin {
@@ -11101,6 +13291,16 @@ impl Default for ForceTransformAlphaMin {
         ForceTransformAlphaMin::Variant0(0.001_f64)
     }
 }
+impl From<f64> for ForceTransformAlphaMin {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformAlphaMin {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaTarget {
@@ -11110,6 +13310,16 @@ pub enum ForceTransformAlphaTarget {
 impl From<&ForceTransformAlphaTarget> for ForceTransformAlphaTarget {
     fn from(value: &ForceTransformAlphaTarget) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ForceTransformAlphaTarget {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformAlphaTarget {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11133,6 +13343,16 @@ impl Default for ForceTransformAs {
         ])
     }
 }
+impl From<Vec<ForceTransformAsVariant0Item>> for ForceTransformAs {
+    fn from(value: Vec<ForceTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAsVariant0Item {
@@ -11142,6 +13362,11 @@ pub enum ForceTransformAsVariant0Item {
 impl From<&ForceTransformAsVariant0Item> for ForceTransformAsVariant0Item {
     fn from(value: &ForceTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ForceTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11269,6 +13494,16 @@ impl From<&ForceTransformForcesItemVariant0X> for ForceTransformForcesItemVarian
         value.clone()
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant0X {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant0X {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant0Y {
@@ -11278,6 +13513,16 @@ pub enum ForceTransformForcesItemVariant0Y {
 impl From<&ForceTransformForcesItemVariant0Y> for ForceTransformForcesItemVariant0Y {
     fn from(value: &ForceTransformForcesItemVariant0Y) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant0Y {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant0Y {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11342,6 +13587,16 @@ impl Default for ForceTransformForcesItemVariant1Iterations {
         ForceTransformForcesItemVariant1Iterations::Variant0(1_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant1Iterations {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant1Iterations {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant1Radius {
@@ -11353,6 +13608,26 @@ pub enum ForceTransformForcesItemVariant1Radius {
 impl From<&ForceTransformForcesItemVariant1Radius> for ForceTransformForcesItemVariant1Radius {
     fn from(value: &ForceTransformForcesItemVariant1Radius) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant1Radius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant1Radius {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant1Radius {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant1Radius {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11371,6 +13646,16 @@ impl Default for ForceTransformForcesItemVariant1Strength {
         ForceTransformForcesItemVariant1Strength::Variant0(0.7_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant1Strength {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant1Strength {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2DistanceMax {
@@ -11382,6 +13667,16 @@ impl From<&ForceTransformForcesItemVariant2DistanceMax>
 {
     fn from(value: &ForceTransformForcesItemVariant2DistanceMax) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant2DistanceMax {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant2DistanceMax {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11400,6 +13695,16 @@ impl From<&ForceTransformForcesItemVariant2DistanceMin>
 impl Default for ForceTransformForcesItemVariant2DistanceMin {
     fn default() -> Self {
         ForceTransformForcesItemVariant2DistanceMin::Variant0(1_f64)
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant2DistanceMin {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant2DistanceMin {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11462,6 +13767,16 @@ impl Default for ForceTransformForcesItemVariant2Strength {
         ForceTransformForcesItemVariant2Strength::Variant0(-30_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant2Strength {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant2Strength {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant2Theta {
@@ -11476,6 +13791,16 @@ impl From<&ForceTransformForcesItemVariant2Theta> for ForceTransformForcesItemVa
 impl Default for ForceTransformForcesItemVariant2Theta {
     fn default() -> Self {
         ForceTransformForcesItemVariant2Theta::Variant0(0.9_f64)
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant2Theta {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant2Theta {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11494,6 +13819,26 @@ impl From<&ForceTransformForcesItemVariant3Distance> for ForceTransformForcesIte
 impl Default for ForceTransformForcesItemVariant3Distance {
     fn default() -> Self {
         ForceTransformForcesItemVariant3Distance::Variant0(30_f64)
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant3Distance {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant3Distance {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant3Distance {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant3Distance {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11552,6 +13897,21 @@ impl From<&ForceTransformForcesItemVariant3Id> for ForceTransformForcesItemVaria
         value.clone()
     }
 }
+impl From<ScaleField> for ForceTransformForcesItemVariant3Id {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant3Id {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant3Id {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Iterations {
@@ -11570,6 +13930,16 @@ impl Default for ForceTransformForcesItemVariant3Iterations {
         ForceTransformForcesItemVariant3Iterations::Variant0(1_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant3Iterations {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant3Iterations {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant3Strength {
@@ -11581,6 +13951,26 @@ pub enum ForceTransformForcesItemVariant3Strength {
 impl From<&ForceTransformForcesItemVariant3Strength> for ForceTransformForcesItemVariant3Strength {
     fn from(value: &ForceTransformForcesItemVariant3Strength) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ForceTransformForcesItemVariant3Strength {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant3Strength {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant3Strength {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant3Strength {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11643,6 +14033,16 @@ impl Default for ForceTransformForcesItemVariant4Strength {
         ForceTransformForcesItemVariant4Strength::Variant0(0.1_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant4Strength {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant4Strength {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant4X {
@@ -11653,6 +14053,21 @@ pub enum ForceTransformForcesItemVariant4X {
 impl From<&ForceTransformForcesItemVariant4X> for ForceTransformForcesItemVariant4X {
     fn from(value: &ForceTransformForcesItemVariant4X) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for ForceTransformForcesItemVariant4X {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant4X {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant4X {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11715,6 +14130,16 @@ impl Default for ForceTransformForcesItemVariant5Strength {
         ForceTransformForcesItemVariant5Strength::Variant0(0.1_f64)
     }
 }
+impl From<f64> for ForceTransformForcesItemVariant5Strength {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformForcesItemVariant5Strength {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemVariant5Y {
@@ -11725,6 +14150,21 @@ pub enum ForceTransformForcesItemVariant5Y {
 impl From<&ForceTransformForcesItemVariant5Y> for ForceTransformForcesItemVariant5Y {
     fn from(value: &ForceTransformForcesItemVariant5Y) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for ForceTransformForcesItemVariant5Y {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ForceTransformForcesItemVariant5Y {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ForceTransformForcesItemVariant5Y {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11743,6 +14183,16 @@ impl Default for ForceTransformIterations {
         ForceTransformIterations::Variant0(300_f64)
     }
 }
+impl From<f64> for ForceTransformIterations {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformIterations {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformRestart {
@@ -11754,6 +14204,16 @@ impl From<&ForceTransformRestart> for ForceTransformRestart {
         value.clone()
     }
 }
+impl From<bool> for ForceTransformRestart {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformRestart {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformStatic {
@@ -11763,6 +14223,16 @@ pub enum ForceTransformStatic {
 impl From<&ForceTransformStatic> for ForceTransformStatic {
     fn from(value: &ForceTransformStatic) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ForceTransformStatic {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformStatic {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11825,6 +14295,16 @@ impl Default for ForceTransformVelocityDecay {
         ForceTransformVelocityDecay::Variant0(0.4_f64)
     }
 }
+impl From<f64> for ForceTransformVelocityDecay {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ForceTransformVelocityDecay {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FormulaTransform {
@@ -11854,6 +14334,11 @@ impl From<&FormulaTransformAs> for FormulaTransformAs {
         value.clone()
     }
 }
+impl From<SignalRef> for FormulaTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FormulaTransformInitonly {
@@ -11863,6 +14348,16 @@ pub enum FormulaTransformInitonly {
 impl From<&FormulaTransformInitonly> for FormulaTransformInitonly {
     fn from(value: &FormulaTransformInitonly) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for FormulaTransformInitonly {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for FormulaTransformInitonly {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -11951,6 +14446,26 @@ impl From<&GeojsonTransformFields> for GeojsonTransformFields {
         value.clone()
     }
 }
+impl
+    From<(
+        GeojsonTransformFieldsVariant0,
+        GeojsonTransformFieldsVariant0,
+    )> for GeojsonTransformFields
+{
+    fn from(
+        value: (
+            GeojsonTransformFieldsVariant0,
+            GeojsonTransformFieldsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GeojsonTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeojsonTransformFieldsVariant0 {
@@ -11963,6 +14478,21 @@ impl From<&GeojsonTransformFieldsVariant0> for GeojsonTransformFieldsVariant0 {
         value.clone()
     }
 }
+impl From<ScaleField> for GeojsonTransformFieldsVariant0 {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for GeojsonTransformFieldsVariant0 {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for GeojsonTransformFieldsVariant0 {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeojsonTransformGeojson {
@@ -11973,6 +14503,21 @@ pub enum GeojsonTransformGeojson {
 impl From<&GeojsonTransformGeojson> for GeojsonTransformGeojson {
     fn from(value: &GeojsonTransformGeojson) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for GeojsonTransformGeojson {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for GeojsonTransformGeojson {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for GeojsonTransformGeojson {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12060,6 +14605,11 @@ impl Default for GeopathTransformAs {
         GeopathTransformAs::Variant0("path".to_string())
     }
 }
+impl From<SignalRef> for GeopathTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeopathTransformField {
@@ -12070,6 +14620,21 @@ pub enum GeopathTransformField {
 impl From<&GeopathTransformField> for GeopathTransformField {
     fn from(value: &GeopathTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for GeopathTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for GeopathTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for GeopathTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12083,6 +14648,26 @@ pub enum GeopathTransformPointRadius {
 impl From<&GeopathTransformPointRadius> for GeopathTransformPointRadius {
     fn from(value: &GeopathTransformPointRadius) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for GeopathTransformPointRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GeopathTransformPointRadius {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for GeopathTransformPointRadius {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for GeopathTransformPointRadius {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12165,6 +14750,16 @@ impl Default for GeopointTransformAs {
         )
     }
 }
+impl From<(GeopointTransformAsVariant0, GeopointTransformAsVariant0)> for GeopointTransformAs {
+    fn from(value: (GeopointTransformAsVariant0, GeopointTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GeopointTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformAsVariant0 {
@@ -12174,6 +14769,11 @@ pub enum GeopointTransformAsVariant0 {
 impl From<&GeopointTransformAsVariant0> for GeopointTransformAsVariant0 {
     fn from(value: &GeopointTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for GeopointTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12190,6 +14790,26 @@ impl From<&GeopointTransformFields> for GeopointTransformFields {
         value.clone()
     }
 }
+impl
+    From<(
+        GeopointTransformFieldsVariant0,
+        GeopointTransformFieldsVariant0,
+    )> for GeopointTransformFields
+{
+    fn from(
+        value: (
+            GeopointTransformFieldsVariant0,
+            GeopointTransformFieldsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GeopointTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformFieldsVariant0 {
@@ -12200,6 +14820,21 @@ pub enum GeopointTransformFieldsVariant0 {
 impl From<&GeopointTransformFieldsVariant0> for GeopointTransformFieldsVariant0 {
     fn from(value: &GeopointTransformFieldsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for GeopointTransformFieldsVariant0 {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for GeopointTransformFieldsVariant0 {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for GeopointTransformFieldsVariant0 {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12287,6 +14922,11 @@ impl Default for GeoshapeTransformAs {
         GeoshapeTransformAs::Variant0("shape".to_string())
     }
 }
+impl From<SignalRef> for GeoshapeTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeoshapeTransformField {
@@ -12306,6 +14946,21 @@ impl Default for GeoshapeTransformField {
         )))
     }
 }
+impl From<ScaleField> for GeoshapeTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for GeoshapeTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for GeoshapeTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeoshapeTransformPointRadius {
@@ -12317,6 +14972,26 @@ pub enum GeoshapeTransformPointRadius {
 impl From<&GeoshapeTransformPointRadius> for GeoshapeTransformPointRadius {
     fn from(value: &GeoshapeTransformPointRadius) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for GeoshapeTransformPointRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GeoshapeTransformPointRadius {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for GeoshapeTransformPointRadius {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for GeoshapeTransformPointRadius {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12449,6 +15124,16 @@ impl From<&GraticuleTransformExtent> for GraticuleTransformExtent {
         value.clone()
     }
 }
+impl From<(serde_json::Value, serde_json::Value)> for GraticuleTransformExtent {
+    fn from(value: (serde_json::Value, serde_json::Value)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMajor {
@@ -12460,6 +15145,16 @@ impl From<&GraticuleTransformExtentMajor> for GraticuleTransformExtentMajor {
         value.clone()
     }
 }
+impl From<(serde_json::Value, serde_json::Value)> for GraticuleTransformExtentMajor {
+    fn from(value: (serde_json::Value, serde_json::Value)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformExtentMajor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMinor {
@@ -12469,6 +15164,16 @@ pub enum GraticuleTransformExtentMinor {
 impl From<&GraticuleTransformExtentMinor> for GraticuleTransformExtentMinor {
     fn from(value: &GraticuleTransformExtentMinor) -> Self {
         value.clone()
+    }
+}
+impl From<(serde_json::Value, serde_json::Value)> for GraticuleTransformExtentMinor {
+    fn from(value: (serde_json::Value, serde_json::Value)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformExtentMinor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12487,6 +15192,16 @@ impl Default for GraticuleTransformPrecision {
         GraticuleTransformPrecision::Variant0(2.5_f64)
     }
 }
+impl From<f64> for GraticuleTransformPrecision {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GraticuleTransformPrecision {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStep {
@@ -12499,6 +15214,26 @@ pub enum GraticuleTransformStep {
 impl From<&GraticuleTransformStep> for GraticuleTransformStep {
     fn from(value: &GraticuleTransformStep) -> Self {
         value.clone()
+    }
+}
+impl
+    From<(
+        GraticuleTransformStepVariant0,
+        GraticuleTransformStepVariant0,
+    )> for GraticuleTransformStep
+{
+    fn from(
+        value: (
+            GraticuleTransformStepVariant0,
+            GraticuleTransformStepVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12523,6 +15258,26 @@ impl Default for GraticuleTransformStepMajor {
         )
     }
 }
+impl
+    From<(
+        GraticuleTransformStepMajorVariant0,
+        GraticuleTransformStepMajorVariant0,
+    )> for GraticuleTransformStepMajor
+{
+    fn from(
+        value: (
+            GraticuleTransformStepMajorVariant0,
+            GraticuleTransformStepMajorVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStepMajor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajorVariant0 {
@@ -12532,6 +15287,16 @@ pub enum GraticuleTransformStepMajorVariant0 {
 impl From<&GraticuleTransformStepMajorVariant0> for GraticuleTransformStepMajorVariant0 {
     fn from(value: &GraticuleTransformStepMajorVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for GraticuleTransformStepMajorVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStepMajorVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12556,6 +15321,26 @@ impl Default for GraticuleTransformStepMinor {
         )
     }
 }
+impl
+    From<(
+        GraticuleTransformStepMinorVariant0,
+        GraticuleTransformStepMinorVariant0,
+    )> for GraticuleTransformStepMinor
+{
+    fn from(
+        value: (
+            GraticuleTransformStepMinorVariant0,
+            GraticuleTransformStepMinorVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStepMinor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinorVariant0 {
@@ -12567,6 +15352,16 @@ impl From<&GraticuleTransformStepMinorVariant0> for GraticuleTransformStepMinorV
         value.clone()
     }
 }
+impl From<f64> for GraticuleTransformStepMinorVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStepMinorVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepVariant0 {
@@ -12576,6 +15371,16 @@ pub enum GraticuleTransformStepVariant0 {
 impl From<&GraticuleTransformStepVariant0> for GraticuleTransformStepVariant0 {
     fn from(value: &GraticuleTransformStepVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for GraticuleTransformStepVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for GraticuleTransformStepVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12676,6 +15481,11 @@ impl Default for HeatmapTransformAs {
         HeatmapTransformAs::Variant0("image".to_string())
     }
 }
+impl From<SignalRef> for HeatmapTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformColor {
@@ -12687,6 +15497,21 @@ pub enum HeatmapTransformColor {
 impl From<&HeatmapTransformColor> for HeatmapTransformColor {
     fn from(value: &HeatmapTransformColor) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for HeatmapTransformColor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for HeatmapTransformColor {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for HeatmapTransformColor {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12701,6 +15526,21 @@ impl From<&HeatmapTransformField> for HeatmapTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for HeatmapTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for HeatmapTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for HeatmapTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformOpacity {
@@ -12712,6 +15552,26 @@ pub enum HeatmapTransformOpacity {
 impl From<&HeatmapTransformOpacity> for HeatmapTransformOpacity {
     fn from(value: &HeatmapTransformOpacity) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for HeatmapTransformOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for HeatmapTransformOpacity {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for HeatmapTransformOpacity {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for HeatmapTransformOpacity {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12728,6 +15588,16 @@ impl From<&HeatmapTransformResolve> for HeatmapTransformResolve {
 impl Default for HeatmapTransformResolve {
     fn default() -> Self {
         HeatmapTransformResolve::Variant0(HeatmapTransformResolveVariant0::Independent)
+    }
+}
+impl From<HeatmapTransformResolveVariant0> for HeatmapTransformResolve {
+    fn from(value: HeatmapTransformResolveVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for HeatmapTransformResolve {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -12848,6 +15718,11 @@ impl From<&IdentifierTransformAs> for IdentifierTransformAs {
         value.clone()
     }
 }
+impl From<SignalRef> for IdentifierTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum IdentifierTransformType {
     #[serde(rename = "identifier")]
@@ -12927,6 +15802,21 @@ impl From<&ImputeTransformField> for ImputeTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for ImputeTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ImputeTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ImputeTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupby {
@@ -12936,6 +15826,16 @@ pub enum ImputeTransformGroupby {
 impl From<&ImputeTransformGroupby> for ImputeTransformGroupby {
     fn from(value: &ImputeTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<ImputeTransformGroupbyVariant0Item>> for ImputeTransformGroupby {
+    fn from(value: Vec<ImputeTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ImputeTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12950,6 +15850,21 @@ impl From<&ImputeTransformGroupbyVariant0Item> for ImputeTransformGroupbyVariant
         value.clone()
     }
 }
+impl From<ScaleField> for ImputeTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ImputeTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ImputeTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformKey {
@@ -12962,6 +15877,21 @@ impl From<&ImputeTransformKey> for ImputeTransformKey {
         value.clone()
     }
 }
+impl From<ScaleField> for ImputeTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ImputeTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ImputeTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformKeyvals {
@@ -12971,6 +15901,16 @@ pub enum ImputeTransformKeyvals {
 impl From<&ImputeTransformKeyvals> for ImputeTransformKeyvals {
     fn from(value: &ImputeTransformKeyvals) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ImputeTransformKeyvals {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ImputeTransformKeyvals {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12987,6 +15927,16 @@ impl From<&ImputeTransformMethod> for ImputeTransformMethod {
 impl Default for ImputeTransformMethod {
     fn default() -> Self {
         ImputeTransformMethod::Variant0(ImputeTransformMethodVariant0::Value)
+    }
+}
+impl From<ImputeTransformMethodVariant0> for ImputeTransformMethod {
+    fn from(value: ImputeTransformMethodVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ImputeTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13143,6 +16093,11 @@ impl Default for IsocontourTransformAs {
         IsocontourTransformAs::Variant0("contour".to_string())
     }
 }
+impl From<SignalRef> for IsocontourTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformField {
@@ -13153,6 +16108,21 @@ pub enum IsocontourTransformField {
 impl From<&IsocontourTransformField> for IsocontourTransformField {
     fn from(value: &IsocontourTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for IsocontourTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for IsocontourTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for IsocontourTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13166,6 +16136,16 @@ impl From<&IsocontourTransformLevels> for IsocontourTransformLevels {
         value.clone()
     }
 }
+impl From<f64> for IsocontourTransformLevels {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformLevels {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformNice {
@@ -13175,6 +16155,16 @@ pub enum IsocontourTransformNice {
 impl From<&IsocontourTransformNice> for IsocontourTransformNice {
     fn from(value: &IsocontourTransformNice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for IsocontourTransformNice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformNice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13191,6 +16181,16 @@ impl From<&IsocontourTransformResolve> for IsocontourTransformResolve {
 impl Default for IsocontourTransformResolve {
     fn default() -> Self {
         IsocontourTransformResolve::Variant0(IsocontourTransformResolveVariant0::Independent)
+    }
+}
+impl From<IsocontourTransformResolveVariant0> for IsocontourTransformResolve {
+    fn from(value: IsocontourTransformResolveVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformResolve {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13254,6 +16254,26 @@ impl From<&IsocontourTransformScale> for IsocontourTransformScale {
         value.clone()
     }
 }
+impl From<f64> for IsocontourTransformScale {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformScale {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for IsocontourTransformScale {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for IsocontourTransformScale {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformSmooth {
@@ -13270,6 +16290,16 @@ impl Default for IsocontourTransformSmooth {
         IsocontourTransformSmooth::Variant0(true)
     }
 }
+impl From<bool> for IsocontourTransformSmooth {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformSmooth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholds {
@@ -13279,6 +16309,16 @@ pub enum IsocontourTransformThresholds {
 impl From<&IsocontourTransformThresholds> for IsocontourTransformThresholds {
     fn from(value: &IsocontourTransformThresholds) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<IsocontourTransformThresholdsVariant0Item>> for IsocontourTransformThresholds {
+    fn from(value: Vec<IsocontourTransformThresholdsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformThresholds {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13294,6 +16334,16 @@ impl From<&IsocontourTransformThresholdsVariant0Item>
         value.clone()
     }
 }
+impl From<f64> for IsocontourTransformThresholdsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformThresholdsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslate {
@@ -13303,6 +16353,16 @@ pub enum IsocontourTransformTranslate {
 impl From<&IsocontourTransformTranslate> for IsocontourTransformTranslate {
     fn from(value: &IsocontourTransformTranslate) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<IsocontourTransformTranslateVariant0Item>> for IsocontourTransformTranslate {
+    fn from(value: Vec<IsocontourTransformTranslateVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformTranslate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13316,6 +16376,26 @@ pub enum IsocontourTransformTranslateVariant0Item {
 impl From<&IsocontourTransformTranslateVariant0Item> for IsocontourTransformTranslateVariant0Item {
     fn from(value: &IsocontourTransformTranslateVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for IsocontourTransformTranslateVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformTranslateVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for IsocontourTransformTranslateVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for IsocontourTransformTranslateVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13378,6 +16458,16 @@ impl Default for IsocontourTransformZero {
         IsocontourTransformZero::Variant0(true)
     }
 }
+impl From<bool> for IsocontourTransformZero {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for IsocontourTransformZero {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JoinaggregateTransform {
@@ -13412,6 +16502,16 @@ impl From<&JoinaggregateTransformAs> for JoinaggregateTransformAs {
         value.clone()
     }
 }
+impl From<Vec<JoinaggregateTransformAsVariant0Item>> for JoinaggregateTransformAs {
+    fn from(value: Vec<JoinaggregateTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for JoinaggregateTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAsVariant0Item {
@@ -13424,6 +16524,11 @@ impl From<&JoinaggregateTransformAsVariant0Item> for JoinaggregateTransformAsVar
         value.clone()
     }
 }
+impl From<SignalRef> for JoinaggregateTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFields {
@@ -13433,6 +16538,16 @@ pub enum JoinaggregateTransformFields {
 impl From<&JoinaggregateTransformFields> for JoinaggregateTransformFields {
     fn from(value: &JoinaggregateTransformFields) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<JoinaggregateTransformFieldsVariant0Item>> for JoinaggregateTransformFields {
+    fn from(value: Vec<JoinaggregateTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for JoinaggregateTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13448,6 +16563,21 @@ impl From<&JoinaggregateTransformFieldsVariant0Item> for JoinaggregateTransformF
         value.clone()
     }
 }
+impl From<ScaleField> for JoinaggregateTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ParamField> for JoinaggregateTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for JoinaggregateTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupby {
@@ -13457,6 +16587,16 @@ pub enum JoinaggregateTransformGroupby {
 impl From<&JoinaggregateTransformGroupby> for JoinaggregateTransformGroupby {
     fn from(value: &JoinaggregateTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<JoinaggregateTransformGroupbyVariant0Item>> for JoinaggregateTransformGroupby {
+    fn from(value: Vec<JoinaggregateTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for JoinaggregateTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13473,6 +16613,21 @@ impl From<&JoinaggregateTransformGroupbyVariant0Item>
         value.clone()
     }
 }
+impl From<ScaleField> for JoinaggregateTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for JoinaggregateTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for JoinaggregateTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformKey {
@@ -13483,6 +16638,21 @@ pub enum JoinaggregateTransformKey {
 impl From<&JoinaggregateTransformKey> for JoinaggregateTransformKey {
     fn from(value: &JoinaggregateTransformKey) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for JoinaggregateTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for JoinaggregateTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for JoinaggregateTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13496,6 +16666,16 @@ impl From<&JoinaggregateTransformOps> for JoinaggregateTransformOps {
         value.clone()
     }
 }
+impl From<Vec<JoinaggregateTransformOpsVariant0Item>> for JoinaggregateTransformOps {
+    fn from(value: Vec<JoinaggregateTransformOpsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for JoinaggregateTransformOps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOpsVariant0Item {
@@ -13505,6 +16685,16 @@ pub enum JoinaggregateTransformOpsVariant0Item {
 impl From<&JoinaggregateTransformOpsVariant0Item> for JoinaggregateTransformOpsVariant0Item {
     fn from(value: &JoinaggregateTransformOpsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<JoinaggregateTransformOpsVariant0ItemVariant0> for JoinaggregateTransformOpsVariant0Item {
+    fn from(value: JoinaggregateTransformOpsVariant0ItemVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for JoinaggregateTransformOpsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13733,6 +16923,11 @@ impl Default for Kde2dTransformAs {
         Kde2dTransformAs::Variant0("grid".to_string())
     }
 }
+impl From<SignalRef> for Kde2dTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidth {
@@ -13747,6 +16942,26 @@ impl From<&Kde2dTransformBandwidth> for Kde2dTransformBandwidth {
         value.clone()
     }
 }
+impl
+    From<(
+        Kde2dTransformBandwidthVariant0,
+        Kde2dTransformBandwidthVariant0,
+    )> for Kde2dTransformBandwidth
+{
+    fn from(
+        value: (
+            Kde2dTransformBandwidthVariant0,
+            Kde2dTransformBandwidthVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for Kde2dTransformBandwidth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidthVariant0 {
@@ -13756,6 +16971,16 @@ pub enum Kde2dTransformBandwidthVariant0 {
 impl From<&Kde2dTransformBandwidthVariant0> for Kde2dTransformBandwidthVariant0 {
     fn from(value: &Kde2dTransformBandwidthVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for Kde2dTransformBandwidthVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Kde2dTransformBandwidthVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13769,6 +16994,16 @@ impl From<&Kde2dTransformCellSize> for Kde2dTransformCellSize {
         value.clone()
     }
 }
+impl From<f64> for Kde2dTransformCellSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Kde2dTransformCellSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformCounts {
@@ -13780,6 +17015,16 @@ impl From<&Kde2dTransformCounts> for Kde2dTransformCounts {
         value.clone()
     }
 }
+impl From<bool> for Kde2dTransformCounts {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Kde2dTransformCounts {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupby {
@@ -13789,6 +17034,16 @@ pub enum Kde2dTransformGroupby {
 impl From<&Kde2dTransformGroupby> for Kde2dTransformGroupby {
     fn from(value: &Kde2dTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<Kde2dTransformGroupbyVariant0Item>> for Kde2dTransformGroupby {
+    fn from(value: Vec<Kde2dTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Kde2dTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13803,6 +17058,21 @@ impl From<&Kde2dTransformGroupbyVariant0Item> for Kde2dTransformGroupbyVariant0I
         value.clone()
     }
 }
+impl From<ScaleField> for Kde2dTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for Kde2dTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for Kde2dTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformSize {
@@ -13814,6 +17084,16 @@ impl From<&Kde2dTransformSize> for Kde2dTransformSize {
         value.clone()
     }
 }
+impl From<(Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0)> for Kde2dTransformSize {
+    fn from(value: (Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for Kde2dTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformSizeVariant0 {
@@ -13823,6 +17103,16 @@ pub enum Kde2dTransformSizeVariant0 {
 impl From<&Kde2dTransformSizeVariant0> for Kde2dTransformSizeVariant0 {
     fn from(value: &Kde2dTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for Kde2dTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Kde2dTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -13881,6 +17171,21 @@ impl From<&Kde2dTransformWeight> for Kde2dTransformWeight {
         value.clone()
     }
 }
+impl From<ScaleField> for Kde2dTransformWeight {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for Kde2dTransformWeight {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for Kde2dTransformWeight {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformX {
@@ -13893,6 +17198,21 @@ impl From<&Kde2dTransformX> for Kde2dTransformX {
         value.clone()
     }
 }
+impl From<ScaleField> for Kde2dTransformX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for Kde2dTransformX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for Kde2dTransformX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformY {
@@ -13903,6 +17223,21 @@ pub enum Kde2dTransformY {
 impl From<&Kde2dTransformY> for Kde2dTransformY {
     fn from(value: &Kde2dTransformY) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for Kde2dTransformY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for Kde2dTransformY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for Kde2dTransformY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13958,6 +17293,16 @@ impl Default for KdeTransformAs {
         ])
     }
 }
+impl From<Vec<KdeTransformAsVariant0Item>> for KdeTransformAs {
+    fn from(value: Vec<KdeTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformAsVariant0Item {
@@ -13967,6 +17312,11 @@ pub enum KdeTransformAsVariant0Item {
 impl From<&KdeTransformAsVariant0Item> for KdeTransformAsVariant0Item {
     fn from(value: &KdeTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for KdeTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13980,6 +17330,16 @@ impl From<&KdeTransformBandwidth> for KdeTransformBandwidth {
         value.clone()
     }
 }
+impl From<f64> for KdeTransformBandwidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformBandwidth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformCounts {
@@ -13989,6 +17349,16 @@ pub enum KdeTransformCounts {
 impl From<&KdeTransformCounts> for KdeTransformCounts {
     fn from(value: &KdeTransformCounts) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for KdeTransformCounts {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformCounts {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14002,6 +17372,16 @@ impl From<&KdeTransformCumulative> for KdeTransformCumulative {
         value.clone()
     }
 }
+impl From<bool> for KdeTransformCumulative {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformCumulative {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformExtent {
@@ -14013,6 +17393,16 @@ impl From<&KdeTransformExtent> for KdeTransformExtent {
         value.clone()
     }
 }
+impl From<(KdeTransformExtentVariant0, KdeTransformExtentVariant0)> for KdeTransformExtent {
+    fn from(value: (KdeTransformExtentVariant0, KdeTransformExtentVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for KdeTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformExtentVariant0 {
@@ -14022,6 +17412,16 @@ pub enum KdeTransformExtentVariant0 {
 impl From<&KdeTransformExtentVariant0> for KdeTransformExtentVariant0 {
     fn from(value: &KdeTransformExtentVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for KdeTransformExtentVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14036,6 +17436,21 @@ impl From<&KdeTransformField> for KdeTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for KdeTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for KdeTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for KdeTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformGroupby {
@@ -14045,6 +17460,16 @@ pub enum KdeTransformGroupby {
 impl From<&KdeTransformGroupby> for KdeTransformGroupby {
     fn from(value: &KdeTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<KdeTransformGroupbyVariant0Item>> for KdeTransformGroupby {
+    fn from(value: Vec<KdeTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14057,6 +17482,21 @@ pub enum KdeTransformGroupbyVariant0Item {
 impl From<&KdeTransformGroupbyVariant0Item> for KdeTransformGroupbyVariant0Item {
     fn from(value: &KdeTransformGroupbyVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for KdeTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for KdeTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for KdeTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14075,6 +17515,16 @@ impl Default for KdeTransformMaxsteps {
         KdeTransformMaxsteps::Variant0(200_f64)
     }
 }
+impl From<f64> for KdeTransformMaxsteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformMaxsteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformMinsteps {
@@ -14091,6 +17541,16 @@ impl Default for KdeTransformMinsteps {
         KdeTransformMinsteps::Variant0(25_f64)
     }
 }
+impl From<f64> for KdeTransformMinsteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformMinsteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformResolve {
@@ -14105,6 +17565,16 @@ impl From<&KdeTransformResolve> for KdeTransformResolve {
 impl Default for KdeTransformResolve {
     fn default() -> Self {
         KdeTransformResolve::Variant0(KdeTransformResolveVariant0::Independent)
+    }
+}
+impl From<KdeTransformResolveVariant0> for KdeTransformResolve {
+    fn from(value: KdeTransformResolveVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformResolve {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14166,6 +17636,16 @@ impl From<&KdeTransformSteps> for KdeTransformSteps {
         value.clone()
     }
 }
+impl From<f64> for KdeTransformSteps {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for KdeTransformSteps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum KdeTransformType {
     #[serde(rename = "kde")]
@@ -14220,6 +17700,21 @@ pub enum LabelOverlap {
 impl From<&LabelOverlap> for LabelOverlap {
     fn from(value: &LabelOverlap) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for LabelOverlap {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<LabelOverlapVariant1> for LabelOverlap {
+    fn from(value: LabelOverlapVariant1) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for LabelOverlap {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14339,6 +17834,16 @@ impl Default for LabelTransformAnchor {
         ])
     }
 }
+impl From<Vec<LabelTransformAnchorVariant0Item>> for LabelTransformAnchor {
+    fn from(value: Vec<LabelTransformAnchorVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformAnchor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAnchorVariant0Item {
@@ -14348,6 +17853,11 @@ pub enum LabelTransformAnchorVariant0Item {
 impl From<&LabelTransformAnchorVariant0Item> for LabelTransformAnchorVariant0Item {
     fn from(value: &LabelTransformAnchorVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for LabelTransformAnchorVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14378,6 +17888,32 @@ impl Default for LabelTransformAs {
         )
     }
 }
+impl
+    From<(
+        LabelTransformAsVariant0,
+        LabelTransformAsVariant0,
+        LabelTransformAsVariant0,
+        LabelTransformAsVariant0,
+        LabelTransformAsVariant0,
+    )> for LabelTransformAs
+{
+    fn from(
+        value: (
+            LabelTransformAsVariant0,
+            LabelTransformAsVariant0,
+            LabelTransformAsVariant0,
+            LabelTransformAsVariant0,
+            LabelTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1, value.2, value.3, value.4)
+    }
+}
+impl From<SignalRef> for LabelTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAsVariant0 {
@@ -14387,6 +17923,11 @@ pub enum LabelTransformAsVariant0 {
 impl From<&LabelTransformAsVariant0> for LabelTransformAsVariant0 {
     fn from(value: &LabelTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for LabelTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14405,6 +17946,16 @@ impl Default for LabelTransformAvoidBaseMark {
         LabelTransformAvoidBaseMark::Variant0(true)
     }
 }
+impl From<bool> for LabelTransformAvoidBaseMark {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformAvoidBaseMark {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidMarks {
@@ -14414,6 +17965,16 @@ pub enum LabelTransformAvoidMarks {
 impl From<&LabelTransformAvoidMarks> for LabelTransformAvoidMarks {
     fn from(value: &LabelTransformAvoidMarks) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<String>> for LabelTransformAvoidMarks {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformAvoidMarks {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14432,6 +17993,11 @@ impl Default for LabelTransformLineAnchor {
         LabelTransformLineAnchor::Variant0("end".to_string())
     }
 }
+impl From<SignalRef> for LabelTransformLineAnchor {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformMarkIndex {
@@ -14441,6 +18007,16 @@ pub enum LabelTransformMarkIndex {
 impl From<&LabelTransformMarkIndex> for LabelTransformMarkIndex {
     fn from(value: &LabelTransformMarkIndex) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LabelTransformMarkIndex {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformMarkIndex {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14459,6 +18035,11 @@ impl Default for LabelTransformMethod {
         LabelTransformMethod::Variant0("naive".to_string())
     }
 }
+impl From<SignalRef> for LabelTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformOffset {
@@ -14475,6 +18056,16 @@ impl Default for LabelTransformOffset {
         LabelTransformOffset::Variant0(vec![LabelTransformOffsetVariant0Item::Variant0(1_f64)])
     }
 }
+impl From<Vec<LabelTransformOffsetVariant0Item>> for LabelTransformOffset {
+    fn from(value: Vec<LabelTransformOffsetVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformOffset {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformOffsetVariant0Item {
@@ -14484,6 +18075,16 @@ pub enum LabelTransformOffsetVariant0Item {
 impl From<&LabelTransformOffsetVariant0Item> for LabelTransformOffsetVariant0Item {
     fn from(value: &LabelTransformOffsetVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LabelTransformOffsetVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformOffsetVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14498,6 +18099,16 @@ impl From<&LabelTransformPadding> for LabelTransformPadding {
         value.clone()
     }
 }
+impl From<f64> for LabelTransformPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformPadding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformSize {
@@ -14509,6 +18120,16 @@ impl From<&LabelTransformSize> for LabelTransformSize {
         value.clone()
     }
 }
+impl From<(LabelTransformSizeVariant0, LabelTransformSizeVariant0)> for LabelTransformSize {
+    fn from(value: (LabelTransformSizeVariant0, LabelTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for LabelTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformSizeVariant0 {
@@ -14518,6 +18139,16 @@ pub enum LabelTransformSizeVariant0 {
 impl From<&LabelTransformSizeVariant0> for LabelTransformSizeVariant0 {
     fn from(value: &LabelTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LabelTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LabelTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14608,6 +18239,11 @@ impl From<&Layout> for Layout {
         value.clone()
     }
 }
+impl From<SignalRef> for Layout {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Align {
@@ -14624,6 +18260,11 @@ impl From<&LayoutVariant0Align> for LayoutVariant0Align {
         value.clone()
     }
 }
+impl From<LayoutVariant0AlignVariant0> for LayoutVariant0Align {
+    fn from(value: LayoutVariant0AlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant0 {
@@ -14633,6 +18274,16 @@ pub enum LayoutVariant0AlignVariant0 {
 impl From<&LayoutVariant0AlignVariant0> for LayoutVariant0AlignVariant0 {
     fn from(value: &LayoutVariant0AlignVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<LayoutVariant0AlignVariant0Variant0> for LayoutVariant0AlignVariant0 {
+    fn from(value: LayoutVariant0AlignVariant0Variant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0AlignVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14696,6 +18347,16 @@ pub enum LayoutVariant0AlignVariant1Column {
 impl From<&LayoutVariant0AlignVariant1Column> for LayoutVariant0AlignVariant1Column {
     fn from(value: &LayoutVariant0AlignVariant1Column) -> Self {
         value.clone()
+    }
+}
+impl From<LayoutVariant0AlignVariant1ColumnVariant0> for LayoutVariant0AlignVariant1Column {
+    fn from(value: LayoutVariant0AlignVariant1ColumnVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0AlignVariant1Column {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14763,6 +18424,16 @@ impl From<&LayoutVariant0AlignVariant1Row> for LayoutVariant0AlignVariant1Row {
         value.clone()
     }
 }
+impl From<LayoutVariant0AlignVariant1RowVariant0> for LayoutVariant0AlignVariant1Row {
+    fn from(value: LayoutVariant0AlignVariant1RowVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0AlignVariant1Row {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LayoutVariant0AlignVariant1RowVariant0 {
     #[serde(rename = "all")]
@@ -14824,6 +18495,16 @@ pub enum LayoutVariant0Bounds {
 impl From<&LayoutVariant0Bounds> for LayoutVariant0Bounds {
     fn from(value: &LayoutVariant0Bounds) -> Self {
         value.clone()
+    }
+}
+impl From<LayoutVariant0BoundsVariant0> for LayoutVariant0Bounds {
+    fn from(value: LayoutVariant0BoundsVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0Bounds {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -14891,6 +18572,16 @@ impl From<&LayoutVariant0Center> for LayoutVariant0Center {
         value.clone()
     }
 }
+impl From<bool> for LayoutVariant0Center {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0Center {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0FooterBand {
@@ -14908,6 +18599,11 @@ impl From<&LayoutVariant0FooterBand> for LayoutVariant0FooterBand {
         value.clone()
     }
 }
+impl From<NumberOrSignal> for LayoutVariant0FooterBand {
+    fn from(value: NumberOrSignal) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0HeaderBand {
@@ -14923,6 +18619,11 @@ pub enum LayoutVariant0HeaderBand {
 impl From<&LayoutVariant0HeaderBand> for LayoutVariant0HeaderBand {
     fn from(value: &LayoutVariant0HeaderBand) -> Self {
         value.clone()
+    }
+}
+impl From<NumberOrSignal> for LayoutVariant0HeaderBand {
+    fn from(value: NumberOrSignal) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14962,6 +18663,16 @@ impl From<&LayoutVariant0Offset> for LayoutVariant0Offset {
         value.clone()
     }
 }
+impl From<f64> for LayoutVariant0Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0Offset {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Padding {
@@ -14977,6 +18688,16 @@ pub enum LayoutVariant0Padding {
 impl From<&LayoutVariant0Padding> for LayoutVariant0Padding {
     fn from(value: &LayoutVariant0Padding) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LayoutVariant0Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0Padding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14995,6 +18716,11 @@ impl From<&LayoutVariant0TitleAnchor> for LayoutVariant0TitleAnchor {
         value.clone()
     }
 }
+impl From<LayoutVariant0TitleAnchorVariant0> for LayoutVariant0TitleAnchor {
+    fn from(value: LayoutVariant0TitleAnchorVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant0 {
@@ -15004,6 +18730,16 @@ pub enum LayoutVariant0TitleAnchorVariant0 {
 impl From<&LayoutVariant0TitleAnchorVariant0> for LayoutVariant0TitleAnchorVariant0 {
     fn from(value: &LayoutVariant0TitleAnchorVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<LayoutVariant0TitleAnchorVariant0Variant0> for LayoutVariant0TitleAnchorVariant0 {
+    fn from(value: LayoutVariant0TitleAnchorVariant0Variant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0TitleAnchorVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15067,6 +18803,18 @@ impl From<&LayoutVariant0TitleAnchorVariant1Column> for LayoutVariant0TitleAncho
         value.clone()
     }
 }
+impl From<LayoutVariant0TitleAnchorVariant1ColumnVariant0>
+    for LayoutVariant0TitleAnchorVariant1Column
+{
+    fn from(value: LayoutVariant0TitleAnchorVariant1ColumnVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0TitleAnchorVariant1Column {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     #[serde(rename = "start")]
@@ -15126,6 +18874,16 @@ pub enum LayoutVariant0TitleAnchorVariant1Row {
 impl From<&LayoutVariant0TitleAnchorVariant1Row> for LayoutVariant0TitleAnchorVariant1Row {
     fn from(value: &LayoutVariant0TitleAnchorVariant1Row) -> Self {
         value.clone()
+    }
+}
+impl From<LayoutVariant0TitleAnchorVariant1RowVariant0> for LayoutVariant0TitleAnchorVariant1Row {
+    fn from(value: LayoutVariant0TitleAnchorVariant1RowVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LayoutVariant0TitleAnchorVariant1Row {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15193,6 +18951,11 @@ pub enum LayoutVariant0TitleBand {
 impl From<&LayoutVariant0TitleBand> for LayoutVariant0TitleBand {
     fn from(value: &LayoutVariant0TitleBand) -> Self {
         value.clone()
+    }
+}
+impl From<NumberOrSignal> for LayoutVariant0TitleBand {
+    fn from(value: NumberOrSignal) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15559,6 +19322,16 @@ impl From<&LegendSubtype0CornerRadius> for LegendSubtype0CornerRadius {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LegendSubtype0Direction {
     #[serde(rename = "vertical")]
@@ -15640,6 +19413,11 @@ impl From<&LegendSubtype0FillColor> for LegendSubtype0FillColor {
         value.clone()
     }
 }
+impl From<ColorValue> for LegendSubtype0FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendSubtype0Format {
@@ -15673,6 +19451,11 @@ impl From<&LegendSubtype0Format> for LegendSubtype0Format {
         value.clone()
     }
 }
+impl From<SignalRef> for LegendSubtype0Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0FormatType {
@@ -15682,6 +19465,16 @@ pub enum LegendSubtype0FormatType {
 impl From<&LegendSubtype0FormatType> for LegendSubtype0FormatType {
     fn from(value: &LegendSubtype0FormatType) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0FormatTypeVariant0> for LegendSubtype0FormatType {
+    fn from(value: LegendSubtype0FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype0FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15747,6 +19540,16 @@ impl From<&LegendSubtype0GradientOpacity> for LegendSubtype0GradientOpacity {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0GradientStrokeColor {
@@ -15757,6 +19560,11 @@ pub enum LegendSubtype0GradientStrokeColor {
 impl From<&LegendSubtype0GradientStrokeColor> for LegendSubtype0GradientStrokeColor {
     fn from(value: &LegendSubtype0GradientStrokeColor) -> Self {
         value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype0GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15770,6 +19578,16 @@ impl From<&LegendSubtype0GradientStrokeWidth> for LegendSubtype0GradientStrokeWi
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0GridAlign {
@@ -15779,6 +19597,16 @@ pub enum LegendSubtype0GridAlign {
 impl From<&LegendSubtype0GridAlign> for LegendSubtype0GridAlign {
     fn from(value: &LegendSubtype0GridAlign) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0GridAlignVariant0> for LegendSubtype0GridAlign {
+    fn from(value: LegendSubtype0GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype0GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15844,6 +19672,16 @@ impl From<&LegendSubtype0LabelAlign> for LegendSubtype0LabelAlign {
         value.clone()
     }
 }
+impl From<LegendSubtype0LabelAlignVariant0> for LegendSubtype0LabelAlign {
+    fn from(value: LegendSubtype0LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype0LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LegendSubtype0LabelAlignVariant0 {
     #[serde(rename = "left")]
@@ -15905,6 +19743,16 @@ pub enum LegendSubtype0LabelBaseline {
 impl From<&LegendSubtype0LabelBaseline> for LegendSubtype0LabelBaseline {
     fn from(value: &LegendSubtype0LabelBaseline) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0LabelBaselineVariant0> for LegendSubtype0LabelBaseline {
+    fn from(value: LegendSubtype0LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype0LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -15983,6 +19831,11 @@ impl From<&LegendSubtype0LabelColor> for LegendSubtype0LabelColor {
         value.clone()
     }
 }
+impl From<ColorValue> for LegendSubtype0LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFont {
@@ -15992,6 +19845,11 @@ pub enum LegendSubtype0LabelFont {
 impl From<&LegendSubtype0LabelFont> for LegendSubtype0LabelFont {
     fn from(value: &LegendSubtype0LabelFont) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype0LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16005,6 +19863,16 @@ impl From<&LegendSubtype0LabelFontSize> for LegendSubtype0LabelFontSize {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelFontStyle {
@@ -16014,6 +19882,11 @@ pub enum LegendSubtype0LabelFontStyle {
 impl From<&LegendSubtype0LabelFontStyle> for LegendSubtype0LabelFontStyle {
     fn from(value: &LegendSubtype0LabelFontStyle) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype0LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16027,6 +19900,16 @@ impl From<&LegendSubtype0LabelFontWeight> for LegendSubtype0LabelFontWeight {
         value.clone()
     }
 }
+impl From<MyEnum> for LegendSubtype0LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype0LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelLimit {
@@ -16036,6 +19919,16 @@ pub enum LegendSubtype0LabelLimit {
 impl From<&LegendSubtype0LabelLimit> for LegendSubtype0LabelLimit {
     fn from(value: &LegendSubtype0LabelLimit) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16049,6 +19942,16 @@ impl From<&LegendSubtype0LabelOffset> for LegendSubtype0LabelOffset {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LabelOpacity {
@@ -16058,6 +19961,16 @@ pub enum LegendSubtype0LabelOpacity {
 impl From<&LegendSubtype0LabelOpacity> for LegendSubtype0LabelOpacity {
     fn from(value: &LegendSubtype0LabelOpacity) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16071,6 +19984,16 @@ impl From<&LegendSubtype0LegendX> for LegendSubtype0LegendX {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0LegendY {
@@ -16080,6 +20003,16 @@ pub enum LegendSubtype0LegendY {
 impl From<&LegendSubtype0LegendY> for LegendSubtype0LegendY {
     fn from(value: &LegendSubtype0LegendY) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16093,6 +20026,16 @@ impl From<&LegendSubtype0Offset> for LegendSubtype0Offset {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0Orient {
@@ -16102,6 +20045,16 @@ pub enum LegendSubtype0Orient {
 impl From<&LegendSubtype0Orient> for LegendSubtype0Orient {
     fn from(value: &LegendSubtype0Orient) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0OrientVariant0> for LegendSubtype0Orient {
+    fn from(value: LegendSubtype0OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype0Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16196,6 +20149,16 @@ impl From<&LegendSubtype0Padding> for LegendSubtype0Padding {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0StrokeColor {
@@ -16206,6 +20169,11 @@ pub enum LegendSubtype0StrokeColor {
 impl From<&LegendSubtype0StrokeColor> for LegendSubtype0StrokeColor {
     fn from(value: &LegendSubtype0StrokeColor) -> Self {
         value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype0StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16219,6 +20187,16 @@ impl From<&LegendSubtype0SymbolDash> for LegendSubtype0SymbolDash {
         value.clone()
     }
 }
+impl From<Vec<f64>> for LegendSubtype0SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype0SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolDashOffset {
@@ -16228,6 +20206,16 @@ pub enum LegendSubtype0SymbolDashOffset {
 impl From<&LegendSubtype0SymbolDashOffset> for LegendSubtype0SymbolDashOffset {
     fn from(value: &LegendSubtype0SymbolDashOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16242,6 +20230,11 @@ impl From<&LegendSubtype0SymbolFillColor> for LegendSubtype0SymbolFillColor {
         value.clone()
     }
 }
+impl From<ColorValue> for LegendSubtype0SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolOffset {
@@ -16251,6 +20244,16 @@ pub enum LegendSubtype0SymbolOffset {
 impl From<&LegendSubtype0SymbolOffset> for LegendSubtype0SymbolOffset {
     fn from(value: &LegendSubtype0SymbolOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16264,6 +20267,16 @@ impl From<&LegendSubtype0SymbolOpacity> for LegendSubtype0SymbolOpacity {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolSize {
@@ -16273,6 +20286,16 @@ pub enum LegendSubtype0SymbolSize {
 impl From<&LegendSubtype0SymbolSize> for LegendSubtype0SymbolSize {
     fn from(value: &LegendSubtype0SymbolSize) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16287,6 +20310,11 @@ impl From<&LegendSubtype0SymbolStrokeColor> for LegendSubtype0SymbolStrokeColor 
         value.clone()
     }
 }
+impl From<ColorValue> for LegendSubtype0SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0SymbolStrokeWidth {
@@ -16296,6 +20324,16 @@ pub enum LegendSubtype0SymbolStrokeWidth {
 impl From<&LegendSubtype0SymbolStrokeWidth> for LegendSubtype0SymbolStrokeWidth {
     fn from(value: &LegendSubtype0SymbolStrokeWidth) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16309,6 +20347,11 @@ impl From<&LegendSubtype0SymbolType> for LegendSubtype0SymbolType {
         value.clone()
     }
 }
+impl From<StringValue> for LegendSubtype0SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleAlign {
@@ -16318,6 +20361,16 @@ pub enum LegendSubtype0TitleAlign {
 impl From<&LegendSubtype0TitleAlign> for LegendSubtype0TitleAlign {
     fn from(value: &LegendSubtype0TitleAlign) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0TitleAlignVariant0> for LegendSubtype0TitleAlign {
+    fn from(value: LegendSubtype0TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype0TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16383,6 +20436,16 @@ impl From<&LegendSubtype0TitleAnchor> for LegendSubtype0TitleAnchor {
         value.clone()
     }
 }
+impl From<Option<LegendSubtype0TitleAnchorVariant0>> for LegendSubtype0TitleAnchor {
+    fn from(value: Option<LegendSubtype0TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype0TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LegendSubtype0TitleAnchorVariant0 {
     #[serde(rename = "start")]
@@ -16444,6 +20507,16 @@ pub enum LegendSubtype0TitleBaseline {
 impl From<&LegendSubtype0TitleBaseline> for LegendSubtype0TitleBaseline {
     fn from(value: &LegendSubtype0TitleBaseline) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0TitleBaselineVariant0> for LegendSubtype0TitleBaseline {
+    fn from(value: LegendSubtype0TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype0TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16522,6 +20595,11 @@ impl From<&LegendSubtype0TitleColor> for LegendSubtype0TitleColor {
         value.clone()
     }
 }
+impl From<ColorValue> for LegendSubtype0TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFont {
@@ -16531,6 +20609,11 @@ pub enum LegendSubtype0TitleFont {
 impl From<&LegendSubtype0TitleFont> for LegendSubtype0TitleFont {
     fn from(value: &LegendSubtype0TitleFont) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype0TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16544,6 +20627,16 @@ impl From<&LegendSubtype0TitleFontSize> for LegendSubtype0TitleFontSize {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleFontStyle {
@@ -16553,6 +20646,11 @@ pub enum LegendSubtype0TitleFontStyle {
 impl From<&LegendSubtype0TitleFontStyle> for LegendSubtype0TitleFontStyle {
     fn from(value: &LegendSubtype0TitleFontStyle) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype0TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16566,6 +20664,16 @@ impl From<&LegendSubtype0TitleFontWeight> for LegendSubtype0TitleFontWeight {
         value.clone()
     }
 }
+impl From<MyEnum> for LegendSubtype0TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype0TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleLimit {
@@ -16575,6 +20683,16 @@ pub enum LegendSubtype0TitleLimit {
 impl From<&LegendSubtype0TitleLimit> for LegendSubtype0TitleLimit {
     fn from(value: &LegendSubtype0TitleLimit) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16588,6 +20706,16 @@ impl From<&LegendSubtype0TitleLineHeight> for LegendSubtype0TitleLineHeight {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleOpacity {
@@ -16599,6 +20727,16 @@ impl From<&LegendSubtype0TitleOpacity> for LegendSubtype0TitleOpacity {
         value.clone()
     }
 }
+impl From<f64> for LegendSubtype0TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LegendSubtype0TitleOrient {
@@ -16608,6 +20746,16 @@ pub enum LegendSubtype0TitleOrient {
 impl From<&LegendSubtype0TitleOrient> for LegendSubtype0TitleOrient {
     fn from(value: &LegendSubtype0TitleOrient) -> Self {
         value.clone()
+    }
+}
+impl From<LegendSubtype0TitleOrientVariant0> for LegendSubtype0TitleOrient {
+    fn from(value: LegendSubtype0TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype0TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16675,6 +20823,16 @@ pub enum LegendSubtype0TitlePadding {
 impl From<&LegendSubtype0TitlePadding> for LegendSubtype0TitlePadding {
     fn from(value: &LegendSubtype0TitlePadding) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for LegendSubtype0TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype0TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16851,6 +21009,11 @@ impl Default for LinkpathTransformAs {
         LinkpathTransformAs::Variant0("path".to_string())
     }
 }
+impl From<SignalRef> for LinkpathTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformOrient {
@@ -16865,6 +21028,16 @@ impl From<&LinkpathTransformOrient> for LinkpathTransformOrient {
 impl Default for LinkpathTransformOrient {
     fn default() -> Self {
         LinkpathTransformOrient::Variant0(LinkpathTransformOrientVariant0::Vertical)
+    }
+}
+impl From<LinkpathTransformOrientVariant0> for LinkpathTransformOrient {
+    fn from(value: LinkpathTransformOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LinkpathTransformOrient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -16933,6 +21106,16 @@ impl From<&LinkpathTransformShape> for LinkpathTransformShape {
 impl Default for LinkpathTransformShape {
     fn default() -> Self {
         LinkpathTransformShape::Variant0(LinkpathTransformShapeVariant0::Line)
+    }
+}
+impl From<LinkpathTransformShapeVariant0> for LinkpathTransformShape {
+    fn from(value: LinkpathTransformShapeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LinkpathTransformShape {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17014,6 +21197,21 @@ impl Default for LinkpathTransformSourceX {
         )))
     }
 }
+impl From<ScaleField> for LinkpathTransformSourceX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LinkpathTransformSourceX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LinkpathTransformSourceX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformSourceY {
@@ -17031,6 +21229,21 @@ impl Default for LinkpathTransformSourceY {
         LinkpathTransformSourceY::ScaleField(ScaleField(StringOrSignal::Variant0(
             "source.y".to_string(),
         )))
+    }
+}
+impl From<ScaleField> for LinkpathTransformSourceY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LinkpathTransformSourceY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LinkpathTransformSourceY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17052,6 +21265,21 @@ impl Default for LinkpathTransformTargetX {
         )))
     }
 }
+impl From<ScaleField> for LinkpathTransformTargetX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LinkpathTransformTargetX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LinkpathTransformTargetX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformTargetY {
@@ -17069,6 +21297,21 @@ impl Default for LinkpathTransformTargetY {
         LinkpathTransformTargetY::ScaleField(ScaleField(StringOrSignal::Variant0(
             "target.y".to_string(),
         )))
+    }
+}
+impl From<ScaleField> for LinkpathTransformTargetY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LinkpathTransformTargetY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LinkpathTransformTargetY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17127,6 +21370,16 @@ impl From<&Listener> for Listener {
         value.clone()
     }
 }
+impl From<SignalRef> for Listener {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Stream> for Listener {
+    fn from(value: Stream) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LoessTransform {
@@ -17159,6 +21412,16 @@ impl From<&LoessTransformAs> for LoessTransformAs {
         value.clone()
     }
 }
+impl From<Vec<LoessTransformAsVariant0Item>> for LoessTransformAs {
+    fn from(value: Vec<LoessTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LoessTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformAsVariant0Item {
@@ -17168,6 +21431,11 @@ pub enum LoessTransformAsVariant0Item {
 impl From<&LoessTransformAsVariant0Item> for LoessTransformAsVariant0Item {
     fn from(value: &LoessTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for LoessTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17186,6 +21454,16 @@ impl Default for LoessTransformBandwidth {
         LoessTransformBandwidth::Variant0(0.3_f64)
     }
 }
+impl From<f64> for LoessTransformBandwidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LoessTransformBandwidth {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformGroupby {
@@ -17195,6 +21473,16 @@ pub enum LoessTransformGroupby {
 impl From<&LoessTransformGroupby> for LoessTransformGroupby {
     fn from(value: &LoessTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<LoessTransformGroupbyVariant0Item>> for LoessTransformGroupby {
+    fn from(value: Vec<LoessTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LoessTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17207,6 +21495,21 @@ pub enum LoessTransformGroupbyVariant0Item {
 impl From<&LoessTransformGroupbyVariant0Item> for LoessTransformGroupbyVariant0Item {
     fn from(value: &LoessTransformGroupbyVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for LoessTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LoessTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LoessTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17265,6 +21568,21 @@ impl From<&LoessTransformX> for LoessTransformX {
         value.clone()
     }
 }
+impl From<ScaleField> for LoessTransformX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LoessTransformX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LoessTransformX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformY {
@@ -17275,6 +21593,21 @@ pub enum LoessTransformY {
 impl From<&LoessTransformY> for LoessTransformY {
     fn from(value: &LoessTransformY) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for LoessTransformY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LoessTransformY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LoessTransformY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17310,6 +21643,16 @@ impl From<&LookupTransformAs> for LookupTransformAs {
         value.clone()
     }
 }
+impl From<Vec<LookupTransformAsVariant0Item>> for LookupTransformAs {
+    fn from(value: Vec<LookupTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LookupTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformAsVariant0Item {
@@ -17321,6 +21664,11 @@ impl From<&LookupTransformAsVariant0Item> for LookupTransformAsVariant0Item {
         value.clone()
     }
 }
+impl From<SignalRef> for LookupTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformFields {
@@ -17330,6 +21678,16 @@ pub enum LookupTransformFields {
 impl From<&LookupTransformFields> for LookupTransformFields {
     fn from(value: &LookupTransformFields) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<LookupTransformFieldsVariant0Item>> for LookupTransformFields {
+    fn from(value: Vec<LookupTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LookupTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17344,6 +21702,21 @@ impl From<&LookupTransformFieldsVariant0Item> for LookupTransformFieldsVariant0I
         value.clone()
     }
 }
+impl From<ScaleField> for LookupTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LookupTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LookupTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformKey {
@@ -17354,6 +21727,21 @@ pub enum LookupTransformKey {
 impl From<&LookupTransformKey> for LookupTransformKey {
     fn from(value: &LookupTransformKey) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for LookupTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LookupTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LookupTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17411,6 +21799,16 @@ impl From<&LookupTransformValues> for LookupTransformValues {
         value.clone()
     }
 }
+impl From<Vec<LookupTransformValuesVariant0Item>> for LookupTransformValues {
+    fn from(value: Vec<LookupTransformValuesVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LookupTransformValues {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformValuesVariant0Item {
@@ -17421,6 +21819,21 @@ pub enum LookupTransformValuesVariant0Item {
 impl From<&LookupTransformValuesVariant0Item> for LookupTransformValuesVariant0Item {
     fn from(value: &LookupTransformValuesVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for LookupTransformValuesVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for LookupTransformValuesVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for LookupTransformValuesVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17482,6 +21895,16 @@ pub enum MarkGroupFrom {
 impl From<&MarkGroupFrom> for MarkGroupFrom {
     fn from(value: &MarkGroupFrom) -> Self {
         value.clone()
+    }
+}
+impl From<From> for MarkGroupFrom {
+    fn from(value: From) -> Self {
+        Self::From(value)
+    }
+}
+impl From<Facet> for MarkGroupFrom {
+    fn from(value: Facet) -> Self {
+        Self::Facet(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17591,6 +22014,11 @@ impl From<&Markclip> for Markclip {
         value.clone()
     }
 }
+impl From<BooleanOrSignal> for Markclip {
+    fn from(value: BooleanOrSignal) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Marktype(pub String);
 impl std::ops::Deref for Marktype {
@@ -17653,6 +22081,16 @@ impl From<&NestTransformGenerate> for NestTransformGenerate {
         value.clone()
     }
 }
+impl From<bool> for NestTransformGenerate {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for NestTransformGenerate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NestTransformKeys {
@@ -17662,6 +22100,16 @@ pub enum NestTransformKeys {
 impl From<&NestTransformKeys> for NestTransformKeys {
     fn from(value: &NestTransformKeys) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<NestTransformKeysVariant0Item>> for NestTransformKeys {
+    fn from(value: Vec<NestTransformKeysVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for NestTransformKeys {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17674,6 +22122,21 @@ pub enum NestTransformKeysVariant0Item {
 impl From<&NestTransformKeysVariant0Item> for NestTransformKeysVariant0Item {
     fn from(value: &NestTransformKeysVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for NestTransformKeysVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for NestTransformKeysVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for NestTransformKeysVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -17791,6 +22254,16 @@ impl ToString for NumberModifiersBand {
         }
     }
 }
+impl From<f64> for NumberModifiersBand {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberModifiersBand {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersExponent {
@@ -17800,6 +22273,16 @@ pub enum NumberModifiersExponent {
 impl From<&NumberModifiersExponent> for NumberModifiersExponent {
     fn from(value: &NumberModifiersExponent) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for NumberModifiersExponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberModifiersExponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17813,6 +22296,16 @@ impl From<&NumberModifiersMult> for NumberModifiersMult {
         value.clone()
     }
 }
+impl From<f64> for NumberModifiersMult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberModifiersMult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersOffset {
@@ -17822,6 +22315,16 @@ pub enum NumberModifiersOffset {
 impl From<&NumberModifiersOffset> for NumberModifiersOffset {
     fn from(value: &NumberModifiersOffset) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for NumberModifiersOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberModifiersOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17835,6 +22338,16 @@ impl From<&NumberOrSignal> for NumberOrSignal {
         value.clone()
     }
 }
+impl From<f64> for NumberOrSignal {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for NumberOrSignal {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NumberValue {
@@ -17844,6 +22357,16 @@ pub enum NumberValue {
 impl From<&NumberValue> for NumberValue {
     fn from(value: &NumberValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<NumberValueVariant0Item>> for NumberValue {
+    fn from(value: Vec<NumberValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValueVariant1> for NumberValue {
+    fn from(value: NumberValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17907,6 +22430,11 @@ impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for NumberValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -17960,6 +22488,16 @@ impl ToString for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18036,6 +22574,11 @@ impl From<&NumberValueVariant1Subtype1Subtype0> for NumberValueVariant1Subtype1S
         value.clone()
     }
 }
+impl From<SignalRef> for NumberValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Subtype1Subtype0Variant3Range {
@@ -18085,6 +22628,16 @@ impl ToString for NumberValueVariant1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18166,6 +22719,21 @@ impl From<&OnEventsItemSubtype0Events> for OnEventsItemSubtype0Events {
         value.clone()
     }
 }
+impl From<Selector> for OnEventsItemSubtype0Events {
+    fn from(value: Selector) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Listener> for OnEventsItemSubtype0Events {
+    fn from(value: Listener) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Vec<Listener>> for OnEventsItemSubtype0Events {
+    fn from(value: Vec<Listener>) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum OnEventsItemSubtype1 {
     #[serde(rename = "encode")]
@@ -18176,6 +22744,11 @@ pub enum OnEventsItemSubtype1 {
 impl From<&OnEventsItemSubtype1> for OnEventsItemSubtype1 {
     fn from(value: &OnEventsItemSubtype1) -> Self {
         value.clone()
+    }
+}
+impl From<OnEventsItemSubtype1Update> for OnEventsItemSubtype1 {
+    fn from(value: OnEventsItemSubtype1Update) -> Self {
+        Self::Update(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18189,6 +22762,21 @@ pub enum OnEventsItemSubtype1Update {
 impl From<&OnEventsItemSubtype1Update> for OnEventsItemSubtype1Update {
     fn from(value: &OnEventsItemSubtype1Update) -> Self {
         value.clone()
+    }
+}
+impl From<ExprString> for OnEventsItemSubtype1Update {
+    fn from(value: ExprString) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Expr> for OnEventsItemSubtype1Update {
+    fn from(value: Expr) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for OnEventsItemSubtype1Update {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18320,6 +22908,16 @@ impl ToString for OnTriggerItemRemove {
         }
     }
 }
+impl From<bool> for OnTriggerItemRemove {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ExprString> for OnTriggerItemRemove {
+    fn from(value: ExprString) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum OrientValue {
@@ -18329,6 +22927,16 @@ pub enum OrientValue {
 impl From<&OrientValue> for OrientValue {
     fn from(value: &OrientValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<OrientValueVariant0Item>> for OrientValue {
+    fn from(value: Vec<OrientValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValueVariant1> for OrientValue {
+    fn from(value: OrientValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18390,6 +22998,11 @@ impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for OrientValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -18509,6 +23122,16 @@ impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -18581,6 +23204,11 @@ pub enum OrientValueVariant1Subtype1Subtype0 {
 impl From<&OrientValueVariant1Subtype1Subtype0> for OrientValueVariant1Subtype1Subtype0 {
     fn from(value: &OrientValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for OrientValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -18692,6 +23320,16 @@ impl ToString for OrientValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for OrientValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for OrientValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1Subtype1 {}
 impl From<&OrientValueVariant1Subtype1Subtype1> for OrientValueVariant1Subtype1Subtype1 {
@@ -18766,6 +23404,32 @@ impl Default for PackTransformAs {
         )
     }
 }
+impl
+    From<(
+        PackTransformAsVariant0,
+        PackTransformAsVariant0,
+        PackTransformAsVariant0,
+        PackTransformAsVariant0,
+        PackTransformAsVariant0,
+    )> for PackTransformAs
+{
+    fn from(
+        value: (
+            PackTransformAsVariant0,
+            PackTransformAsVariant0,
+            PackTransformAsVariant0,
+            PackTransformAsVariant0,
+            PackTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1, value.2, value.3, value.4)
+    }
+}
+impl From<SignalRef> for PackTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PackTransformAsVariant0 {
@@ -18775,6 +23439,11 @@ pub enum PackTransformAsVariant0 {
 impl From<&PackTransformAsVariant0> for PackTransformAsVariant0 {
     fn from(value: &PackTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for PackTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18789,6 +23458,21 @@ impl From<&PackTransformField> for PackTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for PackTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PackTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PackTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PackTransformPadding {
@@ -18798,6 +23482,16 @@ pub enum PackTransformPadding {
 impl From<&PackTransformPadding> for PackTransformPadding {
     fn from(value: &PackTransformPadding) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for PackTransformPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PackTransformPadding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18812,6 +23506,21 @@ impl From<&PackTransformRadius> for PackTransformRadius {
         value.clone()
     }
 }
+impl From<ScaleField> for PackTransformRadius {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PackTransformRadius {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PackTransformRadius {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PackTransformSize {
@@ -18823,6 +23532,16 @@ impl From<&PackTransformSize> for PackTransformSize {
         value.clone()
     }
 }
+impl From<(PackTransformSizeVariant0, PackTransformSizeVariant0)> for PackTransformSize {
+    fn from(value: (PackTransformSizeVariant0, PackTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for PackTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PackTransformSizeVariant0 {
@@ -18832,6 +23551,16 @@ pub enum PackTransformSizeVariant0 {
 impl From<&PackTransformSizeVariant0> for PackTransformSizeVariant0 {
     fn from(value: &PackTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for PackTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PackTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -18897,6 +23626,16 @@ pub enum Padding {
 impl From<&Padding> for Padding {
     fn from(value: &Padding) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for Padding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18966,6 +23705,34 @@ impl Default for PartitionTransformAs {
         )
     }
 }
+impl
+    From<(
+        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0,
+    )> for PartitionTransformAs
+{
+    fn from(
+        value: (
+            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1, value.2, value.3, value.4, value.5)
+    }
+}
+impl From<SignalRef> for PartitionTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformAsVariant0 {
@@ -18975,6 +23742,11 @@ pub enum PartitionTransformAsVariant0 {
 impl From<&PartitionTransformAsVariant0> for PartitionTransformAsVariant0 {
     fn from(value: &PartitionTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for PartitionTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18989,6 +23761,21 @@ impl From<&PartitionTransformField> for PartitionTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for PartitionTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PartitionTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PartitionTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformPadding {
@@ -19000,6 +23787,16 @@ impl From<&PartitionTransformPadding> for PartitionTransformPadding {
         value.clone()
     }
 }
+impl From<f64> for PartitionTransformPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PartitionTransformPadding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformRound {
@@ -19009,6 +23806,16 @@ pub enum PartitionTransformRound {
 impl From<&PartitionTransformRound> for PartitionTransformRound {
     fn from(value: &PartitionTransformRound) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for PartitionTransformRound {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PartitionTransformRound {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19025,6 +23832,26 @@ impl From<&PartitionTransformSize> for PartitionTransformSize {
         value.clone()
     }
 }
+impl
+    From<(
+        PartitionTransformSizeVariant0,
+        PartitionTransformSizeVariant0,
+    )> for PartitionTransformSize
+{
+    fn from(
+        value: (
+            PartitionTransformSizeVariant0,
+            PartitionTransformSizeVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for PartitionTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformSizeVariant0 {
@@ -19034,6 +23861,16 @@ pub enum PartitionTransformSizeVariant0 {
 impl From<&PartitionTransformSizeVariant0> for PartitionTransformSizeVariant0 {
     fn from(value: &PartitionTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for PartitionTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PartitionTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -19126,6 +23963,16 @@ impl Default for PieTransformAs {
         )
     }
 }
+impl From<(PieTransformAsVariant0, PieTransformAsVariant0)> for PieTransformAs {
+    fn from(value: (PieTransformAsVariant0, PieTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for PieTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PieTransformAsVariant0 {
@@ -19135,6 +23982,11 @@ pub enum PieTransformAsVariant0 {
 impl From<&PieTransformAsVariant0> for PieTransformAsVariant0 {
     fn from(value: &PieTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for PieTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19153,6 +24005,16 @@ impl Default for PieTransformEndAngle {
         PieTransformEndAngle::Variant0(6.283185307179586_f64)
     }
 }
+impl From<f64> for PieTransformEndAngle {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PieTransformEndAngle {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PieTransformField {
@@ -19163,6 +24025,21 @@ pub enum PieTransformField {
 impl From<&PieTransformField> for PieTransformField {
     fn from(value: &PieTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for PieTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PieTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PieTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19176,6 +24053,16 @@ impl From<&PieTransformSort> for PieTransformSort {
         value.clone()
     }
 }
+impl From<bool> for PieTransformSort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PieTransformSort {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PieTransformStartAngle {
@@ -19185,6 +24072,16 @@ pub enum PieTransformStartAngle {
 impl From<&PieTransformStartAngle> for PieTransformStartAngle {
     fn from(value: &PieTransformStartAngle) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for PieTransformStartAngle {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PieTransformStartAngle {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -19266,6 +24163,21 @@ impl From<&PivotTransformField> for PivotTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for PivotTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PivotTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PivotTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformGroupby {
@@ -19275,6 +24187,16 @@ pub enum PivotTransformGroupby {
 impl From<&PivotTransformGroupby> for PivotTransformGroupby {
     fn from(value: &PivotTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<PivotTransformGroupbyVariant0Item>> for PivotTransformGroupby {
+    fn from(value: Vec<PivotTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PivotTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19289,6 +24211,21 @@ impl From<&PivotTransformGroupbyVariant0Item> for PivotTransformGroupbyVariant0I
         value.clone()
     }
 }
+impl From<ScaleField> for PivotTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PivotTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PivotTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformKey {
@@ -19301,6 +24238,21 @@ impl From<&PivotTransformKey> for PivotTransformKey {
         value.clone()
     }
 }
+impl From<ScaleField> for PivotTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PivotTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PivotTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformLimit {
@@ -19310,6 +24262,16 @@ pub enum PivotTransformLimit {
 impl From<&PivotTransformLimit> for PivotTransformLimit {
     fn from(value: &PivotTransformLimit) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for PivotTransformLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PivotTransformLimit {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19326,6 +24288,16 @@ impl From<&PivotTransformOp> for PivotTransformOp {
 impl Default for PivotTransformOp {
     fn default() -> Self {
         PivotTransformOp::Variant0(PivotTransformOpVariant0::Sum)
+    }
+}
+impl From<PivotTransformOpVariant0> for PivotTransformOp {
+    fn from(value: PivotTransformOpVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for PivotTransformOp {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -19520,6 +24492,21 @@ impl From<&PivotTransformValue> for PivotTransformValue {
         value.clone()
     }
 }
+impl From<ScaleField> for PivotTransformValue {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for PivotTransformValue {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for PivotTransformValue {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectTransform {
@@ -19548,6 +24535,16 @@ impl From<&ProjectTransformAs> for ProjectTransformAs {
         value.clone()
     }
 }
+impl From<Vec<ProjectTransformAsVariant0Item>> for ProjectTransformAs {
+    fn from(value: Vec<ProjectTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ProjectTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformAsVariant0Item {
@@ -19558,6 +24555,11 @@ pub enum ProjectTransformAsVariant0Item {
 impl From<&ProjectTransformAsVariant0Item> for ProjectTransformAsVariant0Item {
     fn from(value: &ProjectTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ProjectTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19571,6 +24573,16 @@ impl From<&ProjectTransformFields> for ProjectTransformFields {
         value.clone()
     }
 }
+impl From<Vec<ProjectTransformFieldsVariant0Item>> for ProjectTransformFields {
+    fn from(value: Vec<ProjectTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ProjectTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformFieldsVariant0Item {
@@ -19581,6 +24593,21 @@ pub enum ProjectTransformFieldsVariant0Item {
 impl From<&ProjectTransformFieldsVariant0Item> for ProjectTransformFieldsVariant0Item {
     fn from(value: &ProjectTransformFieldsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for ProjectTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for ProjectTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for ProjectTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -19681,6 +24708,16 @@ impl From<&ProjectionCenter> for ProjectionCenter {
         value.clone()
     }
 }
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionCenter {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionCenter {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionClipExtent {
@@ -19690,6 +24727,16 @@ pub enum ProjectionClipExtent {
 impl From<&ProjectionClipExtent> for ProjectionClipExtent {
     fn from(value: &ProjectionClipExtent) -> Self {
         value.clone()
+    }
+}
+impl From<(ProjectionClipExtentVariant0, ProjectionClipExtentVariant0)> for ProjectionClipExtent {
+    fn from(value: (ProjectionClipExtentVariant0, ProjectionClipExtentVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionClipExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19703,6 +24750,16 @@ impl From<&ProjectionClipExtentVariant0> for ProjectionClipExtentVariant0 {
         value.clone()
     }
 }
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionClipExtentVariant0 {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionClipExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionExtent {
@@ -19712,6 +24769,16 @@ pub enum ProjectionExtent {
 impl From<&ProjectionExtent> for ProjectionExtent {
     fn from(value: &ProjectionExtent) -> Self {
         value.clone()
+    }
+}
+impl From<(ProjectionExtentVariant0, ProjectionExtentVariant0)> for ProjectionExtent {
+    fn from(value: (ProjectionExtentVariant0, ProjectionExtentVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19725,6 +24792,16 @@ impl From<&ProjectionExtentVariant0> for ProjectionExtentVariant0 {
         value.clone()
     }
 }
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionExtentVariant0 {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionFit {
@@ -19734,6 +24811,16 @@ pub enum ProjectionFit {
 impl From<&ProjectionFit> for ProjectionFit {
     fn from(value: &ProjectionFit) -> Self {
         value.clone()
+    }
+}
+impl From<std::collections::HashMap<String, serde_json::Value>> for ProjectionFit {
+    fn from(value: std::collections::HashMap<String, serde_json::Value>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<serde_json::Value>> for ProjectionFit {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19747,6 +24834,16 @@ impl From<&ProjectionParallels> for ProjectionParallels {
         value.clone()
     }
 }
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionParallels {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionParallels {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionRotate {
@@ -19756,6 +24853,16 @@ pub enum ProjectionRotate {
 impl From<&ProjectionRotate> for ProjectionRotate {
     fn from(value: &ProjectionRotate) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<NumberOrSignal>> for ProjectionRotate {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ProjectionRotate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19769,6 +24876,16 @@ impl From<&ProjectionSize> for ProjectionSize {
         value.clone()
     }
 }
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionSize {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionTranslate {
@@ -19778,6 +24895,16 @@ pub enum ProjectionTranslate {
 impl From<&ProjectionTranslate> for ProjectionTranslate {
     fn from(value: &ProjectionTranslate) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionTranslate {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ProjectionTranslate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19821,6 +24948,16 @@ impl Default for QuantileTransformAs {
         ])
     }
 }
+impl From<Vec<QuantileTransformAsVariant0Item>> for QuantileTransformAs {
+    fn from(value: Vec<QuantileTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for QuantileTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformAsVariant0Item {
@@ -19830,6 +24967,11 @@ pub enum QuantileTransformAsVariant0Item {
 impl From<&QuantileTransformAsVariant0Item> for QuantileTransformAsVariant0Item {
     fn from(value: &QuantileTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for QuantileTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19844,6 +24986,21 @@ impl From<&QuantileTransformField> for QuantileTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for QuantileTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for QuantileTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for QuantileTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupby {
@@ -19853,6 +25010,16 @@ pub enum QuantileTransformGroupby {
 impl From<&QuantileTransformGroupby> for QuantileTransformGroupby {
     fn from(value: &QuantileTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<QuantileTransformGroupbyVariant0Item>> for QuantileTransformGroupby {
+    fn from(value: Vec<QuantileTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for QuantileTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19867,6 +25034,21 @@ impl From<&QuantileTransformGroupbyVariant0Item> for QuantileTransformGroupbyVar
         value.clone()
     }
 }
+impl From<ScaleField> for QuantileTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for QuantileTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for QuantileTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformProbs {
@@ -19878,6 +25060,16 @@ impl From<&QuantileTransformProbs> for QuantileTransformProbs {
         value.clone()
     }
 }
+impl From<Vec<QuantileTransformProbsVariant0Item>> for QuantileTransformProbs {
+    fn from(value: Vec<QuantileTransformProbsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for QuantileTransformProbs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformProbsVariant0Item {
@@ -19887,6 +25079,16 @@ pub enum QuantileTransformProbsVariant0Item {
 impl From<&QuantileTransformProbsVariant0Item> for QuantileTransformProbsVariant0Item {
     fn from(value: &QuantileTransformProbsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for QuantileTransformProbsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for QuantileTransformProbsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19903,6 +25105,16 @@ impl From<&QuantileTransformStep> for QuantileTransformStep {
 impl Default for QuantileTransformStep {
     fn default() -> Self {
         QuantileTransformStep::Variant0(0.01_f64)
+    }
+}
+impl From<f64> for QuantileTransformStep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for QuantileTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20056,6 +25268,16 @@ impl From<&RegressionTransformAs> for RegressionTransformAs {
         value.clone()
     }
 }
+impl From<Vec<RegressionTransformAsVariant0Item>> for RegressionTransformAs {
+    fn from(value: Vec<RegressionTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for RegressionTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformAsVariant0Item {
@@ -20065,6 +25287,11 @@ pub enum RegressionTransformAsVariant0Item {
 impl From<&RegressionTransformAsVariant0Item> for RegressionTransformAsVariant0Item {
     fn from(value: &RegressionTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for RegressionTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -20081,6 +25308,26 @@ impl From<&RegressionTransformExtent> for RegressionTransformExtent {
         value.clone()
     }
 }
+impl
+    From<(
+        RegressionTransformExtentVariant0,
+        RegressionTransformExtentVariant0,
+    )> for RegressionTransformExtent
+{
+    fn from(
+        value: (
+            RegressionTransformExtentVariant0,
+            RegressionTransformExtentVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for RegressionTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformExtentVariant0 {
@@ -20090,6 +25337,16 @@ pub enum RegressionTransformExtentVariant0 {
 impl From<&RegressionTransformExtentVariant0> for RegressionTransformExtentVariant0 {
     fn from(value: &RegressionTransformExtentVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for RegressionTransformExtentVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for RegressionTransformExtentVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -20103,6 +25360,16 @@ impl From<&RegressionTransformGroupby> for RegressionTransformGroupby {
         value.clone()
     }
 }
+impl From<Vec<RegressionTransformGroupbyVariant0Item>> for RegressionTransformGroupby {
+    fn from(value: Vec<RegressionTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for RegressionTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupbyVariant0Item {
@@ -20113,6 +25380,21 @@ pub enum RegressionTransformGroupbyVariant0Item {
 impl From<&RegressionTransformGroupbyVariant0Item> for RegressionTransformGroupbyVariant0Item {
     fn from(value: &RegressionTransformGroupbyVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for RegressionTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for RegressionTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for RegressionTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -20131,6 +25413,11 @@ impl Default for RegressionTransformMethod {
         RegressionTransformMethod::Variant0("linear".to_string())
     }
 }
+impl From<SignalRef> for RegressionTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformOrder {
@@ -20147,6 +25434,16 @@ impl Default for RegressionTransformOrder {
         RegressionTransformOrder::Variant0(3_f64)
     }
 }
+impl From<f64> for RegressionTransformOrder {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for RegressionTransformOrder {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformParams {
@@ -20156,6 +25453,16 @@ pub enum RegressionTransformParams {
 impl From<&RegressionTransformParams> for RegressionTransformParams {
     fn from(value: &RegressionTransformParams) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for RegressionTransformParams {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for RegressionTransformParams {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20214,6 +25521,21 @@ impl From<&RegressionTransformX> for RegressionTransformX {
         value.clone()
     }
 }
+impl From<ScaleField> for RegressionTransformX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for RegressionTransformX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for RegressionTransformX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformY {
@@ -20224,6 +25546,21 @@ pub enum RegressionTransformY {
 impl From<&RegressionTransformY> for RegressionTransformY {
     fn from(value: &RegressionTransformY) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for RegressionTransformY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for RegressionTransformY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for RegressionTransformY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -20250,6 +25587,16 @@ pub enum ResolvefilterTransformIgnore {
 impl From<&ResolvefilterTransformIgnore> for ResolvefilterTransformIgnore {
     fn from(value: &ResolvefilterTransformIgnore) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for ResolvefilterTransformIgnore {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ResolvefilterTransformIgnore {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20335,6 +25682,16 @@ impl From<&SampleTransformSize> for SampleTransformSize {
 impl Default for SampleTransformSize {
     fn default() -> Self {
         SampleTransformSize::Variant0(1000_f64)
+    }
+}
+impl From<f64> for SampleTransformSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for SampleTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20770,6 +26127,16 @@ impl From<&ScaleBins> for ScaleBins {
         value.clone()
     }
 }
+impl From<Vec<NumberOrSignal>> for ScaleBins {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ScaleBins {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleData {
@@ -20814,6 +26181,11 @@ impl From<&ScaleDataVariant0Sort> for ScaleDataVariant0Sort {
         value.clone()
     }
 }
+impl From<bool> for ScaleDataVariant0Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant1Sort {
@@ -20834,6 +26206,11 @@ pub enum ScaleDataVariant1Sort {
 impl From<&ScaleDataVariant1Sort> for ScaleDataVariant1Sort {
     fn from(value: &ScaleDataVariant1Sort) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleDataVariant1Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -20944,6 +26321,16 @@ impl From<&ScaleDataVariant2FieldsItem> for ScaleDataVariant2FieldsItem {
         value.clone()
     }
 }
+impl From<Vec<ScaleDataVariant2FieldsItemVariant1Item>> for ScaleDataVariant2FieldsItem {
+    fn from(value: Vec<ScaleDataVariant2FieldsItemVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleDataVariant2FieldsItem {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleDataVariant2FieldsItemVariant1Item {
@@ -20997,6 +26384,16 @@ impl ToString for ScaleDataVariant2FieldsItemVariant1Item {
         }
     }
 }
+impl From<f64> for ScaleDataVariant2FieldsItemVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<bool> for ScaleDataVariant2FieldsItemVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2Sort {
@@ -21017,6 +26414,11 @@ pub enum ScaleDataVariant2Sort {
 impl From<&ScaleDataVariant2Sort> for ScaleDataVariant2Sort {
     fn from(value: &ScaleDataVariant2Sort) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleDataVariant2Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21155,6 +26557,11 @@ impl From<&ScaleInterpolate> for ScaleInterpolate {
         value.clone()
     }
 }
+impl From<SignalRef> for ScaleInterpolate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant0Domain {
@@ -21167,6 +26574,21 @@ impl From<&ScaleVariant0Domain> for ScaleVariant0Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant0DomainVariant0Item>> for ScaleVariant0Domain {
+    fn from(value: Vec<ScaleVariant0DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant0Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant0Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant0DomainRaw {
@@ -21177,6 +26599,16 @@ pub enum ScaleVariant0DomainRaw {
 impl From<&ScaleVariant0DomainRaw> for ScaleVariant0DomainRaw {
     fn from(value: &ScaleVariant0DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant0DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant0DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21192,6 +26624,26 @@ pub enum ScaleVariant0DomainVariant0Item {
 impl From<&ScaleVariant0DomainVariant0Item> for ScaleVariant0DomainVariant0Item {
     fn from(value: &ScaleVariant0DomainVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant0DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant0DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant0DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant0DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21250,6 +26702,21 @@ impl From<&ScaleVariant10Domain> for ScaleVariant10Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant10DomainVariant0Item>> for ScaleVariant10Domain {
+    fn from(value: Vec<ScaleVariant10DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant10Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10DomainRaw {
@@ -21260,6 +26727,16 @@ pub enum ScaleVariant10DomainRaw {
 impl From<&ScaleVariant10DomainRaw> for ScaleVariant10DomainRaw {
     fn from(value: &ScaleVariant10DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant10DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21277,6 +26754,26 @@ impl From<&ScaleVariant10DomainVariant0Item> for ScaleVariant10DomainVariant0Ite
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant10DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant10DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant10DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10Nice {
@@ -21287,6 +26784,21 @@ pub enum ScaleVariant10Nice {
 impl From<&ScaleVariant10Nice> for ScaleVariant10Nice {
     fn from(value: &ScaleVariant10Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant10Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for ScaleVariant10Nice {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10Nice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21306,6 +26818,21 @@ pub enum ScaleVariant10Range {
 impl From<&ScaleVariant10Range> for ScaleVariant10Range {
     fn from(value: &ScaleVariant10Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant10RangeVariant0> for ScaleVariant10Range {
+    fn from(value: ScaleVariant10RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant10RangeVariant1Item>> for ScaleVariant10Range {
+    fn from(value: Vec<ScaleVariant10RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21395,6 +26922,26 @@ impl From<&ScaleVariant10RangeVariant1Item> for ScaleVariant10RangeVariant1Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant10RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant10RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant10RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Extent {
@@ -21404,6 +26951,16 @@ pub enum ScaleVariant10RangeVariant2Extent {
 impl From<&ScaleVariant10RangeVariant2Extent> for ScaleVariant10RangeVariant2Extent {
     fn from(value: &ScaleVariant10RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant10RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant10RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21418,6 +26975,18 @@ impl From<&ScaleVariant10RangeVariant2Scheme> for ScaleVariant10RangeVariant2Sch
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>>
+    for ScaleVariant10RangeVariant2Scheme
+{
+    fn from(value: Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant10RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2SchemeVariant1Item {
@@ -21429,6 +26998,11 @@ impl From<&ScaleVariant10RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant10RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant10RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21487,6 +27061,21 @@ impl From<&ScaleVariant11Domain> for ScaleVariant11Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant11DomainVariant0Item>> for ScaleVariant11Domain {
+    fn from(value: Vec<ScaleVariant11DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant11Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11DomainRaw {
@@ -21497,6 +27086,16 @@ pub enum ScaleVariant11DomainRaw {
 impl From<&ScaleVariant11DomainRaw> for ScaleVariant11DomainRaw {
     fn from(value: &ScaleVariant11DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant11DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21514,6 +27113,26 @@ impl From<&ScaleVariant11DomainVariant0Item> for ScaleVariant11DomainVariant0Ite
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant11DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant11DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant11DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11Nice {
@@ -21524,6 +27143,21 @@ pub enum ScaleVariant11Nice {
 impl From<&ScaleVariant11Nice> for ScaleVariant11Nice {
     fn from(value: &ScaleVariant11Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant11Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for ScaleVariant11Nice {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11Nice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21543,6 +27177,21 @@ pub enum ScaleVariant11Range {
 impl From<&ScaleVariant11Range> for ScaleVariant11Range {
     fn from(value: &ScaleVariant11Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant11RangeVariant0> for ScaleVariant11Range {
+    fn from(value: ScaleVariant11RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant11RangeVariant1Item>> for ScaleVariant11Range {
+    fn from(value: Vec<ScaleVariant11RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21632,6 +27281,26 @@ impl From<&ScaleVariant11RangeVariant1Item> for ScaleVariant11RangeVariant1Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant11RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant11RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant11RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Extent {
@@ -21641,6 +27310,16 @@ pub enum ScaleVariant11RangeVariant2Extent {
 impl From<&ScaleVariant11RangeVariant2Extent> for ScaleVariant11RangeVariant2Extent {
     fn from(value: &ScaleVariant11RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant11RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant11RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21655,6 +27334,18 @@ impl From<&ScaleVariant11RangeVariant2Scheme> for ScaleVariant11RangeVariant2Sch
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>>
+    for ScaleVariant11RangeVariant2Scheme
+{
+    fn from(value: Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant11RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2SchemeVariant1Item {
@@ -21666,6 +27357,11 @@ impl From<&ScaleVariant11RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant11RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant11RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21724,6 +27420,21 @@ impl From<&ScaleVariant1Domain> for ScaleVariant1Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant1DomainVariant0Item>> for ScaleVariant1Domain {
+    fn from(value: Vec<ScaleVariant1DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant1Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1DomainRaw {
@@ -21734,6 +27445,16 @@ pub enum ScaleVariant1DomainRaw {
 impl From<&ScaleVariant1DomainRaw> for ScaleVariant1DomainRaw {
     fn from(value: &ScaleVariant1DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant1DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21749,6 +27470,26 @@ pub enum ScaleVariant1DomainVariant0Item {
 impl From<&ScaleVariant1DomainVariant0Item> for ScaleVariant1DomainVariant0Item {
     fn from(value: &ScaleVariant1DomainVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant1DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant1DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant1DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21769,6 +27510,26 @@ pub enum ScaleVariant1Range {
 impl From<&ScaleVariant1Range> for ScaleVariant1Range {
     fn from(value: &ScaleVariant1Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant1RangeVariant0> for ScaleVariant1Range {
+    fn from(value: ScaleVariant1RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant1RangeVariant1Item>> for ScaleVariant1Range {
+    fn from(value: Vec<ScaleVariant1RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<ScaleVariant1RangeVariant3> for ScaleVariant1Range {
+    fn from(value: ScaleVariant1RangeVariant3) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21858,6 +27619,26 @@ impl From<&ScaleVariant1RangeVariant1Item> for ScaleVariant1RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant1RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant1RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant1RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Extent {
@@ -21867,6 +27648,16 @@ pub enum ScaleVariant1RangeVariant2Extent {
 impl From<&ScaleVariant1RangeVariant2Extent> for ScaleVariant1RangeVariant2Extent {
     fn from(value: &ScaleVariant1RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant1RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant1RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21881,6 +27672,16 @@ impl From<&ScaleVariant1RangeVariant2Scheme> for ScaleVariant1RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>> for ScaleVariant1RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2SchemeVariant1Item {
@@ -21892,6 +27693,11 @@ impl From<&ScaleVariant1RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant1RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant1RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21938,6 +27744,11 @@ impl From<&ScaleVariant1RangeVariant3Variant0Sort> for ScaleVariant1RangeVariant
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant1Sort {
@@ -21958,6 +27769,11 @@ pub enum ScaleVariant1RangeVariant3Variant1Sort {
 impl From<&ScaleVariant1RangeVariant3Variant1Sort> for ScaleVariant1RangeVariant3Variant1Sort {
     fn from(value: &ScaleVariant1RangeVariant3Variant1Sort) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant1RangeVariant3Variant1Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22074,6 +27890,18 @@ impl From<&ScaleVariant1RangeVariant3Variant2FieldsItem>
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>>
+    for ScaleVariant1RangeVariant3Variant2FieldsItem
+{
+    fn from(value: Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant1RangeVariant3Variant2FieldsItem {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
@@ -22129,6 +27957,16 @@ impl ToString for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
         }
     }
 }
+impl From<f64> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2Sort {
@@ -22149,6 +27987,11 @@ pub enum ScaleVariant1RangeVariant3Variant2Sort {
 impl From<&ScaleVariant1RangeVariant3Variant2Sort> for ScaleVariant1RangeVariant3Variant2Sort {
     fn from(value: &ScaleVariant1RangeVariant3Variant2Sort) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant1RangeVariant3Variant2Sort {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22307,6 +28150,21 @@ impl From<&ScaleVariant2Domain> for ScaleVariant2Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant2DomainVariant0Item>> for ScaleVariant2Domain {
+    fn from(value: Vec<ScaleVariant2DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant2Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant2Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2DomainRaw {
@@ -22317,6 +28175,16 @@ pub enum ScaleVariant2DomainRaw {
 impl From<&ScaleVariant2DomainRaw> for ScaleVariant2DomainRaw {
     fn from(value: &ScaleVariant2DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant2DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant2DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22334,6 +28202,26 @@ impl From<&ScaleVariant2DomainVariant0Item> for ScaleVariant2DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant2DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant2DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant2DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant2DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant2Range {
@@ -22345,6 +28233,21 @@ pub enum ScaleVariant2Range {
 impl From<&ScaleVariant2Range> for ScaleVariant2Range {
     fn from(value: &ScaleVariant2Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant2RangeVariant0> for ScaleVariant2Range {
+    fn from(value: ScaleVariant2RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant2RangeVariant1Item>> for ScaleVariant2Range {
+    fn from(value: Vec<ScaleVariant2RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant2Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22434,6 +28337,26 @@ impl From<&ScaleVariant2RangeVariant1Item> for ScaleVariant2RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant2RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant2RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant2RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant2RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant2Type {
     #[serde(rename = "band")]
@@ -22490,6 +28413,21 @@ impl From<&ScaleVariant3Domain> for ScaleVariant3Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant3DomainVariant0Item>> for ScaleVariant3Domain {
+    fn from(value: Vec<ScaleVariant3DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant3Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant3Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3DomainRaw {
@@ -22500,6 +28438,16 @@ pub enum ScaleVariant3DomainRaw {
 impl From<&ScaleVariant3DomainRaw> for ScaleVariant3DomainRaw {
     fn from(value: &ScaleVariant3DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant3DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant3DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22517,6 +28465,26 @@ impl From<&ScaleVariant3DomainVariant0Item> for ScaleVariant3DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant3DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant3DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant3DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant3DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant3Range {
@@ -22528,6 +28496,21 @@ pub enum ScaleVariant3Range {
 impl From<&ScaleVariant3Range> for ScaleVariant3Range {
     fn from(value: &ScaleVariant3Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant3RangeVariant0> for ScaleVariant3Range {
+    fn from(value: ScaleVariant3RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant3RangeVariant1Item>> for ScaleVariant3Range {
+    fn from(value: Vec<ScaleVariant3RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant3Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22617,6 +28600,26 @@ impl From<&ScaleVariant3RangeVariant1Item> for ScaleVariant3RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant3RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant3RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant3RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant3RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant3Type {
     #[serde(rename = "point")]
@@ -22673,6 +28676,21 @@ impl From<&ScaleVariant4Domain> for ScaleVariant4Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant4DomainVariant0Item>> for ScaleVariant4Domain {
+    fn from(value: Vec<ScaleVariant4DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant4Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4DomainRaw {
@@ -22683,6 +28701,16 @@ pub enum ScaleVariant4DomainRaw {
 impl From<&ScaleVariant4DomainRaw> for ScaleVariant4DomainRaw {
     fn from(value: &ScaleVariant4DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant4DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22700,6 +28728,26 @@ impl From<&ScaleVariant4DomainVariant0Item> for ScaleVariant4DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant4DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant4DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant4DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4Nice {
@@ -22710,6 +28758,21 @@ pub enum ScaleVariant4Nice {
 impl From<&ScaleVariant4Nice> for ScaleVariant4Nice {
     fn from(value: &ScaleVariant4Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant4Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for ScaleVariant4Nice {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4Nice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22729,6 +28792,21 @@ pub enum ScaleVariant4Range {
 impl From<&ScaleVariant4Range> for ScaleVariant4Range {
     fn from(value: &ScaleVariant4Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant4RangeVariant0> for ScaleVariant4Range {
+    fn from(value: ScaleVariant4RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant4RangeVariant1Item>> for ScaleVariant4Range {
+    fn from(value: Vec<ScaleVariant4RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22818,6 +28896,26 @@ impl From<&ScaleVariant4RangeVariant1Item> for ScaleVariant4RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant4RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant4RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant4RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Extent {
@@ -22827,6 +28925,16 @@ pub enum ScaleVariant4RangeVariant2Extent {
 impl From<&ScaleVariant4RangeVariant2Extent> for ScaleVariant4RangeVariant2Extent {
     fn from(value: &ScaleVariant4RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant4RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant4RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22841,6 +28949,16 @@ impl From<&ScaleVariant4RangeVariant2Scheme> for ScaleVariant4RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>> for ScaleVariant4RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2SchemeVariant1Item {
@@ -22852,6 +28970,11 @@ impl From<&ScaleVariant4RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant4RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant4RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22914,6 +29037,21 @@ impl From<&ScaleVariant5Domain> for ScaleVariant5Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant5DomainVariant0Item>> for ScaleVariant5Domain {
+    fn from(value: Vec<ScaleVariant5DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant5Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5DomainRaw {
@@ -22924,6 +29062,16 @@ pub enum ScaleVariant5DomainRaw {
 impl From<&ScaleVariant5DomainRaw> for ScaleVariant5DomainRaw {
     fn from(value: &ScaleVariant5DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant5DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22939,6 +29087,26 @@ pub enum ScaleVariant5DomainVariant0Item {
 impl From<&ScaleVariant5DomainVariant0Item> for ScaleVariant5DomainVariant0Item {
     fn from(value: &ScaleVariant5DomainVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant5DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant5DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant5DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22958,6 +29126,21 @@ pub enum ScaleVariant5Range {
 impl From<&ScaleVariant5Range> for ScaleVariant5Range {
     fn from(value: &ScaleVariant5Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant5RangeVariant0> for ScaleVariant5Range {
+    fn from(value: ScaleVariant5RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant5RangeVariant1Item>> for ScaleVariant5Range {
+    fn from(value: Vec<ScaleVariant5RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23047,6 +29230,26 @@ impl From<&ScaleVariant5RangeVariant1Item> for ScaleVariant5RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant5RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant5RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant5RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Extent {
@@ -23056,6 +29259,16 @@ pub enum ScaleVariant5RangeVariant2Extent {
 impl From<&ScaleVariant5RangeVariant2Extent> for ScaleVariant5RangeVariant2Extent {
     fn from(value: &ScaleVariant5RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant5RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant5RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23070,6 +29283,16 @@ impl From<&ScaleVariant5RangeVariant2Scheme> for ScaleVariant5RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>> for ScaleVariant5RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant5RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2SchemeVariant1Item {
@@ -23081,6 +29304,11 @@ impl From<&ScaleVariant5RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant5RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant5RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23139,6 +29367,21 @@ impl From<&ScaleVariant6Domain> for ScaleVariant6Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant6DomainVariant0Item>> for ScaleVariant6Domain {
+    fn from(value: Vec<ScaleVariant6DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant6Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6DomainRaw {
@@ -23149,6 +29392,16 @@ pub enum ScaleVariant6DomainRaw {
 impl From<&ScaleVariant6DomainRaw> for ScaleVariant6DomainRaw {
     fn from(value: &ScaleVariant6DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant6DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23164,6 +29417,26 @@ pub enum ScaleVariant6DomainVariant0Item {
 impl From<&ScaleVariant6DomainVariant0Item> for ScaleVariant6DomainVariant0Item {
     fn from(value: &ScaleVariant6DomainVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant6DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant6DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant6DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23183,6 +29456,21 @@ pub enum ScaleVariant6Range {
 impl From<&ScaleVariant6Range> for ScaleVariant6Range {
     fn from(value: &ScaleVariant6Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant6RangeVariant0> for ScaleVariant6Range {
+    fn from(value: ScaleVariant6RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant6RangeVariant1Item>> for ScaleVariant6Range {
+    fn from(value: Vec<ScaleVariant6RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23272,6 +29560,26 @@ impl From<&ScaleVariant6RangeVariant1Item> for ScaleVariant6RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant6RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant6RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant6RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Extent {
@@ -23281,6 +29589,16 @@ pub enum ScaleVariant6RangeVariant2Extent {
 impl From<&ScaleVariant6RangeVariant2Extent> for ScaleVariant6RangeVariant2Extent {
     fn from(value: &ScaleVariant6RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant6RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant6RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23295,6 +29613,16 @@ impl From<&ScaleVariant6RangeVariant2Scheme> for ScaleVariant6RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>> for ScaleVariant6RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant6RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2SchemeVariant1Item {
@@ -23306,6 +29634,11 @@ impl From<&ScaleVariant6RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant6RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant6RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23364,6 +29697,21 @@ impl From<&ScaleVariant7Domain> for ScaleVariant7Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant7DomainVariant0Item>> for ScaleVariant7Domain {
+    fn from(value: Vec<ScaleVariant7DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant7Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7DomainRaw {
@@ -23374,6 +29722,16 @@ pub enum ScaleVariant7DomainRaw {
 impl From<&ScaleVariant7DomainRaw> for ScaleVariant7DomainRaw {
     fn from(value: &ScaleVariant7DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant7DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23391,6 +29749,26 @@ impl From<&ScaleVariant7DomainVariant0Item> for ScaleVariant7DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant7DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant7DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant7DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant7Nice {
@@ -23405,6 +29783,16 @@ pub enum ScaleVariant7Nice {
 impl From<&ScaleVariant7Nice> for ScaleVariant7Nice {
     fn from(value: &ScaleVariant7Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant7Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleVariant7NiceVariant1> for ScaleVariant7Nice {
+    fn from(value: ScaleVariant7NiceVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23488,6 +29876,16 @@ pub enum ScaleVariant7NiceVariant2Interval {
 impl From<&ScaleVariant7NiceVariant2Interval> for ScaleVariant7NiceVariant2Interval {
     fn from(value: &ScaleVariant7NiceVariant2Interval) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant7NiceVariant2IntervalVariant0> for ScaleVariant7NiceVariant2Interval {
+    fn from(value: ScaleVariant7NiceVariant2IntervalVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7NiceVariant2Interval {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23583,6 +29981,21 @@ impl From<&ScaleVariant7Range> for ScaleVariant7Range {
         value.clone()
     }
 }
+impl From<ScaleVariant7RangeVariant0> for ScaleVariant7Range {
+    fn from(value: ScaleVariant7RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant7RangeVariant1Item>> for ScaleVariant7Range {
+    fn from(value: Vec<ScaleVariant7RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ScaleVariant7RangeVariant0 {
     #[serde(rename = "width")]
@@ -23670,6 +30083,26 @@ impl From<&ScaleVariant7RangeVariant1Item> for ScaleVariant7RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant7RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant7RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant7RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Extent {
@@ -23679,6 +30112,16 @@ pub enum ScaleVariant7RangeVariant2Extent {
 impl From<&ScaleVariant7RangeVariant2Extent> for ScaleVariant7RangeVariant2Extent {
     fn from(value: &ScaleVariant7RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant7RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant7RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23693,6 +30136,16 @@ impl From<&ScaleVariant7RangeVariant2Scheme> for ScaleVariant7RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>> for ScaleVariant7RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2SchemeVariant1Item {
@@ -23704,6 +30157,11 @@ impl From<&ScaleVariant7RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant7RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant7RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23766,6 +30224,21 @@ impl From<&ScaleVariant8Domain> for ScaleVariant8Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant8DomainVariant0Item>> for ScaleVariant8Domain {
+    fn from(value: Vec<ScaleVariant8DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant8Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8DomainRaw {
@@ -23776,6 +30249,16 @@ pub enum ScaleVariant8DomainRaw {
 impl From<&ScaleVariant8DomainRaw> for ScaleVariant8DomainRaw {
     fn from(value: &ScaleVariant8DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant8DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23793,6 +30276,26 @@ impl From<&ScaleVariant8DomainVariant0Item> for ScaleVariant8DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant8DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant8DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant8DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8Nice {
@@ -23803,6 +30306,21 @@ pub enum ScaleVariant8Nice {
 impl From<&ScaleVariant8Nice> for ScaleVariant8Nice {
     fn from(value: &ScaleVariant8Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant8Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for ScaleVariant8Nice {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8Nice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23822,6 +30340,21 @@ pub enum ScaleVariant8Range {
 impl From<&ScaleVariant8Range> for ScaleVariant8Range {
     fn from(value: &ScaleVariant8Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant8RangeVariant0> for ScaleVariant8Range {
+    fn from(value: ScaleVariant8RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant8RangeVariant1Item>> for ScaleVariant8Range {
+    fn from(value: Vec<ScaleVariant8RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -23911,6 +30444,26 @@ impl From<&ScaleVariant8RangeVariant1Item> for ScaleVariant8RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant8RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant8RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant8RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Extent {
@@ -23920,6 +30473,16 @@ pub enum ScaleVariant8RangeVariant2Extent {
 impl From<&ScaleVariant8RangeVariant2Extent> for ScaleVariant8RangeVariant2Extent {
     fn from(value: &ScaleVariant8RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant8RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant8RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23934,6 +30497,16 @@ impl From<&ScaleVariant8RangeVariant2Scheme> for ScaleVariant8RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>> for ScaleVariant8RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2SchemeVariant1Item {
@@ -23945,6 +30518,11 @@ impl From<&ScaleVariant8RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant8RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant8RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24011,6 +30589,21 @@ impl From<&ScaleVariant9Domain> for ScaleVariant9Domain {
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant9DomainVariant0Item>> for ScaleVariant9Domain {
+    fn from(value: Vec<ScaleVariant9DomainVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ScaleData> for ScaleVariant9Domain {
+    fn from(value: ScaleData) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9Domain {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9DomainRaw {
@@ -24021,6 +30614,16 @@ pub enum ScaleVariant9DomainRaw {
 impl From<&ScaleVariant9DomainRaw> for ScaleVariant9DomainRaw {
     fn from(value: &ScaleVariant9DomainRaw) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<serde_json::Value>> for ScaleVariant9DomainRaw {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24038,6 +30641,26 @@ impl From<&ScaleVariant9DomainVariant0Item> for ScaleVariant9DomainVariant0Item 
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant9DomainVariant0Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant9DomainVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9DomainVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant9DomainVariant0Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9Nice {
@@ -24048,6 +30671,21 @@ pub enum ScaleVariant9Nice {
 impl From<&ScaleVariant9Nice> for ScaleVariant9Nice {
     fn from(value: &ScaleVariant9Nice) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for ScaleVariant9Nice {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<f64> for ScaleVariant9Nice {
+    fn from(value: f64) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9Nice {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24067,6 +30705,21 @@ pub enum ScaleVariant9Range {
 impl From<&ScaleVariant9Range> for ScaleVariant9Range {
     fn from(value: &ScaleVariant9Range) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleVariant9RangeVariant0> for ScaleVariant9Range {
+    fn from(value: ScaleVariant9RangeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ScaleVariant9RangeVariant1Item>> for ScaleVariant9Range {
+    fn from(value: Vec<ScaleVariant9RangeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9Range {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24156,6 +30809,26 @@ impl From<&ScaleVariant9RangeVariant1Item> for ScaleVariant9RangeVariant1Item {
         value.clone()
     }
 }
+impl From<bool> for ScaleVariant9RangeVariant1Item {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<f64> for ScaleVariant9RangeVariant1Item {
+    fn from(value: f64) -> Self {
+        Self::Variant3(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9RangeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant4(value)
+    }
+}
+impl From<Vec<NumberOrSignal>> for ScaleVariant9RangeVariant1Item {
+    fn from(value: Vec<NumberOrSignal>) -> Self {
+        Self::Variant5(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Extent {
@@ -24165,6 +30838,16 @@ pub enum ScaleVariant9RangeVariant2Extent {
 impl From<&ScaleVariant9RangeVariant2Extent> for ScaleVariant9RangeVariant2Extent {
     fn from(value: &ScaleVariant9RangeVariant2Extent) -> Self {
         value.clone()
+    }
+}
+impl From<(NumberOrSignal, NumberOrSignal)> for ScaleVariant9RangeVariant2Extent {
+    fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for ScaleVariant9RangeVariant2Extent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24179,6 +30862,16 @@ impl From<&ScaleVariant9RangeVariant2Scheme> for ScaleVariant9RangeVariant2Schem
         value.clone()
     }
 }
+impl From<Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>> for ScaleVariant9RangeVariant2Scheme {
+    fn from(value: Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for ScaleVariant9RangeVariant2Scheme {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2SchemeVariant1Item {
@@ -24190,6 +30883,11 @@ impl From<&ScaleVariant9RangeVariant2SchemeVariant1Item>
 {
     fn from(value: &ScaleVariant9RangeVariant2SchemeVariant1Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for ScaleVariant9RangeVariant2SchemeVariant1Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24277,6 +30975,16 @@ impl From<&ScopeMarksItem> for ScopeMarksItem {
         value.clone()
     }
 }
+impl From<MarkGroup> for ScopeMarksItem {
+    fn from(value: MarkGroup) -> Self {
+        Self::Group(value)
+    }
+}
+impl From<MarkVisual> for ScopeMarksItem {
+    fn from(value: MarkVisual) -> Self {
+        Self::Visual(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Selector(pub String);
 impl std::ops::Deref for Selector {
@@ -24346,6 +31054,11 @@ impl Default for SequenceTransformAs {
         SequenceTransformAs::Variant0("data".to_string())
     }
 }
+impl From<SignalRef> for SequenceTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformStart {
@@ -24355,6 +31068,16 @@ pub enum SequenceTransformStart {
 impl From<&SequenceTransformStart> for SequenceTransformStart {
     fn from(value: &SequenceTransformStart) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for SequenceTransformStart {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for SequenceTransformStart {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24373,6 +31096,16 @@ impl Default for SequenceTransformStep {
         SequenceTransformStep::Variant0(1_f64)
     }
 }
+impl From<f64> for SequenceTransformStep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for SequenceTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformStop {
@@ -24382,6 +31115,16 @@ pub enum SequenceTransformStop {
 impl From<&SequenceTransformStop> for SequenceTransformStop {
     fn from(value: &SequenceTransformStop) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for SequenceTransformStop {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for SequenceTransformStop {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24580,6 +31323,16 @@ impl From<&SortOrder> for SortOrder {
         value.clone()
     }
 }
+impl From<SortOrderVariant0> for SortOrder {
+    fn from(value: SortOrderVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for SortOrder {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SortOrderVariant0 {
     #[serde(rename = "ascending")]
@@ -24670,6 +31423,16 @@ impl Default for StackTransformAs {
         )
     }
 }
+impl From<(StackTransformAsVariant0, StackTransformAsVariant0)> for StackTransformAs {
+    fn from(value: (StackTransformAsVariant0, StackTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for StackTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StackTransformAsVariant0 {
@@ -24679,6 +31442,11 @@ pub enum StackTransformAsVariant0 {
 impl From<&StackTransformAsVariant0> for StackTransformAsVariant0 {
     fn from(value: &StackTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for StackTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24693,6 +31461,21 @@ impl From<&StackTransformField> for StackTransformField {
         value.clone()
     }
 }
+impl From<ScaleField> for StackTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for StackTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for StackTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StackTransformGroupby {
@@ -24702,6 +31485,16 @@ pub enum StackTransformGroupby {
 impl From<&StackTransformGroupby> for StackTransformGroupby {
     fn from(value: &StackTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<StackTransformGroupbyVariant0Item>> for StackTransformGroupby {
+    fn from(value: Vec<StackTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for StackTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24714,6 +31507,21 @@ pub enum StackTransformGroupbyVariant0Item {
 impl From<&StackTransformGroupbyVariant0Item> for StackTransformGroupbyVariant0Item {
     fn from(value: &StackTransformGroupbyVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for StackTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for StackTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for StackTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24730,6 +31538,16 @@ impl From<&StackTransformOffset> for StackTransformOffset {
 impl Default for StackTransformOffset {
     fn default() -> Self {
         StackTransformOffset::Variant0(StackTransformOffsetVariant0::Zero)
+    }
+}
+impl From<StackTransformOffsetVariant0> for StackTransformOffset {
+    fn from(value: StackTransformOffsetVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for StackTransformOffset {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24856,6 +31674,21 @@ impl From<&StratifyTransformKey> for StratifyTransformKey {
         value.clone()
     }
 }
+impl From<ScaleField> for StratifyTransformKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for StratifyTransformKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for StratifyTransformKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StratifyTransformParentKey {
@@ -24866,6 +31699,21 @@ pub enum StratifyTransformParentKey {
 impl From<&StratifyTransformParentKey> for StratifyTransformParentKey {
     fn from(value: &StratifyTransformParentKey) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for StratifyTransformParentKey {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for StratifyTransformParentKey {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for StratifyTransformParentKey {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -24957,6 +31805,16 @@ impl From<&StreamSubtype0Filter> for StreamSubtype0Filter {
         value.clone()
     }
 }
+impl From<ExprString> for StreamSubtype0Filter {
+    fn from(value: ExprString) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ExprString>> for StreamSubtype0Filter {
+    fn from(value: Vec<ExprString>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StreamSubtype1 {
@@ -24999,6 +31857,11 @@ impl From<&StringOrSignal> for StringOrSignal {
         value.clone()
     }
 }
+impl From<SignalRef> for StringOrSignal {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringValue {
@@ -25008,6 +31871,16 @@ pub enum StringValue {
 impl From<&StringValue> for StringValue {
     fn from(value: &StringValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<StringValueVariant0Item>> for StringValue {
+    fn from(value: Vec<StringValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<StringValueVariant1> for StringValue {
+    fn from(value: StringValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25071,6 +31944,11 @@ impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for StringValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
@@ -25124,6 +32002,16 @@ impl ToString for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25200,6 +32088,11 @@ impl From<&StringValueVariant1Subtype1Subtype0> for StringValueVariant1Subtype1S
         value.clone()
     }
 }
+impl From<SignalRef> for StringValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant1Subtype1Subtype0Variant3Range {
@@ -25251,6 +32144,16 @@ impl ToString for StringValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for StringValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StringValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1Subtype1 {}
 impl From<&StringValueVariant1Subtype1Subtype1> for StringValueVariant1Subtype1Subtype1 {
@@ -25281,6 +32184,16 @@ pub enum StrokeCapValue {
 impl From<&StrokeCapValue> for StrokeCapValue {
     fn from(value: &StrokeCapValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<StrokeCapValueVariant0Item>> for StrokeCapValue {
+    fn from(value: Vec<StrokeCapValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<StrokeCapValueVariant1> for StrokeCapValue {
+    fn from(value: StrokeCapValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25344,6 +32257,11 @@ impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -25463,6 +32381,16 @@ impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Rang
         }
     }
 }
+impl From<f64> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -25535,6 +32463,11 @@ pub enum StrokeCapValueVariant1Subtype1Subtype0 {
 impl From<&StrokeCapValueVariant1Subtype1Subtype0> for StrokeCapValueVariant1Subtype1Subtype0 {
     fn from(value: &StrokeCapValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for StrokeCapValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -25642,6 +32575,16 @@ impl ToString for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1Subtype1 {}
 impl From<&StrokeCapValueVariant1Subtype1Subtype1> for StrokeCapValueVariant1Subtype1Subtype1 {
@@ -25672,6 +32615,16 @@ pub enum StrokeJoinValue {
 impl From<&StrokeJoinValue> for StrokeJoinValue {
     fn from(value: &StrokeJoinValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<StrokeJoinValueVariant0Item>> for StrokeJoinValue {
+    fn from(value: Vec<StrokeJoinValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<StrokeJoinValueVariant1> for StrokeJoinValue {
+    fn from(value: StrokeJoinValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25735,6 +32688,11 @@ impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0>
 {
     fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -25854,6 +32812,16 @@ impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Ran
         }
     }
 }
+impl From<f64> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1 {}
 impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1>
@@ -25926,6 +32894,11 @@ pub enum StrokeJoinValueVariant1Subtype1Subtype0 {
 impl From<&StrokeJoinValueVariant1Subtype1Subtype0> for StrokeJoinValueVariant1Subtype1Subtype0 {
     fn from(value: &StrokeJoinValueVariant1Subtype1Subtype0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for StrokeJoinValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -26033,6 +33006,16 @@ impl ToString for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1Subtype1 {}
 impl From<&StrokeJoinValueVariant1Subtype1Subtype1> for StrokeJoinValueVariant1Subtype1Subtype1 {
@@ -26065,6 +33048,11 @@ impl From<&Style> for Style {
         value.clone()
     }
 }
+impl From<Vec<String>> for Style {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TextOrSignal {
@@ -26074,6 +33062,16 @@ pub enum TextOrSignal {
 impl From<&TextOrSignal> for TextOrSignal {
     fn from(value: &TextOrSignal) -> Self {
         value.clone()
+    }
+}
+impl From<TextOrSignalVariant0> for TextOrSignal {
+    fn from(value: TextOrSignalVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TextOrSignal {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26087,6 +33085,11 @@ impl From<&TextOrSignalVariant0> for TextOrSignalVariant0 {
         value.clone()
     }
 }
+impl From<Vec<String>> for TextOrSignalVariant0 {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TextValue {
@@ -26096,6 +33099,16 @@ pub enum TextValue {
 impl From<&TextValue> for TextValue {
     fn from(value: &TextValue) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<TextValueVariant0Item>> for TextValue {
+    fn from(value: Vec<TextValueVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<TextValueVariant1> for TextValue {
+    fn from(value: TextValueVariant1) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26159,6 +33172,11 @@ impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype0>
         value.clone()
     }
 }
+impl From<SignalRef> for TextValueVariant0ItemSubtype1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
@@ -26170,6 +33188,11 @@ impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
 {
     fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<String>> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26221,6 +33244,16 @@ impl ToString for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<f64> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26297,6 +33330,11 @@ impl From<&TextValueVariant1Subtype1Subtype0> for TextValueVariant1Subtype1Subty
         value.clone()
     }
 }
+impl From<SignalRef> for TextValueVariant1Subtype1Subtype0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant0(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant1Subtype1Subtype0Variant1Value {
@@ -26308,6 +33346,11 @@ impl From<&TextValueVariant1Subtype1Subtype0Variant1Value>
 {
     fn from(value: &TextValueVariant1Subtype1Subtype0Variant1Value) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<String>> for TextValueVariant1Subtype1Subtype0Variant1Value {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26361,6 +33404,16 @@ impl ToString for TextValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
+impl From<f64> for TextValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for TextValueVariant1Subtype1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1Subtype1 {}
 impl From<&TextValueVariant1Subtype1Subtype1> for TextValueVariant1Subtype1Subtype1 {
@@ -26391,6 +33444,16 @@ pub enum TickBand {
 impl From<&TickBand> for TickBand {
     fn from(value: &TickBand) -> Self {
         value.clone()
+    }
+}
+impl From<TickBandVariant0> for TickBand {
+    fn from(value: TickBandVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TickBand {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -26456,6 +33519,21 @@ pub enum TickCount {
 impl From<&TickCount> for TickCount {
     fn from(value: &TickCount) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TickCount {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<TickCountVariant1> for TickCount {
+    fn from(value: TickCountVariant1) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<SignalRef> for TickCount {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -26539,6 +33617,16 @@ pub enum TickCountVariant2Interval {
 impl From<&TickCountVariant2Interval> for TickCountVariant2Interval {
     fn from(value: &TickCountVariant2Interval) -> Self {
         value.clone()
+    }
+}
+impl From<TickCountVariant2IntervalVariant0> for TickCountVariant2Interval {
+    fn from(value: TickCountVariant2IntervalVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TickCountVariant2Interval {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -26660,6 +33748,16 @@ impl Default for TimeunitTransformAs {
         )
     }
 }
+impl From<(TimeunitTransformAsVariant0, TimeunitTransformAsVariant0)> for TimeunitTransformAs {
+    fn from(value: (TimeunitTransformAsVariant0, TimeunitTransformAsVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for TimeunitTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformAsVariant0 {
@@ -26669,6 +33767,11 @@ pub enum TimeunitTransformAsVariant0 {
 impl From<&TimeunitTransformAsVariant0> for TimeunitTransformAsVariant0 {
     fn from(value: &TimeunitTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for TimeunitTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26682,6 +33785,16 @@ impl From<&TimeunitTransformExtent> for TimeunitTransformExtent {
         value.clone()
     }
 }
+impl From<Vec<TimeunitTransformExtentVariant0Item>> for TimeunitTransformExtent {
+    fn from(value: Vec<TimeunitTransformExtentVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtentVariant0Item {
@@ -26691,6 +33804,16 @@ pub enum TimeunitTransformExtentVariant0Item {
 impl From<&TimeunitTransformExtentVariant0Item> for TimeunitTransformExtentVariant0Item {
     fn from(value: &TimeunitTransformExtentVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TimeunitTransformExtentVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformExtentVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26703,6 +33826,21 @@ pub enum TimeunitTransformField {
 impl From<&TimeunitTransformField> for TimeunitTransformField {
     fn from(value: &TimeunitTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for TimeunitTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for TimeunitTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for TimeunitTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26721,6 +33859,16 @@ impl Default for TimeunitTransformInterval {
         TimeunitTransformInterval::Variant0(true)
     }
 }
+impl From<bool> for TimeunitTransformInterval {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformInterval {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformMaxbins {
@@ -26735,6 +33883,16 @@ impl From<&TimeunitTransformMaxbins> for TimeunitTransformMaxbins {
 impl Default for TimeunitTransformMaxbins {
     fn default() -> Self {
         TimeunitTransformMaxbins::Variant0(40_f64)
+    }
+}
+impl From<f64> for TimeunitTransformMaxbins {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformMaxbins {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26753,6 +33911,16 @@ impl Default for TimeunitTransformStep {
         TimeunitTransformStep::Variant0(1_f64)
     }
 }
+impl From<f64> for TimeunitTransformStep {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformStep {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformTimezone {
@@ -26767,6 +33935,16 @@ impl From<&TimeunitTransformTimezone> for TimeunitTransformTimezone {
 impl Default for TimeunitTransformTimezone {
     fn default() -> Self {
         TimeunitTransformTimezone::Variant0(TimeunitTransformTimezoneVariant0::Local)
+    }
+}
+impl From<TimeunitTransformTimezoneVariant0> for TimeunitTransformTimezone {
+    fn from(value: TimeunitTransformTimezoneVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformTimezone {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -26872,6 +34050,16 @@ impl From<&TimeunitTransformUnits> for TimeunitTransformUnits {
         value.clone()
     }
 }
+impl From<Vec<TimeunitTransformUnitsVariant0Item>> for TimeunitTransformUnits {
+    fn from(value: Vec<TimeunitTransformUnitsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformUnits {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnitsVariant0Item {
@@ -26881,6 +34069,16 @@ pub enum TimeunitTransformUnitsVariant0Item {
 impl From<&TimeunitTransformUnitsVariant0Item> for TimeunitTransformUnitsVariant0Item {
     fn from(value: &TimeunitTransformUnitsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<TimeunitTransformUnitsVariant0ItemVariant0> for TimeunitTransformUnitsVariant0Item {
+    fn from(value: TimeunitTransformUnitsVariant0ItemVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TimeunitTransformUnitsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27090,6 +34288,16 @@ impl From<&TitleVariant1Align> for TitleVariant1Align {
         value.clone()
     }
 }
+impl From<TitleVariant1AlignVariant0> for TitleVariant1Align {
+    fn from(value: TitleVariant1AlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for TitleVariant1Align {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum TitleVariant1AlignVariant0 {
     #[serde(rename = "left")]
@@ -27151,6 +34359,16 @@ pub enum TitleVariant1Anchor {
 impl From<&TitleVariant1Anchor> for TitleVariant1Anchor {
     fn from(value: &TitleVariant1Anchor) -> Self {
         value.clone()
+    }
+}
+impl From<Option<TitleVariant1AnchorVariant0>> for TitleVariant1Anchor {
+    fn from(value: Option<TitleVariant1AnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for TitleVariant1Anchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27216,6 +34434,16 @@ impl From<&TitleVariant1Angle> for TitleVariant1Angle {
         value.clone()
     }
 }
+impl From<f64> for TitleVariant1Angle {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1Angle {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Baseline {
@@ -27225,6 +34453,16 @@ pub enum TitleVariant1Baseline {
 impl From<&TitleVariant1Baseline> for TitleVariant1Baseline {
     fn from(value: &TitleVariant1Baseline) -> Self {
         value.clone()
+    }
+}
+impl From<TitleVariant1BaselineVariant0> for TitleVariant1Baseline {
+    fn from(value: TitleVariant1BaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for TitleVariant1Baseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27303,6 +34541,11 @@ impl From<&TitleVariant1Color> for TitleVariant1Color {
         value.clone()
     }
 }
+impl From<ColorValue> for TitleVariant1Color {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Dx {
@@ -27314,6 +34557,16 @@ impl From<&TitleVariant1Dx> for TitleVariant1Dx {
         value.clone()
     }
 }
+impl From<f64> for TitleVariant1Dx {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1Dx {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Dy {
@@ -27323,6 +34576,16 @@ pub enum TitleVariant1Dy {
 impl From<&TitleVariant1Dy> for TitleVariant1Dy {
     fn from(value: &TitleVariant1Dy) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TitleVariant1Dy {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1Dy {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27371,6 +34634,11 @@ impl From<&TitleVariant1Font> for TitleVariant1Font {
         value.clone()
     }
 }
+impl From<StringValue> for TitleVariant1Font {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1FontSize {
@@ -27380,6 +34648,16 @@ pub enum TitleVariant1FontSize {
 impl From<&TitleVariant1FontSize> for TitleVariant1FontSize {
     fn from(value: &TitleVariant1FontSize) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TitleVariant1FontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1FontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27393,6 +34671,11 @@ impl From<&TitleVariant1FontStyle> for TitleVariant1FontStyle {
         value.clone()
     }
 }
+impl From<StringValue> for TitleVariant1FontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1FontWeight {
@@ -27404,6 +34687,16 @@ impl From<&TitleVariant1FontWeight> for TitleVariant1FontWeight {
         value.clone()
     }
 }
+impl From<MyEnum> for TitleVariant1FontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for TitleVariant1FontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Frame {
@@ -27413,6 +34706,16 @@ pub enum TitleVariant1Frame {
 impl From<&TitleVariant1Frame> for TitleVariant1Frame {
     fn from(value: &TitleVariant1Frame) -> Self {
         value.clone()
+    }
+}
+impl From<TitleVariant1FrameVariant0> for TitleVariant1Frame {
+    fn from(value: TitleVariant1FrameVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<StringValue> for TitleVariant1Frame {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27474,6 +34777,16 @@ impl From<&TitleVariant1Limit> for TitleVariant1Limit {
         value.clone()
     }
 }
+impl From<f64> for TitleVariant1Limit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1Limit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1LineHeight {
@@ -27483,6 +34796,16 @@ pub enum TitleVariant1LineHeight {
 impl From<&TitleVariant1LineHeight> for TitleVariant1LineHeight {
     fn from(value: &TitleVariant1LineHeight) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TitleVariant1LineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1LineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27496,6 +34819,16 @@ impl From<&TitleVariant1Offset> for TitleVariant1Offset {
         value.clone()
     }
 }
+impl From<f64> for TitleVariant1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Orient {
@@ -27505,6 +34838,16 @@ pub enum TitleVariant1Orient {
 impl From<&TitleVariant1Orient> for TitleVariant1Orient {
     fn from(value: &TitleVariant1Orient) -> Self {
         value.clone()
+    }
+}
+impl From<TitleVariant1OrientVariant0> for TitleVariant1Orient {
+    fn from(value: TitleVariant1OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TitleVariant1Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27584,6 +34927,11 @@ impl From<&TitleVariant1SubtitleColor> for TitleVariant1SubtitleColor {
         value.clone()
     }
 }
+impl From<ColorValue> for TitleVariant1SubtitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFont {
@@ -27593,6 +34941,11 @@ pub enum TitleVariant1SubtitleFont {
 impl From<&TitleVariant1SubtitleFont> for TitleVariant1SubtitleFont {
     fn from(value: &TitleVariant1SubtitleFont) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for TitleVariant1SubtitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27606,6 +34959,16 @@ impl From<&TitleVariant1SubtitleFontSize> for TitleVariant1SubtitleFontSize {
         value.clone()
     }
 }
+impl From<f64> for TitleVariant1SubtitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1SubtitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontStyle {
@@ -27615,6 +34978,11 @@ pub enum TitleVariant1SubtitleFontStyle {
 impl From<&TitleVariant1SubtitleFontStyle> for TitleVariant1SubtitleFontStyle {
     fn from(value: &TitleVariant1SubtitleFontStyle) -> Self {
         value.clone()
+    }
+}
+impl From<StringValue> for TitleVariant1SubtitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27628,6 +34996,16 @@ impl From<&TitleVariant1SubtitleFontWeight> for TitleVariant1SubtitleFontWeight 
         value.clone()
     }
 }
+impl From<MyEnum> for TitleVariant1SubtitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for TitleVariant1SubtitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleLineHeight {
@@ -27637,6 +35015,16 @@ pub enum TitleVariant1SubtitleLineHeight {
 impl From<&TitleVariant1SubtitleLineHeight> for TitleVariant1SubtitleLineHeight {
     fn from(value: &TitleVariant1SubtitleLineHeight) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TitleVariant1SubtitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for TitleVariant1SubtitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27699,6 +35087,261 @@ impl From<&Transform> for Transform {
         value.clone()
     }
 }
+impl From<CrossfilterTransform> for Transform {
+    fn from(value: CrossfilterTransform) -> Self {
+        Self::CrossfilterTransform(value)
+    }
+}
+impl From<ResolvefilterTransform> for Transform {
+    fn from(value: ResolvefilterTransform) -> Self {
+        Self::ResolvefilterTransform(value)
+    }
+}
+impl From<LinkpathTransform> for Transform {
+    fn from(value: LinkpathTransform) -> Self {
+        Self::LinkpathTransform(value)
+    }
+}
+impl From<PieTransform> for Transform {
+    fn from(value: PieTransform) -> Self {
+        Self::PieTransform(value)
+    }
+}
+impl From<StackTransform> for Transform {
+    fn from(value: StackTransform) -> Self {
+        Self::StackTransform(value)
+    }
+}
+impl From<ForceTransform> for Transform {
+    fn from(value: ForceTransform) -> Self {
+        Self::ForceTransform(value)
+    }
+}
+impl From<ContourTransform> for Transform {
+    fn from(value: ContourTransform) -> Self {
+        Self::ContourTransform(value)
+    }
+}
+impl From<GeojsonTransform> for Transform {
+    fn from(value: GeojsonTransform) -> Self {
+        Self::GeojsonTransform(value)
+    }
+}
+impl From<GeopathTransform> for Transform {
+    fn from(value: GeopathTransform) -> Self {
+        Self::GeopathTransform(value)
+    }
+}
+impl From<GeopointTransform> for Transform {
+    fn from(value: GeopointTransform) -> Self {
+        Self::GeopointTransform(value)
+    }
+}
+impl From<GeoshapeTransform> for Transform {
+    fn from(value: GeoshapeTransform) -> Self {
+        Self::GeoshapeTransform(value)
+    }
+}
+impl From<GraticuleTransform> for Transform {
+    fn from(value: GraticuleTransform) -> Self {
+        Self::GraticuleTransform(value)
+    }
+}
+impl From<HeatmapTransform> for Transform {
+    fn from(value: HeatmapTransform) -> Self {
+        Self::HeatmapTransform(value)
+    }
+}
+impl From<IsocontourTransform> for Transform {
+    fn from(value: IsocontourTransform) -> Self {
+        Self::IsocontourTransform(value)
+    }
+}
+impl From<Kde2dTransform> for Transform {
+    fn from(value: Kde2dTransform) -> Self {
+        Self::Kde2dTransform(value)
+    }
+}
+impl From<NestTransform> for Transform {
+    fn from(value: NestTransform) -> Self {
+        Self::NestTransform(value)
+    }
+}
+impl From<PackTransform> for Transform {
+    fn from(value: PackTransform) -> Self {
+        Self::PackTransform(value)
+    }
+}
+impl From<PartitionTransform> for Transform {
+    fn from(value: PartitionTransform) -> Self {
+        Self::PartitionTransform(value)
+    }
+}
+impl From<StratifyTransform> for Transform {
+    fn from(value: StratifyTransform) -> Self {
+        Self::StratifyTransform(value)
+    }
+}
+impl From<TreeTransform> for Transform {
+    fn from(value: TreeTransform) -> Self {
+        Self::TreeTransform(value)
+    }
+}
+impl From<TreelinksTransform> for Transform {
+    fn from(value: TreelinksTransform) -> Self {
+        Self::TreelinksTransform(value)
+    }
+}
+impl From<TreemapTransform> for Transform {
+    fn from(value: TreemapTransform) -> Self {
+        Self::TreemapTransform(value)
+    }
+}
+impl From<LabelTransform> for Transform {
+    fn from(value: LabelTransform) -> Self {
+        Self::LabelTransform(value)
+    }
+}
+impl From<LoessTransform> for Transform {
+    fn from(value: LoessTransform) -> Self {
+        Self::LoessTransform(value)
+    }
+}
+impl From<RegressionTransform> for Transform {
+    fn from(value: RegressionTransform) -> Self {
+        Self::RegressionTransform(value)
+    }
+}
+impl From<AggregateTransform> for Transform {
+    fn from(value: AggregateTransform) -> Self {
+        Self::AggregateTransform(value)
+    }
+}
+impl From<BinTransform> for Transform {
+    fn from(value: BinTransform) -> Self {
+        Self::BinTransform(value)
+    }
+}
+impl From<CollectTransform> for Transform {
+    fn from(value: CollectTransform) -> Self {
+        Self::CollectTransform(value)
+    }
+}
+impl From<CountpatternTransform> for Transform {
+    fn from(value: CountpatternTransform) -> Self {
+        Self::CountpatternTransform(value)
+    }
+}
+impl From<CrossTransform> for Transform {
+    fn from(value: CrossTransform) -> Self {
+        Self::CrossTransform(value)
+    }
+}
+impl From<DensityTransform> for Transform {
+    fn from(value: DensityTransform) -> Self {
+        Self::DensityTransform(value)
+    }
+}
+impl From<DotbinTransform> for Transform {
+    fn from(value: DotbinTransform) -> Self {
+        Self::DotbinTransform(value)
+    }
+}
+impl From<ExtentTransform> for Transform {
+    fn from(value: ExtentTransform) -> Self {
+        Self::ExtentTransform(value)
+    }
+}
+impl From<FilterTransform> for Transform {
+    fn from(value: FilterTransform) -> Self {
+        Self::FilterTransform(value)
+    }
+}
+impl From<FlattenTransform> for Transform {
+    fn from(value: FlattenTransform) -> Self {
+        Self::FlattenTransform(value)
+    }
+}
+impl From<FoldTransform> for Transform {
+    fn from(value: FoldTransform) -> Self {
+        Self::FoldTransform(value)
+    }
+}
+impl From<FormulaTransform> for Transform {
+    fn from(value: FormulaTransform) -> Self {
+        Self::FormulaTransform(value)
+    }
+}
+impl From<ImputeTransform> for Transform {
+    fn from(value: ImputeTransform) -> Self {
+        Self::ImputeTransform(value)
+    }
+}
+impl From<JoinaggregateTransform> for Transform {
+    fn from(value: JoinaggregateTransform) -> Self {
+        Self::JoinaggregateTransform(value)
+    }
+}
+impl From<KdeTransform> for Transform {
+    fn from(value: KdeTransform) -> Self {
+        Self::KdeTransform(value)
+    }
+}
+impl From<LookupTransform> for Transform {
+    fn from(value: LookupTransform) -> Self {
+        Self::LookupTransform(value)
+    }
+}
+impl From<PivotTransform> for Transform {
+    fn from(value: PivotTransform) -> Self {
+        Self::PivotTransform(value)
+    }
+}
+impl From<ProjectTransform> for Transform {
+    fn from(value: ProjectTransform) -> Self {
+        Self::ProjectTransform(value)
+    }
+}
+impl From<QuantileTransform> for Transform {
+    fn from(value: QuantileTransform) -> Self {
+        Self::QuantileTransform(value)
+    }
+}
+impl From<SampleTransform> for Transform {
+    fn from(value: SampleTransform) -> Self {
+        Self::SampleTransform(value)
+    }
+}
+impl From<SequenceTransform> for Transform {
+    fn from(value: SequenceTransform) -> Self {
+        Self::SequenceTransform(value)
+    }
+}
+impl From<TimeunitTransform> for Transform {
+    fn from(value: TimeunitTransform) -> Self {
+        Self::TimeunitTransform(value)
+    }
+}
+impl From<WindowTransform> for Transform {
+    fn from(value: WindowTransform) -> Self {
+        Self::WindowTransform(value)
+    }
+}
+impl From<IdentifierTransform> for Transform {
+    fn from(value: IdentifierTransform) -> Self {
+        Self::IdentifierTransform(value)
+    }
+}
+impl From<VoronoiTransform> for Transform {
+    fn from(value: VoronoiTransform) -> Self {
+        Self::VoronoiTransform(value)
+    }
+}
+impl From<WordcloudTransform> for Transform {
+    fn from(value: WordcloudTransform) -> Self {
+        Self::WordcloudTransform(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TransformMark {
@@ -27736,6 +35379,156 @@ pub enum TransformMark {
 impl From<&TransformMark> for TransformMark {
     fn from(value: &TransformMark) -> Self {
         value.clone()
+    }
+}
+impl From<CrossfilterTransform> for TransformMark {
+    fn from(value: CrossfilterTransform) -> Self {
+        Self::CrossfilterTransform(value)
+    }
+}
+impl From<ResolvefilterTransform> for TransformMark {
+    fn from(value: ResolvefilterTransform) -> Self {
+        Self::ResolvefilterTransform(value)
+    }
+}
+impl From<LinkpathTransform> for TransformMark {
+    fn from(value: LinkpathTransform) -> Self {
+        Self::LinkpathTransform(value)
+    }
+}
+impl From<PieTransform> for TransformMark {
+    fn from(value: PieTransform) -> Self {
+        Self::PieTransform(value)
+    }
+}
+impl From<StackTransform> for TransformMark {
+    fn from(value: StackTransform) -> Self {
+        Self::StackTransform(value)
+    }
+}
+impl From<ForceTransform> for TransformMark {
+    fn from(value: ForceTransform) -> Self {
+        Self::ForceTransform(value)
+    }
+}
+impl From<GeojsonTransform> for TransformMark {
+    fn from(value: GeojsonTransform) -> Self {
+        Self::GeojsonTransform(value)
+    }
+}
+impl From<GeopathTransform> for TransformMark {
+    fn from(value: GeopathTransform) -> Self {
+        Self::GeopathTransform(value)
+    }
+}
+impl From<GeopointTransform> for TransformMark {
+    fn from(value: GeopointTransform) -> Self {
+        Self::GeopointTransform(value)
+    }
+}
+impl From<GeoshapeTransform> for TransformMark {
+    fn from(value: GeoshapeTransform) -> Self {
+        Self::GeoshapeTransform(value)
+    }
+}
+impl From<HeatmapTransform> for TransformMark {
+    fn from(value: HeatmapTransform) -> Self {
+        Self::HeatmapTransform(value)
+    }
+}
+impl From<PackTransform> for TransformMark {
+    fn from(value: PackTransform) -> Self {
+        Self::PackTransform(value)
+    }
+}
+impl From<PartitionTransform> for TransformMark {
+    fn from(value: PartitionTransform) -> Self {
+        Self::PartitionTransform(value)
+    }
+}
+impl From<StratifyTransform> for TransformMark {
+    fn from(value: StratifyTransform) -> Self {
+        Self::StratifyTransform(value)
+    }
+}
+impl From<TreeTransform> for TransformMark {
+    fn from(value: TreeTransform) -> Self {
+        Self::TreeTransform(value)
+    }
+}
+impl From<TreemapTransform> for TransformMark {
+    fn from(value: TreemapTransform) -> Self {
+        Self::TreemapTransform(value)
+    }
+}
+impl From<LabelTransform> for TransformMark {
+    fn from(value: LabelTransform) -> Self {
+        Self::LabelTransform(value)
+    }
+}
+impl From<BinTransform> for TransformMark {
+    fn from(value: BinTransform) -> Self {
+        Self::BinTransform(value)
+    }
+}
+impl From<CollectTransform> for TransformMark {
+    fn from(value: CollectTransform) -> Self {
+        Self::CollectTransform(value)
+    }
+}
+impl From<DotbinTransform> for TransformMark {
+    fn from(value: DotbinTransform) -> Self {
+        Self::DotbinTransform(value)
+    }
+}
+impl From<ExtentTransform> for TransformMark {
+    fn from(value: ExtentTransform) -> Self {
+        Self::ExtentTransform(value)
+    }
+}
+impl From<FormulaTransform> for TransformMark {
+    fn from(value: FormulaTransform) -> Self {
+        Self::FormulaTransform(value)
+    }
+}
+impl From<JoinaggregateTransform> for TransformMark {
+    fn from(value: JoinaggregateTransform) -> Self {
+        Self::JoinaggregateTransform(value)
+    }
+}
+impl From<LookupTransform> for TransformMark {
+    fn from(value: LookupTransform) -> Self {
+        Self::LookupTransform(value)
+    }
+}
+impl From<SampleTransform> for TransformMark {
+    fn from(value: SampleTransform) -> Self {
+        Self::SampleTransform(value)
+    }
+}
+impl From<TimeunitTransform> for TransformMark {
+    fn from(value: TimeunitTransform) -> Self {
+        Self::TimeunitTransform(value)
+    }
+}
+impl From<WindowTransform> for TransformMark {
+    fn from(value: WindowTransform) -> Self {
+        Self::WindowTransform(value)
+    }
+}
+impl From<IdentifierTransform> for TransformMark {
+    fn from(value: IdentifierTransform) -> Self {
+        Self::IdentifierTransform(value)
+    }
+}
+impl From<VoronoiTransform> for TransformMark {
+    fn from(value: VoronoiTransform) -> Self {
+        Self::VoronoiTransform(value)
+    }
+}
+impl From<WordcloudTransform> for TransformMark {
+    fn from(value: WordcloudTransform) -> Self {
+        Self::WordcloudTransform(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27791,6 +35584,30 @@ impl Default for TreeTransformAs {
         )
     }
 }
+impl
+    From<(
+        TreeTransformAsVariant0,
+        TreeTransformAsVariant0,
+        TreeTransformAsVariant0,
+        TreeTransformAsVariant0,
+    )> for TreeTransformAs
+{
+    fn from(
+        value: (
+            TreeTransformAsVariant0,
+            TreeTransformAsVariant0,
+            TreeTransformAsVariant0,
+            TreeTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1, value.2, value.3)
+    }
+}
+impl From<SignalRef> for TreeTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformAsVariant0 {
@@ -27800,6 +35617,11 @@ pub enum TreeTransformAsVariant0 {
 impl From<&TreeTransformAsVariant0> for TreeTransformAsVariant0 {
     fn from(value: &TreeTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for TreeTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27812,6 +35634,21 @@ pub enum TreeTransformField {
 impl From<&TreeTransformField> for TreeTransformField {
     fn from(value: &TreeTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for TreeTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for TreeTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for TreeTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27828,6 +35665,16 @@ impl From<&TreeTransformMethod> for TreeTransformMethod {
 impl Default for TreeTransformMethod {
     fn default() -> Self {
         TreeTransformMethod::Variant0(TreeTransformMethodVariant0::Tidy)
+    }
+}
+impl From<TreeTransformMethodVariant0> for TreeTransformMethod {
+    fn from(value: TreeTransformMethodVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreeTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -27889,6 +35736,18 @@ impl From<&TreeTransformNodeSize> for TreeTransformNodeSize {
         value.clone()
     }
 }
+impl From<(TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0)>
+    for TreeTransformNodeSize
+{
+    fn from(value: (TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for TreeTransformNodeSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSizeVariant0 {
@@ -27898,6 +35757,16 @@ pub enum TreeTransformNodeSizeVariant0 {
 impl From<&TreeTransformNodeSizeVariant0> for TreeTransformNodeSizeVariant0 {
     fn from(value: &TreeTransformNodeSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreeTransformNodeSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreeTransformNodeSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27916,6 +35785,16 @@ impl Default for TreeTransformSeparation {
         TreeTransformSeparation::Variant0(true)
     }
 }
+impl From<bool> for TreeTransformSeparation {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreeTransformSeparation {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSize {
@@ -27927,6 +35806,16 @@ impl From<&TreeTransformSize> for TreeTransformSize {
         value.clone()
     }
 }
+impl From<(TreeTransformSizeVariant0, TreeTransformSizeVariant0)> for TreeTransformSize {
+    fn from(value: (TreeTransformSizeVariant0, TreeTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for TreeTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSizeVariant0 {
@@ -27936,6 +35825,16 @@ pub enum TreeTransformSizeVariant0 {
 impl From<&TreeTransformSizeVariant0> for TreeTransformSizeVariant0 {
     fn from(value: &TreeTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreeTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreeTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28134,6 +36033,34 @@ impl Default for TreemapTransformAs {
         )
     }
 }
+impl
+    From<(
+        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0,
+    )> for TreemapTransformAs
+{
+    fn from(
+        value: (
+            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1, value.2, value.3, value.4, value.5)
+    }
+}
+impl From<SignalRef> for TreemapTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformAsVariant0 {
@@ -28143,6 +36070,11 @@ pub enum TreemapTransformAsVariant0 {
 impl From<&TreemapTransformAsVariant0> for TreemapTransformAsVariant0 {
     fn from(value: &TreemapTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for TreemapTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28155,6 +36087,21 @@ pub enum TreemapTransformField {
 impl From<&TreemapTransformField> for TreemapTransformField {
     fn from(value: &TreemapTransformField) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for TreemapTransformField {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for TreemapTransformField {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for TreemapTransformField {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28171,6 +36118,16 @@ impl From<&TreemapTransformMethod> for TreemapTransformMethod {
 impl Default for TreemapTransformMethod {
     fn default() -> Self {
         TreemapTransformMethod::Variant0(TreemapTransformMethodVariant0::Squarify)
+    }
+}
+impl From<TreemapTransformMethodVariant0> for TreemapTransformMethod {
+    fn from(value: TreemapTransformMethodVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformMethod {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28248,6 +36205,16 @@ impl From<&TreemapTransformPadding> for TreemapTransformPadding {
         value.clone()
     }
 }
+impl From<f64> for TreemapTransformPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPadding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingBottom {
@@ -28257,6 +36224,16 @@ pub enum TreemapTransformPaddingBottom {
 impl From<&TreemapTransformPaddingBottom> for TreemapTransformPaddingBottom {
     fn from(value: &TreemapTransformPaddingBottom) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreemapTransformPaddingBottom {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingBottom {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28270,6 +36247,16 @@ impl From<&TreemapTransformPaddingInner> for TreemapTransformPaddingInner {
         value.clone()
     }
 }
+impl From<f64> for TreemapTransformPaddingInner {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingInner {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingLeft {
@@ -28279,6 +36266,16 @@ pub enum TreemapTransformPaddingLeft {
 impl From<&TreemapTransformPaddingLeft> for TreemapTransformPaddingLeft {
     fn from(value: &TreemapTransformPaddingLeft) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreemapTransformPaddingLeft {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingLeft {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28292,6 +36289,16 @@ impl From<&TreemapTransformPaddingOuter> for TreemapTransformPaddingOuter {
         value.clone()
     }
 }
+impl From<f64> for TreemapTransformPaddingOuter {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingOuter {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingRight {
@@ -28303,6 +36310,16 @@ impl From<&TreemapTransformPaddingRight> for TreemapTransformPaddingRight {
         value.clone()
     }
 }
+impl From<f64> for TreemapTransformPaddingRight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingRight {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingTop {
@@ -28312,6 +36329,16 @@ pub enum TreemapTransformPaddingTop {
 impl From<&TreemapTransformPaddingTop> for TreemapTransformPaddingTop {
     fn from(value: &TreemapTransformPaddingTop) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreemapTransformPaddingTop {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformPaddingTop {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28330,6 +36357,16 @@ impl Default for TreemapTransformRatio {
         TreemapTransformRatio::Variant0(1.618033988749895_f64)
     }
 }
+impl From<f64> for TreemapTransformRatio {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformRatio {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformRound {
@@ -28339,6 +36376,16 @@ pub enum TreemapTransformRound {
 impl From<&TreemapTransformRound> for TreemapTransformRound {
     fn from(value: &TreemapTransformRound) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for TreemapTransformRound {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformRound {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28352,6 +36399,16 @@ impl From<&TreemapTransformSize> for TreemapTransformSize {
         value.clone()
     }
 }
+impl From<(TreemapTransformSizeVariant0, TreemapTransformSizeVariant0)> for TreemapTransformSize {
+    fn from(value: (TreemapTransformSizeVariant0, TreemapTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for TreemapTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformSizeVariant0 {
@@ -28361,6 +36418,16 @@ pub enum TreemapTransformSizeVariant0 {
 impl From<&TreemapTransformSizeVariant0> for TreemapTransformSizeVariant0 {
     fn from(value: &TreemapTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for TreemapTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for TreemapTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28444,6 +36511,11 @@ impl Default for VoronoiTransformAs {
         VoronoiTransformAs::Variant0("path".to_string())
     }
 }
+impl From<SignalRef> for VoronoiTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformExtent {
@@ -28463,6 +36535,16 @@ impl Default for VoronoiTransformExtent {
         )
     }
 }
+impl From<(serde_json::Value, serde_json::Value)> for VoronoiTransformExtent {
+    fn from(value: (serde_json::Value, serde_json::Value)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for VoronoiTransformExtent {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformSize {
@@ -28474,6 +36556,16 @@ impl From<&VoronoiTransformSize> for VoronoiTransformSize {
         value.clone()
     }
 }
+impl From<(VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0)> for VoronoiTransformSize {
+    fn from(value: (VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for VoronoiTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformSizeVariant0 {
@@ -28483,6 +36575,16 @@ pub enum VoronoiTransformSizeVariant0 {
 impl From<&VoronoiTransformSizeVariant0> for VoronoiTransformSizeVariant0 {
     fn from(value: &VoronoiTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for VoronoiTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for VoronoiTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28541,6 +36643,21 @@ impl From<&VoronoiTransformX> for VoronoiTransformX {
         value.clone()
     }
 }
+impl From<ScaleField> for VoronoiTransformX {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for VoronoiTransformX {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for VoronoiTransformX {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformY {
@@ -28551,6 +36668,21 @@ pub enum VoronoiTransformY {
 impl From<&VoronoiTransformY> for VoronoiTransformY {
     fn from(value: &VoronoiTransformY) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for VoronoiTransformY {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for VoronoiTransformY {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for VoronoiTransformY {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28597,6 +36729,16 @@ impl From<&WindowTransformAs> for WindowTransformAs {
         value.clone()
     }
 }
+impl From<Vec<WindowTransformAsVariant0Item>> for WindowTransformAs {
+    fn from(value: Vec<WindowTransformAsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformAsVariant0Item {
@@ -28607,6 +36749,11 @@ pub enum WindowTransformAsVariant0Item {
 impl From<&WindowTransformAsVariant0Item> for WindowTransformAsVariant0Item {
     fn from(value: &WindowTransformAsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for WindowTransformAsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28620,6 +36767,16 @@ impl From<&WindowTransformFields> for WindowTransformFields {
         value.clone()
     }
 }
+impl From<Vec<WindowTransformFieldsVariant0Item>> for WindowTransformFields {
+    fn from(value: Vec<WindowTransformFieldsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformFields {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFieldsVariant0Item {
@@ -28631,6 +36788,21 @@ pub enum WindowTransformFieldsVariant0Item {
 impl From<&WindowTransformFieldsVariant0Item> for WindowTransformFieldsVariant0Item {
     fn from(value: &WindowTransformFieldsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for WindowTransformFieldsVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ParamField> for WindowTransformFieldsVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WindowTransformFieldsVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28652,6 +36824,16 @@ impl Default for WindowTransformFrame {
         )
     }
 }
+impl From<(WindowTransformFrameVariant0, WindowTransformFrameVariant0)> for WindowTransformFrame {
+    fn from(value: (WindowTransformFrameVariant0, WindowTransformFrameVariant0)) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for WindowTransformFrame {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFrameVariant0 {
@@ -28664,6 +36846,16 @@ impl From<&WindowTransformFrameVariant0> for WindowTransformFrameVariant0 {
         value.clone()
     }
 }
+impl From<f64> for WindowTransformFrameVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformFrameVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformGroupby {
@@ -28673,6 +36865,16 @@ pub enum WindowTransformGroupby {
 impl From<&WindowTransformGroupby> for WindowTransformGroupby {
     fn from(value: &WindowTransformGroupby) -> Self {
         value.clone()
+    }
+}
+impl From<Vec<WindowTransformGroupbyVariant0Item>> for WindowTransformGroupby {
+    fn from(value: Vec<WindowTransformGroupbyVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformGroupby {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28687,6 +36889,21 @@ impl From<&WindowTransformGroupbyVariant0Item> for WindowTransformGroupbyVariant
         value.clone()
     }
 }
+impl From<ScaleField> for WindowTransformGroupbyVariant0Item {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for WindowTransformGroupbyVariant0Item {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for WindowTransformGroupbyVariant0Item {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformIgnorePeers {
@@ -28696,6 +36913,16 @@ pub enum WindowTransformIgnorePeers {
 impl From<&WindowTransformIgnorePeers> for WindowTransformIgnorePeers {
     fn from(value: &WindowTransformIgnorePeers) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for WindowTransformIgnorePeers {
+    fn from(value: bool) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformIgnorePeers {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28709,6 +36936,16 @@ impl From<&WindowTransformOps> for WindowTransformOps {
         value.clone()
     }
 }
+impl From<Vec<WindowTransformOpsVariant0Item>> for WindowTransformOps {
+    fn from(value: Vec<WindowTransformOpsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformOps {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformOpsVariant0Item {
@@ -28718,6 +36955,16 @@ pub enum WindowTransformOpsVariant0Item {
 impl From<&WindowTransformOpsVariant0Item> for WindowTransformOpsVariant0Item {
     fn from(value: &WindowTransformOpsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<WindowTransformOpsVariant0ItemVariant0> for WindowTransformOpsVariant0Item {
+    fn from(value: WindowTransformOpsVariant0ItemVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformOpsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28919,6 +37166,16 @@ impl From<&WindowTransformParams> for WindowTransformParams {
         value.clone()
     }
 }
+impl From<Vec<WindowTransformParamsVariant0Item>> for WindowTransformParams {
+    fn from(value: Vec<WindowTransformParamsVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformParams {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformParamsVariant0Item {
@@ -28929,6 +37186,16 @@ pub enum WindowTransformParamsVariant0Item {
 impl From<&WindowTransformParamsVariant0Item> for WindowTransformParamsVariant0Item {
     fn from(value: &WindowTransformParamsVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for WindowTransformParamsVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WindowTransformParamsVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -29054,6 +37321,38 @@ impl Default for WordcloudTransformAs {
         )
     }
 }
+impl
+    From<(
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0,
+    )> for WordcloudTransformAs
+{
+    fn from(
+        value: (
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(
+            value.0, value.1, value.2, value.3, value.4, value.5, value.6,
+        )
+    }
+}
+impl From<SignalRef> for WordcloudTransformAs {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformAsVariant0 {
@@ -29063,6 +37362,11 @@ pub enum WordcloudTransformAsVariant0 {
 impl From<&WordcloudTransformAsVariant0> for WordcloudTransformAsVariant0 {
     fn from(value: &WordcloudTransformAsVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<SignalRef> for WordcloudTransformAsVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29083,6 +37387,21 @@ impl Default for WordcloudTransformFont {
         WordcloudTransformFont::Variant0("sans-serif".to_string())
     }
 }
+impl From<SignalRef> for WordcloudTransformFont {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformFont {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformFont {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSize {
@@ -29099,6 +37418,26 @@ impl From<&WordcloudTransformFontSize> for WordcloudTransformFontSize {
 impl Default for WordcloudTransformFontSize {
     fn default() -> Self {
         WordcloudTransformFontSize::Variant0(14_f64)
+    }
+}
+impl From<f64> for WordcloudTransformFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformFontSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformFontSize {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformFontSize {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29121,6 +37460,16 @@ impl Default for WordcloudTransformFontSizeRange {
         ])
     }
 }
+impl From<Vec<WordcloudTransformFontSizeRangeVariant0Item>> for WordcloudTransformFontSizeRange {
+    fn from(value: Vec<WordcloudTransformFontSizeRangeVariant0Item>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformFontSizeRange {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRangeVariant0Item {
@@ -29132,6 +37481,16 @@ impl From<&WordcloudTransformFontSizeRangeVariant0Item>
 {
     fn from(value: &WordcloudTransformFontSizeRangeVariant0Item) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for WordcloudTransformFontSizeRangeVariant0Item {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformFontSizeRangeVariant0Item {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29152,6 +37511,21 @@ impl Default for WordcloudTransformFontStyle {
         WordcloudTransformFontStyle::Variant0("normal".to_string())
     }
 }
+impl From<SignalRef> for WordcloudTransformFontStyle {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformFontStyle {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformFontStyle {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontWeight {
@@ -29170,6 +37544,21 @@ impl Default for WordcloudTransformFontWeight {
         WordcloudTransformFontWeight::Variant0("normal".to_string())
     }
 }
+impl From<SignalRef> for WordcloudTransformFontWeight {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformFontWeight {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformFontWeight {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformPadding {
@@ -29183,6 +37572,26 @@ impl From<&WordcloudTransformPadding> for WordcloudTransformPadding {
         value.clone()
     }
 }
+impl From<f64> for WordcloudTransformPadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformPadding {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformPadding {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformPadding {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformRotate {
@@ -29194,6 +37603,26 @@ pub enum WordcloudTransformRotate {
 impl From<&WordcloudTransformRotate> for WordcloudTransformRotate {
     fn from(value: &WordcloudTransformRotate) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for WordcloudTransformRotate {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformRotate {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Expr> for WordcloudTransformRotate {
+    fn from(value: Expr) -> Self {
+        Self::Variant2(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformRotate {
+    fn from(value: ParamField) -> Self {
+        Self::Variant3(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29210,6 +37639,26 @@ impl From<&WordcloudTransformSize> for WordcloudTransformSize {
         value.clone()
     }
 }
+impl
+    From<(
+        WordcloudTransformSizeVariant0,
+        WordcloudTransformSizeVariant0,
+    )> for WordcloudTransformSize
+{
+    fn from(
+        value: (
+            WordcloudTransformSizeVariant0,
+            WordcloudTransformSizeVariant0,
+        ),
+    ) -> Self {
+        Self::Variant0(value.0, value.1)
+    }
+}
+impl From<SignalRef> for WordcloudTransformSize {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformSizeVariant0 {
@@ -29219,6 +37668,16 @@ pub enum WordcloudTransformSizeVariant0 {
 impl From<&WordcloudTransformSizeVariant0> for WordcloudTransformSizeVariant0 {
     fn from(value: &WordcloudTransformSizeVariant0) -> Self {
         value.clone()
+    }
+}
+impl From<f64> for WordcloudTransformSizeVariant0 {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for WordcloudTransformSizeVariant0 {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29232,6 +37691,11 @@ impl From<&WordcloudTransformSpiral> for WordcloudTransformSpiral {
         value.clone()
     }
 }
+impl From<SignalRef> for WordcloudTransformSpiral {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformText {
@@ -29242,6 +37706,21 @@ pub enum WordcloudTransformText {
 impl From<&WordcloudTransformText> for WordcloudTransformText {
     fn from(value: &WordcloudTransformText) -> Self {
         value.clone()
+    }
+}
+impl From<ScaleField> for WordcloudTransformText {
+    fn from(value: ScaleField) -> Self {
+        Self::ScaleField(value)
+    }
+}
+impl From<ParamField> for WordcloudTransformText {
+    fn from(value: ParamField) -> Self {
+        Self::ParamField(value)
+    }
+}
+impl From<Expr> for WordcloudTransformText {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -49,6 +49,16 @@ impl ToString for IdOrName {
         }
     }
 }
+impl From<uuid::Uuid> for IdOrName {
+    fn from(value: uuid::Uuid) -> Self {
+        Self::Id(value)
+    }
+}
+impl From<Name> for IdOrName {
+    fn from(value: Name) -> Self {
+        Self::Name(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IdOrNameRedundant {
@@ -96,6 +106,16 @@ impl ToString for IdOrNameRedundant {
             Self::Variant0(x) => x.to_string(),
             Self::Variant1(x) => x.to_string(),
         }
+    }
+}
+impl From<uuid::Uuid> for IdOrNameRedundant {
+    fn from(value: uuid::Uuid) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Name> for IdOrNameRedundant {
+    fn from(value: Name) -> Self {
+        Self::Variant1(value)
     }
 }
 #[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID."]

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -49,6 +49,11 @@ impl ToString for IntOrStr {
         }
     }
 }
+impl From<i64> for IntOrStr {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum OneOfSeveral {
@@ -62,6 +67,26 @@ pub enum OneOfSeveral {
 impl From<&OneOfSeveral> for OneOfSeveral {
     fn from(value: &OneOfSeveral) -> Self {
         value.clone()
+    }
+}
+impl From<bool> for OneOfSeveral {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+impl From<std::collections::HashMap<String, serde_json::Value>> for OneOfSeveral {
+    fn from(value: std::collections::HashMap<String, serde_json::Value>) -> Self {
+        Self::Object(value)
+    }
+}
+impl From<Vec<serde_json::Value>> for OneOfSeveral {
+    fn from(value: Vec<serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl From<i64> for OneOfSeveral {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -41,7 +41,7 @@
           "title": "V6",
           "allOf": [
             {
-              "$ref": "#/components/schemas/Ipv4Net"
+              "$ref": "#/components/schemas/Ipv6Net"
             }
           ]
         }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -133,7 +133,7 @@ impl Default for DiskAttachmentState {
 #[serde(untagged)]
 pub enum IpNet {
     V4(Ipv4Net),
-    V6(Ipv4Net),
+    V6(Ipv6Net),
 }
 impl From<&IpNet> for IpNet {
     fn from(value: &IpNet) -> Self {
@@ -176,6 +176,16 @@ impl ToString for IpNet {
             Self::V4(x) => x.to_string(),
             Self::V6(x) => x.to_string(),
         }
+    }
+}
+impl From<Ipv4Net> for IpNet {
+    fn from(value: Ipv4Net) -> Self {
+        Self::V4(value)
+    }
+}
+impl From<Ipv6Net> for IpNet {
+    fn from(value: Ipv6Net) -> Self {
+        Self::V6(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -255,6 +265,11 @@ pub enum JankNames {
 impl From<&JankNames> for JankNames {
     fn from(value: &JankNames) -> Self {
         value.clone()
+    }
+}
+impl From<AnimationSpecification> for JankNames {
+    fn from(value: AnimationSpecification) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Not 100% sure about this; it could conceivably cause a problem if a user replaced a type with `String`. We may need to rethink how we use `FromStr` vs `TryFrom<String>` for enums.