### PR TITLE
Fix recursion overflow when comparing mutual exclusivity of subschemas

### DIFF
--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -125,7 +125,7 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                 if_schema: None,
                 then_schema: None,
                 else_schema: None,
-            } => s.iter().all(|sub| schemas_mutually_exclusive(sub, b)),
+            } => s.iter().all(|sub| schemas_mutually_exclusive(sub, other)),
 
             // For a not, they're mutually exclusive if they *do* match.
             SubschemaValidation {


### PR DESCRIPTION
When comparing two `one_of` (or likely `any_of`) subschemas, this was passing the original schemas back to itself (until a stack overflow).