### PR TITLE
Various improvement to enums, arrays, and `deny_unknown_fields`

### DIFF
--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -80,7 +80,10 @@ impl TypeSpace {
             }
             None => false,
 
-            // Only particular additional properties are allowed.
+            // Only particular additional properties are allowed. Note that
+            // #[serde(deny_unknown_fields)] is incompatible with
+            // #[serde(flatten)] so we allow them even though that doesn't seem
+            // quite right.
             additional_properties @ Some(_) => {
                 let sub_type_name = type_name.as_ref().map(|base| format!("{}_extra", base));
                 let (map_type, _) = self.make_map(
@@ -98,7 +101,7 @@ impl TypeSpace {
                 };
 
                 properties.push(extra_prop);
-                true
+                false
             }
         };
 
@@ -330,7 +333,7 @@ impl TypeSpace {
             _ => None,
         }?;
         let tmp_type_name = get_type_name(&type_name, metadata);
-        let (unnamed_properties, deny) = self.struct_members(tmp_type_name, validation).ok()?;
+        let (unnamed_properties, _) = self.struct_members(tmp_type_name, validation).ok()?;
 
         let named_properties = named
             .iter()
@@ -361,7 +364,9 @@ impl TypeSpace {
                 .into_iter()
                 .chain(unnamed_properties.into_iter())
                 .collect(),
-            deny,
+            // Note that #[serde(deny_unknown_fields)] is incompatible with
+            // #[serde(flatten)] which we use for the superclass(es).
+            false,
         ))
     }
 

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -832,17 +832,6 @@ pub(crate) fn type_patch(type_space: &TypeSpace, type_name: String) -> (String, 
     }
 }
 
