### PR TITLE
Use extra angle brackets to avoid ambiguity with the less-than operator

### DIFF
--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1326,7 +1326,7 @@ impl TypeEntry {
                             D: serde::Deserializer<'de>,
                         {
                             Self::try_from(
-                                #inner_type_name::deserialize(deserializer)?,
+                                <#inner_type_name>::deserialize(deserializer)?,
                             )
                             .map_err(|e| {
                                 <D::Error as serde::de::Error>::custom(

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -5447,7 +5447,7 @@ impl<'de> serde::Deserialize<'de> for BindVariant3Input {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
+        Self::try_from(<String>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
@@ -21734,7 +21734,7 @@ impl<'de> serde::Deserialize<'de> for MarkVisualType {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
+        Self::try_from(<String>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
@@ -30894,7 +30894,7 @@ impl<'de> serde::Deserialize<'de> for SignalName {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
+        Self::try_from(<String>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -43,7 +43,7 @@ impl<'de> serde::Deserialize<'de> for TestTypeWhereNot {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
+        Self::try_from(<String>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
@@ -80,7 +80,7 @@ impl<'de> serde::Deserialize<'de> for TestTypeWhyNot {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(String::deserialize(deserializer)?)
+        Self::try_from(<String>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -88,7 +88,7 @@ impl<'de> serde::Deserialize<'de> for Sub10Primes {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::try_from(u32::deserialize(deserializer)?)
+        Self::try_from(<u32>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -95,6 +95,15 @@
         "alternate"
       ]
     },
+    "EmptyObject": {
+      "type": "object",
+      "properties": {
+        "prop": {
+          "type": "object",
+          "enum": [{}]
+        }
+      }
+    },
     "JankNames": {
       "oneOf": [
         {

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -119,6 +119,55 @@ impl Default for DiskAttachmentState {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EmptyObject {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prop: Option<EmptyObjectProp>,
+}
+impl From<&EmptyObject> for EmptyObject {
+    fn from(value: &EmptyObject) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct EmptyObjectProp(serde_json::Map<String, serde_json::Value>);
+impl std::ops::Deref for EmptyObjectProp {
+    type Target = serde_json::Map<String, serde_json::Value>;
+    fn deref(&self) -> &serde_json::Map<String, serde_json::Value> {
+        &self.0
+    }
+}
+impl From<EmptyObjectProp> for serde_json::Map<String, serde_json::Value> {
+    fn from(value: EmptyObjectProp) -> Self {
+        value.0
+    }
+}
+impl From<&EmptyObjectProp> for EmptyObjectProp {
+    fn from(value: &EmptyObjectProp) -> Self {
+        value.clone()
+    }
+}
+impl std::convert::TryFrom<serde_json::Map<String, serde_json::Value>> for EmptyObjectProp {
+    type Error = &'static str;
+    fn try_from(value: serde_json::Map<String, serde_json::Value>) -> Result<Self, &'static str> {
+        if ![[].into_iter().collect()].contains(&value) {
+            Err("invalid value")
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for EmptyObjectProp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::try_from(<serde_json::Map<String, serde_json::Value>>::deserialize(
+            deserializer,
+        )?)
+        .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IpNet {
     V4(Ipv4Net),


### PR DESCRIPTION
Fixes #329.

Helped-by: Adam Leventhal <ahl@oxide.computer>