### PR TITLE
`impl From<SomeType> for builder::SomeType` to construct builders

### DIFF
--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -130,6 +130,14 @@ mod builder {
             })
         }
     }
+    impl From<super::Veggie> for Veggie {
+        fn from(value: super::Veggie) -> Self {
+            Self {
+                veggie_like: Ok(value.veggie_like),
+                veggie_name: Ok(value.veggie_name),
+            }
+        }
+    }
     pub struct Veggies {
         fruits: Result<Vec<String>, String>,
         vegetables: Result<Vec<super::Veggie>, String>,
@@ -171,6 +179,14 @@ mod builder {
                 fruits: value.fruits?,
                 vegetables: value.vegetables?,
             })
+        }
+    }
+    impl From<super::Veggies> for Veggies {
+        fn from(value: super::Veggies) -> Self {
+            Self {
+                fruits: Ok(value.fruits),
+                vegetables: Ok(value.vegetables),
+            }
         }
     }
 }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1092,7 +1092,10 @@ impl TypeEntry {
                         )*
                     }
 
-                    impl std::convert::TryFrom<#type_name> for super::#type_name {
+                    // This is how the item is built.
+                    impl std::convert::TryFrom<#type_name>
+                        for super::#type_name
+                    {
                         type Error = String;
 
                         fn try_from(value: #type_name)
@@ -1103,6 +1106,17 @@ impl TypeEntry {
                                     #prop_name: value.#prop_name?,
                                 )*
                             })
+                        }
+                    }
+
+                    // Construct a builder from the item.
+                    impl From<super::#type_name> for #type_name {
+                        fn from(value: super::#type_name) -> Self {
+                            Self {
+                                #(
+                                    #prop_name: Ok(value.#prop_name),
+                                )*
+                            }
                         }
                     }
                 },

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -127,6 +127,11 @@ mod types {
                 Ok(Self { ok: value.ok? })
             }
         }
+        impl From<super::AllTheTraits> for AllTheTraits {
+            fn from(value: super::AllTheTraits) -> Self {
+                Self { ok: Ok(value.ok) }
+            }
+        }
         pub struct CompoundType {
             value1: Result<String, String>,
             value2: Result<u64, String>,
@@ -170,6 +175,14 @@ mod types {
                 })
             }
         }
+        impl From<super::CompoundType> for CompoundType {
+            fn from(value: super::CompoundType) -> Self {
+                Self {
+                    value1: Ok(value.value1),
+                    value2: Ok(value.value2),
+                }
+            }
+        }
         pub struct Pair {
             a: Result<super::StringEnum, String>,
             b: Result<super::StringEnum, String>,
@@ -211,6 +224,14 @@ mod types {
                     a: value.a?,
                     b: value.b?,
                 })
+            }
+        }
+        impl From<super::Pair> for Pair {
+            fn from(value: super::Pair) -> Self {
+                Self {
+                    a: Ok(value.a),
+                    b: Ok(value.b),
+                }
             }
         }
     }


### PR DESCRIPTION
I intend to use this to change how progenitor handles body parameters in its builder style. And then I want to use that to make it simpler to construct requests in the CLI code-gen.