-pub(crate) fn none_or_single<T>(test: &Option<SingleOrVec<T>>, value: &T) -> bool
-where
-    T: Eq,
-{
-    match test {
-        None => true,
-        Some(SingleOrVec::Single(single)) if single.as_ref() == value => true,
-        _ => false,
-    }
-}
-
 pub(crate) struct StringValidator {
     max_length: Option<u32>,
     min_length: Option<u32>,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -26903,7 +26903,7 @@ impl std::convert::TryFrom<String> for WatchStartedAction {
 #[serde(untagged)]
 pub enum WebhookEvents {
     Variant0(Vec<WebhookEventsVariant0Item>),
-    Variant1(Vec<String>),
+    Variant1((String,)),
 }
 impl From<&WebhookEvents> for WebhookEvents {
     fn from(value: &WebhookEvents) -> Self {
@@ -26915,9 +26915,9 @@ impl From<Vec<WebhookEventsVariant0Item>> for WebhookEvents {
         Self::Variant0(value)
     }
 }
-impl From<Vec<String>> for WebhookEvents {
-    fn from(value: Vec<String>) -> Self {
-        Self::Variant1(value)
+impl From<(String,)> for WebhookEvents {
+    fn from(value: (String,)) -> Self {
+        Self::Variant1(value.0)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -462,7 +462,12 @@ impl std::convert::TryFrom<String> for AggregateTransformType {
 #[serde(untagged)]
 pub enum AlignValue {
     Variant0(Vec<AlignValueVariant0Item>),
-    Variant1(AlignValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: AlignValueVariant1Subtype1,
+    },
 }
 impl From<&AlignValue> for AlignValue {
     fn from(value: &AlignValue) -> Self {
@@ -472,11 +477,6 @@ impl From<&AlignValue> for AlignValue {
 impl From<Vec<AlignValueVariant0Item>> for AlignValue {
     fn from(value: Vec<AlignValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<AlignValueVariant1> for AlignValue {
-    fn from(value: AlignValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -692,18 +692,6 @@ impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AlignValueVariant1Subtype1,
-}
-impl From<&AlignValueVariant1> for AlignValueVariant1 {
-    fn from(value: &AlignValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AlignValueVariant1Subtype1Subtype0>,
@@ -883,7 +871,12 @@ impl From<&AlignValueVariant1Subtype1Subtype3> for AlignValueVariant1Subtype1Sub
 #[serde(untagged)]
 pub enum AnchorValue {
     Variant0(Vec<AnchorValueVariant0Item>),
-    Variant1(AnchorValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: AnchorValueVariant1Subtype1,
+    },
 }
 impl From<&AnchorValue> for AnchorValue {
     fn from(value: &AnchorValue) -> Self {
@@ -893,11 +886,6 @@ impl From<&AnchorValue> for AnchorValue {
 impl From<Vec<AnchorValueVariant0Item>> for AnchorValue {
     fn from(value: Vec<AnchorValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<AnchorValueVariant1> for AnchorValue {
-    fn from(value: AnchorValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1117,18 +1105,6 @@ impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AnchorValueVariant1Subtype1,
-}
-impl From<&AnchorValueVariant1> for AnchorValueVariant1 {
-    fn from(value: &AnchorValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnchorValueVariant1Subtype1Subtype0>,
@@ -1308,7 +1284,12 @@ impl From<&AnchorValueVariant1Subtype1Subtype3> for AnchorValueVariant1Subtype1S
 #[serde(untagged)]
 pub enum AnyValue {
     Variant0(Vec<AnyValueVariant0Item>),
-    Variant1(AnyValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: AnyValueVariant1Subtype1,
+    },
 }
 impl From<&AnyValue> for AnyValue {
     fn from(value: &AnyValue) -> Self {
@@ -1318,11 +1299,6 @@ impl From<&AnyValue> for AnyValue {
 impl From<Vec<AnyValueVariant0Item>> for AnyValue {
     fn from(value: Vec<AnyValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<AnyValueVariant1> for AnyValue {
-    fn from(value: AnyValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1480,18 +1456,6 @@ impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AnyValueVariant1Subtype1,
-}
-impl From<&AnyValueVariant1> for AnyValueVariant1 {
-    fn from(value: &AnyValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<AnyValueVariant1Subtype1Subtype0>,
@@ -1638,7 +1602,12 @@ impl From<SignalRef> for ArrayOrSignal {
 #[serde(untagged)]
 pub enum ArrayValue {
     Variant0(Vec<ArrayValueVariant0Item>),
-    Variant1(ArrayValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: ArrayValueVariant1Subtype1,
+    },
 }
 impl From<&ArrayValue> for ArrayValue {
     fn from(value: &ArrayValue) -> Self {
@@ -1648,11 +1617,6 @@ impl From<&ArrayValue> for ArrayValue {
 impl From<Vec<ArrayValueVariant0Item>> for ArrayValue {
     fn from(value: Vec<ArrayValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<ArrayValueVariant1> for ArrayValue {
-    fn from(value: ArrayValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1808,18 +1772,6 @@ impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype3>
     for ArrayValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: ArrayValueVariant1Subtype1,
-}
-impl From<&ArrayValueVariant1> for ArrayValueVariant1 {
-    fn from(value: &ArrayValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -2032,11 +1984,6 @@ impl std::convert::TryFrom<String> for AutosizeVariant0 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
-    }
-}
-impl Default for AutosizeVariant0 {
-    fn default() -> Self {
-        AutosizeVariant0::Pad
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -4158,7 +4105,12 @@ impl From<StringOrSignal> for Background {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum BaseColorValue {
-    Variant0(BaseColorValueVariant0),
+    Variant0 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: BaseColorValueVariant0Subtype1,
+    },
     Variant1 {
         value: LinearGradient,
     },
@@ -4169,10 +4121,10 @@ pub enum BaseColorValue {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         count: Option<f64>,
         gradient: Field,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        start: Vec<f64>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        stop: Vec<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start: Option<(f64, f64)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stop: Option<(f64, f64)>,
     },
     Variant4 {
         color: BaseColorValueVariant4Color,
@@ -4180,23 +4132,6 @@ pub enum BaseColorValue {
 }
 impl From<&BaseColorValue> for BaseColorValue {
     fn from(value: &BaseColorValue) -> Self {
-        value.clone()
-    }
-}
-impl From<BaseColorValueVariant0> for BaseColorValue {
-    fn from(value: BaseColorValueVariant0) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaseColorValueVariant0 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BaseColorValueVariant0Subtype1,
-}
-impl From<&BaseColorValueVariant0> for BaseColorValueVariant0 {
-    fn from(value: &BaseColorValueVariant0) -> Self {
         value.clone()
     }
 }
@@ -4359,7 +4294,12 @@ impl From<ColorHcl> for BaseColorValueVariant4Color {
 #[serde(untagged)]
 pub enum BaselineValue {
     Variant0(Vec<BaselineValueVariant0Item>),
-    Variant1(BaselineValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: BaselineValueVariant1Subtype1,
+    },
 }
 impl From<&BaselineValue> for BaselineValue {
     fn from(value: &BaselineValue) -> Self {
@@ -4369,11 +4309,6 @@ impl From<&BaselineValue> for BaselineValue {
 impl From<Vec<BaselineValueVariant0Item>> for BaselineValue {
     fn from(value: Vec<BaselineValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<BaselineValueVariant1> for BaselineValue {
-    fn from(value: BaselineValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4599,18 +4534,6 @@ impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype3>
     for BaselineValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BaselineValueVariant1Subtype1,
-}
-impl From<&BaselineValueVariant1> for BaselineValueVariant1 {
-    fn from(value: &BaselineValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -4857,7 +4780,7 @@ impl From<SignalRef> for BinTransformAnchor {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAs {
-    Variant0(BinTransformAsVariant0, BinTransformAsVariant0),
+    Variant0(BinTransformAsVariant0Item, BinTransformAsVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&BinTransformAs> for BinTransformAs {
@@ -4868,13 +4791,13 @@ impl From<&BinTransformAs> for BinTransformAs {
 impl Default for BinTransformAs {
     fn default() -> Self {
         BinTransformAs::Variant0(
-            BinTransformAsVariant0::Variant0("bin0".to_string()),
-            BinTransformAsVariant0::Variant0("bin1".to_string()),
+            BinTransformAsVariant0Item::Variant0("bin0".to_string()),
+            BinTransformAsVariant0Item::Variant0("bin1".to_string()),
         )
     }
 }
-impl From<(BinTransformAsVariant0, BinTransformAsVariant0)> for BinTransformAs {
-    fn from(value: (BinTransformAsVariant0, BinTransformAsVariant0)) -> Self {
+impl From<(BinTransformAsVariant0Item, BinTransformAsVariant0Item)> for BinTransformAs {
+    fn from(value: (BinTransformAsVariant0Item, BinTransformAsVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -4885,16 +4808,16 @@ impl From<SignalRef> for BinTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BinTransformAsVariant0 {
+pub enum BinTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&BinTransformAsVariant0> for BinTransformAsVariant0 {
-    fn from(value: &BinTransformAsVariant0) -> Self {
+impl From<&BinTransformAsVariant0Item> for BinTransformAsVariant0Item {
+    fn from(value: &BinTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for BinTransformAsVariant0 {
+impl From<SignalRef> for BinTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -4978,7 +4901,10 @@ impl From<SignalRef> for BinTransformDivideVariant0Item {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BinTransformExtent {
-    Variant0(BinTransformExtentVariant0, BinTransformExtentVariant0),
+    Variant0(
+        BinTransformExtentVariant0Item,
+        BinTransformExtentVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&BinTransformExtent> for BinTransformExtent {
@@ -4986,8 +4912,18 @@ impl From<&BinTransformExtent> for BinTransformExtent {
         value.clone()
     }
 }
-impl From<(BinTransformExtentVariant0, BinTransformExtentVariant0)> for BinTransformExtent {
-    fn from(value: (BinTransformExtentVariant0, BinTransformExtentVariant0)) -> Self {
+impl
+    From<(
+        BinTransformExtentVariant0Item,
+        BinTransformExtentVariant0Item,
+    )> for BinTransformExtent
+{
+    fn from(
+        value: (
+            BinTransformExtentVariant0Item,
+            BinTransformExtentVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -4998,21 +4934,21 @@ impl From<SignalRef> for BinTransformExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BinTransformExtentVariant0 {
+pub enum BinTransformExtentVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&BinTransformExtentVariant0> for BinTransformExtentVariant0 {
-    fn from(value: &BinTransformExtentVariant0) -> Self {
+impl From<&BinTransformExtentVariant0Item> for BinTransformExtentVariant0Item {
+    fn from(value: &BinTransformExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for BinTransformExtentVariant0 {
+impl From<f64> for BinTransformExtentVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for BinTransformExtentVariant0 {
+impl From<SignalRef> for BinTransformExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -5532,7 +5468,12 @@ impl<'de> serde::Deserialize<'de> for BindVariant3Input {
 #[serde(untagged)]
 pub enum BlendValue {
     Variant0(Vec<BlendValueVariant0Item>),
-    Variant1(BlendValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: BlendValueVariant1Subtype1,
+    },
 }
 impl From<&BlendValue> for BlendValue {
     fn from(value: &BlendValue) -> Self {
@@ -5542,11 +5483,6 @@ impl From<&BlendValue> for BlendValue {
 impl From<Vec<BlendValueVariant0Item>> for BlendValue {
     fn from(value: Vec<BlendValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<BlendValueVariant1> for BlendValue {
-    fn from(value: BlendValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -5810,18 +5746,6 @@ impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BlendValueVariant1Subtype1,
-}
-impl From<&BlendValueVariant1> for BlendValueVariant1 {
-    fn from(value: &BlendValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<BlendValueVariant1Subtype1Subtype0>,
@@ -6070,7 +5994,12 @@ impl From<SignalRef> for BooleanOrSignal {
 #[serde(untagged)]
 pub enum BooleanValue {
     Variant0(Vec<BooleanValueVariant0Item>),
-    Variant1(BooleanValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: BooleanValueVariant1Subtype1,
+    },
 }
 impl From<&BooleanValue> for BooleanValue {
     fn from(value: &BooleanValue) -> Self {
@@ -6080,11 +6009,6 @@ impl From<&BooleanValue> for BooleanValue {
 impl From<Vec<BooleanValueVariant0Item>> for BooleanValue {
     fn from(value: Vec<BooleanValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<BooleanValueVariant1> for BooleanValue {
-    fn from(value: BooleanValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6242,18 +6166,6 @@ impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype3>
     for BooleanValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BooleanValueVariant1Subtype1,
-}
-impl From<&BooleanValueVariant1> for BooleanValueVariant1 {
-    fn from(value: &BooleanValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -6699,7 +6611,10 @@ impl From<SignalRef> for ContourTransformNice {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformSize {
-    Variant0(ContourTransformSizeVariant0, ContourTransformSizeVariant0),
+    Variant0(
+        ContourTransformSizeVariant0Item,
+        ContourTransformSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&ContourTransformSize> for ContourTransformSize {
@@ -6707,8 +6622,18 @@ impl From<&ContourTransformSize> for ContourTransformSize {
         value.clone()
     }
 }
-impl From<(ContourTransformSizeVariant0, ContourTransformSizeVariant0)> for ContourTransformSize {
-    fn from(value: (ContourTransformSizeVariant0, ContourTransformSizeVariant0)) -> Self {
+impl
+    From<(
+        ContourTransformSizeVariant0Item,
+        ContourTransformSizeVariant0Item,
+    )> for ContourTransformSize
+{
+    fn from(
+        value: (
+            ContourTransformSizeVariant0Item,
+            ContourTransformSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -6719,21 +6644,21 @@ impl From<SignalRef> for ContourTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ContourTransformSizeVariant0 {
+pub enum ContourTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&ContourTransformSizeVariant0> for ContourTransformSizeVariant0 {
-    fn from(value: &ContourTransformSizeVariant0) -> Self {
+impl From<&ContourTransformSizeVariant0Item> for ContourTransformSizeVariant0Item {
+    fn from(value: &ContourTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for ContourTransformSizeVariant0 {
+impl From<f64> for ContourTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for ContourTransformSizeVariant0 {
+impl From<SignalRef> for ContourTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -6999,8 +6924,8 @@ impl From<&CountpatternTransform> for CountpatternTransform {
 #[serde(untagged)]
 pub enum CountpatternTransformAs {
     Variant0(
-        CountpatternTransformAsVariant0,
-        CountpatternTransformAsVariant0,
+        CountpatternTransformAsVariant0Item,
+        CountpatternTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -7012,21 +6937,21 @@ impl From<&CountpatternTransformAs> for CountpatternTransformAs {
 impl Default for CountpatternTransformAs {
     fn default() -> Self {
         CountpatternTransformAs::Variant0(
-            CountpatternTransformAsVariant0::Variant0("text".to_string()),
-            CountpatternTransformAsVariant0::Variant0("count".to_string()),
+            CountpatternTransformAsVariant0Item::Variant0("text".to_string()),
+            CountpatternTransformAsVariant0Item::Variant0("count".to_string()),
         )
     }
 }
 impl
     From<(
-        CountpatternTransformAsVariant0,
-        CountpatternTransformAsVariant0,
+        CountpatternTransformAsVariant0Item,
+        CountpatternTransformAsVariant0Item,
     )> for CountpatternTransformAs
 {
     fn from(
         value: (
-            CountpatternTransformAsVariant0,
-            CountpatternTransformAsVariant0,
+            CountpatternTransformAsVariant0Item,
+            CountpatternTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -7039,16 +6964,16 @@ impl From<SignalRef> for CountpatternTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum CountpatternTransformAsVariant0 {
+pub enum CountpatternTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&CountpatternTransformAsVariant0> for CountpatternTransformAsVariant0 {
-    fn from(value: &CountpatternTransformAsVariant0) -> Self {
+impl From<&CountpatternTransformAsVariant0Item> for CountpatternTransformAsVariant0Item {
+    fn from(value: &CountpatternTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for CountpatternTransformAsVariant0 {
+impl From<SignalRef> for CountpatternTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -7259,7 +7184,7 @@ impl From<&CrossTransform> for CrossTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CrossTransformAs {
-    Variant0(CrossTransformAsVariant0, CrossTransformAsVariant0),
+    Variant0(CrossTransformAsVariant0Item, CrossTransformAsVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&CrossTransformAs> for CrossTransformAs {
@@ -7270,13 +7195,13 @@ impl From<&CrossTransformAs> for CrossTransformAs {
 impl Default for CrossTransformAs {
     fn default() -> Self {
         CrossTransformAs::Variant0(
-            CrossTransformAsVariant0::Variant0("a".to_string()),
-            CrossTransformAsVariant0::Variant0("b".to_string()),
+            CrossTransformAsVariant0Item::Variant0("a".to_string()),
+            CrossTransformAsVariant0Item::Variant0("b".to_string()),
         )
     }
 }
-impl From<(CrossTransformAsVariant0, CrossTransformAsVariant0)> for CrossTransformAs {
-    fn from(value: (CrossTransformAsVariant0, CrossTransformAsVariant0)) -> Self {
+impl From<(CrossTransformAsVariant0Item, CrossTransformAsVariant0Item)> for CrossTransformAs {
+    fn from(value: (CrossTransformAsVariant0Item, CrossTransformAsVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -7287,16 +7212,16 @@ impl From<SignalRef> for CrossTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum CrossTransformAsVariant0 {
+pub enum CrossTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&CrossTransformAsVariant0> for CrossTransformAsVariant0 {
-    fn from(value: &CrossTransformAsVariant0) -> Self {
+impl From<&CrossTransformAsVariant0Item> for CrossTransformAsVariant0Item {
+    fn from(value: &CrossTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for CrossTransformAsVariant0 {
+impl From<SignalRef> for CrossTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -7540,7 +7465,18 @@ impl From<Vec<String>> for DataVariant1Source {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2Format {
-    Variant0(DataVariant2FormatVariant0),
+    Variant0 {
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<DataVariant2FormatVariant0Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<DataVariant2FormatVariant0Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<DataVariant2FormatVariant0Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<DataVariant2FormatVariant0Subtype3>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_4: Option<DataVariant2FormatVariant0Subtype4>,
+    },
     Variant1(SignalRef),
 }
 impl From<&DataVariant2Format> for DataVariant2Format {
@@ -7548,32 +7484,9 @@ impl From<&DataVariant2Format> for DataVariant2Format {
         value.clone()
     }
 }
-impl From<DataVariant2FormatVariant0> for DataVariant2Format {
-    fn from(value: DataVariant2FormatVariant0) -> Self {
-        Self::Variant0(value)
-    }
-}
 impl From<SignalRef> for DataVariant2Format {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DataVariant2FormatVariant0 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<DataVariant2FormatVariant0Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<DataVariant2FormatVariant0Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<DataVariant2FormatVariant0Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<DataVariant2FormatVariant0Subtype3>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_4: Option<DataVariant2FormatVariant0Subtype4>,
-}
-impl From<&DataVariant2FormatVariant0> for DataVariant2FormatVariant0 {
-    fn from(value: &DataVariant2FormatVariant0) -> Self {
-        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7589,16 +7502,12 @@ impl From<&DataVariant2FormatVariant0Subtype0> for DataVariant2FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype0Parse {
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant2FormatVariant0Subtype0ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant2FormatVariant0Subtype0Parse> for DataVariant2FormatVariant0Subtype0Parse {
@@ -7611,6 +7520,18 @@ impl From<DataVariant2FormatVariant0Subtype0ParseVariant0>
 {
     fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant2FormatVariant0Subtype0ParseVariant1Value>>
+    for DataVariant2FormatVariant0Subtype0Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant2FormatVariant0Subtype0ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant2FormatVariant0Subtype0Parse {
@@ -7666,18 +7587,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
-    Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1),
+pub enum DataVariant2FormatVariant0Subtype0ParseVariant1Value {
+    Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0),
+    Variant1(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1Value>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -7689,25 +7610,25 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -7715,22 +7636,22 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -7740,14 +7661,14 @@ pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -7757,7 +7678,7 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -7769,16 +7690,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -7786,7 +7705,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -7794,26 +7713,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -7826,16 +7745,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -7843,16 +7760,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -7880,16 +7795,12 @@ impl From<&DataVariant2FormatVariant0Subtype1> for DataVariant2FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype1Parse {
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant2FormatVariant0Subtype1ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant2FormatVariant0Subtype1Parse> for DataVariant2FormatVariant0Subtype1Parse {
@@ -7902,6 +7813,18 @@ impl From<DataVariant2FormatVariant0Subtype1ParseVariant0>
 {
     fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant2FormatVariant0Subtype1ParseVariant1Value>>
+    for DataVariant2FormatVariant0Subtype1Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant2FormatVariant0Subtype1ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant2FormatVariant0Subtype1Parse {
@@ -7957,18 +7880,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
-    Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1),
+pub enum DataVariant2FormatVariant0Subtype1ParseVariant1Value {
+    Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0),
+    Variant1(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1Value>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -7980,25 +7903,25 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -8006,22 +7929,22 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -8031,14 +7954,14 @@ pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -8048,7 +7971,7 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -8060,16 +7983,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8077,7 +7998,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -8085,26 +8006,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -8117,16 +8038,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8134,16 +8053,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -8213,16 +8130,12 @@ impl From<&DataVariant2FormatVariant0Subtype2> for DataVariant2FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype2Parse {
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant2FormatVariant0Subtype2ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant2FormatVariant0Subtype2Parse> for DataVariant2FormatVariant0Subtype2Parse {
@@ -8235,6 +8148,18 @@ impl From<DataVariant2FormatVariant0Subtype2ParseVariant0>
 {
     fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant2FormatVariant0Subtype2ParseVariant1Value>>
+    for DataVariant2FormatVariant0Subtype2Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant2FormatVariant0Subtype2ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant2FormatVariant0Subtype2Parse {
@@ -8290,18 +8215,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
-    Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1),
+pub enum DataVariant2FormatVariant0Subtype2ParseVariant1Value {
+    Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0),
+    Variant1(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1Value>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -8313,25 +8238,25 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -8339,22 +8264,22 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -8364,14 +8289,14 @@ pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -8381,7 +8306,7 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -8393,16 +8318,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8410,7 +8333,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -8418,26 +8341,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -8450,16 +8373,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8467,16 +8388,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -8551,16 +8470,12 @@ impl From<&DataVariant2FormatVariant0Subtype3> for DataVariant2FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype3Parse {
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant2FormatVariant0Subtype3ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant2FormatVariant0Subtype3Parse> for DataVariant2FormatVariant0Subtype3Parse {
@@ -8573,6 +8488,18 @@ impl From<DataVariant2FormatVariant0Subtype3ParseVariant0>
 {
     fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant2FormatVariant0Subtype3ParseVariant1Value>>
+    for DataVariant2FormatVariant0Subtype3Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant2FormatVariant0Subtype3ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant2FormatVariant0Subtype3Parse {
@@ -8628,18 +8555,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
-    Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1),
+pub enum DataVariant2FormatVariant0Subtype3ParseVariant1Value {
+    Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0),
+    Variant1(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1Value>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -8651,25 +8578,25 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -8677,22 +8604,22 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -8702,14 +8629,14 @@ pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -8719,7 +8646,7 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -8731,16 +8658,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8748,7 +8673,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -8756,26 +8681,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1>
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -8788,16 +8713,14 @@ impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -8805,16 +8728,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -9038,7 +8959,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3Format {
-    Variant0(DataVariant3FormatVariant0),
+    Variant0 {
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<DataVariant3FormatVariant0Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<DataVariant3FormatVariant0Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<DataVariant3FormatVariant0Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<DataVariant3FormatVariant0Subtype3>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_4: Option<DataVariant3FormatVariant0Subtype4>,
+    },
     Variant1(SignalRef),
 }
 impl From<&DataVariant3Format> for DataVariant3Format {
@@ -9046,32 +8978,9 @@ impl From<&DataVariant3Format> for DataVariant3Format {
         value.clone()
     }
 }
-impl From<DataVariant3FormatVariant0> for DataVariant3Format {
-    fn from(value: DataVariant3FormatVariant0) -> Self {
-        Self::Variant0(value)
-    }
-}
 impl From<SignalRef> for DataVariant3Format {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DataVariant3FormatVariant0 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<DataVariant3FormatVariant0Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<DataVariant3FormatVariant0Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<DataVariant3FormatVariant0Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<DataVariant3FormatVariant0Subtype3>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_4: Option<DataVariant3FormatVariant0Subtype4>,
-}
-impl From<&DataVariant3FormatVariant0> for DataVariant3FormatVariant0 {
-    fn from(value: &DataVariant3FormatVariant0) -> Self {
-        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9087,16 +8996,12 @@ impl From<&DataVariant3FormatVariant0Subtype0> for DataVariant3FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype0Parse {
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant3FormatVariant0Subtype0ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant3FormatVariant0Subtype0Parse> for DataVariant3FormatVariant0Subtype0Parse {
@@ -9109,6 +9014,18 @@ impl From<DataVariant3FormatVariant0Subtype0ParseVariant0>
 {
     fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant3FormatVariant0Subtype0ParseVariant1Value>>
+    for DataVariant3FormatVariant0Subtype0Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant3FormatVariant0Subtype0ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant3FormatVariant0Subtype0Parse {
@@ -9164,18 +9081,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
-    Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1),
+pub enum DataVariant3FormatVariant0Subtype0ParseVariant1Value {
+    Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0),
+    Variant1(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1Value>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -9187,25 +9104,25 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
+impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -9213,22 +9130,22 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -9238,14 +9155,14 @@ pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -9255,7 +9172,7 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -9267,16 +9184,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9284,7 +9199,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -9292,26 +9207,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -9324,16 +9239,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9341,16 +9254,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -9378,16 +9289,12 @@ impl From<&DataVariant3FormatVariant0Subtype1> for DataVariant3FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype1Parse {
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant3FormatVariant0Subtype1ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant3FormatVariant0Subtype1Parse> for DataVariant3FormatVariant0Subtype1Parse {
@@ -9400,6 +9307,18 @@ impl From<DataVariant3FormatVariant0Subtype1ParseVariant0>
 {
     fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant3FormatVariant0Subtype1ParseVariant1Value>>
+    for DataVariant3FormatVariant0Subtype1Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant3FormatVariant0Subtype1ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant3FormatVariant0Subtype1Parse {
@@ -9455,18 +9374,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
-    Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1),
+pub enum DataVariant3FormatVariant0Subtype1ParseVariant1Value {
+    Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0),
+    Variant1(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1Value>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -9478,25 +9397,25 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
+impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -9504,22 +9423,22 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -9529,14 +9448,14 @@ pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -9546,7 +9465,7 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -9558,16 +9477,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9575,7 +9492,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -9583,26 +9500,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -9615,16 +9532,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9632,16 +9547,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -9711,16 +9624,12 @@ impl From<&DataVariant3FormatVariant0Subtype2> for DataVariant3FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype2Parse {
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant3FormatVariant0Subtype2ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant3FormatVariant0Subtype2Parse> for DataVariant3FormatVariant0Subtype2Parse {
@@ -9733,6 +9642,18 @@ impl From<DataVariant3FormatVariant0Subtype2ParseVariant0>
 {
     fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant3FormatVariant0Subtype2ParseVariant1Value>>
+    for DataVariant3FormatVariant0Subtype2Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant3FormatVariant0Subtype2ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant3FormatVariant0Subtype2Parse {
@@ -9788,18 +9709,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
-    Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1),
+pub enum DataVariant3FormatVariant0Subtype2ParseVariant1Value {
+    Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0),
+    Variant1(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1Value>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -9811,25 +9732,25 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
+impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -9837,22 +9758,22 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -9862,14 +9783,14 @@ pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -9879,7 +9800,7 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -9891,16 +9812,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9908,7 +9827,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -9916,26 +9835,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -9948,16 +9867,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -9965,16 +9882,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -10049,16 +9964,12 @@ impl From<&DataVariant3FormatVariant0Subtype3> for DataVariant3FormatVariant0Sub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype3Parse {
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant0),
-    Variant1 {
-        #[serde(flatten)]
-        extra: std::collections::HashMap<
-            String,
-            DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue,
-        >,
-    },
+    Variant1(
+        std::collections::HashMap<String, DataVariant3FormatVariant0Subtype3ParseVariant1Value>,
+    ),
     Variant2(SignalRef),
 }
 impl From<&DataVariant3FormatVariant0Subtype3Parse> for DataVariant3FormatVariant0Subtype3Parse {
@@ -10071,6 +9982,18 @@ impl From<DataVariant3FormatVariant0Subtype3ParseVariant0>
 {
     fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant0) -> Self {
         Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, DataVariant3FormatVariant0Subtype3ParseVariant1Value>>
+    for DataVariant3FormatVariant0Subtype3Parse
+{
+    fn from(
+        value: std::collections::HashMap<
+            String,
+            DataVariant3FormatVariant0Subtype3ParseVariant1Value,
+        >,
+    ) -> Self {
+        Self::Variant1(value)
     }
 }
 impl From<SignalRef> for DataVariant3FormatVariant0Subtype3Parse {
@@ -10126,18 +10049,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVa
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
-    Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0),
-    Variant1(DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1),
+pub enum DataVariant3FormatVariant0Subtype3ParseVariant1Value {
+    Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0),
+    Variant1(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1),
 }
-impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1Value>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1Value) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -10149,25 +10072,25 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
+impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -10175,22 +10098,22 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue {
         }
     }
 }
-impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValue
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1Value
 {
-    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
     #[serde(rename = "number")]
@@ -10200,14 +10123,14 @@ pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn to_string(&self) -> String {
         match *self {
             Self::Boolean => "boolean".to_string(),
@@ -10217,7 +10140,7 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVaria
         }
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -10229,16 +10152,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraV
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -10246,7 +10167,7 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant0
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -10254,26 +10175,26 @@ impl std::convert::TryFrom<String>
     }
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1(String);
-impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1 {
+pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1(String);
+impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1> for String {
-    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1> for String {
+    fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.0
     }
 }
-impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1>
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1) -> Self {
+    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1 {
+impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new("^(date|utc):.*$")
@@ -10286,16 +10207,14 @@ impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraV
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
-{
+impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
@@ -10303,16 +10222,14 @@ impl std::convert::TryFrom<&String>
     }
 }
 impl std::convert::TryFrom<String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
+    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ExtraValueVariant1
-{
+impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -11173,8 +11090,8 @@ impl From<SignalRef> for DensityTransformDistributionVariant4WeightsVariant0Item
 #[serde(untagged)]
 pub enum DensityTransformExtent {
     Variant0(
-        DensityTransformExtentVariant0,
-        DensityTransformExtentVariant0,
+        DensityTransformExtentVariant0Item,
+        DensityTransformExtentVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -11185,14 +11102,14 @@ impl From<&DensityTransformExtent> for DensityTransformExtent {
 }
 impl
     From<(
-        DensityTransformExtentVariant0,
-        DensityTransformExtentVariant0,
+        DensityTransformExtentVariant0Item,
+        DensityTransformExtentVariant0Item,
     )> for DensityTransformExtent
 {
     fn from(
         value: (
-            DensityTransformExtentVariant0,
-            DensityTransformExtentVariant0,
+            DensityTransformExtentVariant0Item,
+            DensityTransformExtentVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -11205,21 +11122,21 @@ impl From<SignalRef> for DensityTransformExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DensityTransformExtentVariant0 {
+pub enum DensityTransformExtentVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&DensityTransformExtentVariant0> for DensityTransformExtentVariant0 {
-    fn from(value: &DensityTransformExtentVariant0) -> Self {
+impl From<&DensityTransformExtentVariant0Item> for DensityTransformExtentVariant0Item {
+    fn from(value: &DensityTransformExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for DensityTransformExtentVariant0 {
+impl From<f64> for DensityTransformExtentVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for DensityTransformExtentVariant0 {
+impl From<SignalRef> for DensityTransformExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -11366,7 +11283,12 @@ impl std::convert::TryFrom<String> for DensityTransformType {
 #[serde(untagged)]
 pub enum DirectionValue {
     Variant0(Vec<DirectionValueVariant0Item>),
-    Variant1(DirectionValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: DirectionValueVariant1Subtype1,
+    },
 }
 impl From<&DirectionValue> for DirectionValue {
     fn from(value: &DirectionValue) -> Self {
@@ -11376,11 +11298,6 @@ impl From<&DirectionValue> for DirectionValue {
 impl From<Vec<DirectionValueVariant0Item>> for DirectionValue {
     fn from(value: Vec<DirectionValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<DirectionValueVariant1> for DirectionValue {
-    fn from(value: DirectionValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11598,18 +11515,6 @@ impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype3>
     for DirectionValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: DirectionValueVariant1Subtype1,
-}
-impl From<&DirectionValueVariant1> for DirectionValueVariant1 {
-    fn from(value: &DirectionValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -12760,7 +12665,7 @@ impl From<&FoldTransform> for FoldTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformAs {
-    Variant0(FoldTransformAsVariant0, FoldTransformAsVariant0),
+    Variant0(FoldTransformAsVariant0Item, FoldTransformAsVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&FoldTransformAs> for FoldTransformAs {
@@ -12771,13 +12676,13 @@ impl From<&FoldTransformAs> for FoldTransformAs {
 impl Default for FoldTransformAs {
     fn default() -> Self {
         FoldTransformAs::Variant0(
-            FoldTransformAsVariant0::Variant0("key".to_string()),
-            FoldTransformAsVariant0::Variant0("value".to_string()),
+            FoldTransformAsVariant0Item::Variant0("key".to_string()),
+            FoldTransformAsVariant0Item::Variant0("value".to_string()),
         )
     }
 }
-impl From<(FoldTransformAsVariant0, FoldTransformAsVariant0)> for FoldTransformAs {
-    fn from(value: (FoldTransformAsVariant0, FoldTransformAsVariant0)) -> Self {
+impl From<(FoldTransformAsVariant0Item, FoldTransformAsVariant0Item)> for FoldTransformAs {
+    fn from(value: (FoldTransformAsVariant0Item, FoldTransformAsVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -12788,16 +12693,16 @@ impl From<SignalRef> for FoldTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum FoldTransformAsVariant0 {
+pub enum FoldTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&FoldTransformAsVariant0> for FoldTransformAsVariant0 {
-    fn from(value: &FoldTransformAsVariant0) -> Self {
+impl From<&FoldTransformAsVariant0Item> for FoldTransformAsVariant0Item {
+    fn from(value: &FoldTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for FoldTransformAsVariant0 {
+impl From<SignalRef> for FoldTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -12898,7 +12803,12 @@ impl std::convert::TryFrom<String> for FoldTransformType {
 #[serde(untagged)]
 pub enum FontWeightValue {
     Variant0(Vec<FontWeightValueVariant0Item>),
-    Variant1(FontWeightValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: FontWeightValueVariant1Subtype1,
+    },
 }
 impl From<&FontWeightValue> for FontWeightValue {
     fn from(value: &FontWeightValue) -> Self {
@@ -12908,11 +12818,6 @@ impl From<&FontWeightValue> for FontWeightValue {
 impl From<Vec<FontWeightValueVariant0Item>> for FontWeightValue {
     fn from(value: Vec<FontWeightValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<FontWeightValueVariant1> for FontWeightValue {
-    fn from(value: FontWeightValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13074,18 +12979,6 @@ impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype3>
     for FontWeightValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: FontWeightValueVariant1Subtype1,
-}
-impl From<&FontWeightValueVariant1> for FontWeightValueVariant1 {
-    fn from(value: &FontWeightValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -14436,8 +14329,8 @@ impl From<&GeojsonTransform> for GeojsonTransform {
 #[serde(untagged)]
 pub enum GeojsonTransformFields {
     Variant0(
-        GeojsonTransformFieldsVariant0,
-        GeojsonTransformFieldsVariant0,
+        GeojsonTransformFieldsVariant0Item,
+        GeojsonTransformFieldsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -14448,14 +14341,14 @@ impl From<&GeojsonTransformFields> for GeojsonTransformFields {
 }
 impl
     From<(
-        GeojsonTransformFieldsVariant0,
-        GeojsonTransformFieldsVariant0,
+        GeojsonTransformFieldsVariant0Item,
+        GeojsonTransformFieldsVariant0Item,
     )> for GeojsonTransformFields
 {
     fn from(
         value: (
-            GeojsonTransformFieldsVariant0,
-            GeojsonTransformFieldsVariant0,
+            GeojsonTransformFieldsVariant0Item,
+            GeojsonTransformFieldsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -14468,27 +14361,27 @@ impl From<SignalRef> for GeojsonTransformFields {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GeojsonTransformFieldsVariant0 {
+pub enum GeojsonTransformFieldsVariant0Item {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl From<&GeojsonTransformFieldsVariant0> for GeojsonTransformFieldsVariant0 {
-    fn from(value: &GeojsonTransformFieldsVariant0) -> Self {
+impl From<&GeojsonTransformFieldsVariant0Item> for GeojsonTransformFieldsVariant0Item {
+    fn from(value: &GeojsonTransformFieldsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<ScaleField> for GeojsonTransformFieldsVariant0 {
+impl From<ScaleField> for GeojsonTransformFieldsVariant0Item {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl From<ParamField> for GeojsonTransformFieldsVariant0 {
+impl From<ParamField> for GeojsonTransformFieldsVariant0Item {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl From<Expr> for GeojsonTransformFieldsVariant0 {
+impl From<Expr> for GeojsonTransformFieldsVariant0Item {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -14734,7 +14627,10 @@ impl From<&GeopointTransform> for GeopointTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformAs {
-    Variant0(GeopointTransformAsVariant0, GeopointTransformAsVariant0),
+    Variant0(
+        GeopointTransformAsVariant0Item,
+        GeopointTransformAsVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&GeopointTransformAs> for GeopointTransformAs {
@@ -14745,13 +14641,23 @@ impl From<&GeopointTransformAs> for GeopointTransformAs {
 impl Default for GeopointTransformAs {
     fn default() -> Self {
         GeopointTransformAs::Variant0(
-            GeopointTransformAsVariant0::Variant0("x".to_string()),
-            GeopointTransformAsVariant0::Variant0("y".to_string()),
+            GeopointTransformAsVariant0Item::Variant0("x".to_string()),
+            GeopointTransformAsVariant0Item::Variant0("y".to_string()),
         )
     }
 }
-impl From<(GeopointTransformAsVariant0, GeopointTransformAsVariant0)> for GeopointTransformAs {
-    fn from(value: (GeopointTransformAsVariant0, GeopointTransformAsVariant0)) -> Self {
+impl
+    From<(
+        GeopointTransformAsVariant0Item,
+        GeopointTransformAsVariant0Item,
+    )> for GeopointTransformAs
+{
+    fn from(
+        value: (
+            GeopointTransformAsVariant0Item,
+            GeopointTransformAsVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -14762,16 +14668,16 @@ impl From<SignalRef> for GeopointTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GeopointTransformAsVariant0 {
+pub enum GeopointTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&GeopointTransformAsVariant0> for GeopointTransformAsVariant0 {
-    fn from(value: &GeopointTransformAsVariant0) -> Self {
+impl From<&GeopointTransformAsVariant0Item> for GeopointTransformAsVariant0Item {
+    fn from(value: &GeopointTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for GeopointTransformAsVariant0 {
+impl From<SignalRef> for GeopointTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -14780,8 +14686,8 @@ impl From<SignalRef> for GeopointTransformAsVariant0 {
 #[serde(untagged)]
 pub enum GeopointTransformFields {
     Variant0(
-        GeopointTransformFieldsVariant0,
-        GeopointTransformFieldsVariant0,
+        GeopointTransformFieldsVariant0Item,
+        GeopointTransformFieldsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -14792,14 +14698,14 @@ impl From<&GeopointTransformFields> for GeopointTransformFields {
 }
 impl
     From<(
-        GeopointTransformFieldsVariant0,
-        GeopointTransformFieldsVariant0,
+        GeopointTransformFieldsVariant0Item,
+        GeopointTransformFieldsVariant0Item,
     )> for GeopointTransformFields
 {
     fn from(
         value: (
-            GeopointTransformFieldsVariant0,
-            GeopointTransformFieldsVariant0,
+            GeopointTransformFieldsVariant0Item,
+            GeopointTransformFieldsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -14812,27 +14718,27 @@ impl From<SignalRef> for GeopointTransformFields {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GeopointTransformFieldsVariant0 {
+pub enum GeopointTransformFieldsVariant0Item {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl From<&GeopointTransformFieldsVariant0> for GeopointTransformFieldsVariant0 {
-    fn from(value: &GeopointTransformFieldsVariant0) -> Self {
+impl From<&GeopointTransformFieldsVariant0Item> for GeopointTransformFieldsVariant0Item {
+    fn from(value: &GeopointTransformFieldsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<ScaleField> for GeopointTransformFieldsVariant0 {
+impl From<ScaleField> for GeopointTransformFieldsVariant0Item {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl From<ParamField> for GeopointTransformFieldsVariant0 {
+impl From<ParamField> for GeopointTransformFieldsVariant0Item {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl From<Expr> for GeopointTransformFieldsVariant0 {
+impl From<Expr> for GeopointTransformFieldsVariant0Item {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -15206,8 +15112,8 @@ impl From<SignalRef> for GraticuleTransformPrecision {
 #[serde(untagged)]
 pub enum GraticuleTransformStep {
     Variant0(
-        GraticuleTransformStepVariant0,
-        GraticuleTransformStepVariant0,
+        GraticuleTransformStepVariant0Item,
+        GraticuleTransformStepVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -15218,14 +15124,14 @@ impl From<&GraticuleTransformStep> for GraticuleTransformStep {
 }
 impl
     From<(
-        GraticuleTransformStepVariant0,
-        GraticuleTransformStepVariant0,
+        GraticuleTransformStepVariant0Item,
+        GraticuleTransformStepVariant0Item,
     )> for GraticuleTransformStep
 {
     fn from(
         value: (
-            GraticuleTransformStepVariant0,
-            GraticuleTransformStepVariant0,
+            GraticuleTransformStepVariant0Item,
+            GraticuleTransformStepVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -15240,8 +15146,8 @@ impl From<SignalRef> for GraticuleTransformStep {
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajor {
     Variant0(
-        GraticuleTransformStepMajorVariant0,
-        GraticuleTransformStepMajorVariant0,
+        GraticuleTransformStepMajorVariant0Item,
+        GraticuleTransformStepMajorVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -15253,21 +15159,21 @@ impl From<&GraticuleTransformStepMajor> for GraticuleTransformStepMajor {
 impl Default for GraticuleTransformStepMajor {
     fn default() -> Self {
         GraticuleTransformStepMajor::Variant0(
-            GraticuleTransformStepMajorVariant0::Variant0(90_f64),
-            GraticuleTransformStepMajorVariant0::Variant0(360_f64),
+            GraticuleTransformStepMajorVariant0Item::Variant0(90_f64),
+            GraticuleTransformStepMajorVariant0Item::Variant0(360_f64),
         )
     }
 }
 impl
     From<(
-        GraticuleTransformStepMajorVariant0,
-        GraticuleTransformStepMajorVariant0,
+        GraticuleTransformStepMajorVariant0Item,
+        GraticuleTransformStepMajorVariant0Item,
     )> for GraticuleTransformStepMajor
 {
     fn from(
         value: (
-            GraticuleTransformStepMajorVariant0,
-            GraticuleTransformStepMajorVariant0,
+            GraticuleTransformStepMajorVariant0Item,
+            GraticuleTransformStepMajorVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -15280,21 +15186,21 @@ impl From<SignalRef> for GraticuleTransformStepMajor {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GraticuleTransformStepMajorVariant0 {
+pub enum GraticuleTransformStepMajorVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&GraticuleTransformStepMajorVariant0> for GraticuleTransformStepMajorVariant0 {
-    fn from(value: &GraticuleTransformStepMajorVariant0) -> Self {
+impl From<&GraticuleTransformStepMajorVariant0Item> for GraticuleTransformStepMajorVariant0Item {
+    fn from(value: &GraticuleTransformStepMajorVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for GraticuleTransformStepMajorVariant0 {
+impl From<f64> for GraticuleTransformStepMajorVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for GraticuleTransformStepMajorVariant0 {
+impl From<SignalRef> for GraticuleTransformStepMajorVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -15303,8 +15209,8 @@ impl From<SignalRef> for GraticuleTransformStepMajorVariant0 {
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinor {
     Variant0(
-        GraticuleTransformStepMinorVariant0,
-        GraticuleTransformStepMinorVariant0,
+        GraticuleTransformStepMinorVariant0Item,
+        GraticuleTransformStepMinorVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -15316,21 +15222,21 @@ impl From<&GraticuleTransformStepMinor> for GraticuleTransformStepMinor {
 impl Default for GraticuleTransformStepMinor {
     fn default() -> Self {
         GraticuleTransformStepMinor::Variant0(
-            GraticuleTransformStepMinorVariant0::Variant0(10_f64),
-            GraticuleTransformStepMinorVariant0::Variant0(10_f64),
+            GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
+            GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
         )
     }
 }
 impl
     From<(
-        GraticuleTransformStepMinorVariant0,
-        GraticuleTransformStepMinorVariant0,
+        GraticuleTransformStepMinorVariant0Item,
+        GraticuleTransformStepMinorVariant0Item,
     )> for GraticuleTransformStepMinor
 {
     fn from(
         value: (
-            GraticuleTransformStepMinorVariant0,
-            GraticuleTransformStepMinorVariant0,
+            GraticuleTransformStepMinorVariant0Item,
+            GraticuleTransformStepMinorVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -15343,42 +15249,42 @@ impl From<SignalRef> for GraticuleTransformStepMinor {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GraticuleTransformStepMinorVariant0 {
+pub enum GraticuleTransformStepMinorVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&GraticuleTransformStepMinorVariant0> for GraticuleTransformStepMinorVariant0 {
-    fn from(value: &GraticuleTransformStepMinorVariant0) -> Self {
+impl From<&GraticuleTransformStepMinorVariant0Item> for GraticuleTransformStepMinorVariant0Item {
+    fn from(value: &GraticuleTransformStepMinorVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for GraticuleTransformStepMinorVariant0 {
+impl From<f64> for GraticuleTransformStepMinorVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for GraticuleTransformStepMinorVariant0 {
+impl From<SignalRef> for GraticuleTransformStepMinorVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GraticuleTransformStepVariant0 {
+pub enum GraticuleTransformStepVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&GraticuleTransformStepVariant0> for GraticuleTransformStepVariant0 {
-    fn from(value: &GraticuleTransformStepVariant0) -> Self {
+impl From<&GraticuleTransformStepVariant0Item> for GraticuleTransformStepVariant0Item {
+    fn from(value: &GraticuleTransformStepVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for GraticuleTransformStepVariant0 {
+impl From<f64> for GraticuleTransformStepVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for GraticuleTransformStepVariant0 {
+impl From<SignalRef> for GraticuleTransformStepVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -16932,8 +16838,8 @@ impl From<SignalRef> for Kde2dTransformAs {
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidth {
     Variant0(
-        Kde2dTransformBandwidthVariant0,
-        Kde2dTransformBandwidthVariant0,
+        Kde2dTransformBandwidthVariant0Item,
+        Kde2dTransformBandwidthVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -16944,14 +16850,14 @@ impl From<&Kde2dTransformBandwidth> for Kde2dTransformBandwidth {
 }
 impl
     From<(
-        Kde2dTransformBandwidthVariant0,
-        Kde2dTransformBandwidthVariant0,
+        Kde2dTransformBandwidthVariant0Item,
+        Kde2dTransformBandwidthVariant0Item,
     )> for Kde2dTransformBandwidth
 {
     fn from(
         value: (
-            Kde2dTransformBandwidthVariant0,
-            Kde2dTransformBandwidthVariant0,
+            Kde2dTransformBandwidthVariant0Item,
+            Kde2dTransformBandwidthVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -16964,21 +16870,21 @@ impl From<SignalRef> for Kde2dTransformBandwidth {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum Kde2dTransformBandwidthVariant0 {
+pub enum Kde2dTransformBandwidthVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&Kde2dTransformBandwidthVariant0> for Kde2dTransformBandwidthVariant0 {
-    fn from(value: &Kde2dTransformBandwidthVariant0) -> Self {
+impl From<&Kde2dTransformBandwidthVariant0Item> for Kde2dTransformBandwidthVariant0Item {
+    fn from(value: &Kde2dTransformBandwidthVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for Kde2dTransformBandwidthVariant0 {
+impl From<f64> for Kde2dTransformBandwidthVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for Kde2dTransformBandwidthVariant0 {
+impl From<SignalRef> for Kde2dTransformBandwidthVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -17076,7 +16982,10 @@ impl From<Expr> for Kde2dTransformGroupbyVariant0Item {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformSize {
-    Variant0(Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0),
+    Variant0(
+        Kde2dTransformSizeVariant0Item,
+        Kde2dTransformSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&Kde2dTransformSize> for Kde2dTransformSize {
@@ -17084,8 +16993,18 @@ impl From<&Kde2dTransformSize> for Kde2dTransformSize {
         value.clone()
     }
 }
-impl From<(Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0)> for Kde2dTransformSize {
-    fn from(value: (Kde2dTransformSizeVariant0, Kde2dTransformSizeVariant0)) -> Self {
+impl
+    From<(
+        Kde2dTransformSizeVariant0Item,
+        Kde2dTransformSizeVariant0Item,
+    )> for Kde2dTransformSize
+{
+    fn from(
+        value: (
+            Kde2dTransformSizeVariant0Item,
+            Kde2dTransformSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -17096,21 +17015,21 @@ impl From<SignalRef> for Kde2dTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum Kde2dTransformSizeVariant0 {
+pub enum Kde2dTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&Kde2dTransformSizeVariant0> for Kde2dTransformSizeVariant0 {
-    fn from(value: &Kde2dTransformSizeVariant0) -> Self {
+impl From<&Kde2dTransformSizeVariant0Item> for Kde2dTransformSizeVariant0Item {
+    fn from(value: &Kde2dTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for Kde2dTransformSizeVariant0 {
+impl From<f64> for Kde2dTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for Kde2dTransformSizeVariant0 {
+impl From<SignalRef> for Kde2dTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -17385,7 +17304,10 @@ impl From<SignalRef> for KdeTransformCumulative {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformExtent {
-    Variant0(KdeTransformExtentVariant0, KdeTransformExtentVariant0),
+    Variant0(
+        KdeTransformExtentVariant0Item,
+        KdeTransformExtentVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&KdeTransformExtent> for KdeTransformExtent {
@@ -17393,8 +17315,18 @@ impl From<&KdeTransformExtent> for KdeTransformExtent {
         value.clone()
     }
 }
-impl From<(KdeTransformExtentVariant0, KdeTransformExtentVariant0)> for KdeTransformExtent {
-    fn from(value: (KdeTransformExtentVariant0, KdeTransformExtentVariant0)) -> Self {
+impl
+    From<(
+        KdeTransformExtentVariant0Item,
+        KdeTransformExtentVariant0Item,
+    )> for KdeTransformExtent
+{
+    fn from(
+        value: (
+            KdeTransformExtentVariant0Item,
+            KdeTransformExtentVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -17405,21 +17337,21 @@ impl From<SignalRef> for KdeTransformExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum KdeTransformExtentVariant0 {
+pub enum KdeTransformExtentVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&KdeTransformExtentVariant0> for KdeTransformExtentVariant0 {
-    fn from(value: &KdeTransformExtentVariant0) -> Self {
+impl From<&KdeTransformExtentVariant0Item> for KdeTransformExtentVariant0Item {
+    fn from(value: &KdeTransformExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for KdeTransformExtentVariant0 {
+impl From<f64> for KdeTransformExtentVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for KdeTransformExtentVariant0 {
+impl From<SignalRef> for KdeTransformExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -17864,11 +17796,11 @@ impl From<SignalRef> for LabelTransformAnchorVariant0Item {
 #[serde(untagged)]
 pub enum LabelTransformAs {
     Variant0(
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -17880,30 +17812,30 @@ impl From<&LabelTransformAs> for LabelTransformAs {
 impl Default for LabelTransformAs {
     fn default() -> Self {
         LabelTransformAs::Variant0(
-            LabelTransformAsVariant0::Variant0("x".to_string()),
-            LabelTransformAsVariant0::Variant0("y".to_string()),
-            LabelTransformAsVariant0::Variant0("opacity".to_string()),
-            LabelTransformAsVariant0::Variant0("align".to_string()),
-            LabelTransformAsVariant0::Variant0("baseline".to_string()),
+            LabelTransformAsVariant0Item::Variant0("x".to_string()),
+            LabelTransformAsVariant0Item::Variant0("y".to_string()),
+            LabelTransformAsVariant0Item::Variant0("opacity".to_string()),
+            LabelTransformAsVariant0Item::Variant0("align".to_string()),
+            LabelTransformAsVariant0Item::Variant0("baseline".to_string()),
         )
     }
 }
 impl
     From<(
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
-        LabelTransformAsVariant0,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
+        LabelTransformAsVariant0Item,
     )> for LabelTransformAs
 {
     fn from(
         value: (
-            LabelTransformAsVariant0,
-            LabelTransformAsVariant0,
-            LabelTransformAsVariant0,
-            LabelTransformAsVariant0,
-            LabelTransformAsVariant0,
+            LabelTransformAsVariant0Item,
+            LabelTransformAsVariant0Item,
+            LabelTransformAsVariant0Item,
+            LabelTransformAsVariant0Item,
+            LabelTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1, value.2, value.3, value.4)
@@ -17916,16 +17848,16 @@ impl From<SignalRef> for LabelTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum LabelTransformAsVariant0 {
+pub enum LabelTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&LabelTransformAsVariant0> for LabelTransformAsVariant0 {
-    fn from(value: &LabelTransformAsVariant0) -> Self {
+impl From<&LabelTransformAsVariant0Item> for LabelTransformAsVariant0Item {
+    fn from(value: &LabelTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for LabelTransformAsVariant0 {
+impl From<SignalRef> for LabelTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -18112,7 +18044,10 @@ impl From<SignalRef> for LabelTransformPadding {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformSize {
-    Variant0(LabelTransformSizeVariant0, LabelTransformSizeVariant0),
+    Variant0(
+        LabelTransformSizeVariant0Item,
+        LabelTransformSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&LabelTransformSize> for LabelTransformSize {
@@ -18120,8 +18055,18 @@ impl From<&LabelTransformSize> for LabelTransformSize {
         value.clone()
     }
 }
-impl From<(LabelTransformSizeVariant0, LabelTransformSizeVariant0)> for LabelTransformSize {
-    fn from(value: (LabelTransformSizeVariant0, LabelTransformSizeVariant0)) -> Self {
+impl
+    From<(
+        LabelTransformSizeVariant0Item,
+        LabelTransformSizeVariant0Item,
+    )> for LabelTransformSize
+{
+    fn from(
+        value: (
+            LabelTransformSizeVariant0Item,
+            LabelTransformSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -18132,21 +18077,21 @@ impl From<SignalRef> for LabelTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum LabelTransformSizeVariant0 {
+pub enum LabelTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&LabelTransformSizeVariant0> for LabelTransformSizeVariant0 {
-    fn from(value: &LabelTransformSizeVariant0) -> Self {
+impl From<&LabelTransformSizeVariant0Item> for LabelTransformSizeVariant0Item {
+    fn from(value: &LabelTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for LabelTransformSizeVariant0 {
+impl From<f64> for LabelTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for LabelTransformSizeVariant0 {
+impl From<SignalRef> for LabelTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -20131,11 +20076,6 @@ impl std::convert::TryFrom<String> for LegendSubtype0OrientVariant0 {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
-    }
-}
-impl Default for LegendSubtype0OrientVariant0 {
-    fn default() -> Self {
-        LegendSubtype0OrientVariant0::Right
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22352,7 +22292,12 @@ impl From<SignalRef> for NumberOrSignal {
 #[serde(untagged)]
 pub enum NumberValue {
     Variant0(Vec<NumberValueVariant0Item>),
-    Variant1(NumberValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: NumberModifiers,
+        #[serde(flatten)]
+        subtype_1: NumberValueVariant1Subtype1,
+    },
 }
 impl From<&NumberValue> for NumberValue {
     fn from(value: &NumberValue) -> Self {
@@ -22362,11 +22307,6 @@ impl From<&NumberValue> for NumberValue {
 impl From<Vec<NumberValueVariant0Item>> for NumberValue {
     fn from(value: Vec<NumberValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<NumberValueVariant1> for NumberValue {
-    fn from(value: NumberValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22524,18 +22464,6 @@ impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype3>
     for NumberValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: NumberModifiers,
-    #[serde(flatten)]
-    pub subtype_1: NumberValueVariant1Subtype1,
-}
-impl From<&NumberValueVariant1> for NumberValueVariant1 {
-    fn from(value: &NumberValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -22922,7 +22850,12 @@ impl From<ExprString> for OnTriggerItemRemove {
 #[serde(untagged)]
 pub enum OrientValue {
     Variant0(Vec<OrientValueVariant0Item>),
-    Variant1(OrientValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: OrientValueVariant1Subtype1,
+    },
 }
 impl From<&OrientValue> for OrientValue {
     fn from(value: &OrientValue) -> Self {
@@ -22932,11 +22865,6 @@ impl From<&OrientValue> for OrientValue {
 impl From<Vec<OrientValueVariant0Item>> for OrientValue {
     fn from(value: Vec<OrientValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<OrientValueVariant1> for OrientValue {
-    fn from(value: OrientValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23160,18 +23088,6 @@ impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: OrientValueVariant1Subtype1,
-}
-impl From<&OrientValueVariant1> for OrientValueVariant1 {
-    fn from(value: &OrientValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<OrientValueVariant1Subtype1Subtype0>,
@@ -23380,11 +23296,11 @@ impl From<&PackTransform> for PackTransform {
 #[serde(untagged)]
 pub enum PackTransformAs {
     Variant0(
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -23396,30 +23312,30 @@ impl From<&PackTransformAs> for PackTransformAs {
 impl Default for PackTransformAs {
     fn default() -> Self {
         PackTransformAs::Variant0(
-            PackTransformAsVariant0::Variant0("x".to_string()),
-            PackTransformAsVariant0::Variant0("y".to_string()),
-            PackTransformAsVariant0::Variant0("r".to_string()),
-            PackTransformAsVariant0::Variant0("depth".to_string()),
-            PackTransformAsVariant0::Variant0("children".to_string()),
+            PackTransformAsVariant0Item::Variant0("x".to_string()),
+            PackTransformAsVariant0Item::Variant0("y".to_string()),
+            PackTransformAsVariant0Item::Variant0("r".to_string()),
+            PackTransformAsVariant0Item::Variant0("depth".to_string()),
+            PackTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
 }
 impl
     From<(
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
-        PackTransformAsVariant0,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
+        PackTransformAsVariant0Item,
     )> for PackTransformAs
 {
     fn from(
         value: (
-            PackTransformAsVariant0,
-            PackTransformAsVariant0,
-            PackTransformAsVariant0,
-            PackTransformAsVariant0,
-            PackTransformAsVariant0,
+            PackTransformAsVariant0Item,
+            PackTransformAsVariant0Item,
+            PackTransformAsVariant0Item,
+            PackTransformAsVariant0Item,
+            PackTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1, value.2, value.3, value.4)
@@ -23432,16 +23348,16 @@ impl From<SignalRef> for PackTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum PackTransformAsVariant0 {
+pub enum PackTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&PackTransformAsVariant0> for PackTransformAsVariant0 {
-    fn from(value: &PackTransformAsVariant0) -> Self {
+impl From<&PackTransformAsVariant0Item> for PackTransformAsVariant0Item {
+    fn from(value: &PackTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for PackTransformAsVariant0 {
+impl From<SignalRef> for PackTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -23524,7 +23440,7 @@ impl From<Expr> for PackTransformRadius {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PackTransformSize {
-    Variant0(PackTransformSizeVariant0, PackTransformSizeVariant0),
+    Variant0(PackTransformSizeVariant0Item, PackTransformSizeVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&PackTransformSize> for PackTransformSize {
@@ -23532,8 +23448,8 @@ impl From<&PackTransformSize> for PackTransformSize {
         value.clone()
     }
 }
-impl From<(PackTransformSizeVariant0, PackTransformSizeVariant0)> for PackTransformSize {
-    fn from(value: (PackTransformSizeVariant0, PackTransformSizeVariant0)) -> Self {
+impl From<(PackTransformSizeVariant0Item, PackTransformSizeVariant0Item)> for PackTransformSize {
+    fn from(value: (PackTransformSizeVariant0Item, PackTransformSizeVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -23544,21 +23460,21 @@ impl From<SignalRef> for PackTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum PackTransformSizeVariant0 {
+pub enum PackTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&PackTransformSizeVariant0> for PackTransformSizeVariant0 {
-    fn from(value: &PackTransformSizeVariant0) -> Self {
+impl From<&PackTransformSizeVariant0Item> for PackTransformSizeVariant0Item {
+    fn from(value: &PackTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for PackTransformSizeVariant0 {
+impl From<f64> for PackTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for PackTransformSizeVariant0 {
+impl From<SignalRef> for PackTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -23679,12 +23595,12 @@ impl From<&PartitionTransform> for PartitionTransform {
 #[serde(untagged)]
 pub enum PartitionTransformAs {
     Variant0(
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -23696,33 +23612,33 @@ impl From<&PartitionTransformAs> for PartitionTransformAs {
 impl Default for PartitionTransformAs {
     fn default() -> Self {
         PartitionTransformAs::Variant0(
-            PartitionTransformAsVariant0::Variant0("x0".to_string()),
-            PartitionTransformAsVariant0::Variant0("y0".to_string()),
-            PartitionTransformAsVariant0::Variant0("x1".to_string()),
-            PartitionTransformAsVariant0::Variant0("y1".to_string()),
-            PartitionTransformAsVariant0::Variant0("depth".to_string()),
-            PartitionTransformAsVariant0::Variant0("children".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("x0".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("y0".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("x1".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("y1".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("depth".to_string()),
+            PartitionTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
 }
 impl
     From<(
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
-        PartitionTransformAsVariant0,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
+        PartitionTransformAsVariant0Item,
     )> for PartitionTransformAs
 {
     fn from(
         value: (
-            PartitionTransformAsVariant0,
-            PartitionTransformAsVariant0,
-            PartitionTransformAsVariant0,
-            PartitionTransformAsVariant0,
-            PartitionTransformAsVariant0,
-            PartitionTransformAsVariant0,
+            PartitionTransformAsVariant0Item,
+            PartitionTransformAsVariant0Item,
+            PartitionTransformAsVariant0Item,
+            PartitionTransformAsVariant0Item,
+            PartitionTransformAsVariant0Item,
+            PartitionTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1, value.2, value.3, value.4, value.5)
@@ -23735,16 +23651,16 @@ impl From<SignalRef> for PartitionTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum PartitionTransformAsVariant0 {
+pub enum PartitionTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&PartitionTransformAsVariant0> for PartitionTransformAsVariant0 {
-    fn from(value: &PartitionTransformAsVariant0) -> Self {
+impl From<&PartitionTransformAsVariant0Item> for PartitionTransformAsVariant0Item {
+    fn from(value: &PartitionTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for PartitionTransformAsVariant0 {
+impl From<SignalRef> for PartitionTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -23822,8 +23738,8 @@ impl From<SignalRef> for PartitionTransformRound {
 #[serde(untagged)]
 pub enum PartitionTransformSize {
     Variant0(
-        PartitionTransformSizeVariant0,
-        PartitionTransformSizeVariant0,
+        PartitionTransformSizeVariant0Item,
+        PartitionTransformSizeVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -23834,14 +23750,14 @@ impl From<&PartitionTransformSize> for PartitionTransformSize {
 }
 impl
     From<(
-        PartitionTransformSizeVariant0,
-        PartitionTransformSizeVariant0,
+        PartitionTransformSizeVariant0Item,
+        PartitionTransformSizeVariant0Item,
     )> for PartitionTransformSize
 {
     fn from(
         value: (
-            PartitionTransformSizeVariant0,
-            PartitionTransformSizeVariant0,
+            PartitionTransformSizeVariant0Item,
+            PartitionTransformSizeVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -23854,21 +23770,21 @@ impl From<SignalRef> for PartitionTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum PartitionTransformSizeVariant0 {
+pub enum PartitionTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&PartitionTransformSizeVariant0> for PartitionTransformSizeVariant0 {
-    fn from(value: &PartitionTransformSizeVariant0) -> Self {
+impl From<&PartitionTransformSizeVariant0Item> for PartitionTransformSizeVariant0Item {
+    fn from(value: &PartitionTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for PartitionTransformSizeVariant0 {
+impl From<f64> for PartitionTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for PartitionTransformSizeVariant0 {
+impl From<SignalRef> for PartitionTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -23947,7 +23863,7 @@ impl From<&PieTransform> for PieTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PieTransformAs {
-    Variant0(PieTransformAsVariant0, PieTransformAsVariant0),
+    Variant0(PieTransformAsVariant0Item, PieTransformAsVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&PieTransformAs> for PieTransformAs {
@@ -23958,13 +23874,13 @@ impl From<&PieTransformAs> for PieTransformAs {
 impl Default for PieTransformAs {
     fn default() -> Self {
         PieTransformAs::Variant0(
-            PieTransformAsVariant0::Variant0("startAngle".to_string()),
-            PieTransformAsVariant0::Variant0("endAngle".to_string()),
+            PieTransformAsVariant0Item::Variant0("startAngle".to_string()),
+            PieTransformAsVariant0Item::Variant0("endAngle".to_string()),
         )
     }
 }
-impl From<(PieTransformAsVariant0, PieTransformAsVariant0)> for PieTransformAs {
-    fn from(value: (PieTransformAsVariant0, PieTransformAsVariant0)) -> Self {
+impl From<(PieTransformAsVariant0Item, PieTransformAsVariant0Item)> for PieTransformAs {
+    fn from(value: (PieTransformAsVariant0Item, PieTransformAsVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -23975,16 +23891,16 @@ impl From<SignalRef> for PieTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum PieTransformAsVariant0 {
+pub enum PieTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&PieTransformAsVariant0> for PieTransformAsVariant0 {
-    fn from(value: &PieTransformAsVariant0) -> Self {
+impl From<&PieTransformAsVariant0Item> for PieTransformAsVariant0Item {
+    fn from(value: &PieTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for PieTransformAsVariant0 {
+impl From<SignalRef> for PieTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -24721,7 +24637,10 @@ impl From<SignalRef> for ProjectionCenter {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionClipExtent {
-    Variant0(ProjectionClipExtentVariant0, ProjectionClipExtentVariant0),
+    Variant0(
+        ProjectionClipExtentVariant0Item,
+        ProjectionClipExtentVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&ProjectionClipExtent> for ProjectionClipExtent {
@@ -24729,8 +24648,18 @@ impl From<&ProjectionClipExtent> for ProjectionClipExtent {
         value.clone()
     }
 }
-impl From<(ProjectionClipExtentVariant0, ProjectionClipExtentVariant0)> for ProjectionClipExtent {
-    fn from(value: (ProjectionClipExtentVariant0, ProjectionClipExtentVariant0)) -> Self {
+impl
+    From<(
+        ProjectionClipExtentVariant0Item,
+        ProjectionClipExtentVariant0Item,
+    )> for ProjectionClipExtent
+{
+    fn from(
+        value: (
+            ProjectionClipExtentVariant0Item,
+            ProjectionClipExtentVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -24741,21 +24670,21 @@ impl From<SignalRef> for ProjectionClipExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ProjectionClipExtentVariant0 {
+pub enum ProjectionClipExtentVariant0Item {
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-impl From<&ProjectionClipExtentVariant0> for ProjectionClipExtentVariant0 {
-    fn from(value: &ProjectionClipExtentVariant0) -> Self {
+impl From<&ProjectionClipExtentVariant0Item> for ProjectionClipExtentVariant0Item {
+    fn from(value: &ProjectionClipExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionClipExtentVariant0 {
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionClipExtentVariant0Item {
     fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
-impl From<SignalRef> for ProjectionClipExtentVariant0 {
+impl From<SignalRef> for ProjectionClipExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -24763,7 +24692,7 @@ impl From<SignalRef> for ProjectionClipExtentVariant0 {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ProjectionExtent {
-    Variant0(ProjectionExtentVariant0, ProjectionExtentVariant0),
+    Variant0(ProjectionExtentVariant0Item, ProjectionExtentVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&ProjectionExtent> for ProjectionExtent {
@@ -24771,8 +24700,8 @@ impl From<&ProjectionExtent> for ProjectionExtent {
         value.clone()
     }
 }
-impl From<(ProjectionExtentVariant0, ProjectionExtentVariant0)> for ProjectionExtent {
-    fn from(value: (ProjectionExtentVariant0, ProjectionExtentVariant0)) -> Self {
+impl From<(ProjectionExtentVariant0Item, ProjectionExtentVariant0Item)> for ProjectionExtent {
+    fn from(value: (ProjectionExtentVariant0Item, ProjectionExtentVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -24783,21 +24712,21 @@ impl From<SignalRef> for ProjectionExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ProjectionExtentVariant0 {
+pub enum ProjectionExtentVariant0Item {
     Variant0(NumberOrSignal, NumberOrSignal),
     Variant1(SignalRef),
 }
-impl From<&ProjectionExtentVariant0> for ProjectionExtentVariant0 {
-    fn from(value: &ProjectionExtentVariant0) -> Self {
+impl From<&ProjectionExtentVariant0Item> for ProjectionExtentVariant0Item {
+    fn from(value: &ProjectionExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionExtentVariant0 {
+impl From<(NumberOrSignal, NumberOrSignal)> for ProjectionExtentVariant0Item {
     fn from(value: (NumberOrSignal, NumberOrSignal)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
-impl From<SignalRef> for ProjectionExtentVariant0 {
+impl From<SignalRef> for ProjectionExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -25298,8 +25227,8 @@ impl From<SignalRef> for RegressionTransformAsVariant0Item {
 #[serde(untagged)]
 pub enum RegressionTransformExtent {
     Variant0(
-        RegressionTransformExtentVariant0,
-        RegressionTransformExtentVariant0,
+        RegressionTransformExtentVariant0Item,
+        RegressionTransformExtentVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -25310,14 +25239,14 @@ impl From<&RegressionTransformExtent> for RegressionTransformExtent {
 }
 impl
     From<(
-        RegressionTransformExtentVariant0,
-        RegressionTransformExtentVariant0,
+        RegressionTransformExtentVariant0Item,
+        RegressionTransformExtentVariant0Item,
     )> for RegressionTransformExtent
 {
     fn from(
         value: (
-            RegressionTransformExtentVariant0,
-            RegressionTransformExtentVariant0,
+            RegressionTransformExtentVariant0Item,
+            RegressionTransformExtentVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -25330,21 +25259,21 @@ impl From<SignalRef> for RegressionTransformExtent {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum RegressionTransformExtentVariant0 {
+pub enum RegressionTransformExtentVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&RegressionTransformExtentVariant0> for RegressionTransformExtentVariant0 {
-    fn from(value: &RegressionTransformExtentVariant0) -> Self {
+impl From<&RegressionTransformExtentVariant0Item> for RegressionTransformExtentVariant0Item {
+    fn from(value: &RegressionTransformExtentVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for RegressionTransformExtentVariant0 {
+impl From<f64> for RegressionTransformExtentVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for RegressionTransformExtentVariant0 {
+impl From<SignalRef> for RegressionTransformExtentVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -31407,7 +31336,7 @@ impl From<&StackTransform> for StackTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StackTransformAs {
-    Variant0(StackTransformAsVariant0, StackTransformAsVariant0),
+    Variant0(StackTransformAsVariant0Item, StackTransformAsVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&StackTransformAs> for StackTransformAs {
@@ -31418,13 +31347,13 @@ impl From<&StackTransformAs> for StackTransformAs {
 impl Default for StackTransformAs {
     fn default() -> Self {
         StackTransformAs::Variant0(
-            StackTransformAsVariant0::Variant0("y0".to_string()),
-            StackTransformAsVariant0::Variant0("y1".to_string()),
+            StackTransformAsVariant0Item::Variant0("y0".to_string()),
+            StackTransformAsVariant0Item::Variant0("y1".to_string()),
         )
     }
 }
-impl From<(StackTransformAsVariant0, StackTransformAsVariant0)> for StackTransformAs {
-    fn from(value: (StackTransformAsVariant0, StackTransformAsVariant0)) -> Self {
+impl From<(StackTransformAsVariant0Item, StackTransformAsVariant0Item)> for StackTransformAs {
+    fn from(value: (StackTransformAsVariant0Item, StackTransformAsVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -31435,16 +31364,16 @@ impl From<SignalRef> for StackTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StackTransformAsVariant0 {
+pub enum StackTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&StackTransformAsVariant0> for StackTransformAsVariant0 {
-    fn from(value: &StackTransformAsVariant0) -> Self {
+impl From<&StackTransformAsVariant0Item> for StackTransformAsVariant0Item {
+    fn from(value: &StackTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for StackTransformAsVariant0 {
+impl From<SignalRef> for StackTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -31774,8 +31703,8 @@ impl From<&Stream> for Stream {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamSubtype0 {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub between: Vec<Stream>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub between: Option<(Stream, Stream)>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub consume: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -31866,7 +31795,12 @@ impl From<SignalRef> for StringOrSignal {
 #[serde(untagged)]
 pub enum StringValue {
     Variant0(Vec<StringValueVariant0Item>),
-    Variant1(StringValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: StringValueVariant1Subtype1,
+    },
 }
 impl From<&StringValue> for StringValue {
     fn from(value: &StringValue) -> Self {
@@ -31876,11 +31810,6 @@ impl From<&StringValue> for StringValue {
 impl From<Vec<StringValueVariant0Item>> for StringValue {
     fn from(value: Vec<StringValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<StringValueVariant1> for StringValue {
-    fn from(value: StringValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -32042,18 +31971,6 @@ impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StringValueVariant1Subtype1,
-}
-impl From<&StringValueVariant1> for StringValueVariant1 {
-    fn from(value: &StringValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StringValueVariant1Subtype1Subtype0>,
@@ -32179,7 +32096,12 @@ impl From<&StringValueVariant1Subtype1Subtype3> for StringValueVariant1Subtype1S
 #[serde(untagged)]
 pub enum StrokeCapValue {
     Variant0(Vec<StrokeCapValueVariant0Item>),
-    Variant1(StrokeCapValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: StrokeCapValueVariant1Subtype1,
+    },
 }
 impl From<&StrokeCapValue> for StrokeCapValue {
     fn from(value: &StrokeCapValue) -> Self {
@@ -32189,11 +32111,6 @@ impl From<&StrokeCapValue> for StrokeCapValue {
 impl From<Vec<StrokeCapValueVariant0Item>> for StrokeCapValue {
     fn from(value: Vec<StrokeCapValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<StrokeCapValueVariant1> for StrokeCapValue {
-    fn from(value: StrokeCapValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -32419,18 +32336,6 @@ impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3>
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StrokeCapValueVariant1Subtype1,
-}
-impl From<&StrokeCapValueVariant1> for StrokeCapValueVariant1 {
-    fn from(value: &StrokeCapValueVariant1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1 {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<StrokeCapValueVariant1Subtype1Subtype0>,
@@ -32610,7 +32515,12 @@ impl From<&StrokeCapValueVariant1Subtype1Subtype3> for StrokeCapValueVariant1Sub
 #[serde(untagged)]
 pub enum StrokeJoinValue {
     Variant0(Vec<StrokeJoinValueVariant0Item>),
-    Variant1(StrokeJoinValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: StrokeJoinValueVariant1Subtype1,
+    },
 }
 impl From<&StrokeJoinValue> for StrokeJoinValue {
     fn from(value: &StrokeJoinValue) -> Self {
@@ -32620,11 +32530,6 @@ impl From<&StrokeJoinValue> for StrokeJoinValue {
 impl From<Vec<StrokeJoinValueVariant0Item>> for StrokeJoinValue {
     fn from(value: Vec<StrokeJoinValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<StrokeJoinValueVariant1> for StrokeJoinValue {
-    fn from(value: StrokeJoinValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -32846,18 +32751,6 @@ impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3>
     for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StrokeJoinValueVariant1Subtype1,
-}
-impl From<&StrokeJoinValueVariant1> for StrokeJoinValueVariant1 {
-    fn from(value: &StrokeJoinValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -33094,7 +32987,12 @@ impl From<Vec<String>> for TextOrSignalVariant0 {
 #[serde(untagged)]
 pub enum TextValue {
     Variant0(Vec<TextValueVariant0Item>),
-    Variant1(TextValueVariant1),
+    Variant1 {
+        #[serde(flatten)]
+        subtype_0: StringModifiers,
+        #[serde(flatten)]
+        subtype_1: TextValueVariant1Subtype1,
+    },
 }
 impl From<&TextValue> for TextValue {
     fn from(value: &TextValue) -> Self {
@@ -33104,11 +33002,6 @@ impl From<&TextValue> for TextValue {
 impl From<Vec<TextValueVariant0Item>> for TextValue {
     fn from(value: Vec<TextValueVariant0Item>) -> Self {
         Self::Variant0(value)
-    }
-}
-impl From<TextValueVariant1> for TextValue {
-    fn from(value: TextValueVariant1) -> Self {
-        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -33280,18 +33173,6 @@ impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype3>
     for TextValueVariant0ItemSubtype1Subtype1Subtype3
 {
     fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: TextValueVariant1Subtype1,
-}
-impl From<&TextValueVariant1> for TextValueVariant1 {
-    fn from(value: &TextValueVariant1) -> Self {
         value.clone()
     }
 }
@@ -33732,7 +33613,10 @@ impl From<&TimeunitTransform> for TimeunitTransform {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformAs {
-    Variant0(TimeunitTransformAsVariant0, TimeunitTransformAsVariant0),
+    Variant0(
+        TimeunitTransformAsVariant0Item,
+        TimeunitTransformAsVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&TimeunitTransformAs> for TimeunitTransformAs {
@@ -33743,13 +33627,23 @@ impl From<&TimeunitTransformAs> for TimeunitTransformAs {
 impl Default for TimeunitTransformAs {
     fn default() -> Self {
         TimeunitTransformAs::Variant0(
-            TimeunitTransformAsVariant0::Variant0("unit0".to_string()),
-            TimeunitTransformAsVariant0::Variant0("unit1".to_string()),
+            TimeunitTransformAsVariant0Item::Variant0("unit0".to_string()),
+            TimeunitTransformAsVariant0Item::Variant0("unit1".to_string()),
         )
     }
 }
-impl From<(TimeunitTransformAsVariant0, TimeunitTransformAsVariant0)> for TimeunitTransformAs {
-    fn from(value: (TimeunitTransformAsVariant0, TimeunitTransformAsVariant0)) -> Self {
+impl
+    From<(
+        TimeunitTransformAsVariant0Item,
+        TimeunitTransformAsVariant0Item,
+    )> for TimeunitTransformAs
+{
+    fn from(
+        value: (
+            TimeunitTransformAsVariant0Item,
+            TimeunitTransformAsVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -33760,16 +33654,16 @@ impl From<SignalRef> for TimeunitTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TimeunitTransformAsVariant0 {
+pub enum TimeunitTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&TimeunitTransformAsVariant0> for TimeunitTransformAsVariant0 {
-    fn from(value: &TimeunitTransformAsVariant0) -> Self {
+impl From<&TimeunitTransformAsVariant0Item> for TimeunitTransformAsVariant0Item {
+    fn from(value: &TimeunitTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for TimeunitTransformAsVariant0 {
+impl From<SignalRef> for TimeunitTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -34910,11 +34804,6 @@ impl std::convert::TryFrom<String> for TitleVariant1OrientVariant0 {
         value.parse()
     }
 }
-impl Default for TitleVariant1OrientVariant0 {
-    fn default() -> Self {
-        TitleVariant1OrientVariant0::Top
-    }
-}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleColor {
@@ -35562,10 +35451,10 @@ impl From<&TreeTransform> for TreeTransform {
 #[serde(untagged)]
 pub enum TreeTransformAs {
     Variant0(
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -35577,27 +35466,27 @@ impl From<&TreeTransformAs> for TreeTransformAs {
 impl Default for TreeTransformAs {
     fn default() -> Self {
         TreeTransformAs::Variant0(
-            TreeTransformAsVariant0::Variant0("x".to_string()),
-            TreeTransformAsVariant0::Variant0("y".to_string()),
-            TreeTransformAsVariant0::Variant0("depth".to_string()),
-            TreeTransformAsVariant0::Variant0("children".to_string()),
+            TreeTransformAsVariant0Item::Variant0("x".to_string()),
+            TreeTransformAsVariant0Item::Variant0("y".to_string()),
+            TreeTransformAsVariant0Item::Variant0("depth".to_string()),
+            TreeTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
 }
 impl
     From<(
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
-        TreeTransformAsVariant0,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
+        TreeTransformAsVariant0Item,
     )> for TreeTransformAs
 {
     fn from(
         value: (
-            TreeTransformAsVariant0,
-            TreeTransformAsVariant0,
-            TreeTransformAsVariant0,
-            TreeTransformAsVariant0,
+            TreeTransformAsVariant0Item,
+            TreeTransformAsVariant0Item,
+            TreeTransformAsVariant0Item,
+            TreeTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1, value.2, value.3)
@@ -35610,16 +35499,16 @@ impl From<SignalRef> for TreeTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TreeTransformAsVariant0 {
+pub enum TreeTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&TreeTransformAsVariant0> for TreeTransformAsVariant0 {
-    fn from(value: &TreeTransformAsVariant0) -> Self {
+impl From<&TreeTransformAsVariant0Item> for TreeTransformAsVariant0Item {
+    fn from(value: &TreeTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for TreeTransformAsVariant0 {
+impl From<SignalRef> for TreeTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -35728,7 +35617,10 @@ impl std::convert::TryFrom<String> for TreeTransformMethodVariant0 {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSize {
-    Variant0(TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0),
+    Variant0(
+        TreeTransformNodeSizeVariant0Item,
+        TreeTransformNodeSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&TreeTransformNodeSize> for TreeTransformNodeSize {
@@ -35736,10 +35628,18 @@ impl From<&TreeTransformNodeSize> for TreeTransformNodeSize {
         value.clone()
     }
 }
-impl From<(TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0)>
-    for TreeTransformNodeSize
+impl
+    From<(
+        TreeTransformNodeSizeVariant0Item,
+        TreeTransformNodeSizeVariant0Item,
+    )> for TreeTransformNodeSize
 {
-    fn from(value: (TreeTransformNodeSizeVariant0, TreeTransformNodeSizeVariant0)) -> Self {
+    fn from(
+        value: (
+            TreeTransformNodeSizeVariant0Item,
+            TreeTransformNodeSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -35750,21 +35650,21 @@ impl From<SignalRef> for TreeTransformNodeSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TreeTransformNodeSizeVariant0 {
+pub enum TreeTransformNodeSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&TreeTransformNodeSizeVariant0> for TreeTransformNodeSizeVariant0 {
-    fn from(value: &TreeTransformNodeSizeVariant0) -> Self {
+impl From<&TreeTransformNodeSizeVariant0Item> for TreeTransformNodeSizeVariant0Item {
+    fn from(value: &TreeTransformNodeSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for TreeTransformNodeSizeVariant0 {
+impl From<f64> for TreeTransformNodeSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for TreeTransformNodeSizeVariant0 {
+impl From<SignalRef> for TreeTransformNodeSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -35798,7 +35698,7 @@ impl From<SignalRef> for TreeTransformSeparation {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSize {
-    Variant0(TreeTransformSizeVariant0, TreeTransformSizeVariant0),
+    Variant0(TreeTransformSizeVariant0Item, TreeTransformSizeVariant0Item),
     Variant1(SignalRef),
 }
 impl From<&TreeTransformSize> for TreeTransformSize {
@@ -35806,8 +35706,8 @@ impl From<&TreeTransformSize> for TreeTransformSize {
         value.clone()
     }
 }
-impl From<(TreeTransformSizeVariant0, TreeTransformSizeVariant0)> for TreeTransformSize {
-    fn from(value: (TreeTransformSizeVariant0, TreeTransformSizeVariant0)) -> Self {
+impl From<(TreeTransformSizeVariant0Item, TreeTransformSizeVariant0Item)> for TreeTransformSize {
+    fn from(value: (TreeTransformSizeVariant0Item, TreeTransformSizeVariant0Item)) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -35818,21 +35718,21 @@ impl From<SignalRef> for TreeTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TreeTransformSizeVariant0 {
+pub enum TreeTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&TreeTransformSizeVariant0> for TreeTransformSizeVariant0 {
-    fn from(value: &TreeTransformSizeVariant0) -> Self {
+impl From<&TreeTransformSizeVariant0Item> for TreeTransformSizeVariant0Item {
+    fn from(value: &TreeTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for TreeTransformSizeVariant0 {
+impl From<f64> for TreeTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for TreeTransformSizeVariant0 {
+impl From<SignalRef> for TreeTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -36007,12 +35907,12 @@ impl From<&TreemapTransform> for TreemapTransform {
 #[serde(untagged)]
 pub enum TreemapTransformAs {
     Variant0(
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -36024,33 +35924,33 @@ impl From<&TreemapTransformAs> for TreemapTransformAs {
 impl Default for TreemapTransformAs {
     fn default() -> Self {
         TreemapTransformAs::Variant0(
-            TreemapTransformAsVariant0::Variant0("x0".to_string()),
-            TreemapTransformAsVariant0::Variant0("y0".to_string()),
-            TreemapTransformAsVariant0::Variant0("x1".to_string()),
-            TreemapTransformAsVariant0::Variant0("y1".to_string()),
-            TreemapTransformAsVariant0::Variant0("depth".to_string()),
-            TreemapTransformAsVariant0::Variant0("children".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("x0".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("y0".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("x1".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("y1".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("depth".to_string()),
+            TreemapTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
 }
 impl
     From<(
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
-        TreemapTransformAsVariant0,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
+        TreemapTransformAsVariant0Item,
     )> for TreemapTransformAs
 {
     fn from(
         value: (
-            TreemapTransformAsVariant0,
-            TreemapTransformAsVariant0,
-            TreemapTransformAsVariant0,
-            TreemapTransformAsVariant0,
-            TreemapTransformAsVariant0,
-            TreemapTransformAsVariant0,
+            TreemapTransformAsVariant0Item,
+            TreemapTransformAsVariant0Item,
+            TreemapTransformAsVariant0Item,
+            TreemapTransformAsVariant0Item,
+            TreemapTransformAsVariant0Item,
+            TreemapTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1, value.2, value.3, value.4, value.5)
@@ -36063,16 +35963,16 @@ impl From<SignalRef> for TreemapTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TreemapTransformAsVariant0 {
+pub enum TreemapTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&TreemapTransformAsVariant0> for TreemapTransformAsVariant0 {
-    fn from(value: &TreemapTransformAsVariant0) -> Self {
+impl From<&TreemapTransformAsVariant0Item> for TreemapTransformAsVariant0Item {
+    fn from(value: &TreemapTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for TreemapTransformAsVariant0 {
+impl From<SignalRef> for TreemapTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -36391,7 +36291,10 @@ impl From<SignalRef> for TreemapTransformRound {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformSize {
-    Variant0(TreemapTransformSizeVariant0, TreemapTransformSizeVariant0),
+    Variant0(
+        TreemapTransformSizeVariant0Item,
+        TreemapTransformSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&TreemapTransformSize> for TreemapTransformSize {
@@ -36399,8 +36302,18 @@ impl From<&TreemapTransformSize> for TreemapTransformSize {
         value.clone()
     }
 }
-impl From<(TreemapTransformSizeVariant0, TreemapTransformSizeVariant0)> for TreemapTransformSize {
-    fn from(value: (TreemapTransformSizeVariant0, TreemapTransformSizeVariant0)) -> Self {
+impl
+    From<(
+        TreemapTransformSizeVariant0Item,
+        TreemapTransformSizeVariant0Item,
+    )> for TreemapTransformSize
+{
+    fn from(
+        value: (
+            TreemapTransformSizeVariant0Item,
+            TreemapTransformSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -36411,21 +36324,21 @@ impl From<SignalRef> for TreemapTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TreemapTransformSizeVariant0 {
+pub enum TreemapTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&TreemapTransformSizeVariant0> for TreemapTransformSizeVariant0 {
-    fn from(value: &TreemapTransformSizeVariant0) -> Self {
+impl From<&TreemapTransformSizeVariant0Item> for TreemapTransformSizeVariant0Item {
+    fn from(value: &TreemapTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for TreemapTransformSizeVariant0 {
+impl From<f64> for TreemapTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for TreemapTransformSizeVariant0 {
+impl From<SignalRef> for TreemapTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -36548,7 +36461,10 @@ impl From<SignalRef> for VoronoiTransformExtent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformSize {
-    Variant0(VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0),
+    Variant0(
+        VoronoiTransformSizeVariant0Item,
+        VoronoiTransformSizeVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&VoronoiTransformSize> for VoronoiTransformSize {
@@ -36556,8 +36472,18 @@ impl From<&VoronoiTransformSize> for VoronoiTransformSize {
         value.clone()
     }
 }
-impl From<(VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0)> for VoronoiTransformSize {
-    fn from(value: (VoronoiTransformSizeVariant0, VoronoiTransformSizeVariant0)) -> Self {
+impl
+    From<(
+        VoronoiTransformSizeVariant0Item,
+        VoronoiTransformSizeVariant0Item,
+    )> for VoronoiTransformSize
+{
+    fn from(
+        value: (
+            VoronoiTransformSizeVariant0Item,
+            VoronoiTransformSizeVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -36568,21 +36494,21 @@ impl From<SignalRef> for VoronoiTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum VoronoiTransformSizeVariant0 {
+pub enum VoronoiTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&VoronoiTransformSizeVariant0> for VoronoiTransformSizeVariant0 {
-    fn from(value: &VoronoiTransformSizeVariant0) -> Self {
+impl From<&VoronoiTransformSizeVariant0Item> for VoronoiTransformSizeVariant0Item {
+    fn from(value: &VoronoiTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for VoronoiTransformSizeVariant0 {
+impl From<f64> for VoronoiTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for VoronoiTransformSizeVariant0 {
+impl From<SignalRef> for VoronoiTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -36808,7 +36734,10 @@ impl From<Expr> for WindowTransformFieldsVariant0Item {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFrame {
-    Variant0(WindowTransformFrameVariant0, WindowTransformFrameVariant0),
+    Variant0(
+        WindowTransformFrameVariant0Item,
+        WindowTransformFrameVariant0Item,
+    ),
     Variant1(SignalRef),
 }
 impl From<&WindowTransformFrame> for WindowTransformFrame {
@@ -36819,13 +36748,23 @@ impl From<&WindowTransformFrame> for WindowTransformFrame {
 impl Default for WindowTransformFrame {
     fn default() -> Self {
         WindowTransformFrame::Variant0(
-            WindowTransformFrameVariant0::Variant2,
-            WindowTransformFrameVariant0::Variant0(0_f64),
+            WindowTransformFrameVariant0Item::Variant2,
+            WindowTransformFrameVariant0Item::Variant0(0_f64),
         )
     }
 }
-impl From<(WindowTransformFrameVariant0, WindowTransformFrameVariant0)> for WindowTransformFrame {
-    fn from(value: (WindowTransformFrameVariant0, WindowTransformFrameVariant0)) -> Self {
+impl
+    From<(
+        WindowTransformFrameVariant0Item,
+        WindowTransformFrameVariant0Item,
+    )> for WindowTransformFrame
+{
+    fn from(
+        value: (
+            WindowTransformFrameVariant0Item,
+            WindowTransformFrameVariant0Item,
+        ),
+    ) -> Self {
         Self::Variant0(value.0, value.1)
     }
 }
@@ -36836,22 +36775,22 @@ impl From<SignalRef> for WindowTransformFrame {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum WindowTransformFrameVariant0 {
+pub enum WindowTransformFrameVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
     Variant2,
 }
-impl From<&WindowTransformFrameVariant0> for WindowTransformFrameVariant0 {
-    fn from(value: &WindowTransformFrameVariant0) -> Self {
+impl From<&WindowTransformFrameVariant0Item> for WindowTransformFrameVariant0Item {
+    fn from(value: &WindowTransformFrameVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for WindowTransformFrameVariant0 {
+impl From<f64> for WindowTransformFrameVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for WindowTransformFrameVariant0 {
+impl From<SignalRef> for WindowTransformFrameVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -37293,13 +37232,13 @@ impl From<&WordcloudTransform> for WordcloudTransform {
 #[serde(untagged)]
 pub enum WordcloudTransformAs {
     Variant0(
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -37311,36 +37250,36 @@ impl From<&WordcloudTransformAs> for WordcloudTransformAs {
 impl Default for WordcloudTransformAs {
     fn default() -> Self {
         WordcloudTransformAs::Variant0(
-            WordcloudTransformAsVariant0::Variant0("x".to_string()),
-            WordcloudTransformAsVariant0::Variant0("y".to_string()),
-            WordcloudTransformAsVariant0::Variant0("font".to_string()),
-            WordcloudTransformAsVariant0::Variant0("fontSize".to_string()),
-            WordcloudTransformAsVariant0::Variant0("fontStyle".to_string()),
-            WordcloudTransformAsVariant0::Variant0("fontWeight".to_string()),
-            WordcloudTransformAsVariant0::Variant0("angle".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("x".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("y".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("font".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("fontSize".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("fontStyle".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("fontWeight".to_string()),
+            WordcloudTransformAsVariant0Item::Variant0("angle".to_string()),
         )
     }
 }
 impl
     From<(
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
-        WordcloudTransformAsVariant0,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
+        WordcloudTransformAsVariant0Item,
     )> for WordcloudTransformAs
 {
     fn from(
         value: (
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
-            WordcloudTransformAsVariant0,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
+            WordcloudTransformAsVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(
@@ -37355,16 +37294,16 @@ impl From<SignalRef> for WordcloudTransformAs {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum WordcloudTransformAsVariant0 {
+pub enum WordcloudTransformAsVariant0Item {
     Variant0(String),
     Variant1(SignalRef),
 }
-impl From<&WordcloudTransformAsVariant0> for WordcloudTransformAsVariant0 {
-    fn from(value: &WordcloudTransformAsVariant0) -> Self {
+impl From<&WordcloudTransformAsVariant0Item> for WordcloudTransformAsVariant0Item {
+    fn from(value: &WordcloudTransformAsVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for WordcloudTransformAsVariant0 {
+impl From<SignalRef> for WordcloudTransformAsVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -37629,8 +37568,8 @@ impl From<ParamField> for WordcloudTransformRotate {
 #[serde(untagged)]
 pub enum WordcloudTransformSize {
     Variant0(
-        WordcloudTransformSizeVariant0,
-        WordcloudTransformSizeVariant0,
+        WordcloudTransformSizeVariant0Item,
+        WordcloudTransformSizeVariant0Item,
     ),
     Variant1(SignalRef),
 }
@@ -37641,14 +37580,14 @@ impl From<&WordcloudTransformSize> for WordcloudTransformSize {
 }
 impl
     From<(
-        WordcloudTransformSizeVariant0,
-        WordcloudTransformSizeVariant0,
+        WordcloudTransformSizeVariant0Item,
+        WordcloudTransformSizeVariant0Item,
     )> for WordcloudTransformSize
 {
     fn from(
         value: (
-            WordcloudTransformSizeVariant0,
-            WordcloudTransformSizeVariant0,
+            WordcloudTransformSizeVariant0Item,
+            WordcloudTransformSizeVariant0Item,
         ),
     ) -> Self {
         Self::Variant0(value.0, value.1)
@@ -37661,21 +37600,21 @@ impl From<SignalRef> for WordcloudTransformSize {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum WordcloudTransformSizeVariant0 {
+pub enum WordcloudTransformSizeVariant0Item {
     Variant0(f64),
     Variant1(SignalRef),
 }
-impl From<&WordcloudTransformSizeVariant0> for WordcloudTransformSizeVariant0 {
-    fn from(value: &WordcloudTransformSizeVariant0) -> Self {
+impl From<&WordcloudTransformSizeVariant0Item> for WordcloudTransformSizeVariant0Item {
+    fn from(value: &WordcloudTransformSizeVariant0Item) -> Self {
         value.clone()
     }
 }
-impl From<f64> for WordcloudTransformSizeVariant0 {
+impl From<f64> for WordcloudTransformSizeVariant0Item {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<SignalRef> for WordcloudTransformSizeVariant0 {
+impl From<SignalRef> for WordcloudTransformSizeVariant0Item {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
@@ -37783,8 +37722,8 @@ pub mod defaults {
     }
     pub(super) fn bin_transform_as() -> super::BinTransformAs {
         super::BinTransformAs::Variant0(
-            super::BinTransformAsVariant0::Variant0("bin0".to_string()),
-            super::BinTransformAsVariant0::Variant0("bin1".to_string()),
+            super::BinTransformAsVariant0Item::Variant0("bin0".to_string()),
+            super::BinTransformAsVariant0Item::Variant0("bin1".to_string()),
         )
     }
     pub(super) fn bin_transform_base() -> super::BinTransformBase {
@@ -37810,8 +37749,8 @@ pub mod defaults {
     }
     pub(super) fn countpattern_transform_as() -> super::CountpatternTransformAs {
         super::CountpatternTransformAs::Variant0(
-            super::CountpatternTransformAsVariant0::Variant0("text".to_string()),
-            super::CountpatternTransformAsVariant0::Variant0("count".to_string()),
+            super::CountpatternTransformAsVariant0Item::Variant0("text".to_string()),
+            super::CountpatternTransformAsVariant0Item::Variant0("count".to_string()),
         )
     }
     pub(super) fn countpattern_transform_case() -> super::CountpatternTransformCase {
@@ -37822,8 +37761,8 @@ pub mod defaults {
     }
     pub(super) fn cross_transform_as() -> super::CrossTransformAs {
         super::CrossTransformAs::Variant0(
-            super::CrossTransformAsVariant0::Variant0("a".to_string()),
-            super::CrossTransformAsVariant0::Variant0("b".to_string()),
+            super::CrossTransformAsVariant0Item::Variant0("a".to_string()),
+            super::CrossTransformAsVariant0Item::Variant0("b".to_string()),
         )
     }
     pub(super) fn density_transform_as() -> super::DensityTransformAs {
@@ -37858,8 +37797,8 @@ pub mod defaults {
     }
     pub(super) fn fold_transform_as() -> super::FoldTransformAs {
         super::FoldTransformAs::Variant0(
-            super::FoldTransformAsVariant0::Variant0("key".to_string()),
-            super::FoldTransformAsVariant0::Variant0("value".to_string()),
+            super::FoldTransformAsVariant0Item::Variant0("key".to_string()),
+            super::FoldTransformAsVariant0Item::Variant0("value".to_string()),
         )
     }
     pub(super) fn force_transform_alpha() -> super::ForceTransformAlpha {
@@ -37923,8 +37862,8 @@ pub mod defaults {
     }
     pub(super) fn geopoint_transform_as() -> super::GeopointTransformAs {
         super::GeopointTransformAs::Variant0(
-            super::GeopointTransformAsVariant0::Variant0("x".to_string()),
-            super::GeopointTransformAsVariant0::Variant0("y".to_string()),
+            super::GeopointTransformAsVariant0Item::Variant0("x".to_string()),
+            super::GeopointTransformAsVariant0Item::Variant0("y".to_string()),
         )
     }
     pub(super) fn geoshape_transform_as() -> super::GeoshapeTransformAs {
@@ -37940,14 +37879,14 @@ pub mod defaults {
     }
     pub(super) fn graticule_transform_step_major() -> super::GraticuleTransformStepMajor {
         super::GraticuleTransformStepMajor::Variant0(
-            super::GraticuleTransformStepMajorVariant0::Variant0(90_f64),
-            super::GraticuleTransformStepMajorVariant0::Variant0(360_f64),
+            super::GraticuleTransformStepMajorVariant0Item::Variant0(90_f64),
+            super::GraticuleTransformStepMajorVariant0Item::Variant0(360_f64),
         )
     }
     pub(super) fn graticule_transform_step_minor() -> super::GraticuleTransformStepMinor {
         super::GraticuleTransformStepMinor::Variant0(
-            super::GraticuleTransformStepMinorVariant0::Variant0(10_f64),
-            super::GraticuleTransformStepMinorVariant0::Variant0(10_f64),
+            super::GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
+            super::GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
         )
     }
     pub(super) fn heatmap_transform_as() -> super::HeatmapTransformAs {
@@ -38007,11 +37946,11 @@ pub mod defaults {
     }
     pub(super) fn label_transform_as() -> super::LabelTransformAs {
         super::LabelTransformAs::Variant0(
-            super::LabelTransformAsVariant0::Variant0("x".to_string()),
-            super::LabelTransformAsVariant0::Variant0("y".to_string()),
-            super::LabelTransformAsVariant0::Variant0("opacity".to_string()),
-            super::LabelTransformAsVariant0::Variant0("align".to_string()),
-            super::LabelTransformAsVariant0::Variant0("baseline".to_string()),
+            super::LabelTransformAsVariant0Item::Variant0("x".to_string()),
+            super::LabelTransformAsVariant0Item::Variant0("y".to_string()),
+            super::LabelTransformAsVariant0Item::Variant0("opacity".to_string()),
+            super::LabelTransformAsVariant0Item::Variant0("align".to_string()),
+            super::LabelTransformAsVariant0Item::Variant0("baseline".to_string()),
         )
     }
     pub(super) fn label_transform_avoid_base_mark() -> super::LabelTransformAvoidBaseMark {
@@ -38062,27 +38001,27 @@ pub mod defaults {
     }
     pub(super) fn pack_transform_as() -> super::PackTransformAs {
         super::PackTransformAs::Variant0(
-            super::PackTransformAsVariant0::Variant0("x".to_string()),
-            super::PackTransformAsVariant0::Variant0("y".to_string()),
-            super::PackTransformAsVariant0::Variant0("r".to_string()),
-            super::PackTransformAsVariant0::Variant0("depth".to_string()),
-            super::PackTransformAsVariant0::Variant0("children".to_string()),
+            super::PackTransformAsVariant0Item::Variant0("x".to_string()),
+            super::PackTransformAsVariant0Item::Variant0("y".to_string()),
+            super::PackTransformAsVariant0Item::Variant0("r".to_string()),
+            super::PackTransformAsVariant0Item::Variant0("depth".to_string()),
+            super::PackTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
     pub(super) fn partition_transform_as() -> super::PartitionTransformAs {
         super::PartitionTransformAs::Variant0(
-            super::PartitionTransformAsVariant0::Variant0("x0".to_string()),
-            super::PartitionTransformAsVariant0::Variant0("y0".to_string()),
-            super::PartitionTransformAsVariant0::Variant0("x1".to_string()),
-            super::PartitionTransformAsVariant0::Variant0("y1".to_string()),
-            super::PartitionTransformAsVariant0::Variant0("depth".to_string()),
-            super::PartitionTransformAsVariant0::Variant0("children".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("x0".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("y0".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("x1".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("y1".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("depth".to_string()),
+            super::PartitionTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
     pub(super) fn pie_transform_as() -> super::PieTransformAs {
         super::PieTransformAs::Variant0(
-            super::PieTransformAsVariant0::Variant0("startAngle".to_string()),
-            super::PieTransformAsVariant0::Variant0("endAngle".to_string()),
+            super::PieTransformAsVariant0Item::Variant0("startAngle".to_string()),
+            super::PieTransformAsVariant0Item::Variant0("endAngle".to_string()),
         )
     }
     pub(super) fn pie_transform_end_angle() -> super::PieTransformEndAngle {
@@ -38117,8 +38056,8 @@ pub mod defaults {
     }
     pub(super) fn stack_transform_as() -> super::StackTransformAs {
         super::StackTransformAs::Variant0(
-            super::StackTransformAsVariant0::Variant0("y0".to_string()),
-            super::StackTransformAsVariant0::Variant0("y1".to_string()),
+            super::StackTransformAsVariant0Item::Variant0("y0".to_string()),
+            super::StackTransformAsVariant0Item::Variant0("y1".to_string()),
         )
     }
     pub(super) fn stack_transform_offset() -> super::StackTransformOffset {
@@ -38126,8 +38065,8 @@ pub mod defaults {
     }
     pub(super) fn timeunit_transform_as() -> super::TimeunitTransformAs {
         super::TimeunitTransformAs::Variant0(
-            super::TimeunitTransformAsVariant0::Variant0("unit0".to_string()),
-            super::TimeunitTransformAsVariant0::Variant0("unit1".to_string()),
+            super::TimeunitTransformAsVariant0Item::Variant0("unit0".to_string()),
+            super::TimeunitTransformAsVariant0Item::Variant0("unit1".to_string()),
         )
     }
     pub(super) fn timeunit_transform_interval() -> super::TimeunitTransformInterval {
@@ -38144,10 +38083,10 @@ pub mod defaults {
     }
     pub(super) fn tree_transform_as() -> super::TreeTransformAs {
         super::TreeTransformAs::Variant0(
-            super::TreeTransformAsVariant0::Variant0("x".to_string()),
-            super::TreeTransformAsVariant0::Variant0("y".to_string()),
-            super::TreeTransformAsVariant0::Variant0("depth".to_string()),
-            super::TreeTransformAsVariant0::Variant0("children".to_string()),
+            super::TreeTransformAsVariant0Item::Variant0("x".to_string()),
+            super::TreeTransformAsVariant0Item::Variant0("y".to_string()),
+            super::TreeTransformAsVariant0Item::Variant0("depth".to_string()),
+            super::TreeTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
     pub(super) fn tree_transform_method() -> super::TreeTransformMethod {
@@ -38158,12 +38097,12 @@ pub mod defaults {
     }
     pub(super) fn treemap_transform_as() -> super::TreemapTransformAs {
         super::TreemapTransformAs::Variant0(
-            super::TreemapTransformAsVariant0::Variant0("x0".to_string()),
-            super::TreemapTransformAsVariant0::Variant0("y0".to_string()),
-            super::TreemapTransformAsVariant0::Variant0("x1".to_string()),
-            super::TreemapTransformAsVariant0::Variant0("y1".to_string()),
-            super::TreemapTransformAsVariant0::Variant0("depth".to_string()),
-            super::TreemapTransformAsVariant0::Variant0("children".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("x0".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("y0".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("x1".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("y1".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("depth".to_string()),
+            super::TreemapTransformAsVariant0Item::Variant0("children".to_string()),
         )
     }
     pub(super) fn treemap_transform_method() -> super::TreemapTransformMethod {
@@ -38183,19 +38122,19 @@ pub mod defaults {
     }
     pub(super) fn window_transform_frame() -> super::WindowTransformFrame {
         super::WindowTransformFrame::Variant0(
-            super::WindowTransformFrameVariant0::Variant2,
-            super::WindowTransformFrameVariant0::Variant0(0_f64),
+            super::WindowTransformFrameVariant0Item::Variant2,
+            super::WindowTransformFrameVariant0Item::Variant0(0_f64),
         )
     }
     pub(super) fn wordcloud_transform_as() -> super::WordcloudTransformAs {
         super::WordcloudTransformAs::Variant0(
-            super::WordcloudTransformAsVariant0::Variant0("x".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("y".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("font".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("fontSize".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("fontStyle".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("fontWeight".to_string()),
-            super::WordcloudTransformAsVariant0::Variant0("angle".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("x".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("y".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("font".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("fontSize".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("fontStyle".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("fontWeight".to_string()),
+            super::WordcloudTransformAsVariant0Item::Variant0("angle".to_string()),
         )
     }
     pub(super) fn wordcloud_transform_font() -> super::WordcloudTransformFont {

--- a/typify/tests/schemas/arrays-and-tuples.json
+++ b/typify/tests/schemas/arrays-and-tuples.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "simple-two-tuple": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "simpler-two-tuple": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "string"
+      }
+    },
+    "less-simple-two-tuple": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "unsimple-two-tuple": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "type": "string"
+        }
+      ],
+      "additionalItems": {
+        "type": "string"
+      }
+    },
+    "yolo-two-tuple": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "additionalItems": {
+        "$comment": "ignored",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -1,0 +1,118 @@
+#[allow(unused_imports)]
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LessSimpleTwoTuple(pub (String, String));
+impl std::ops::Deref for LessSimpleTwoTuple {
+    type Target = (String, String);
+    fn deref(&self) -> &(String, String) {
+        &self.0
+    }
+}
+impl From<LessSimpleTwoTuple> for (String, String) {
+    fn from(value: LessSimpleTwoTuple) -> Self {
+        value.0
+    }
+}
+impl From<&LessSimpleTwoTuple> for LessSimpleTwoTuple {
+    fn from(value: &LessSimpleTwoTuple) -> Self {
+        value.clone()
+    }
+}
+impl From<(String, String)> for LessSimpleTwoTuple {
+    fn from(value: (String, String)) -> Self {
+        Self(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SimpleTwoTuple(pub (String, String));
+impl std::ops::Deref for SimpleTwoTuple {
+    type Target = (String, String);
+    fn deref(&self) -> &(String, String) {
+        &self.0
+    }
+}
+impl From<SimpleTwoTuple> for (String, String) {
+    fn from(value: SimpleTwoTuple) -> Self {
+        value.0
+    }
+}
+impl From<&SimpleTwoTuple> for SimpleTwoTuple {
+    fn from(value: &SimpleTwoTuple) -> Self {
+        value.clone()
+    }
+}
+impl From<(String, String)> for SimpleTwoTuple {
+    fn from(value: (String, String)) -> Self {
+        Self(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SimplerTwoTuple(pub (String, String));
+impl std::ops::Deref for SimplerTwoTuple {
+    type Target = (String, String);
+    fn deref(&self) -> &(String, String) {
+        &self.0
+    }
+}
+impl From<SimplerTwoTuple> for (String, String) {
+    fn from(value: SimplerTwoTuple) -> Self {
+        value.0
+    }
+}
+impl From<&SimplerTwoTuple> for SimplerTwoTuple {
+    fn from(value: &SimplerTwoTuple) -> Self {
+        value.clone()
+    }
+}
+impl From<(String, String)> for SimplerTwoTuple {
+    fn from(value: (String, String)) -> Self {
+        Self(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UnsimpleTwoTuple(pub (String, String));
+impl std::ops::Deref for UnsimpleTwoTuple {
+    type Target = (String, String);
+    fn deref(&self) -> &(String, String) {
+        &self.0
+    }
+}
+impl From<UnsimpleTwoTuple> for (String, String) {
+    fn from(value: UnsimpleTwoTuple) -> Self {
+        value.0
+    }
+}
+impl From<&UnsimpleTwoTuple> for UnsimpleTwoTuple {
+    fn from(value: &UnsimpleTwoTuple) -> Self {
+        value.clone()
+    }
+}
+impl From<(String, String)> for UnsimpleTwoTuple {
+    fn from(value: (String, String)) -> Self {
+        Self(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct YoloTwoTuple(pub (serde_json::Value, serde_json::Value));
+impl std::ops::Deref for YoloTwoTuple {
+    type Target = (serde_json::Value, serde_json::Value);
+    fn deref(&self) -> &(serde_json::Value, serde_json::Value) {
+        &self.0
+    }
+}
+impl From<YoloTwoTuple> for (serde_json::Value, serde_json::Value) {
+    fn from(value: YoloTwoTuple) -> Self {
+        value.0
+    }
+}
+impl From<&YoloTwoTuple> for YoloTwoTuple {
+    fn from(value: &YoloTwoTuple) -> Self {
+        value.clone()
+    }
+}
+impl From<(serde_json::Value, serde_json::Value)> for YoloTwoTuple {
+    fn from(value: (serde_json::Value, serde_json::Value)) -> Self {
+        Self(value)
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -96,7 +96,7 @@
       ]
     },
     "JankNames": {
-      "anyOf": [
+      "oneOf": [
         {
           "title": "Animation Specification",
           "type": "string"
@@ -109,8 +109,47 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        {
+          "type": "object",
+          "maxProperties": 2,
+          "minProperties": 2,
+          "additionalProperties": {
+            "type": "integer"
+          }
         }
       ]
+    },
+    "References": {
+      "description": "issue 280",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$comment": "Mapping of mod name to the desired version",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/StringVersion"
+              },
+              {
+                "$ref": "#/definitions/ReferenceDef"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "StringVersion": {
+      "type": "string"
+    },
+    "ReferenceDef": {
+      "type": "string"
     }
   }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -55,17 +55,6 @@ impl Default for AlternativeEnum {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct AnimationSpecification {
-    #[serde(flatten)]
-    pub extra: std::collections::HashMap<String, String>,
-}
-impl From<&AnimationSpecification> for AnimationSpecification {
-    fn from(value: &AnimationSpecification) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DiskAttachment {
     pub alternate: AlternativeEnum,
     pub state: DiskAttachmentState,
@@ -260,16 +249,22 @@ impl ToString for Ipv6Net {
 #[serde(untagged)]
 pub enum JankNames {
     Variant0(String),
-    Variant1(AnimationSpecification),
+    Variant1(std::collections::HashMap<String, String>),
+    Variant2(std::collections::HashMap<String, i64>),
 }
 impl From<&JankNames> for JankNames {
     fn from(value: &JankNames) -> Self {
         value.clone()
     }
 }
-impl From<AnimationSpecification> for JankNames {
-    fn from(value: AnimationSpecification) -> Self {
+impl From<std::collections::HashMap<String, String>> for JankNames {
+    fn from(value: std::collections::HashMap<String, String>) -> Self {
         Self::Variant1(value)
+    }
+}
+impl From<std::collections::HashMap<String, i64>> for JankNames {
+    fn from(value: std::collections::HashMap<String, i64>) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -362,6 +357,155 @@ impl From<&OneOfTypes> for OneOfTypes {
 impl From<i64> for OneOfTypes {
     fn from(value: i64) -> Self {
         Self::Bar(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ReferenceDef(pub String);
+impl std::ops::Deref for ReferenceDef {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<ReferenceDef> for String {
+    fn from(value: ReferenceDef) -> Self {
+        value.0
+    }
+}
+impl From<&ReferenceDef> for ReferenceDef {
+    fn from(value: &ReferenceDef) -> Self {
+        value.clone()
+    }
+}
+impl From<String> for ReferenceDef {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for ReferenceDef {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_string()))
+    }
+}
+impl ToString for ReferenceDef {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+#[doc = "issue 280"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum References {
+    Variant0(Vec<String>),
+    Variant1(std::collections::HashMap<String, ReferencesVariant1Value>),
+}
+impl From<&References> for References {
+    fn from(value: &References) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<String>> for References {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<std::collections::HashMap<String, ReferencesVariant1Value>> for References {
+    fn from(value: std::collections::HashMap<String, ReferencesVariant1Value>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ReferencesVariant1Value {
+    StringVersion(StringVersion),
+    ReferenceDef(ReferenceDef),
+}
+impl From<&ReferencesVariant1Value> for ReferencesVariant1Value {
+    fn from(value: &ReferencesVariant1Value) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for ReferencesVariant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::StringVersion(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::ReferenceDef(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for ReferencesVariant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ReferencesVariant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for ReferencesVariant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for ReferencesVariant1Value {
+    fn to_string(&self) -> String {
+        match self {
+            Self::StringVersion(x) => x.to_string(),
+            Self::ReferenceDef(x) => x.to_string(),
+        }
+    }
+}
+impl From<StringVersion> for ReferencesVariant1Value {
+    fn from(value: StringVersion) -> Self {
+        Self::StringVersion(value)
+    }
+}
+impl From<ReferenceDef> for ReferencesVariant1Value {
+    fn from(value: ReferenceDef) -> Self {
+        Self::ReferenceDef(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StringVersion(pub String);
+impl std::ops::Deref for StringVersion {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<StringVersion> for String {
+    fn from(value: StringVersion) -> Self {
+        value.0
+    }
+}
+impl From<&StringVersion> for StringVersion {
+    fn from(value: &StringVersion) -> Self {
+        value.clone()
+    }
+}
+impl From<String> for StringVersion {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for StringVersion {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_string()))
+    }
+}
+impl ToString for StringVersion {
+    fn to_string(&self) -> String {
+        self.0.to_string()
     }
 }
 fn main() {}


### PR DESCRIPTION
Fix (and simplify) enum variant construction by converting the schema to a type and then subsuming that type into the variant.

Avoid using serde's deny_unknown_fields with serde's flatten... with which it is incompatible.

Significantly improve handling of various tuple-generating types (only a few trivial cases were handled).

Correct handling of singleton (one-element) tuples which require a tailing comma in order to be treated as tuples (rather than merely as extraneously parenthesized types).

Closes #280 and #244 