### PR TITLE
handle `allOf` by merging schemas

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@
 
 == Unreleased changes (release date TBD)
 
+* Handle arbitrary containment cycles (#300)
+* More permissive of valid (if useless) schema constructions (#306, #320)
+* Much better handling of `allOf` constructions by merging schemas (#405)
+
 https://github.com/oxidecomputer/typify/compare/v0.0.13\...HEAD[Full list of commits]
 
 == 0.0.13 (released 2023-05-14)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bstr"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +188,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "color-eyre",
+ "env_logger",
  "expectorate",
  "newline-converter",
  "rustfmt-wrapper",
@@ -341,6 +348,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "example-build"
 version = "0.0.0"
 dependencies = [
@@ -425,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "home"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +479,12 @@ checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -482,6 +535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,9 +577,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "log"
@@ -697,7 +767,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -759,6 +829,19 @@ dependencies = [
  "thiserror",
  "toml",
  "toolchain_find",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "color-eyre",
+ "env_logger",
  "expectorate",
  "newline-converter",
  "rustfmt-wrapper",
@@ -344,6 +345,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +476,12 @@ checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -16,9 +16,10 @@ typify = { version = "0.0.13", path = "../typify" }
 
 clap = { version = "4.3.21", features = ["derive"] }
 color-eyre = "0.6"
+env_logger = "0.10"
+rustfmt-wrapper = "0.2.0"
 serde_json = "1.0.104"
 schemars = "0.8.12"
-rustfmt-wrapper = "0.2.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/cargo-typify/src/main.rs
+++ b/cargo-typify/src/main.rs
@@ -1,3 +1,5 @@
+// Copyright 2023 Oxide Computer Company
+
 use cargo_typify::{convert, CliArgs};
 use clap::Parser;
 
@@ -11,6 +13,7 @@ enum CargoCli {
 }
 
 fn main() -> Result<()> {
+    env_logger::init();
     color_eyre::install()?;
 
     let cli = CargoCli::parse();

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1029,13 +1029,17 @@ impl TypeSpace {
                 && additional_properties.as_ref().map(AsRef::as_ref)
                     != Some(&Schema::Bool(false)) =>
             {
-                self.make_map(
+                let type_entry = self.make_map(
                     type_name.into_option(),
                     property_names,
                     additional_properties,
-                )
+                )?;
+                Ok((type_entry, metadata))
             }
-            None => self.make_map(type_name.into_option(), &None, &None),
+            None => {
+                let type_entry = self.make_map(type_name.into_option(), &None, &None)?;
+                Ok((type_entry, metadata))
+            }
 
             // The typical case
             Some(validation) => {

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -696,7 +696,6 @@ impl TypeSpace {
                     metadata,
                 ))
             }
-
             Some("date-time") => {
                 self.uses_chrono = true;
                 Ok((
@@ -729,6 +728,7 @@ impl TypeSpace {
                 ),
                 metadata,
             )),
+
             Some(unhandled) => {
                 info!("treating a string format '{}' as a String", unhandled);
                 Ok((TypeEntryDetails::String.into(), metadata))
@@ -1055,6 +1055,29 @@ impl TypeSpace {
         if let Some(ty) = self.maybe_singleton_subschema(type_name.clone(), subschemas) {
             return Ok((ty, metadata));
         }
+
+        // TODO With logic to merge types, I think that becomes the general
+        // case: merge all subschemas, convert to a type, (later/optional) add
+        // conversion methods into the named subtypes (i.e. the refs).
+        //
+        // Note that this merge/convert mechanism isn't specific to objects.
+        // It's equally applicable to other types.
+        //
+        // Also note that sometimes we might end up with a type that we
+        // determine to be invalid or unsatisfiable, for example if there's an
+        // integer whose minimum is greater than its maximum. In that case we
+        // could either blow up or generate some sort of Never equivalent.
+        //
+        // Beyond that there is a special case to consider where named
+        // subschemas are objects that are orthogonal to all other named
+        // schemas (an those are also objects). In that case (and in that case
+        // only) we could embed and flatten the named type. However, this seems
+        // like a convenience rather than a critical feature. The only
+        // advantage of pulling out this special case is the ease of
+        // translating between the big type and its component type.
+        //
+        // The existing special cases should go away as should the "flattened
+        // union" handling.
 
         if let Some(ty) = self.maybe_all_of_constraints(type_name.clone(), subschemas) {
             return Ok((ty, metadata));

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -24,6 +24,7 @@ mod convert;
 mod cycles;
 mod defaults;
 mod enums;
+mod merge;
 mod output;
 mod structs;
 mod type_entry;

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -508,6 +508,12 @@ impl TypeSpace {
             // For types that don't have names, this is effectively a type
             // alias which we treat as a newtype.
             _ => {
+                info!(
+                    "type alias {:?} {}\n{:?}",
+                    type_name,
+                    serde_json::to_string_pretty(&schema).unwrap(),
+                    metadata
+                );
                 let subtype_id = self.assign_type(type_entry);
                 TypeEntryNewtype::from_metadata(self, type_name, metadata, subtype_id)
             }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -29,6 +29,7 @@ mod output;
 mod structs;
 mod type_entry;
 mod util;
+mod validate;
 mod value;
 
 #[derive(Error, Debug)]

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -76,6 +76,7 @@ impl TypeSpace {
             {
                 false
             }
+
             None => false,
 
             // Only particular additional properties are allowed. Note that
@@ -84,7 +85,7 @@ impl TypeSpace {
             // quite right.
             additional_properties @ Some(_) => {
                 let sub_type_name = type_name.as_ref().map(|base| format!("{}_extra", base));
-                let (map_type, _) = self.make_map(
+                let map_type = self.make_map(
                     sub_type_name,
                     &validation.property_names,
                     additional_properties,
@@ -174,7 +175,7 @@ impl TypeSpace {
         type_name: Option<String>,
         property_names: &Option<Box<Schema>>,
         additional_properties: &Option<Box<Schema>>,
-    ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
+    ) -> Result<TypeEntry> {
         let key_id = match property_names.as_deref() {
             Some(Schema::Bool(true)) | None => self.assign_type(TypeEntryDetails::String.into()),
 
@@ -203,7 +204,7 @@ impl TypeSpace {
             None => self.id_for_schema(Name::Unknown, &Schema::Bool(true))?,
         };
 
-        Ok((TypeEntryDetails::Map(key_id, value_id).into(), &None))
+        Ok(TypeEntryDetails::Map(key_id, value_id).into())
     }
 
     /// Perform a schema conversion for a type that must be string-like.

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -3,9 +3,7 @@
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::quote;
-use schemars::schema::{
-    InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
-};
+use schemars::schema::{InstanceType, Metadata, ObjectValidation, Schema, SchemaObject};
 
 use crate::{
     output::{OutputSpace, OutputSpaceMod},
@@ -13,7 +11,7 @@ use crate::{
         StructProperty, StructPropertyRename, StructPropertyState, TypeEntry, TypeEntryStruct,
         WrappedValue,
     },
-    util::{get_object_ref, get_type_name, metadata_description, recase, schema_is_named, Case},
+    util::{get_type_name, metadata_description, recase, Case},
     Name, Result, TypeEntryDetails, TypeId, TypeSpace,
 };
 
@@ -297,194 +295,6 @@ impl TypeSpace {
             TypeEntryStruct::from_metadata(self, type_name, metadata, properties, false),
             metadata,
         ))
-    }
-
-    /// This handles the case where an allOf is used to effect inheritance: the
-    /// subschemas consist of one or more "super classes" that have names with
-    /// a final, anonymous object.
-    ///
-    /// ```text
-    /// "allOf": [
-    ///     { "$ref": "#/definitions/SuperClass" },
-    ///     { "type": "object", "properties": { "prop_a": .., "prop_b": .. }}
-    /// ]
-    /// ```
-    ///
-    /// This turns into a struct of this form:
-    /// ```compile_fail
-    /// struct MyType {
-    ///     #[serde(flatten)]
-    ///     super_class: SuperClass,
-    ///     prop_a: (),
-    ///     prop_b: (),
-    /// }
-    /// ```
-    ///
-    /// Note that the super class member names are derived from the type and
-    /// are flattened into the struct; the subclass properties are simply
-    /// included alongside.
-    pub(crate) fn maybe_all_of_subclass(
-        &mut self,
-        type_name: Name,
-        metadata: &Option<Box<Metadata>>,
-        subschemas: &[Schema],
-    ) -> Option<TypeEntry> {
-        assert!(subschemas.len() > 1);
-
-        // Split the subschemas into named (superclass) and unnamed (subclass)
-        // schemas.
-        let mut named = Vec::new();
-        let mut unnamed = Vec::new();
-        for schema in subschemas {
-            match schema_is_named(schema) {
-                Some(name) => named.push((schema, name)),
-                None => unnamed.push(schema),
-            }
-        }
-
-        // We required exactly one unnamed subschema for this special case.
-        // Note that zero unnamed subschemas would be trivial to handle, but
-        // the generic case already does so albeit slightly differently.
-        if unnamed.len() != 1 {
-            return None;
-        }
-
-        // Get the object validation (or fail to match this special case).
-        let unnamed_schema = unnamed.first()?;
-        let validation = match unnamed_schema {
-            Schema::Object(SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(single)),
-                format: None,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: Some(validation),
-                reference: None,
-                extensions: _,
-            }) if single.as_ref() == &InstanceType::Object => Some(validation),
-            _ => None,
-        }?;
-        let tmp_type_name = get_type_name(&type_name, metadata);
-        let (unnamed_properties, _) = self.struct_members(tmp_type_name, validation).ok()?;
-
-        let named_properties = named
-            .iter()
-            .map(|(schema, property_name)| {
-                let (type_id, metadata) = self.id_for_schema(type_name.clone(), schema)?;
-                let (name, _) = recase(property_name, Case::Snake);
-                let name = if validation.properties.contains_key(&name) {
-                    format!("{}__", name)
-                } else {
-                    name
-                };
-                Ok(StructProperty {
-                    name,
-                    rename: StructPropertyRename::Flatten,
-                    state: StructPropertyState::Required,
-                    description: metadata_description(metadata),
-                    type_id,
-                })
-            })
-            .collect::<Result<Vec<_>>>()
-            .ok()?;
-
-        Some(TypeEntryStruct::from_metadata(
-            self,
-            type_name,
-            metadata,
-            named_properties
-                .into_iter()
-                .chain(unnamed_properties.into_iter())
-                .collect(),
-            // Note that #[serde(deny_unknown_fields)] is incompatible with
-            // #[serde(flatten)] which we use for the superclass(es).
-            false,
-        ))
-    }
-
-    /// This handles the case where an allOf is used to denote constraints.
-    /// Currently we just look for a referenced type, which may be "closed"
-    /// (i.e. no unknown fields permitted) and an explicit type. The latter
-    /// must be a subset of the former and compatible from the perspective of
-    /// JSON Schema validation (that is to say, it must be "open" or must fully
-    /// cover the named type).
-    ///
-    /// ```text
-    /// "allOf": [
-    ///     { "$ref": "#/definitions/SomeType" },
-    ///     { "type": "object", "properties": { "prop_a": .., "prop_b": .. }}
-    /// ]
-    /// ```
-    ///
-    /// Types such as these should be treated as the named type along with
-    /// constraints. What do we do to enforce these constraints or communicate
-    /// them to the consumer? Nothing!
-    ///
-    /// What could we do? We could add a custom `serialize_with` /
-    /// `deserialize_with` functions to validate the constrains in and out.
-    /// Or we could introduce a newtype wrapper to enforce those constraints.
-    pub(crate) fn maybe_all_of_constraints(
-        &mut self,
-        type_name: Name,
-        subschemas: &[Schema],
-    ) -> Option<TypeEntry> {
-        assert!(subschemas.len() > 1);
-
-        // Split the subschemas into named (superclass) and unnamed (subclass)
-        // schemas.
-        let mut named = Vec::new();
-        let mut unnamed = Vec::new();
-        for schema in subschemas {
-            // TODO this might not be quite right since this will be true for
-            // schemas that have a title; we may want to look only for types
-            // with a mandatory name. Types with a title (optional name) are
-            // reasonable to inline generally.
-            match schema_is_named(schema) {
-                Some(name) => named.push((schema, name)),
-                None => unnamed.push(schema),
-            }
-        }
-
-        // We required exactly one named subschema and at least one unnamed
-        // subschema.
-        if named.len() != 1 || unnamed.is_empty() {
-            return None;
-        }
-
-        let (named_schema, _) = named.first()?;
-        let validation = get_object_ref(named_schema, &self.definitions)?;
-
-        // We need all unnamed schemas to be a subset of the named schema.
-        if !unnamed
-            .into_iter()
-            .all(|constraint_schema| is_obj_subset(validation, constraint_schema))
-        {
-            return None;
-        }
-
-        let (type_entry, _) = self.convert_schema(type_name, named_schema).ok()?;
-        Some(type_entry)
-    }
-}
-
-fn is_obj_subset(validation: &ObjectValidation, constraint_schema: &Schema) -> bool {
-    if let Schema::Object(SchemaObject {
-        object: Some(obj), ..
-    }) = constraint_schema
-    {
-        // TODO there's a lot more we could do to determine whether this is a
-        // subset including inspection of the property types and confirming
-        // that either all properties are covered or that the constraint object
-        // is "open".
-        obj.properties
-            .keys()
-            .all(|key| validation.properties.contains_key(key))
-    } else {
-        false
     }
 }
 

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -170,7 +170,7 @@ impl TypeSpace {
         })
     }
 
-    pub(crate) fn make_map<'a>(
+    pub(crate) fn make_map(
         &mut self,
         type_name: Option<String>,
         property_names: &Option<Box<Schema>>,

--- a/typify-impl/src/validate.rs
+++ b/typify-impl/src/validate.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 Oxide Computer Company
+
+use std::collections::BTreeMap;
+
+use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec};
+use serde_json::Value;
+
+use crate::RefKey;
+
+pub(crate) fn schema_value_validate(
+    schema: &Schema,
+    value: &Value,
+    defs: &BTreeMap<RefKey, Schema>,
+) -> Result<(), String> {
+    match schema {
+        Schema::Bool(false) => Err("never schema".to_string()),
+        Schema::Bool(true) => Ok(()),
+        Schema::Object(object) => schema_object_value_validate(object, value, defs),
+    }
+}
+
+fn schema_object_value_validate(
+    object: &SchemaObject,
+    value: &Value,
+    _defs: &BTreeMap<RefKey, Schema>,
+) -> Result<(), String> {
+    assert!(object.enum_values.is_none());
+    assert!(object.const_value.is_none());
+
+    let SchemaObject { instance_type, .. } = object;
+
+    schema_object_value_validate_instance_type(instance_type.as_ref(), value)?;
+
+    Ok(())
+}
+
+fn schema_object_value_validate_instance_type(
+    instance_type: Option<&SingleOrVec<InstanceType>>,
+    value: &Value,
+) -> Result<(), String> {
+    match instance_type {
+        None => Ok(()),
+        Some(SingleOrVec::Single(it)) => check_instance(it, value),
+        Some(SingleOrVec::Vec(its)) => its
+            .iter()
+            .any(|it| check_instance(it, value).is_ok())
+            .then_some(())
+            .ok_or_else(|| "no valid instance type".to_string()),
+    }
+}
+
+fn check_instance(it: &InstanceType, value: &Value) -> Result<(), String> {
+    match it {
+        InstanceType::Null => value
+            .is_null()
+            .then_some(())
+            .ok_or_else(|| "not null".to_string()),
+        InstanceType::Boolean => value
+            .is_boolean()
+            .then_some(())
+            .ok_or_else(|| "not boolean".to_string()),
+        InstanceType::Object => value
+            .is_object()
+            .then_some(())
+            .ok_or_else(|| "not object".to_string()),
+        InstanceType::Array => value
+            .is_array()
+            .then_some(())
+            .ok_or_else(|| "not array".to_string()),
+        InstanceType::Number => value
+            .is_number()
+            .then_some(())
+            .ok_or_else(|| "not number".to_string()),
+        InstanceType::String => value
+            .is_string()
+            .then_some(())
+            .ok_or_else(|| "not string".to_string()),
+        InstanceType::Integer => (value.is_i64() || value.is_u64())
+            .then_some(())
+            .ok_or_else(|| "not integer".to_string()),
+    }
+}

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -5670,7 +5670,7 @@ pub struct CodeScanningAlertClosedByUserAlert {
     pub dismissed_reason: Option<CodeScanningAlertClosedByUserAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+    pub instances: Vec<CodeScanningAlertClosedByUserAlertInstancesItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub most_recent_instance: Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
@@ -5736,6 +5736,113 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertDismis
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertDismissedReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
+    #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
+    pub analysis_key: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classifications: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
+    pub environment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<CodeScanningAlertClosedByUserAlertInstancesItemLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<CodeScanningAlertClosedByUserAlertInstancesItemMessage>,
+    #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub state: CodeScanningAlertClosedByUserAlertInstancesItemState,
+}
+impl From<&CodeScanningAlertClosedByUserAlertInstancesItem>
+    for CodeScanningAlertClosedByUserAlertInstancesItem
+{
+    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<i64>,
+}
+impl From<&CodeScanningAlertClosedByUserAlertInstancesItemLocation>
+    for CodeScanningAlertClosedByUserAlertInstancesItemLocation
+{
+    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemLocation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertClosedByUserAlertInstancesItemMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+impl From<&CodeScanningAlertClosedByUserAlertInstancesItemMessage>
+    for CodeScanningAlertClosedByUserAlertInstancesItemMessage
+{
+    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemMessage) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum CodeScanningAlertClosedByUserAlertInstancesItemState {
+    #[serde(rename = "dismissed")]
+    Dismissed,
+}
+impl From<&CodeScanningAlertClosedByUserAlertInstancesItemState>
+    for CodeScanningAlertClosedByUserAlertInstancesItemState
+{
+    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Dismissed => "dismissed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for CodeScanningAlertClosedByUserAlertInstancesItemState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "dismissed" => Ok(Self::Dismissed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertInstancesItemState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -5962,7 +6069,7 @@ pub struct CodeScanningAlertCreatedAlert {
     pub dismissed_reason: (),
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+    pub instances: Vec<CodeScanningAlertCreatedAlertInstancesItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub most_recent_instance: Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
@@ -5976,6 +6083,117 @@ pub struct CodeScanningAlertCreatedAlert {
 impl From<&CodeScanningAlertCreatedAlert> for CodeScanningAlertCreatedAlert {
     fn from(value: &CodeScanningAlertCreatedAlert) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertCreatedAlertInstancesItem {
+    #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
+    pub analysis_key: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classifications: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
+    pub environment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<CodeScanningAlertCreatedAlertInstancesItemLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<CodeScanningAlertCreatedAlertInstancesItemMessage>,
+    #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub state: CodeScanningAlertCreatedAlertInstancesItemState,
+}
+impl From<&CodeScanningAlertCreatedAlertInstancesItem>
+    for CodeScanningAlertCreatedAlertInstancesItem
+{
+    fn from(value: &CodeScanningAlertCreatedAlertInstancesItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<i64>,
+}
+impl From<&CodeScanningAlertCreatedAlertInstancesItemLocation>
+    for CodeScanningAlertCreatedAlertInstancesItemLocation
+{
+    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemLocation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertCreatedAlertInstancesItemMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+impl From<&CodeScanningAlertCreatedAlertInstancesItemMessage>
+    for CodeScanningAlertCreatedAlertInstancesItemMessage
+{
+    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemMessage) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum CodeScanningAlertCreatedAlertInstancesItemState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "dismissed")]
+    Dismissed,
+}
+impl From<&CodeScanningAlertCreatedAlertInstancesItemState>
+    for CodeScanningAlertCreatedAlertInstancesItemState
+{
+    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for CodeScanningAlertCreatedAlertInstancesItemState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Dismissed => "dismissed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for CodeScanningAlertCreatedAlertInstancesItemState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "dismissed" => Ok(Self::Dismissed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6248,7 +6466,7 @@ pub struct CodeScanningAlertFixedAlert {
     pub dismissed_reason: Option<CodeScanningAlertFixedAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+    pub instances: Vec<CodeScanningAlertFixedAlertInstancesItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instances_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6316,6 +6534,111 @@ impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertDismissedReas
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertDismissedReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertFixedAlertInstancesItem {
+    #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
+    pub analysis_key: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classifications: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
+    pub environment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<CodeScanningAlertFixedAlertInstancesItemLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<CodeScanningAlertFixedAlertInstancesItemMessage>,
+    #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub state: CodeScanningAlertFixedAlertInstancesItemState,
+}
+impl From<&CodeScanningAlertFixedAlertInstancesItem> for CodeScanningAlertFixedAlertInstancesItem {
+    fn from(value: &CodeScanningAlertFixedAlertInstancesItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<i64>,
+}
+impl From<&CodeScanningAlertFixedAlertInstancesItemLocation>
+    for CodeScanningAlertFixedAlertInstancesItemLocation
+{
+    fn from(value: &CodeScanningAlertFixedAlertInstancesItemLocation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertFixedAlertInstancesItemMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+impl From<&CodeScanningAlertFixedAlertInstancesItemMessage>
+    for CodeScanningAlertFixedAlertInstancesItemMessage
+{
+    fn from(value: &CodeScanningAlertFixedAlertInstancesItemMessage) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum CodeScanningAlertFixedAlertInstancesItemState {
+    #[serde(rename = "fixed")]
+    Fixed,
+}
+impl From<&CodeScanningAlertFixedAlertInstancesItemState>
+    for CodeScanningAlertFixedAlertInstancesItemState
+{
+    fn from(value: &CodeScanningAlertFixedAlertInstancesItemState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for CodeScanningAlertFixedAlertInstancesItemState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Fixed => "fixed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for CodeScanningAlertFixedAlertInstancesItemState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "fixed" => Ok(Self::Fixed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertInstancesItemState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -6540,7 +6863,7 @@ pub struct CodeScanningAlertReopenedAlert {
     pub dismissed_reason: (),
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+    pub instances: Vec<CodeScanningAlertReopenedAlertInstancesItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub most_recent_instance: Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
@@ -6554,6 +6877,113 @@ pub struct CodeScanningAlertReopenedAlert {
 impl From<&CodeScanningAlertReopenedAlert> for CodeScanningAlertReopenedAlert {
     fn from(value: &CodeScanningAlertReopenedAlert) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedAlertInstancesItem {
+    #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
+    pub analysis_key: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classifications: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
+    pub environment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<CodeScanningAlertReopenedAlertInstancesItemLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<CodeScanningAlertReopenedAlertInstancesItemMessage>,
+    #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub state: CodeScanningAlertReopenedAlertInstancesItemState,
+}
+impl From<&CodeScanningAlertReopenedAlertInstancesItem>
+    for CodeScanningAlertReopenedAlertInstancesItem
+{
+    fn from(value: &CodeScanningAlertReopenedAlertInstancesItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<i64>,
+}
+impl From<&CodeScanningAlertReopenedAlertInstancesItemLocation>
+    for CodeScanningAlertReopenedAlertInstancesItemLocation
+{
+    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemLocation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedAlertInstancesItemMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+impl From<&CodeScanningAlertReopenedAlertInstancesItemMessage>
+    for CodeScanningAlertReopenedAlertInstancesItemMessage
+{
+    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemMessage) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum CodeScanningAlertReopenedAlertInstancesItemState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&CodeScanningAlertReopenedAlertInstancesItemState>
+    for CodeScanningAlertReopenedAlertInstancesItemState
+{
+    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for CodeScanningAlertReopenedAlertInstancesItemState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for CodeScanningAlertReopenedAlertInstancesItemState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -6785,7 +7215,7 @@ pub struct CodeScanningAlertReopenedByUserAlert {
     pub dismissed_reason: (),
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: String,
-    pub instances: Vec<AlertInstance>,
+    pub instances: Vec<CodeScanningAlertReopenedByUserAlertInstancesItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub most_recent_instance: Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
@@ -6799,6 +7229,113 @@ pub struct CodeScanningAlertReopenedByUserAlert {
 impl From<&CodeScanningAlertReopenedByUserAlert> for CodeScanningAlertReopenedByUserAlert {
     fn from(value: &CodeScanningAlertReopenedByUserAlert) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
+    #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
+    pub analysis_key: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classifications: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
+    pub environment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<CodeScanningAlertReopenedByUserAlertInstancesItemLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<CodeScanningAlertReopenedByUserAlertInstancesItemMessage>,
+    #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub state: CodeScanningAlertReopenedByUserAlertInstancesItemState,
+}
+impl From<&CodeScanningAlertReopenedByUserAlertInstancesItem>
+    for CodeScanningAlertReopenedByUserAlertInstancesItem
+{
+    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<i64>,
+}
+impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemLocation>
+    for CodeScanningAlertReopenedByUserAlertInstancesItemLocation
+{
+    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemLocation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemMessage>
+    for CodeScanningAlertReopenedByUserAlertInstancesItemMessage
+{
+    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemMessage) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemState>
+    for CodeScanningAlertReopenedByUserAlertInstancesItemState
+{
+    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -7834,7 +8371,7 @@ impl From<&Discussion> for Discussion {
 pub struct DiscussionAnswered {
     pub action: DiscussionAnsweredAction,
     pub answer: DiscussionAnsweredAnswer,
-    pub discussion: Discussion,
+    pub discussion: DiscussionAnsweredDiscussion,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7910,6 +8447,188 @@ pub struct DiscussionAnsweredAnswer {
 impl From<&DiscussionAnsweredAnswer> for DiscussionAnsweredAnswer {
     fn from(value: &DiscussionAnsweredAnswer) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionAnsweredDiscussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: chrono::DateTime<chrono::offset::Utc>,
+    pub answer_chosen_by: DiscussionAnsweredDiscussionAnswerChosenBy,
+    pub answer_html_url: String,
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionAnsweredDiscussionCategory,
+    pub comments: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    pub id: i64,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionAnsweredDiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+impl From<&DiscussionAnsweredDiscussion> for DiscussionAnsweredDiscussion {
+    fn from(value: &DiscussionAnsweredDiscussion) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DiscussionAnsweredDiscussionAnswerChosenBy {
+    pub avatar_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub node_id: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: DiscussionAnsweredDiscussionAnswerChosenByType,
+    pub url: String,
+}
+impl From<&DiscussionAnsweredDiscussionAnswerChosenBy>
+    for DiscussionAnsweredDiscussionAnswerChosenBy
+{
+    fn from(value: &DiscussionAnsweredDiscussionAnswerChosenBy) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionAnsweredDiscussionAnswerChosenByType {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&DiscussionAnsweredDiscussionAnswerChosenByType>
+    for DiscussionAnsweredDiscussionAnswerChosenByType
+{
+    fn from(value: &DiscussionAnsweredDiscussionAnswerChosenByType) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionAnsweredDiscussionAnswerChosenByType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionAnsweredDiscussionAnswerChosenByType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionAnswerChosenByType {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionAnsweredDiscussionAnswerChosenByType {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionAnswerChosenByType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionAnsweredDiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+impl From<&DiscussionAnsweredDiscussionCategory> for DiscussionAnsweredDiscussionCategory {
+    fn from(value: &DiscussionAnsweredDiscussionCategory) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionAnsweredDiscussionState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "locked")]
+    Locked,
+    #[serde(rename = "converting")]
+    Converting,
+}
+impl From<&DiscussionAnsweredDiscussionState> for DiscussionAnsweredDiscussionState {
+    fn from(value: &DiscussionAnsweredDiscussionState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionAnsweredDiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Locked => "locked".to_string(),
+            Self::Converting => "converting".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionAnsweredDiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "locked" => Ok(Self::Locked),
+            "converting" => Ok(Self::Converting),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionAnsweredDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -8330,7 +9049,7 @@ impl From<DiscussionCommentEdited> for DiscussionCommentEvent {
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreated {
     pub action: DiscussionCreatedAction,
-    pub discussion: Discussion,
+    pub discussion: DiscussionCreatedDiscussion,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8382,6 +9101,100 @@ impl std::convert::TryFrom<&String> for DiscussionCreatedAction {
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCreatedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCreatedDiscussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: (),
+    pub answer_chosen_by: (),
+    pub answer_html_url: (),
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionCreatedDiscussionCategory,
+    pub comments: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    pub id: i64,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionCreatedDiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+impl From<&DiscussionCreatedDiscussion> for DiscussionCreatedDiscussion {
+    fn from(value: &DiscussionCreatedDiscussion) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionCreatedDiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+impl From<&DiscussionCreatedDiscussionCategory> for DiscussionCreatedDiscussionCategory {
+    fn from(value: &DiscussionCreatedDiscussionCategory) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionCreatedDiscussionState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "converting")]
+    Converting,
+}
+impl From<&DiscussionCreatedDiscussionState> for DiscussionCreatedDiscussionState {
+    fn from(value: &DiscussionCreatedDiscussionState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionCreatedDiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Converting => "converting".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionCreatedDiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "converting" => Ok(Self::Converting),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionCreatedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionCreatedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionCreatedDiscussionState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -8697,7 +9510,7 @@ impl std::convert::TryFrom<String> for DiscussionLabeledAction {
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLocked {
     pub action: DiscussionLockedAction,
-    pub discussion: Discussion,
+    pub discussion: DiscussionLockedDiscussion,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8749,6 +9562,96 @@ impl std::convert::TryFrom<&String> for DiscussionLockedAction {
     }
 }
 impl std::convert::TryFrom<String> for DiscussionLockedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionLockedDiscussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: Option<String>,
+    pub answer_chosen_by: Option<User>,
+    pub answer_html_url: Option<String>,
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionLockedDiscussionCategory,
+    pub comments: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    pub id: i64,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionLockedDiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+impl From<&DiscussionLockedDiscussion> for DiscussionLockedDiscussion {
+    fn from(value: &DiscussionLockedDiscussion) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionLockedDiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+impl From<&DiscussionLockedDiscussionCategory> for DiscussionLockedDiscussionCategory {
+    fn from(value: &DiscussionLockedDiscussionCategory) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionLockedDiscussionState {
+    #[serde(rename = "locked")]
+    Locked,
+}
+impl From<&DiscussionLockedDiscussionState> for DiscussionLockedDiscussionState {
+    fn from(value: &DiscussionLockedDiscussionState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionLockedDiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Locked => "locked".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionLockedDiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "locked" => Ok(Self::Locked),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionLockedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionLockedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionLockedDiscussionState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -8944,7 +9847,7 @@ impl From<&DiscussionTransferredChanges> for DiscussionTransferredChanges {
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnanswered {
     pub action: DiscussionUnansweredAction,
-    pub discussion: Discussion,
+    pub discussion: DiscussionUnansweredDiscussion,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     pub old_answer: DiscussionUnansweredOldAnswer,
@@ -8997,6 +9900,104 @@ impl std::convert::TryFrom<&String> for DiscussionUnansweredAction {
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnansweredAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnansweredDiscussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: (),
+    pub answer_chosen_by: (),
+    pub answer_html_url: (),
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionUnansweredDiscussionCategory,
+    pub comments: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    pub id: i64,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionUnansweredDiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+impl From<&DiscussionUnansweredDiscussion> for DiscussionUnansweredDiscussion {
+    fn from(value: &DiscussionUnansweredDiscussion) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnansweredDiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+impl From<&DiscussionUnansweredDiscussionCategory> for DiscussionUnansweredDiscussionCategory {
+    fn from(value: &DiscussionUnansweredDiscussionCategory) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnansweredDiscussionState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "locked")]
+    Locked,
+    #[serde(rename = "converting")]
+    Converting,
+}
+impl From<&DiscussionUnansweredDiscussionState> for DiscussionUnansweredDiscussionState {
+    fn from(value: &DiscussionUnansweredDiscussionState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionUnansweredDiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Locked => "locked".to_string(),
+            Self::Converting => "converting".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnansweredDiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "locked" => Ok(Self::Locked),
+            "converting" => Ok(Self::Converting),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionUnansweredDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnansweredDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionUnansweredDiscussionState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -9089,7 +10090,7 @@ impl std::convert::TryFrom<String> for DiscussionUnlabeledAction {
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlocked {
     pub action: DiscussionUnlockedAction,
-    pub discussion: Discussion,
+    pub discussion: DiscussionUnlockedDiscussion,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9141,6 +10142,96 @@ impl std::convert::TryFrom<&String> for DiscussionUnlockedAction {
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnlockedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnlockedDiscussion {
+    pub active_lock_reason: Option<String>,
+    pub answer_chosen_at: Option<String>,
+    pub answer_chosen_by: Option<User>,
+    pub answer_html_url: Option<String>,
+    pub author_association: AuthorAssociation,
+    pub body: String,
+    pub category: DiscussionUnlockedDiscussionCategory,
+    pub comments: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub html_url: String,
+    pub id: i64,
+    pub locked: bool,
+    pub node_id: String,
+    pub number: i64,
+    pub repository_url: String,
+    pub state: DiscussionUnlockedDiscussionState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub user: User,
+}
+impl From<&DiscussionUnlockedDiscussion> for DiscussionUnlockedDiscussion {
+    fn from(value: &DiscussionUnlockedDiscussion) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscussionUnlockedDiscussionCategory {
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub description: String,
+    pub emoji: String,
+    pub id: i64,
+    pub is_answerable: bool,
+    pub name: String,
+    pub repository_id: i64,
+    pub slug: String,
+    pub updated_at: String,
+}
+impl From<&DiscussionUnlockedDiscussionCategory> for DiscussionUnlockedDiscussionCategory {
+    fn from(value: &DiscussionUnlockedDiscussionCategory) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DiscussionUnlockedDiscussionState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&DiscussionUnlockedDiscussionState> for DiscussionUnlockedDiscussionState {
+    fn from(value: &DiscussionUnlockedDiscussionState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DiscussionUnlockedDiscussionState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DiscussionUnlockedDiscussionState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DiscussionUnlockedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DiscussionUnlockedDiscussionState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DiscussionUnlockedDiscussionState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -9550,8 +10641,7 @@ impl From<WorkflowRunEvent> for Everything {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForkEvent {
-    #[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
-    pub forkee: Repository,
+    pub forkee: ForkEventForkee,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9562,6 +10652,225 @@ pub struct ForkEvent {
 impl From<&ForkEvent> for ForkEvent {
     fn from(value: &ForkEvent) -> Self {
         value.clone()
+    }
+}
+#[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForkEventForkee {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: ForkEventForkeeCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<ForkEventForkeePermissions>,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: ForkEventForkeePushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&ForkEventForkee> for ForkEventForkee {
+    fn from(value: &ForkEventForkee) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ForkEventForkeeCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&ForkEventForkeeCreatedAt> for ForkEventForkeeCreatedAt {
+    fn from(value: &ForkEventForkeeCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for ForkEventForkeeCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for ForkEventForkeeCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ForkEventForkeeCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for ForkEventForkeeCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for ForkEventForkeeCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for ForkEventForkeeCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for ForkEventForkeeCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ForkEventForkeePermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&ForkEventForkeePermissions> for ForkEventForkeePermissions {
+    fn from(value: &ForkEventForkeePermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ForkEventForkeePushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&ForkEventForkeePushedAt> for ForkEventForkeePushedAt {
+    fn from(value: &ForkEventForkeePushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for ForkEventForkeePushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for ForkEventForkeePushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12528,7 +13837,7 @@ impl std::convert::TryFrom<String> for InstallationRepositorySelection {
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspend {
     pub action: InstallationSuspendAction,
-    pub installation: Installation,
+    pub installation: InstallationSuspendInstallation,
     #[doc = "An array of repository objects that the installation can access."]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repositories: Vec<InstallationSuspendRepositoriesItem>,
@@ -12583,6 +13892,2465 @@ impl std::convert::TryFrom<String> for InstallationSuspendAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationSuspendInstallation {
+    pub access_tokens_url: String,
+    pub account: User,
+    pub app_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_slug: Option<String>,
+    pub created_at: InstallationSuspendInstallationCreatedAt,
+    pub events: Vec<InstallationSuspendInstallationEventsItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_multiple_single_files: Option<bool>,
+    pub html_url: String,
+    #[doc = "The ID of the installation."]
+    pub id: i64,
+    pub permissions: InstallationSuspendInstallationPermissions,
+    pub repositories_url: String,
+    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+    pub repository_selection: InstallationSuspendInstallationRepositorySelection,
+    pub single_file_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub single_file_paths: Vec<String>,
+    pub suspended_at: chrono::DateTime<chrono::offset::Utc>,
+    pub suspended_by: InstallationSuspendInstallationSuspendedBy,
+    #[doc = "The ID of the user or organization this token is being scoped to."]
+    pub target_id: i64,
+    pub target_type: InstallationSuspendInstallationTargetType,
+    pub updated_at: InstallationSuspendInstallationUpdatedAt,
+}
+impl From<&InstallationSuspendInstallation> for InstallationSuspendInstallation {
+    fn from(value: &InstallationSuspendInstallation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InstallationSuspendInstallationCreatedAt {
+    Variant0(chrono::DateTime<chrono::offset::Utc>),
+    Variant1(i64),
+}
+impl From<&InstallationSuspendInstallationCreatedAt> for InstallationSuspendInstallationCreatedAt {
+    fn from(value: &InstallationSuspendInstallationCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for InstallationSuspendInstallationCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationSuspendInstallationCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationSuspendInstallationCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationEventsItem {
+    #[serde(rename = "check_run")]
+    CheckRun,
+    #[serde(rename = "check_suite")]
+    CheckSuite,
+    #[serde(rename = "code_scanning_alert")]
+    CodeScanningAlert,
+    #[serde(rename = "commit_comment")]
+    CommitComment,
+    #[serde(rename = "content_reference")]
+    ContentReference,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "deployment")]
+    Deployment,
+    #[serde(rename = "deployment_review")]
+    DeploymentReview,
+    #[serde(rename = "deployment_status")]
+    DeploymentStatus,
+    #[serde(rename = "deploy_key")]
+    DeployKey,
+    #[serde(rename = "discussion")]
+    Discussion,
+    #[serde(rename = "discussion_comment")]
+    DiscussionComment,
+    #[serde(rename = "fork")]
+    Fork,
+    #[serde(rename = "gollum")]
+    Gollum,
+    #[serde(rename = "issues")]
+    Issues,
+    #[serde(rename = "issue_comment")]
+    IssueComment,
+    #[serde(rename = "label")]
+    Label,
+    #[serde(rename = "member")]
+    Member,
+    #[serde(rename = "membership")]
+    Membership,
+    #[serde(rename = "merge_queue_entry")]
+    MergeQueueEntry,
+    #[serde(rename = "milestone")]
+    Milestone,
+    #[serde(rename = "organization")]
+    Organization,
+    #[serde(rename = "org_block")]
+    OrgBlock,
+    #[serde(rename = "page_build")]
+    PageBuild,
+    #[serde(rename = "project")]
+    Project,
+    #[serde(rename = "project_card")]
+    ProjectCard,
+    #[serde(rename = "project_column")]
+    ProjectColumn,
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "pull_request")]
+    PullRequest,
+    #[serde(rename = "pull_request_review")]
+    PullRequestReview,
+    #[serde(rename = "pull_request_review_comment")]
+    PullRequestReviewComment,
+    #[serde(rename = "push")]
+    Push,
+    #[serde(rename = "registry_package")]
+    RegistryPackage,
+    #[serde(rename = "release")]
+    Release,
+    #[serde(rename = "repository")]
+    Repository,
+    #[serde(rename = "repository_dispatch")]
+    RepositoryDispatch,
+    #[serde(rename = "secret_scanning_alert")]
+    SecretScanningAlert,
+    #[serde(rename = "star")]
+    Star,
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "team")]
+    Team,
+    #[serde(rename = "team_add")]
+    TeamAdd,
+    #[serde(rename = "watch")]
+    Watch,
+    #[serde(rename = "workflow_dispatch")]
+    WorkflowDispatch,
+    #[serde(rename = "workflow_run")]
+    WorkflowRun,
+}
+impl From<&InstallationSuspendInstallationEventsItem>
+    for InstallationSuspendInstallationEventsItem
+{
+    fn from(value: &InstallationSuspendInstallationEventsItem) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationEventsItem {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::CheckRun => "check_run".to_string(),
+            Self::CheckSuite => "check_suite".to_string(),
+            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
+            Self::CommitComment => "commit_comment".to_string(),
+            Self::ContentReference => "content_reference".to_string(),
+            Self::Create => "create".to_string(),
+            Self::Delete => "delete".to_string(),
+            Self::Deployment => "deployment".to_string(),
+            Self::DeploymentReview => "deployment_review".to_string(),
+            Self::DeploymentStatus => "deployment_status".to_string(),
+            Self::DeployKey => "deploy_key".to_string(),
+            Self::Discussion => "discussion".to_string(),
+            Self::DiscussionComment => "discussion_comment".to_string(),
+            Self::Fork => "fork".to_string(),
+            Self::Gollum => "gollum".to_string(),
+            Self::Issues => "issues".to_string(),
+            Self::IssueComment => "issue_comment".to_string(),
+            Self::Label => "label".to_string(),
+            Self::Member => "member".to_string(),
+            Self::Membership => "membership".to_string(),
+            Self::MergeQueueEntry => "merge_queue_entry".to_string(),
+            Self::Milestone => "milestone".to_string(),
+            Self::Organization => "organization".to_string(),
+            Self::OrgBlock => "org_block".to_string(),
+            Self::PageBuild => "page_build".to_string(),
+            Self::Project => "project".to_string(),
+            Self::ProjectCard => "project_card".to_string(),
+            Self::ProjectColumn => "project_column".to_string(),
+            Self::Public => "public".to_string(),
+            Self::PullRequest => "pull_request".to_string(),
+            Self::PullRequestReview => "pull_request_review".to_string(),
+            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
+            Self::Push => "push".to_string(),
+            Self::RegistryPackage => "registry_package".to_string(),
+            Self::Release => "release".to_string(),
+            Self::Repository => "repository".to_string(),
+            Self::RepositoryDispatch => "repository_dispatch".to_string(),
+            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
+            Self::Star => "star".to_string(),
+            Self::Status => "status".to_string(),
+            Self::Team => "team".to_string(),
+            Self::TeamAdd => "team_add".to_string(),
+            Self::Watch => "watch".to_string(),
+            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
+            Self::WorkflowRun => "workflow_run".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationEventsItem {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "check_run" => Ok(Self::CheckRun),
+            "check_suite" => Ok(Self::CheckSuite),
+            "code_scanning_alert" => Ok(Self::CodeScanningAlert),
+            "commit_comment" => Ok(Self::CommitComment),
+            "content_reference" => Ok(Self::ContentReference),
+            "create" => Ok(Self::Create),
+            "delete" => Ok(Self::Delete),
+            "deployment" => Ok(Self::Deployment),
+            "deployment_review" => Ok(Self::DeploymentReview),
+            "deployment_status" => Ok(Self::DeploymentStatus),
+            "deploy_key" => Ok(Self::DeployKey),
+            "discussion" => Ok(Self::Discussion),
+            "discussion_comment" => Ok(Self::DiscussionComment),
+            "fork" => Ok(Self::Fork),
+            "gollum" => Ok(Self::Gollum),
+            "issues" => Ok(Self::Issues),
+            "issue_comment" => Ok(Self::IssueComment),
+            "label" => Ok(Self::Label),
+            "member" => Ok(Self::Member),
+            "membership" => Ok(Self::Membership),
+            "merge_queue_entry" => Ok(Self::MergeQueueEntry),
+            "milestone" => Ok(Self::Milestone),
+            "organization" => Ok(Self::Organization),
+            "org_block" => Ok(Self::OrgBlock),
+            "page_build" => Ok(Self::PageBuild),
+            "project" => Ok(Self::Project),
+            "project_card" => Ok(Self::ProjectCard),
+            "project_column" => Ok(Self::ProjectColumn),
+            "public" => Ok(Self::Public),
+            "pull_request" => Ok(Self::PullRequest),
+            "pull_request_review" => Ok(Self::PullRequestReview),
+            "pull_request_review_comment" => Ok(Self::PullRequestReviewComment),
+            "push" => Ok(Self::Push),
+            "registry_package" => Ok(Self::RegistryPackage),
+            "release" => Ok(Self::Release),
+            "repository" => Ok(Self::Repository),
+            "repository_dispatch" => Ok(Self::RepositoryDispatch),
+            "secret_scanning_alert" => Ok(Self::SecretScanningAlert),
+            "star" => Ok(Self::Star),
+            "status" => Ok(Self::Status),
+            "team" => Ok(Self::Team),
+            "team_add" => Ok(Self::TeamAdd),
+            "watch" => Ok(Self::Watch),
+            "workflow_dispatch" => Ok(Self::WorkflowDispatch),
+            "workflow_run" => Ok(Self::WorkflowRun),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationSuspendInstallationPermissions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions: Option<InstallationSuspendInstallationPermissionsActions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub administration: Option<InstallationSuspendInstallationPermissionsAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checks: Option<InstallationSuspendInstallationPermissionsChecks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_references: Option<InstallationSuspendInstallationPermissionsContentReferences>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contents: Option<InstallationSuspendInstallationPermissionsContents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployments: Option<InstallationSuspendInstallationPermissionsDeployments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discussions: Option<InstallationSuspendInstallationPermissionsDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emails: Option<InstallationSuspendInstallationPermissionsEmails>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environments: Option<InstallationSuspendInstallationPermissionsEnvironments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issues: Option<InstallationSuspendInstallationPermissionsIssues>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub members: Option<InstallationSuspendInstallationPermissionsMembers>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<InstallationSuspendInstallationPermissionsMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_administration:
+        Option<InstallationSuspendInstallationPermissionsOrganizationAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_events: Option<InstallationSuspendInstallationPermissionsOrganizationEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_hooks: Option<InstallationSuspendInstallationPermissionsOrganizationHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_packages:
+        Option<InstallationSuspendInstallationPermissionsOrganizationPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_plan: Option<InstallationSuspendInstallationPermissionsOrganizationPlan>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_projects:
+        Option<InstallationSuspendInstallationPermissionsOrganizationProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_secrets: Option<InstallationSuspendInstallationPermissionsOrganizationSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_self_hosted_runners:
+        Option<InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_user_blocking:
+        Option<InstallationSuspendInstallationPermissionsOrganizationUserBlocking>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packages: Option<InstallationSuspendInstallationPermissionsPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pages: Option<InstallationSuspendInstallationPermissionsPages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_requests: Option<InstallationSuspendInstallationPermissionsPullRequests>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_hooks: Option<InstallationSuspendInstallationPermissionsRepositoryHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_projects: Option<InstallationSuspendInstallationPermissionsRepositoryProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_scanning_alerts:
+        Option<InstallationSuspendInstallationPermissionsSecretScanningAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<InstallationSuspendInstallationPermissionsSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_events: Option<InstallationSuspendInstallationPermissionsSecurityEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_scanning_alert:
+        Option<InstallationSuspendInstallationPermissionsSecurityScanningAlert>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub single_file: Option<InstallationSuspendInstallationPermissionsSingleFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub statuses: Option<InstallationSuspendInstallationPermissionsStatuses>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_discussions: Option<InstallationSuspendInstallationPermissionsTeamDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerability_alerts: Option<InstallationSuspendInstallationPermissionsVulnerabilityAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflows: Option<InstallationSuspendInstallationPermissionsWorkflows>,
+}
+impl From<&InstallationSuspendInstallationPermissions>
+    for InstallationSuspendInstallationPermissions
+{
+    fn from(value: &InstallationSuspendInstallationPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsActions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsActions>
+    for InstallationSuspendInstallationPermissionsActions
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsActions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsActions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsActions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsAdministration {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsAdministration>
+    for InstallationSuspendInstallationPermissionsAdministration
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsAdministration) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsAdministration {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsAdministration {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsChecks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsChecks>
+    for InstallationSuspendInstallationPermissionsChecks
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsChecks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsChecks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsChecks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsContentReferences {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsContentReferences>
+    for InstallationSuspendInstallationPermissionsContentReferences
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsContentReferences) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsContentReferences {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsContentReferences {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsContentReferences {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsContentReferences
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsContentReferences {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsContents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsContents>
+    for InstallationSuspendInstallationPermissionsContents
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsContents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsContents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsContents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsDeployments {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsDeployments>
+    for InstallationSuspendInstallationPermissionsDeployments
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsDeployments) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsDeployments {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsDeployments {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsDiscussions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsDiscussions>
+    for InstallationSuspendInstallationPermissionsDiscussions
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsDiscussions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsDiscussions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsDiscussions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsEmails {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsEmails>
+    for InstallationSuspendInstallationPermissionsEmails
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsEmails) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsEmails {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsEmails {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsEnvironments {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsEnvironments>
+    for InstallationSuspendInstallationPermissionsEnvironments
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsEnvironments) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsEnvironments {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsEnvironments {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsIssues {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsIssues>
+    for InstallationSuspendInstallationPermissionsIssues
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsIssues) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsIssues {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsIssues {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsMembers {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsMembers>
+    for InstallationSuspendInstallationPermissionsMembers
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsMembers) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsMembers {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsMembers {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsMetadata {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsMetadata>
+    for InstallationSuspendInstallationPermissionsMetadata
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsMetadata) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsMetadata {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsMetadata {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationAdministration {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationAdministration>
+    for InstallationSuspendInstallationPermissionsOrganizationAdministration
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationAdministration) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationAdministration {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationAdministration {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationEvents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationEvents>
+    for InstallationSuspendInstallationPermissionsOrganizationEvents
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationEvents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationEvents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationEvents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationEvents {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationEvents
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationEvents
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationHooks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationHooks>
+    for InstallationSuspendInstallationPermissionsOrganizationHooks
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationHooks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationHooks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationHooks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationHooks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationHooks
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsOrganizationHooks {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationPackages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationPackages>
+    for InstallationSuspendInstallationPermissionsOrganizationPackages
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationPackages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationPackages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationPackages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationPlan {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationPlan>
+    for InstallationSuspendInstallationPermissionsOrganizationPlan
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationPlan) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationProjects {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationProjects>
+    for InstallationSuspendInstallationPermissionsOrganizationProjects
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationProjects) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationProjects {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationProjects {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationSecrets {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationSecrets>
+    for InstallationSuspendInstallationPermissionsOrganizationSecrets
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationSecrets) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationSecrets {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationSecrets {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationSecrets {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationSecrets
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationSecrets
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners>
+    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    fn from(
+        value: &InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners,
+    ) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsOrganizationUserBlocking>
+    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationUserBlocking) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsPackages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsPackages>
+    for InstallationSuspendInstallationPermissionsPackages
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsPackages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsPackages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsPackages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsPages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsPages>
+    for InstallationSuspendInstallationPermissionsPages
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsPages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsPages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsPages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsPullRequests {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsPullRequests>
+    for InstallationSuspendInstallationPermissionsPullRequests
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsPullRequests) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsPullRequests {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsPullRequests {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsRepositoryHooks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsRepositoryHooks>
+    for InstallationSuspendInstallationPermissionsRepositoryHooks
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsRepositoryHooks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsRepositoryProjects {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsRepositoryProjects>
+    for InstallationSuspendInstallationPermissionsRepositoryProjects
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsRepositoryProjects) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsRepositoryProjects {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsRepositoryProjects {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsRepositoryProjects {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsRepositoryProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsRepositoryProjects
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsSecretScanningAlerts {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsSecretScanningAlerts>
+    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsSecretScanningAlerts) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsSecrets {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsSecrets>
+    for InstallationSuspendInstallationPermissionsSecrets
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsSecrets) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsSecrets {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecrets {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsSecurityEvents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsSecurityEvents>
+    for InstallationSuspendInstallationPermissionsSecurityEvents
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsSecurityEvents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsSecurityEvents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecurityEvents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsSecurityScanningAlert {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsSecurityScanningAlert>
+    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsSecurityScanningAlert) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsSingleFile {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsSingleFile>
+    for InstallationSuspendInstallationPermissionsSingleFile
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsSingleFile) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsSingleFile {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsSingleFile {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsStatuses {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsStatuses>
+    for InstallationSuspendInstallationPermissionsStatuses
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsStatuses) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsStatuses {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsStatuses {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsTeamDiscussions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsTeamDiscussions>
+    for InstallationSuspendInstallationPermissionsTeamDiscussions
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsTeamDiscussions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsVulnerabilityAlerts>
+    for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsVulnerabilityAlerts) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationPermissionsWorkflows {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationSuspendInstallationPermissionsWorkflows>
+    for InstallationSuspendInstallationPermissionsWorkflows
+{
+    fn from(value: &InstallationSuspendInstallationPermissionsWorkflows) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationPermissionsWorkflows {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationPermissionsWorkflows {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationRepositorySelection {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "selected")]
+    Selected,
+}
+impl From<&InstallationSuspendInstallationRepositorySelection>
+    for InstallationSuspendInstallationRepositorySelection
+{
+    fn from(value: &InstallationSuspendInstallationRepositorySelection) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationRepositorySelection {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Selected => "selected".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationRepositorySelection {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "selected" => Ok(Self::Selected),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InstallationSuspendInstallationSuspendedBy {
+    pub avatar_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub node_id: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: InstallationSuspendInstallationSuspendedByType,
+    pub url: String,
+}
+impl From<&InstallationSuspendInstallationSuspendedBy>
+    for InstallationSuspendInstallationSuspendedBy
+{
+    fn from(value: &InstallationSuspendInstallationSuspendedBy) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationSuspendedByType {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&InstallationSuspendInstallationSuspendedByType>
+    for InstallationSuspendInstallationSuspendedByType
+{
+    fn from(value: &InstallationSuspendInstallationSuspendedByType) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationSuspendedByType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationSuspendedByType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationSuspendedByType {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationSuspendedByType {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationSuspendedByType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationSuspendInstallationTargetType {
+    User,
+    Organization,
+}
+impl From<&InstallationSuspendInstallationTargetType>
+    for InstallationSuspendInstallationTargetType
+{
+    fn from(value: &InstallationSuspendInstallationTargetType) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationSuspendInstallationTargetType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationTargetType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InstallationSuspendInstallationUpdatedAt {
+    Variant0(chrono::DateTime<chrono::offset::Utc>),
+    Variant1(i64),
+}
+impl From<&InstallationSuspendInstallationUpdatedAt> for InstallationSuspendInstallationUpdatedAt {
+    fn from(value: &InstallationSuspendInstallationUpdatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationSuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationSuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationSuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for InstallationSuspendInstallationUpdatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationSuspendInstallationUpdatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationSuspendInstallationUpdatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12652,7 +16420,7 @@ impl std::convert::TryFrom<String> for InstallationTargetType {
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspend {
     pub action: InstallationUnsuspendAction,
-    pub installation: Installation,
+    pub installation: InstallationUnsuspendInstallation,
     #[doc = "An array of repository objects that the installation can access."]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repositories: Vec<InstallationUnsuspendRepositoriesItem>,
@@ -12707,6 +16475,2411 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationUnsuspendInstallation {
+    pub access_tokens_url: String,
+    pub account: User,
+    pub app_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_slug: Option<String>,
+    pub created_at: InstallationUnsuspendInstallationCreatedAt,
+    pub events: Vec<InstallationUnsuspendInstallationEventsItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_multiple_single_files: Option<bool>,
+    pub html_url: String,
+    #[doc = "The ID of the installation."]
+    pub id: i64,
+    pub permissions: InstallationUnsuspendInstallationPermissions,
+    pub repositories_url: String,
+    #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+    pub repository_selection: InstallationUnsuspendInstallationRepositorySelection,
+    pub single_file_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub single_file_paths: Vec<String>,
+    pub suspended_at: (),
+    pub suspended_by: (),
+    #[doc = "The ID of the user or organization this token is being scoped to."]
+    pub target_id: i64,
+    pub target_type: InstallationUnsuspendInstallationTargetType,
+    pub updated_at: InstallationUnsuspendInstallationUpdatedAt,
+}
+impl From<&InstallationUnsuspendInstallation> for InstallationUnsuspendInstallation {
+    fn from(value: &InstallationUnsuspendInstallation) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InstallationUnsuspendInstallationCreatedAt {
+    Variant0(chrono::DateTime<chrono::offset::Utc>),
+    Variant1(i64),
+}
+impl From<&InstallationUnsuspendInstallationCreatedAt>
+    for InstallationUnsuspendInstallationCreatedAt
+{
+    fn from(value: &InstallationUnsuspendInstallationCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationUnsuspendInstallationCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationUnsuspendInstallationCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationEventsItem {
+    #[serde(rename = "check_run")]
+    CheckRun,
+    #[serde(rename = "check_suite")]
+    CheckSuite,
+    #[serde(rename = "code_scanning_alert")]
+    CodeScanningAlert,
+    #[serde(rename = "commit_comment")]
+    CommitComment,
+    #[serde(rename = "content_reference")]
+    ContentReference,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "deployment")]
+    Deployment,
+    #[serde(rename = "deployment_review")]
+    DeploymentReview,
+    #[serde(rename = "deployment_status")]
+    DeploymentStatus,
+    #[serde(rename = "deploy_key")]
+    DeployKey,
+    #[serde(rename = "discussion")]
+    Discussion,
+    #[serde(rename = "discussion_comment")]
+    DiscussionComment,
+    #[serde(rename = "fork")]
+    Fork,
+    #[serde(rename = "gollum")]
+    Gollum,
+    #[serde(rename = "issues")]
+    Issues,
+    #[serde(rename = "issue_comment")]
+    IssueComment,
+    #[serde(rename = "label")]
+    Label,
+    #[serde(rename = "member")]
+    Member,
+    #[serde(rename = "membership")]
+    Membership,
+    #[serde(rename = "merge_queue_entry")]
+    MergeQueueEntry,
+    #[serde(rename = "milestone")]
+    Milestone,
+    #[serde(rename = "organization")]
+    Organization,
+    #[serde(rename = "org_block")]
+    OrgBlock,
+    #[serde(rename = "page_build")]
+    PageBuild,
+    #[serde(rename = "project")]
+    Project,
+    #[serde(rename = "project_card")]
+    ProjectCard,
+    #[serde(rename = "project_column")]
+    ProjectColumn,
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "pull_request")]
+    PullRequest,
+    #[serde(rename = "pull_request_review")]
+    PullRequestReview,
+    #[serde(rename = "pull_request_review_comment")]
+    PullRequestReviewComment,
+    #[serde(rename = "push")]
+    Push,
+    #[serde(rename = "registry_package")]
+    RegistryPackage,
+    #[serde(rename = "release")]
+    Release,
+    #[serde(rename = "repository")]
+    Repository,
+    #[serde(rename = "repository_dispatch")]
+    RepositoryDispatch,
+    #[serde(rename = "secret_scanning_alert")]
+    SecretScanningAlert,
+    #[serde(rename = "star")]
+    Star,
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "team")]
+    Team,
+    #[serde(rename = "team_add")]
+    TeamAdd,
+    #[serde(rename = "watch")]
+    Watch,
+    #[serde(rename = "workflow_dispatch")]
+    WorkflowDispatch,
+    #[serde(rename = "workflow_run")]
+    WorkflowRun,
+}
+impl From<&InstallationUnsuspendInstallationEventsItem>
+    for InstallationUnsuspendInstallationEventsItem
+{
+    fn from(value: &InstallationUnsuspendInstallationEventsItem) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationEventsItem {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::CheckRun => "check_run".to_string(),
+            Self::CheckSuite => "check_suite".to_string(),
+            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
+            Self::CommitComment => "commit_comment".to_string(),
+            Self::ContentReference => "content_reference".to_string(),
+            Self::Create => "create".to_string(),
+            Self::Delete => "delete".to_string(),
+            Self::Deployment => "deployment".to_string(),
+            Self::DeploymentReview => "deployment_review".to_string(),
+            Self::DeploymentStatus => "deployment_status".to_string(),
+            Self::DeployKey => "deploy_key".to_string(),
+            Self::Discussion => "discussion".to_string(),
+            Self::DiscussionComment => "discussion_comment".to_string(),
+            Self::Fork => "fork".to_string(),
+            Self::Gollum => "gollum".to_string(),
+            Self::Issues => "issues".to_string(),
+            Self::IssueComment => "issue_comment".to_string(),
+            Self::Label => "label".to_string(),
+            Self::Member => "member".to_string(),
+            Self::Membership => "membership".to_string(),
+            Self::MergeQueueEntry => "merge_queue_entry".to_string(),
+            Self::Milestone => "milestone".to_string(),
+            Self::Organization => "organization".to_string(),
+            Self::OrgBlock => "org_block".to_string(),
+            Self::PageBuild => "page_build".to_string(),
+            Self::Project => "project".to_string(),
+            Self::ProjectCard => "project_card".to_string(),
+            Self::ProjectColumn => "project_column".to_string(),
+            Self::Public => "public".to_string(),
+            Self::PullRequest => "pull_request".to_string(),
+            Self::PullRequestReview => "pull_request_review".to_string(),
+            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
+            Self::Push => "push".to_string(),
+            Self::RegistryPackage => "registry_package".to_string(),
+            Self::Release => "release".to_string(),
+            Self::Repository => "repository".to_string(),
+            Self::RepositoryDispatch => "repository_dispatch".to_string(),
+            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
+            Self::Star => "star".to_string(),
+            Self::Status => "status".to_string(),
+            Self::Team => "team".to_string(),
+            Self::TeamAdd => "team_add".to_string(),
+            Self::Watch => "watch".to_string(),
+            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
+            Self::WorkflowRun => "workflow_run".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationEventsItem {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "check_run" => Ok(Self::CheckRun),
+            "check_suite" => Ok(Self::CheckSuite),
+            "code_scanning_alert" => Ok(Self::CodeScanningAlert),
+            "commit_comment" => Ok(Self::CommitComment),
+            "content_reference" => Ok(Self::ContentReference),
+            "create" => Ok(Self::Create),
+            "delete" => Ok(Self::Delete),
+            "deployment" => Ok(Self::Deployment),
+            "deployment_review" => Ok(Self::DeploymentReview),
+            "deployment_status" => Ok(Self::DeploymentStatus),
+            "deploy_key" => Ok(Self::DeployKey),
+            "discussion" => Ok(Self::Discussion),
+            "discussion_comment" => Ok(Self::DiscussionComment),
+            "fork" => Ok(Self::Fork),
+            "gollum" => Ok(Self::Gollum),
+            "issues" => Ok(Self::Issues),
+            "issue_comment" => Ok(Self::IssueComment),
+            "label" => Ok(Self::Label),
+            "member" => Ok(Self::Member),
+            "membership" => Ok(Self::Membership),
+            "merge_queue_entry" => Ok(Self::MergeQueueEntry),
+            "milestone" => Ok(Self::Milestone),
+            "organization" => Ok(Self::Organization),
+            "org_block" => Ok(Self::OrgBlock),
+            "page_build" => Ok(Self::PageBuild),
+            "project" => Ok(Self::Project),
+            "project_card" => Ok(Self::ProjectCard),
+            "project_column" => Ok(Self::ProjectColumn),
+            "public" => Ok(Self::Public),
+            "pull_request" => Ok(Self::PullRequest),
+            "pull_request_review" => Ok(Self::PullRequestReview),
+            "pull_request_review_comment" => Ok(Self::PullRequestReviewComment),
+            "push" => Ok(Self::Push),
+            "registry_package" => Ok(Self::RegistryPackage),
+            "release" => Ok(Self::Release),
+            "repository" => Ok(Self::Repository),
+            "repository_dispatch" => Ok(Self::RepositoryDispatch),
+            "secret_scanning_alert" => Ok(Self::SecretScanningAlert),
+            "star" => Ok(Self::Star),
+            "status" => Ok(Self::Status),
+            "team" => Ok(Self::Team),
+            "team_add" => Ok(Self::TeamAdd),
+            "watch" => Ok(Self::Watch),
+            "workflow_dispatch" => Ok(Self::WorkflowDispatch),
+            "workflow_run" => Ok(Self::WorkflowRun),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationEventsItem {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationUnsuspendInstallationPermissions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions: Option<InstallationUnsuspendInstallationPermissionsActions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub administration: Option<InstallationUnsuspendInstallationPermissionsAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checks: Option<InstallationUnsuspendInstallationPermissionsChecks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_references: Option<InstallationUnsuspendInstallationPermissionsContentReferences>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contents: Option<InstallationUnsuspendInstallationPermissionsContents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployments: Option<InstallationUnsuspendInstallationPermissionsDeployments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discussions: Option<InstallationUnsuspendInstallationPermissionsDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emails: Option<InstallationUnsuspendInstallationPermissionsEmails>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environments: Option<InstallationUnsuspendInstallationPermissionsEnvironments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issues: Option<InstallationUnsuspendInstallationPermissionsIssues>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub members: Option<InstallationUnsuspendInstallationPermissionsMembers>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<InstallationUnsuspendInstallationPermissionsMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_administration:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationAdministration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_events: Option<InstallationUnsuspendInstallationPermissionsOrganizationEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_hooks: Option<InstallationUnsuspendInstallationPermissionsOrganizationHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_packages:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_plan: Option<InstallationUnsuspendInstallationPermissionsOrganizationPlan>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_projects:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_secrets:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_self_hosted_runners:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_user_blocking:
+        Option<InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packages: Option<InstallationUnsuspendInstallationPermissionsPackages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pages: Option<InstallationUnsuspendInstallationPermissionsPages>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_requests: Option<InstallationUnsuspendInstallationPermissionsPullRequests>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_hooks: Option<InstallationUnsuspendInstallationPermissionsRepositoryHooks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_projects: Option<InstallationUnsuspendInstallationPermissionsRepositoryProjects>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_scanning_alerts:
+        Option<InstallationUnsuspendInstallationPermissionsSecretScanningAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<InstallationUnsuspendInstallationPermissionsSecrets>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_events: Option<InstallationUnsuspendInstallationPermissionsSecurityEvents>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_scanning_alert:
+        Option<InstallationUnsuspendInstallationPermissionsSecurityScanningAlert>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub single_file: Option<InstallationUnsuspendInstallationPermissionsSingleFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub statuses: Option<InstallationUnsuspendInstallationPermissionsStatuses>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_discussions: Option<InstallationUnsuspendInstallationPermissionsTeamDiscussions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerability_alerts:
+        Option<InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflows: Option<InstallationUnsuspendInstallationPermissionsWorkflows>,
+}
+impl From<&InstallationUnsuspendInstallationPermissions>
+    for InstallationUnsuspendInstallationPermissions
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsActions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsActions>
+    for InstallationUnsuspendInstallationPermissionsActions
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsActions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsActions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsActions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsActions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsAdministration {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsAdministration>
+    for InstallationUnsuspendInstallationPermissionsAdministration
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsAdministration) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsAdministration {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsAdministration {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsAdministration {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsChecks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsChecks>
+    for InstallationUnsuspendInstallationPermissionsChecks
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsChecks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsChecks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsChecks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsChecks {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsContentReferences {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsContentReferences>
+    for InstallationUnsuspendInstallationPermissionsContentReferences
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsContentReferences) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsContentReferences {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsContentReferences {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsContentReferences {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsContentReferences
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsContentReferences
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsContents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsContents>
+    for InstallationUnsuspendInstallationPermissionsContents
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsContents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsContents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsContents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsContents {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsDeployments {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsDeployments>
+    for InstallationUnsuspendInstallationPermissionsDeployments
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsDeployments) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsDeployments {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsDeployments {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsDeployments {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsDiscussions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsDiscussions>
+    for InstallationUnsuspendInstallationPermissionsDiscussions
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsDiscussions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsDiscussions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsDiscussions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsDiscussions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsEmails {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsEmails>
+    for InstallationUnsuspendInstallationPermissionsEmails
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsEmails) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsEmails {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsEmails {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsEmails {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsEnvironments {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsEnvironments>
+    for InstallationUnsuspendInstallationPermissionsEnvironments
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsEnvironments) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsEnvironments {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsEnvironments {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsEnvironments {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsIssues {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsIssues>
+    for InstallationUnsuspendInstallationPermissionsIssues
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsIssues) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsIssues {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsIssues {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsIssues {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsMembers {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsMembers>
+    for InstallationUnsuspendInstallationPermissionsMembers
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsMembers) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsMembers {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsMembers {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsMembers {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsMetadata {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsMetadata>
+    for InstallationUnsuspendInstallationPermissionsMetadata
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsMetadata) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsMetadata {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsMetadata {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsMetadata {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationAdministration>
+    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
+{
+    fn from(
+        value: &InstallationUnsuspendInstallationPermissionsOrganizationAdministration,
+    ) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationEvents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationEvents>
+    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationEvents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationHooks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationHooks>
+    for InstallationUnsuspendInstallationPermissionsOrganizationHooks
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationHooks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationHooks
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationHooks
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationPackages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationPackages>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationPackages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationPlan {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationPlan>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPlan
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationPlan) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPlan
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationPlan
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationProjects {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationProjects>
+    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationProjects) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationSecrets>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationSecrets) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    fn from(
+        value: &InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners,
+    ) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking>
+    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsPackages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsPackages>
+    for InstallationUnsuspendInstallationPermissionsPackages
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsPackages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsPackages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPackages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPackages {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsPages {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsPages>
+    for InstallationUnsuspendInstallationPermissionsPages
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsPages) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsPages {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPages {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPages {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsPullRequests {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsPullRequests>
+    for InstallationUnsuspendInstallationPermissionsPullRequests
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsPullRequests) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsPullRequests {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPullRequests {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPullRequests {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsRepositoryHooks>
+    for InstallationUnsuspendInstallationPermissionsRepositoryHooks
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsRepositoryHooks) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsRepositoryHooks
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsRepositoryProjects {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsRepositoryProjects>
+    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsRepositoryProjects) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsSecretScanningAlerts>
+    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsSecretScanningAlerts) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsSecrets {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsSecrets>
+    for InstallationUnsuspendInstallationPermissionsSecrets
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsSecrets) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsSecrets {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecrets {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSecrets {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsSecurityEvents>
+    for InstallationUnsuspendInstallationPermissionsSecurityEvents
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsSecurityEvents) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsSecurityScanningAlert>
+    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsSecurityScanningAlert) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsSingleFile {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsSingleFile>
+    for InstallationUnsuspendInstallationPermissionsSingleFile
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsSingleFile) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsSingleFile {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSingleFile {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSingleFile {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsStatuses {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsStatuses>
+    for InstallationUnsuspendInstallationPermissionsStatuses
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsStatuses) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsStatuses {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsStatuses {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsStatuses {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsTeamDiscussions>
+    for InstallationUnsuspendInstallationPermissionsTeamDiscussions
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsTeamDiscussions) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsTeamDiscussions
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts>
+    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str>
+    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String>
+    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String>
+    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
+{
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationPermissionsWorkflows {
+    #[serde(rename = "read")]
+    Read,
+    #[serde(rename = "write")]
+    Write,
+}
+impl From<&InstallationUnsuspendInstallationPermissionsWorkflows>
+    for InstallationUnsuspendInstallationPermissionsWorkflows
+{
+    fn from(value: &InstallationUnsuspendInstallationPermissionsWorkflows) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationPermissionsWorkflows {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Read => "read".to_string(),
+            Self::Write => "write".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsWorkflows {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "read" => Ok(Self::Read),
+            "write" => Ok(Self::Write),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsWorkflows {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[doc = "Describe whether all repositories have been selected or there's a selection involved"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationRepositorySelection {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "selected")]
+    Selected,
+}
+impl From<&InstallationUnsuspendInstallationRepositorySelection>
+    for InstallationUnsuspendInstallationRepositorySelection
+{
+    fn from(value: &InstallationUnsuspendInstallationRepositorySelection) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationRepositorySelection {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Selected => "selected".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationRepositorySelection {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "selected" => Ok(Self::Selected),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationRepositorySelection {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum InstallationUnsuspendInstallationTargetType {
+    User,
+    Organization,
+}
+impl From<&InstallationUnsuspendInstallationTargetType>
+    for InstallationUnsuspendInstallationTargetType
+{
+    fn from(value: &InstallationUnsuspendInstallationTargetType) -> Self {
+        value.clone()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationTargetType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationTargetType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationTargetType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InstallationUnsuspendInstallationUpdatedAt {
+    Variant0(chrono::DateTime<chrono::offset::Utc>),
+    Variant1(i64),
+}
+impl From<&InstallationUnsuspendInstallationUpdatedAt>
+    for InstallationUnsuspendInstallationUpdatedAt
+{
+    fn from(value: &InstallationUnsuspendInstallationUpdatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationUpdatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for InstallationUnsuspendInstallationUpdatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for InstallationUnsuspendInstallationUpdatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<i64> for InstallationUnsuspendInstallationUpdatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12918,8 +19091,7 @@ pub struct IssueCommentCreated {
     pub comment: IssueComment,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
+    pub issue: IssueCommentCreatedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -12974,6 +19146,264 @@ impl std::convert::TryFrom<String> for IssueCommentCreatedAction {
         value.parse()
     }
 }
+#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentCreatedIssue {
+    pub active_lock_reason: Option<IssueCommentCreatedIssueActiveLockReason>,
+    pub assignee: IssueCommentCreatedIssueAssignee,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<IssueCommentCreatedIssueLabelsItem>,
+    pub labels_url: String,
+    pub locked: bool,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssueCommentCreatedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssueCommentCreatedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssueCommentCreatedIssue> for IssueCommentCreatedIssue {
+    fn from(value: &IssueCommentCreatedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentCreatedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssueCommentCreatedIssueActiveLockReason> for IssueCommentCreatedIssueActiveLockReason {
+    fn from(value: &IssueCommentCreatedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentCreatedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentCreatedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentCreatedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IssueCommentCreatedIssueAssignee {
+    Variant0 {
+        avatar_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        email: Option<String>,
+        events_url: String,
+        followers_url: String,
+        following_url: String,
+        gists_url: String,
+        gravatar_id: String,
+        html_url: String,
+        id: i64,
+        login: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        node_id: String,
+        organizations_url: String,
+        received_events_url: String,
+        repos_url: String,
+        site_admin: bool,
+        starred_url: String,
+        subscriptions_url: String,
+        #[serde(rename = "type")]
+        type_: IssueCommentCreatedIssueAssigneeVariant0Type,
+        url: String,
+    },
+    Variant1,
+}
+impl From<&IssueCommentCreatedIssueAssignee> for IssueCommentCreatedIssueAssignee {
+    fn from(value: &IssueCommentCreatedIssueAssignee) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentCreatedIssueAssigneeVariant0Type {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&IssueCommentCreatedIssueAssigneeVariant0Type>
+    for IssueCommentCreatedIssueAssigneeVariant0Type
+{
+    fn from(value: &IssueCommentCreatedIssueAssigneeVariant0Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentCreatedIssueAssigneeVariant0Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentCreatedIssueAssigneeVariant0Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentCreatedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentCreatedIssueLabelsItem {
+    pub color: String,
+    pub default: bool,
+    pub description: Option<String>,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    pub url: String,
+}
+impl From<&IssueCommentCreatedIssueLabelsItem> for IssueCommentCreatedIssueLabelsItem {
+    fn from(value: &IssueCommentCreatedIssueLabelsItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentCreatedIssuePullRequest {
+    pub diff_url: String,
+    pub html_url: String,
+    pub patch_url: String,
+    pub url: String,
+}
+impl From<&IssueCommentCreatedIssuePullRequest> for IssueCommentCreatedIssuePullRequest {
+    fn from(value: &IssueCommentCreatedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentCreatedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssueCommentCreatedIssueState> for IssueCommentCreatedIssueState {
+    fn from(value: &IssueCommentCreatedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentCreatedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentCreatedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentCreatedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeleted {
@@ -12981,8 +19411,7 @@ pub struct IssueCommentDeleted {
     pub comment: IssueComment,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
+    pub issue: IssueCommentDeletedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -13037,6 +19466,264 @@ impl std::convert::TryFrom<String> for IssueCommentDeletedAction {
         value.parse()
     }
 }
+#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentDeletedIssue {
+    pub active_lock_reason: Option<IssueCommentDeletedIssueActiveLockReason>,
+    pub assignee: IssueCommentDeletedIssueAssignee,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<IssueCommentDeletedIssueLabelsItem>,
+    pub labels_url: String,
+    pub locked: bool,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssueCommentDeletedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssueCommentDeletedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssueCommentDeletedIssue> for IssueCommentDeletedIssue {
+    fn from(value: &IssueCommentDeletedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentDeletedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssueCommentDeletedIssueActiveLockReason> for IssueCommentDeletedIssueActiveLockReason {
+    fn from(value: &IssueCommentDeletedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentDeletedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentDeletedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentDeletedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IssueCommentDeletedIssueAssignee {
+    Variant0 {
+        avatar_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        email: Option<String>,
+        events_url: String,
+        followers_url: String,
+        following_url: String,
+        gists_url: String,
+        gravatar_id: String,
+        html_url: String,
+        id: i64,
+        login: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        node_id: String,
+        organizations_url: String,
+        received_events_url: String,
+        repos_url: String,
+        site_admin: bool,
+        starred_url: String,
+        subscriptions_url: String,
+        #[serde(rename = "type")]
+        type_: IssueCommentDeletedIssueAssigneeVariant0Type,
+        url: String,
+    },
+    Variant1,
+}
+impl From<&IssueCommentDeletedIssueAssignee> for IssueCommentDeletedIssueAssignee {
+    fn from(value: &IssueCommentDeletedIssueAssignee) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentDeletedIssueAssigneeVariant0Type {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&IssueCommentDeletedIssueAssigneeVariant0Type>
+    for IssueCommentDeletedIssueAssigneeVariant0Type
+{
+    fn from(value: &IssueCommentDeletedIssueAssigneeVariant0Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentDeletedIssueAssigneeVariant0Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentDeletedIssueAssigneeVariant0Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentDeletedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentDeletedIssueLabelsItem {
+    pub color: String,
+    pub default: bool,
+    pub description: Option<String>,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    pub url: String,
+}
+impl From<&IssueCommentDeletedIssueLabelsItem> for IssueCommentDeletedIssueLabelsItem {
+    fn from(value: &IssueCommentDeletedIssueLabelsItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentDeletedIssuePullRequest {
+    pub diff_url: String,
+    pub html_url: String,
+    pub patch_url: String,
+    pub url: String,
+}
+impl From<&IssueCommentDeletedIssuePullRequest> for IssueCommentDeletedIssuePullRequest {
+    fn from(value: &IssueCommentDeletedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentDeletedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssueCommentDeletedIssueState> for IssueCommentDeletedIssueState {
+    fn from(value: &IssueCommentDeletedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentDeletedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentDeletedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentDeletedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEdited {
@@ -13045,8 +19732,7 @@ pub struct IssueCommentEdited {
     pub comment: IssueComment,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
-    pub issue: Issue,
+    pub issue: IssueCommentEditedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -13122,6 +19808,264 @@ pub struct IssueCommentEditedChangesBody {
 impl From<&IssueCommentEditedChangesBody> for IssueCommentEditedChangesBody {
     fn from(value: &IssueCommentEditedChangesBody) -> Self {
         value.clone()
+    }
+}
+#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueCommentEditedIssue {
+    pub active_lock_reason: Option<IssueCommentEditedIssueActiveLockReason>,
+    pub assignee: IssueCommentEditedIssueAssignee,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<IssueCommentEditedIssueLabelsItem>,
+    pub labels_url: String,
+    pub locked: bool,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssueCommentEditedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssueCommentEditedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssueCommentEditedIssue> for IssueCommentEditedIssue {
+    fn from(value: &IssueCommentEditedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentEditedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssueCommentEditedIssueActiveLockReason> for IssueCommentEditedIssueActiveLockReason {
+    fn from(value: &IssueCommentEditedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentEditedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentEditedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentEditedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentEditedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentEditedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IssueCommentEditedIssueAssignee {
+    Variant0 {
+        avatar_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        email: Option<String>,
+        events_url: String,
+        followers_url: String,
+        following_url: String,
+        gists_url: String,
+        gravatar_id: String,
+        html_url: String,
+        id: i64,
+        login: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        node_id: String,
+        organizations_url: String,
+        received_events_url: String,
+        repos_url: String,
+        site_admin: bool,
+        starred_url: String,
+        subscriptions_url: String,
+        #[serde(rename = "type")]
+        type_: IssueCommentEditedIssueAssigneeVariant0Type,
+        url: String,
+    },
+    Variant1,
+}
+impl From<&IssueCommentEditedIssueAssignee> for IssueCommentEditedIssueAssignee {
+    fn from(value: &IssueCommentEditedIssueAssignee) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentEditedIssueAssigneeVariant0Type {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&IssueCommentEditedIssueAssigneeVariant0Type>
+    for IssueCommentEditedIssueAssigneeVariant0Type
+{
+    fn from(value: &IssueCommentEditedIssueAssigneeVariant0Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentEditedIssueAssigneeVariant0Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentEditedIssueAssigneeVariant0Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentEditedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentEditedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentEditedIssueAssigneeVariant0Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentEditedIssueLabelsItem {
+    pub color: String,
+    pub default: bool,
+    pub description: Option<String>,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    pub url: String,
+}
+impl From<&IssueCommentEditedIssueLabelsItem> for IssueCommentEditedIssueLabelsItem {
+    fn from(value: &IssueCommentEditedIssueLabelsItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssueCommentEditedIssuePullRequest {
+    pub diff_url: String,
+    pub html_url: String,
+    pub patch_url: String,
+    pub url: String,
+}
+impl From<&IssueCommentEditedIssuePullRequest> for IssueCommentEditedIssuePullRequest {
+    fn from(value: &IssueCommentEditedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssueCommentEditedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssueCommentEditedIssueState> for IssueCommentEditedIssueState {
+    fn from(value: &IssueCommentEditedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssueCommentEditedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssueCommentEditedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssueCommentEditedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssueCommentEditedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssueCommentEditedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13291,8 +20235,7 @@ pub struct IssuesClosed {
     pub action: IssuesClosedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
-    pub issue: Issue,
+    pub issue: IssuesClosedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -13343,6 +20286,167 @@ impl std::convert::TryFrom<&String> for IssuesClosedAction {
     }
 }
 impl std::convert::TryFrom<String> for IssuesClosedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesClosedIssue {
+    pub active_lock_reason: Option<IssuesClosedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: chrono::DateTime<chrono::offset::Utc>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesClosedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssuesClosedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesClosedIssue> for IssuesClosedIssue {
+    fn from(value: &IssuesClosedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesClosedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesClosedIssueActiveLockReason> for IssuesClosedIssueActiveLockReason {
+    fn from(value: &IssuesClosedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesClosedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesClosedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesClosedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesClosedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesClosedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesClosedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesClosedIssuePullRequest> for IssuesClosedIssuePullRequest {
+    fn from(value: &IssuesClosedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesClosedIssueState {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesClosedIssueState> for IssuesClosedIssueState {
+    fn from(value: &IssuesClosedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesClosedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesClosedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesClosedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesClosedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesClosedIssueState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -13415,7 +20519,7 @@ pub struct IssuesDemilestoned {
     pub action: IssuesDemilestonedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesDemilestonedIssue,
     pub milestone: Milestone,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
@@ -13466,6 +20570,173 @@ impl std::convert::TryFrom<&String> for IssuesDemilestonedAction {
     }
 }
 impl std::convert::TryFrom<String> for IssuesDemilestonedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesDemilestonedIssue {
+    pub active_lock_reason: Option<IssuesDemilestonedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: (),
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesDemilestonedIssuePullRequest>,
+    pub repository_url: String,
+    #[doc = "State of the issue; either 'open' or 'closed'"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssuesDemilestonedIssueState>,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesDemilestonedIssue> for IssuesDemilestonedIssue {
+    fn from(value: &IssuesDemilestonedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesDemilestonedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesDemilestonedIssueActiveLockReason> for IssuesDemilestonedIssueActiveLockReason {
+    fn from(value: &IssuesDemilestonedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesDemilestonedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesDemilestonedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesDemilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesDemilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesDemilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesDemilestonedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesDemilestonedIssuePullRequest> for IssuesDemilestonedIssuePullRequest {
+    fn from(value: &IssuesDemilestonedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "State of the issue; either 'open' or 'closed'"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesDemilestonedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesDemilestonedIssueState> for IssuesDemilestonedIssueState {
+    fn from(value: &IssuesDemilestonedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesDemilestonedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesDemilestonedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesDemilestonedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesDemilestonedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesDemilestonedIssueState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -13746,7 +21017,7 @@ pub struct IssuesLocked {
     pub action: IssuesLockedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesLockedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -13803,11 +21074,177 @@ impl std::convert::TryFrom<String> for IssuesLockedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct IssuesLockedIssue {
+    pub active_lock_reason: Option<IssuesLockedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    pub locked: bool,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesLockedIssuePullRequest>,
+    pub repository_url: String,
+    #[doc = "State of the issue; either 'open' or 'closed'"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssuesLockedIssueState>,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesLockedIssue> for IssuesLockedIssue {
+    fn from(value: &IssuesLockedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesLockedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesLockedIssueActiveLockReason> for IssuesLockedIssueActiveLockReason {
+    fn from(value: &IssuesLockedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesLockedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesLockedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesLockedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesLockedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesLockedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesLockedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesLockedIssuePullRequest> for IssuesLockedIssuePullRequest {
+    fn from(value: &IssuesLockedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "State of the issue; either 'open' or 'closed'"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesLockedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesLockedIssueState> for IssuesLockedIssueState {
+    fn from(value: &IssuesLockedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesLockedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesLockedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesLockedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesLockedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesLockedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IssuesMilestoned {
     pub action: IssuesMilestonedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesMilestonedIssue,
     pub milestone: Milestone,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
@@ -13865,13 +21302,334 @@ impl std::convert::TryFrom<String> for IssuesMilestonedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct IssuesMilestonedIssue {
+    pub active_lock_reason: Option<IssuesMilestonedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: IssuesMilestonedIssueMilestone,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesMilestonedIssuePullRequest>,
+    pub repository_url: String,
+    #[doc = "State of the issue; either 'open' or 'closed'"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssuesMilestonedIssueState>,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesMilestonedIssue> for IssuesMilestonedIssue {
+    fn from(value: &IssuesMilestonedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesMilestonedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesMilestonedIssueActiveLockReason> for IssuesMilestonedIssueActiveLockReason {
+    fn from(value: &IssuesMilestonedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesMilestonedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesMilestonedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesMilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesMilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesMilestonedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssuesMilestonedIssueMilestone {
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub closed_issues: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: IssuesMilestonedIssueMilestoneCreator,
+    pub description: Option<String>,
+    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub html_url: String,
+    pub id: i64,
+    pub labels_url: String,
+    pub node_id: String,
+    pub number: i64,
+    pub open_issues: i64,
+    pub state: IssuesMilestonedIssueMilestoneState,
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+impl From<&IssuesMilestonedIssueMilestone> for IssuesMilestonedIssueMilestone {
+    fn from(value: &IssuesMilestonedIssueMilestone) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssuesMilestonedIssueMilestoneCreator {
+    pub avatar_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub events_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub gravatar_id: String,
+    pub html_url: String,
+    pub id: i64,
+    pub login: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub node_id: String,
+    pub organizations_url: String,
+    pub received_events_url: String,
+    pub repos_url: String,
+    pub site_admin: bool,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    #[serde(rename = "type")]
+    pub type_: IssuesMilestonedIssueMilestoneCreatorType,
+    pub url: String,
+}
+impl From<&IssuesMilestonedIssueMilestoneCreator> for IssuesMilestonedIssueMilestoneCreator {
+    fn from(value: &IssuesMilestonedIssueMilestoneCreator) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesMilestonedIssueMilestoneCreatorType {
+    Bot,
+    User,
+    Organization,
+}
+impl From<&IssuesMilestonedIssueMilestoneCreatorType>
+    for IssuesMilestonedIssueMilestoneCreatorType
+{
+    fn from(value: &IssuesMilestonedIssueMilestoneCreatorType) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesMilestonedIssueMilestoneCreatorType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Bot => "Bot".to_string(),
+            Self::User => "User".to_string(),
+            Self::Organization => "Organization".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesMilestonedIssueMilestoneCreatorType {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "Bot" => Ok(Self::Bot),
+            "User" => Ok(Self::User),
+            "Organization" => Ok(Self::Organization),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesMilestonedIssueMilestoneCreatorType {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesMilestonedIssueMilestoneCreatorType {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesMilestonedIssueMilestoneCreatorType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesMilestonedIssueMilestoneState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesMilestonedIssueMilestoneState> for IssuesMilestonedIssueMilestoneState {
+    fn from(value: &IssuesMilestonedIssueMilestoneState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesMilestonedIssueMilestoneState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesMilestonedIssueMilestoneState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesMilestonedIssueMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesMilestonedIssueMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesMilestonedIssueMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesMilestonedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesMilestonedIssuePullRequest> for IssuesMilestonedIssuePullRequest {
+    fn from(value: &IssuesMilestonedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "State of the issue; either 'open' or 'closed'"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesMilestonedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesMilestonedIssueState> for IssuesMilestonedIssueState {
+    fn from(value: &IssuesMilestonedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesMilestonedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesMilestonedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesMilestonedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesMilestonedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesMilestonedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IssuesOpened {
     pub action: IssuesOpenedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changes: Option<IssuesOpenedChanges>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesOpenedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -13935,6 +21693,166 @@ pub struct IssuesOpenedChanges {
 impl From<&IssuesOpenedChanges> for IssuesOpenedChanges {
     fn from(value: &IssuesOpenedChanges) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesOpenedIssue {
+    pub active_lock_reason: Option<IssuesOpenedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: (),
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesOpenedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssuesOpenedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesOpenedIssue> for IssuesOpenedIssue {
+    fn from(value: &IssuesOpenedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesOpenedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesOpenedIssueActiveLockReason> for IssuesOpenedIssueActiveLockReason {
+    fn from(value: &IssuesOpenedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesOpenedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesOpenedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesOpenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesOpenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesOpenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesOpenedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesOpenedIssuePullRequest> for IssuesOpenedIssuePullRequest {
+    fn from(value: &IssuesOpenedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesOpenedIssueState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&IssuesOpenedIssueState> for IssuesOpenedIssueState {
+    fn from(value: &IssuesOpenedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesOpenedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesOpenedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesOpenedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesOpenedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesOpenedIssueState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14004,7 +21922,7 @@ pub struct IssuesReopened {
     pub action: IssuesReopenedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesReopenedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -14054,6 +21972,166 @@ impl std::convert::TryFrom<&String> for IssuesReopenedAction {
     }
 }
 impl std::convert::TryFrom<String> for IssuesReopenedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesReopenedIssue {
+    pub active_lock_reason: Option<IssuesReopenedIssueActiveLockReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesReopenedIssuePullRequest>,
+    pub repository_url: String,
+    pub state: IssuesReopenedIssueState,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesReopenedIssue> for IssuesReopenedIssue {
+    fn from(value: &IssuesReopenedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesReopenedIssueActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&IssuesReopenedIssueActiveLockReason> for IssuesReopenedIssueActiveLockReason {
+    fn from(value: &IssuesReopenedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesReopenedIssueActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesReopenedIssueActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesReopenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesReopenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesReopenedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesReopenedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesReopenedIssuePullRequest> for IssuesReopenedIssuePullRequest {
+    fn from(value: &IssuesReopenedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesReopenedIssueState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&IssuesReopenedIssueState> for IssuesReopenedIssueState {
+    fn from(value: &IssuesReopenedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesReopenedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesReopenedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesReopenedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesReopenedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesReopenedIssueState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -14268,7 +22346,7 @@ pub struct IssuesUnlocked {
     pub action: IssuesUnlockedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub issue: Issue,
+    pub issue: IssuesUnlockedIssue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -14318,6 +22396,153 @@ impl std::convert::TryFrom<&String> for IssuesUnlockedAction {
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnlockedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnlockedIssue {
+    pub active_lock_reason: IssuesUnlockedIssueActiveLockReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    #[doc = "Contents of the issue"]
+    pub body: Option<String>,
+    pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub events_url: String,
+    pub html_url: String,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+    pub labels_url: String,
+    pub locked: bool,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    pub number: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub performed_via_github_app: Option<App>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<IssuesUnlockedIssuePullRequest>,
+    pub repository_url: String,
+    #[doc = "State of the issue; either 'open' or 'closed'"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssuesUnlockedIssueState>,
+    #[doc = "Title of the issue"]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "URL for the issue"]
+    pub url: String,
+    pub user: User,
+}
+impl From<&IssuesUnlockedIssue> for IssuesUnlockedIssue {
+    fn from(value: &IssuesUnlockedIssue) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct IssuesUnlockedIssueActiveLockReason(());
+impl std::ops::Deref for IssuesUnlockedIssueActiveLockReason {
+    type Target = ();
+    fn deref(&self) -> &() {
+        &self.0
+    }
+}
+impl From<IssuesUnlockedIssueActiveLockReason> for () {
+    fn from(value: IssuesUnlockedIssueActiveLockReason) -> Self {
+        value.0
+    }
+}
+impl From<&IssuesUnlockedIssueActiveLockReason> for IssuesUnlockedIssueActiveLockReason {
+    fn from(value: &IssuesUnlockedIssueActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl std::convert::TryFrom<()> for IssuesUnlockedIssueActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: ()) -> Result<Self, &'static str> {
+        if ![()].contains(&value) {
+            Err("invalid value")
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for IssuesUnlockedIssueActiveLockReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::try_from(<()>::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuesUnlockedIssuePullRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+impl From<&IssuesUnlockedIssuePullRequest> for IssuesUnlockedIssuePullRequest {
+    fn from(value: &IssuesUnlockedIssuePullRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "State of the issue; either 'open' or 'closed'"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum IssuesUnlockedIssueState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&IssuesUnlockedIssueState> for IssuesUnlockedIssueState {
+    fn from(value: &IssuesUnlockedIssueState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for IssuesUnlockedIssueState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for IssuesUnlockedIssueState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for IssuesUnlockedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for IssuesUnlockedIssueState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for IssuesUnlockedIssueState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -14728,7 +22953,7 @@ impl From<&MarketplacePurchaseAccount> for MarketplacePurchaseAccount {
 pub struct MarketplacePurchaseCancelled {
     pub action: MarketplacePurchaseCancelledAction,
     pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
+    pub marketplace_purchase: MarketplacePurchaseCancelledMarketplacePurchase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseCancelledSender,
@@ -14784,6 +23009,61 @@ impl std::convert::TryFrom<String> for MarketplacePurchaseCancelledAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseCancelledMarketplacePurchase {
+    pub account: MarketplacePurchaseCancelledMarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
+    pub next_billing_date: String,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchaseCancelledMarketplacePurchasePlan,
+    pub unit_count: i64,
+}
+impl From<&MarketplacePurchaseCancelledMarketplacePurchase>
+    for MarketplacePurchaseCancelledMarketplacePurchase
+{
+    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseCancelledMarketplacePurchaseAccount {
+    pub id: i64,
+    pub login: String,
+    pub node_id: String,
+    pub organization_billing_email: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+impl From<&MarketplacePurchaseCancelledMarketplacePurchaseAccount>
+    for MarketplacePurchaseCancelledMarketplacePurchaseAccount
+{
+    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchaseAccount) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseCancelledMarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+impl From<&MarketplacePurchaseCancelledMarketplacePurchasePlan>
+    for MarketplacePurchaseCancelledMarketplacePurchasePlan
+{
+    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchasePlan) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledSender {
     pub avatar_url: String,
     pub email: String,
@@ -14815,7 +23095,7 @@ impl From<&MarketplacePurchaseCancelledSender> for MarketplacePurchaseCancelledS
 pub struct MarketplacePurchaseChanged {
     pub action: MarketplacePurchaseChangedAction,
     pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
+    pub marketplace_purchase: MarketplacePurchaseChangedMarketplacePurchase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseChangedSender,
@@ -14867,6 +23147,61 @@ impl std::convert::TryFrom<String> for MarketplacePurchaseChangedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseChangedMarketplacePurchase {
+    pub account: MarketplacePurchaseChangedMarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
+    pub next_billing_date: String,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchaseChangedMarketplacePurchasePlan,
+    pub unit_count: i64,
+}
+impl From<&MarketplacePurchaseChangedMarketplacePurchase>
+    for MarketplacePurchaseChangedMarketplacePurchase
+{
+    fn from(value: &MarketplacePurchaseChangedMarketplacePurchase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseChangedMarketplacePurchaseAccount {
+    pub id: i64,
+    pub login: String,
+    pub node_id: String,
+    pub organization_billing_email: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+impl From<&MarketplacePurchaseChangedMarketplacePurchaseAccount>
+    for MarketplacePurchaseChangedMarketplacePurchaseAccount
+{
+    fn from(value: &MarketplacePurchaseChangedMarketplacePurchaseAccount) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchaseChangedMarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+impl From<&MarketplacePurchaseChangedMarketplacePurchasePlan>
+    for MarketplacePurchaseChangedMarketplacePurchasePlan
+{
+    fn from(value: &MarketplacePurchaseChangedMarketplacePurchasePlan) -> Self {
+        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14941,7 +23276,7 @@ impl From<MarketplacePurchasePurchased> for MarketplacePurchaseEvent {
 pub struct MarketplacePurchasePendingChange {
     pub action: MarketplacePurchasePendingChangeAction,
     pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
+    pub marketplace_purchase: MarketplacePurchasePendingChangeMarketplacePurchase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeSender,
@@ -15000,7 +23335,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeAction {
 pub struct MarketplacePurchasePendingChangeCancelled {
     pub action: MarketplacePurchasePendingChangeCancelledAction,
     pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
+    pub marketplace_purchase: MarketplacePurchasePendingChangeCancelledMarketplacePurchase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeCancelledSender,
@@ -15060,6 +23395,61 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeCancelled
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchase {
+    pub account: MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
+    pub next_billing_date: String,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan,
+    pub unit_count: i64,
+}
+impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchase>
+    for MarketplacePurchasePendingChangeCancelledMarketplacePurchase
+{
+    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount {
+    pub id: i64,
+    pub login: String,
+    pub node_id: String,
+    pub organization_billing_email: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount>
+    for MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount
+{
+    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan>
+    for MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan
+{
+    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub avatar_url: String,
     pub email: String,
@@ -15085,6 +23475,61 @@ impl From<&MarketplacePurchasePendingChangeCancelledSender>
     for MarketplacePurchasePendingChangeCancelledSender
 {
     fn from(value: &MarketplacePurchasePendingChangeCancelledSender) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeMarketplacePurchase {
+    pub account: MarketplacePurchasePendingChangeMarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
+    pub next_billing_date: String,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchasePendingChangeMarketplacePurchasePlan,
+    pub unit_count: i64,
+}
+impl From<&MarketplacePurchasePendingChangeMarketplacePurchase>
+    for MarketplacePurchasePendingChangeMarketplacePurchase
+{
+    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeMarketplacePurchaseAccount {
+    pub id: i64,
+    pub login: String,
+    pub node_id: String,
+    pub organization_billing_email: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+impl From<&MarketplacePurchasePendingChangeMarketplacePurchaseAccount>
+    for MarketplacePurchasePendingChangeMarketplacePurchaseAccount
+{
+    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchaseAccount) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePendingChangeMarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+impl From<&MarketplacePurchasePendingChangeMarketplacePurchasePlan>
+    for MarketplacePurchasePendingChangeMarketplacePurchasePlan
+{
+    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchasePlan) -> Self {
         value.clone()
     }
 }
@@ -15139,7 +23584,7 @@ impl From<&MarketplacePurchasePlan> for MarketplacePurchasePlan {
 pub struct MarketplacePurchasePurchased {
     pub action: MarketplacePurchasePurchasedAction,
     pub effective_date: String,
-    pub marketplace_purchase: MarketplacePurchase,
+    pub marketplace_purchase: MarketplacePurchasePurchasedMarketplacePurchase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_marketplace_purchase: Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePurchasedSender,
@@ -15191,6 +23636,61 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePurchasedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePurchasedMarketplacePurchase {
+    pub account: MarketplacePurchasePurchasedMarketplacePurchaseAccount,
+    pub billing_cycle: String,
+    pub free_trial_ends_on: (),
+    pub next_billing_date: String,
+    pub on_free_trial: bool,
+    pub plan: MarketplacePurchasePurchasedMarketplacePurchasePlan,
+    pub unit_count: i64,
+}
+impl From<&MarketplacePurchasePurchasedMarketplacePurchase>
+    for MarketplacePurchasePurchasedMarketplacePurchase
+{
+    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePurchasedMarketplacePurchaseAccount {
+    pub id: i64,
+    pub login: String,
+    pub node_id: String,
+    pub organization_billing_email: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+impl From<&MarketplacePurchasePurchasedMarketplacePurchaseAccount>
+    for MarketplacePurchasePurchasedMarketplacePurchaseAccount
+{
+    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchaseAccount) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarketplacePurchasePurchasedMarketplacePurchasePlan {
+    pub bullets: Vec<String>,
+    pub description: String,
+    pub has_free_trial: bool,
+    pub id: i64,
+    pub monthly_price_in_cents: i64,
+    pub name: String,
+    pub price_model: String,
+    pub unit_name: Option<String>,
+    pub yearly_price_in_cents: i64,
+}
+impl From<&MarketplacePurchasePurchasedMarketplacePurchasePlan>
+    for MarketplacePurchasePurchasedMarketplacePurchasePlan
+{
+    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchasePlan) -> Self {
+        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15999,7 +24499,7 @@ pub struct MilestoneClosed {
     pub action: MilestoneClosedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
+    pub milestone: MilestoneClosedMilestone,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -16056,11 +24556,82 @@ impl std::convert::TryFrom<String> for MilestoneClosedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct MilestoneClosedMilestone {
+    pub closed_at: chrono::DateTime<chrono::offset::Utc>,
+    pub closed_issues: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    pub description: Option<String>,
+    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub html_url: String,
+    pub id: i64,
+    pub labels_url: String,
+    pub node_id: String,
+    #[doc = "The number of the milestone."]
+    pub number: i64,
+    pub open_issues: i64,
+    pub state: MilestoneClosedMilestoneState,
+    #[doc = "The title of the milestone."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+impl From<&MilestoneClosedMilestone> for MilestoneClosedMilestone {
+    fn from(value: &MilestoneClosedMilestone) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneClosedMilestoneState {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&MilestoneClosedMilestoneState> for MilestoneClosedMilestoneState {
+    fn from(value: &MilestoneClosedMilestoneState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for MilestoneClosedMilestoneState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneClosedMilestoneState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneClosedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneClosedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for MilestoneClosedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MilestoneCreated {
     pub action: MilestoneCreatedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
+    pub milestone: MilestoneCreatedMilestone,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -16110,6 +24681,77 @@ impl std::convert::TryFrom<&String> for MilestoneCreatedAction {
     }
 }
 impl std::convert::TryFrom<String> for MilestoneCreatedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneCreatedMilestone {
+    pub closed_at: (),
+    pub closed_issues: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    pub description: Option<String>,
+    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub html_url: String,
+    pub id: i64,
+    pub labels_url: String,
+    pub node_id: String,
+    #[doc = "The number of the milestone."]
+    pub number: i64,
+    pub open_issues: i64,
+    pub state: MilestoneCreatedMilestoneState,
+    #[doc = "The title of the milestone."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+impl From<&MilestoneCreatedMilestone> for MilestoneCreatedMilestone {
+    fn from(value: &MilestoneCreatedMilestone) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneCreatedMilestoneState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&MilestoneCreatedMilestoneState> for MilestoneCreatedMilestoneState {
+    fn from(value: &MilestoneCreatedMilestoneState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for MilestoneCreatedMilestoneState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneCreatedMilestoneState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneCreatedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneCreatedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for MilestoneCreatedMilestoneState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -16332,7 +24974,7 @@ pub struct MilestoneOpened {
     pub action: MilestoneOpenedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
-    pub milestone: Milestone,
+    pub milestone: MilestoneOpenedMilestone,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     pub repository: Repository,
@@ -16382,6 +25024,77 @@ impl std::convert::TryFrom<&String> for MilestoneOpenedAction {
     }
 }
 impl std::convert::TryFrom<String> for MilestoneOpenedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MilestoneOpenedMilestone {
+    pub closed_at: (),
+    pub closed_issues: i64,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    pub description: Option<String>,
+    pub due_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub html_url: String,
+    pub id: i64,
+    pub labels_url: String,
+    pub node_id: String,
+    #[doc = "The number of the milestone."]
+    pub number: i64,
+    pub open_issues: i64,
+    pub state: MilestoneOpenedMilestoneState,
+    #[doc = "The title of the milestone."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+impl From<&MilestoneOpenedMilestone> for MilestoneOpenedMilestone {
+    fn from(value: &MilestoneOpenedMilestone) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MilestoneOpenedMilestoneState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&MilestoneOpenedMilestoneState> for MilestoneOpenedMilestoneState {
+    fn from(value: &MilestoneOpenedMilestoneState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for MilestoneOpenedMilestoneState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for MilestoneOpenedMilestoneState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for MilestoneOpenedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for MilestoneOpenedMilestoneState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for MilestoneOpenedMilestoneState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -17873,7 +26586,7 @@ pub struct ProjectCardMoved {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub project_card: ProjectCard,
+    pub project_card: ProjectCardMovedProjectCard,
     pub repository: Repository,
     pub sender: User,
 }
@@ -17943,6 +26656,31 @@ pub struct ProjectCardMovedChangesColumnId {
 }
 impl From<&ProjectCardMovedChangesColumnId> for ProjectCardMovedChangesColumnId {
     fn from(value: &ProjectCardMovedChangesColumnId) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectCardMovedProjectCard {
+    pub after_id: (),
+    #[doc = "Whether or not the card is archived"]
+    pub archived: bool,
+    pub column_id: i64,
+    pub column_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_url: Option<String>,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub creator: User,
+    #[doc = "The project card's ID"]
+    pub id: i64,
+    pub node_id: String,
+    pub note: Option<String>,
+    pub project_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+}
+impl From<&ProjectCardMovedProjectCard> for ProjectCardMovedProjectCard {
+    fn from(value: &ProjectCardMovedProjectCard) -> Self {
         value.clone()
     }
 }
@@ -18702,12 +27440,229 @@ pub struct PublicEvent {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub repository: Repository,
+    pub repository: PublicEventRepository,
     pub sender: User,
 }
 impl From<&PublicEvent> for PublicEvent {
     fn from(value: &PublicEvent) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicEventRepository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: PublicEventRepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<PublicEventRepositoryPermissions>,
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: PublicEventRepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&PublicEventRepository> for PublicEventRepository {
+    fn from(value: &PublicEventRepository) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PublicEventRepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&PublicEventRepositoryCreatedAt> for PublicEventRepositoryCreatedAt {
+    fn from(value: &PublicEventRepositoryCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for PublicEventRepositoryCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PublicEventRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PublicEventRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PublicEventRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for PublicEventRepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for PublicEventRepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for PublicEventRepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicEventRepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&PublicEventRepositoryPermissions> for PublicEventRepositoryPermissions {
+    fn from(value: &PublicEventRepositoryPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PublicEventRepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&PublicEventRepositoryPushedAt> for PublicEventRepositoryPushedAt {
+    fn from(value: &PublicEventRepositoryPushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for PublicEventRepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for PublicEventRepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -19042,7 +27997,7 @@ pub struct PullRequestClosed {
     pub number: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
+    pub pull_request: PullRequestClosedPullRequest,
     pub repository: Repository,
     pub sender: User,
 }
@@ -19097,6 +28052,241 @@ impl std::convert::TryFrom<String> for PullRequestClosedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct PullRequestClosedPullRequest {
+    pub active_lock_reason: Option<PullRequestClosedPullRequestActiveLockReason>,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestClosedPullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: chrono::DateTime<chrono::offset::Utc>,
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    #[doc = "Indicates whether or not the pull request is a draft."]
+    pub draft: bool,
+    pub head: PullRequestClosedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestClosedPullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: Option<String>,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: bool,
+    pub merged_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    pub merged_by: Option<User>,
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestClosedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    pub state: PullRequestClosedPullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
+}
+impl From<&PullRequestClosedPullRequest> for PullRequestClosedPullRequest {
+    fn from(value: &PullRequestClosedPullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestClosedPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&PullRequestClosedPullRequestActiveLockReason>
+    for PullRequestClosedPullRequestActiveLockReason
+{
+    fn from(value: &PullRequestClosedPullRequestActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestClosedPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestClosedPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestClosedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestClosedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestClosedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestClosedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestClosedPullRequestBase> for PullRequestClosedPullRequestBase {
+    fn from(value: &PullRequestClosedPullRequestBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestClosedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestClosedPullRequestHead> for PullRequestClosedPullRequestHead {
+    fn from(value: &PullRequestClosedPullRequestHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestClosedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+impl From<&PullRequestClosedPullRequestLinks> for PullRequestClosedPullRequestLinks {
+    fn from(value: &PullRequestClosedPullRequestLinks) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestClosedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+impl From<&PullRequestClosedPullRequestRequestedReviewersItem>
+    for PullRequestClosedPullRequestRequestedReviewersItem
+{
+    fn from(value: &PullRequestClosedPullRequestRequestedReviewersItem) -> Self {
+        value.clone()
+    }
+}
+impl From<User> for PullRequestClosedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestClosedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestClosedPullRequestState {
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&PullRequestClosedPullRequestState> for PullRequestClosedPullRequestState {
+    fn from(value: &PullRequestClosedPullRequestState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestClosedPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestClosedPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestClosedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestClosedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestClosedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraft {
     pub action: PullRequestConvertedToDraftAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -19105,7 +28295,7 @@ pub struct PullRequestConvertedToDraft {
     pub number: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
+    pub pull_request: PullRequestConvertedToDraftPullRequest,
     pub repository: Repository,
     pub sender: User,
 }
@@ -19153,6 +28343,254 @@ impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftAction {
     }
 }
 impl std::convert::TryFrom<String> for PullRequestConvertedToDraftAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestConvertedToDraftPullRequest {
+    pub active_lock_reason: Option<PullRequestConvertedToDraftPullRequestActiveLockReason>,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestConvertedToDraftPullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: (),
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    pub draft: bool,
+    pub head: PullRequestConvertedToDraftPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestConvertedToDraftPullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: Option<String>,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: bool,
+    pub merged_at: (),
+    pub merged_by: (),
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestConvertedToDraftPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    #[doc = "State of this Pull Request. Either `open` or `closed`."]
+    pub state: PullRequestConvertedToDraftPullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
+}
+impl From<&PullRequestConvertedToDraftPullRequest> for PullRequestConvertedToDraftPullRequest {
+    fn from(value: &PullRequestConvertedToDraftPullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestConvertedToDraftPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&PullRequestConvertedToDraftPullRequestActiveLockReason>
+    for PullRequestConvertedToDraftPullRequestActiveLockReason
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestConvertedToDraftPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestConvertedToDraftPullRequestBase>
+    for PullRequestConvertedToDraftPullRequestBase
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestConvertedToDraftPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestConvertedToDraftPullRequestHead>
+    for PullRequestConvertedToDraftPullRequestHead
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestConvertedToDraftPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+impl From<&PullRequestConvertedToDraftPullRequestLinks>
+    for PullRequestConvertedToDraftPullRequestLinks
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestLinks) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+impl From<&PullRequestConvertedToDraftPullRequestRequestedReviewersItem>
+    for PullRequestConvertedToDraftPullRequestRequestedReviewersItem
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestRequestedReviewersItem) -> Self {
+        value.clone()
+    }
+}
+impl From<User> for PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
+#[doc = "State of this Pull Request. Either `open` or `closed`."]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestConvertedToDraftPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl From<&PullRequestConvertedToDraftPullRequestState>
+    for PullRequestConvertedToDraftPullRequestState
+{
+    fn from(value: &PullRequestConvertedToDraftPullRequestState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestConvertedToDraftPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+            Self::Closed => "closed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestConvertedToDraftPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -19539,7 +28977,7 @@ pub struct PullRequestOpened {
     pub number: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
+    pub pull_request: PullRequestOpenedPullRequest,
     pub repository: Repository,
     pub sender: User,
 }
@@ -19594,6 +29032,222 @@ impl std::convert::TryFrom<String> for PullRequestOpenedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct PullRequestOpenedPullRequest {
+    pub active_lock_reason: PullRequestOpenedPullRequestActiveLockReason,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestOpenedPullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: (),
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    #[doc = "Indicates whether or not the pull request is a draft."]
+    pub draft: bool,
+    pub head: PullRequestOpenedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestOpenedPullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: (),
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: Option<bool>,
+    pub merged_at: (),
+    pub merged_by: (),
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestOpenedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    pub state: PullRequestOpenedPullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
+}
+impl From<&PullRequestOpenedPullRequest> for PullRequestOpenedPullRequest {
+    fn from(value: &PullRequestOpenedPullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct PullRequestOpenedPullRequestActiveLockReason(());
+impl std::ops::Deref for PullRequestOpenedPullRequestActiveLockReason {
+    type Target = ();
+    fn deref(&self) -> &() {
+        &self.0
+    }
+}
+impl From<PullRequestOpenedPullRequestActiveLockReason> for () {
+    fn from(value: PullRequestOpenedPullRequestActiveLockReason) -> Self {
+        value.0
+    }
+}
+impl From<&PullRequestOpenedPullRequestActiveLockReason>
+    for PullRequestOpenedPullRequestActiveLockReason
+{
+    fn from(value: &PullRequestOpenedPullRequestActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl std::convert::TryFrom<()> for PullRequestOpenedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: ()) -> Result<Self, &'static str> {
+        if ![()].contains(&value) {
+            Err("invalid value")
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for PullRequestOpenedPullRequestActiveLockReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::try_from(<()>::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestOpenedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestOpenedPullRequestBase> for PullRequestOpenedPullRequestBase {
+    fn from(value: &PullRequestOpenedPullRequestBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestOpenedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestOpenedPullRequestHead> for PullRequestOpenedPullRequestHead {
+    fn from(value: &PullRequestOpenedPullRequestHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestOpenedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+impl From<&PullRequestOpenedPullRequestLinks> for PullRequestOpenedPullRequestLinks {
+    fn from(value: &PullRequestOpenedPullRequestLinks) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestOpenedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+impl From<&PullRequestOpenedPullRequestRequestedReviewersItem>
+    for PullRequestOpenedPullRequestRequestedReviewersItem
+{
+    fn from(value: &PullRequestOpenedPullRequestRequestedReviewersItem) -> Self {
+        value.clone()
+    }
+}
+impl From<User> for PullRequestOpenedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestOpenedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestOpenedPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&PullRequestOpenedPullRequestState> for PullRequestOpenedPullRequestState {
+    fn from(value: &PullRequestOpenedPullRequestState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestOpenedPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestOpenedPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestOpenedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestOpenedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestOpenedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReview {
     pub action: PullRequestReadyForReviewAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -19602,7 +29256,7 @@ pub struct PullRequestReadyForReview {
     pub number: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
+    pub pull_request: PullRequestReadyForReviewPullRequest,
     pub repository: Repository,
     pub sender: User,
 }
@@ -19657,6 +29311,244 @@ impl std::convert::TryFrom<String> for PullRequestReadyForReviewAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct PullRequestReadyForReviewPullRequest {
+    pub active_lock_reason: Option<PullRequestReadyForReviewPullRequestActiveLockReason>,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestReadyForReviewPullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: (),
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    pub draft: bool,
+    pub head: PullRequestReadyForReviewPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReadyForReviewPullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: Option<String>,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: bool,
+    pub merged_at: (),
+    pub merged_by: (),
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestReadyForReviewPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    pub state: PullRequestReadyForReviewPullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
+}
+impl From<&PullRequestReadyForReviewPullRequest> for PullRequestReadyForReviewPullRequest {
+    fn from(value: &PullRequestReadyForReviewPullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReadyForReviewPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&PullRequestReadyForReviewPullRequestActiveLockReason>
+    for PullRequestReadyForReviewPullRequestActiveLockReason
+{
+    fn from(value: &PullRequestReadyForReviewPullRequestActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestReadyForReviewPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReadyForReviewPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReadyForReviewPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReadyForReviewPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestReadyForReviewPullRequestBase> for PullRequestReadyForReviewPullRequestBase {
+    fn from(value: &PullRequestReadyForReviewPullRequestBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReadyForReviewPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestReadyForReviewPullRequestHead> for PullRequestReadyForReviewPullRequestHead {
+    fn from(value: &PullRequestReadyForReviewPullRequestHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReadyForReviewPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+impl From<&PullRequestReadyForReviewPullRequestLinks>
+    for PullRequestReadyForReviewPullRequestLinks
+{
+    fn from(value: &PullRequestReadyForReviewPullRequestLinks) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestReadyForReviewPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+impl From<&PullRequestReadyForReviewPullRequestRequestedReviewersItem>
+    for PullRequestReadyForReviewPullRequestRequestedReviewersItem
+{
+    fn from(value: &PullRequestReadyForReviewPullRequestRequestedReviewersItem) -> Self {
+        value.clone()
+    }
+}
+impl From<User> for PullRequestReadyForReviewPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestReadyForReviewPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReadyForReviewPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&PullRequestReadyForReviewPullRequestState>
+    for PullRequestReadyForReviewPullRequestState
+{
+    fn from(value: &PullRequestReadyForReviewPullRequestState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestReadyForReviewPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReadyForReviewPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReadyForReviewPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PullRequestReopened {
     pub action: PullRequestReopenedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -19665,7 +29557,7 @@ pub struct PullRequestReopened {
     pub number: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub pull_request: PullRequest,
+    pub pull_request: PullRequestReopenedPullRequest,
     pub repository: Repository,
     pub sender: User,
 }
@@ -19713,6 +29605,241 @@ impl std::convert::TryFrom<&String> for PullRequestReopenedAction {
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReopenedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReopenedPullRequest {
+    pub active_lock_reason: Option<PullRequestReopenedPullRequestActiveLockReason>,
+    pub additions: i64,
+    pub assignee: Option<User>,
+    pub assignees: Vec<User>,
+    pub author_association: AuthorAssociation,
+    pub auto_merge: (),
+    pub base: PullRequestReopenedPullRequestBase,
+    pub body: Option<String>,
+    pub changed_files: i64,
+    pub closed_at: (),
+    pub comments: i64,
+    pub comments_url: String,
+    pub commits: i64,
+    pub commits_url: String,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub deletions: i64,
+    pub diff_url: String,
+    #[doc = "Indicates whether or not the pull request is a draft."]
+    pub draft: bool,
+    pub head: PullRequestReopenedPullRequestHead,
+    pub html_url: String,
+    pub id: i64,
+    pub issue_url: String,
+    pub labels: Vec<Label>,
+    #[serde(rename = "_links")]
+    pub links: PullRequestReopenedPullRequestLinks,
+    pub locked: bool,
+    #[doc = "Indicates whether maintainers can modify the pull request."]
+    pub maintainer_can_modify: bool,
+    pub merge_commit_sha: (),
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merged: bool,
+    pub merged_at: (),
+    pub merged_by: (),
+    pub milestone: Option<Milestone>,
+    pub node_id: String,
+    #[doc = "Number uniquely identifying the pull request within its repository."]
+    pub number: i64,
+    pub patch_url: String,
+    pub rebaseable: Option<bool>,
+    pub requested_reviewers: Vec<PullRequestReopenedPullRequestRequestedReviewersItem>,
+    pub requested_teams: Vec<Team>,
+    pub review_comment_url: String,
+    pub review_comments: i64,
+    pub review_comments_url: String,
+    pub state: PullRequestReopenedPullRequestState,
+    pub statuses_url: String,
+    #[doc = "The title of the pull request."]
+    pub title: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub user: User,
+}
+impl From<&PullRequestReopenedPullRequest> for PullRequestReopenedPullRequest {
+    fn from(value: &PullRequestReopenedPullRequest) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReopenedPullRequestActiveLockReason {
+    #[serde(rename = "resolved")]
+    Resolved,
+    #[serde(rename = "off-topic")]
+    OffTopic,
+    #[serde(rename = "too heated")]
+    TooHeated,
+    #[serde(rename = "spam")]
+    Spam,
+}
+impl From<&PullRequestReopenedPullRequestActiveLockReason>
+    for PullRequestReopenedPullRequestActiveLockReason
+{
+    fn from(value: &PullRequestReopenedPullRequestActiveLockReason) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestReopenedPullRequestActiveLockReason {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Resolved => "resolved".to_string(),
+            Self::OffTopic => "off-topic".to_string(),
+            Self::TooHeated => "too heated".to_string(),
+            Self::Spam => "spam".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReopenedPullRequestActiveLockReason {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "resolved" => Ok(Self::Resolved),
+            "off-topic" => Ok(Self::OffTopic),
+            "too heated" => Ok(Self::TooHeated),
+            "spam" => Ok(Self::Spam),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReopenedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReopenedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestActiveLockReason {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReopenedPullRequestBase {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestReopenedPullRequestBase> for PullRequestReopenedPullRequestBase {
+    fn from(value: &PullRequestReopenedPullRequestBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReopenedPullRequestHead {
+    pub label: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: Repository,
+    pub sha: String,
+    pub user: User,
+}
+impl From<&PullRequestReopenedPullRequestHead> for PullRequestReopenedPullRequestHead {
+    fn from(value: &PullRequestReopenedPullRequestHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PullRequestReopenedPullRequestLinks {
+    pub comments: Link,
+    pub commits: Link,
+    pub html: Link,
+    pub issue: Link,
+    pub review_comment: Link,
+    pub review_comments: Link,
+    #[serde(rename = "self")]
+    pub self_: Link,
+    pub statuses: Link,
+}
+impl From<&PullRequestReopenedPullRequestLinks> for PullRequestReopenedPullRequestLinks {
+    fn from(value: &PullRequestReopenedPullRequestLinks) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PullRequestReopenedPullRequestRequestedReviewersItem {
+    User(User),
+    Team(Team),
+}
+impl From<&PullRequestReopenedPullRequestRequestedReviewersItem>
+    for PullRequestReopenedPullRequestRequestedReviewersItem
+{
+    fn from(value: &PullRequestReopenedPullRequestRequestedReviewersItem) -> Self {
+        value.clone()
+    }
+}
+impl From<User> for PullRequestReopenedPullRequestRequestedReviewersItem {
+    fn from(value: User) -> Self {
+        Self::User(value)
+    }
+}
+impl From<Team> for PullRequestReopenedPullRequestRequestedReviewersItem {
+    fn from(value: Team) -> Self {
+        Self::Team(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PullRequestReopenedPullRequestState {
+    #[serde(rename = "open")]
+    Open,
+}
+impl From<&PullRequestReopenedPullRequestState> for PullRequestReopenedPullRequestState {
+    fn from(value: &PullRequestReopenedPullRequestState) -> Self {
+        value.clone()
+    }
+}
+impl ToString for PullRequestReopenedPullRequestState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Open => "open".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for PullRequestReopenedPullRequestState {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "open" => Ok(Self::Open),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for PullRequestReopenedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for PullRequestReopenedPullRequestState {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestState {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -22206,7 +32333,7 @@ pub struct ReleasePrereleased {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub release: Release,
+    pub release: ReleasePrereleasedRelease,
     pub repository: Repository,
     pub sender: User,
 }
@@ -22261,13 +32388,43 @@ impl std::convert::TryFrom<String> for ReleasePrereleasedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct ReleasePrereleasedRelease {
+    pub assets: Vec<ReleaseAsset>,
+    pub assets_url: String,
+    pub author: User,
+    pub body: String,
+    pub created_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "Wether the release is a draft or published"]
+    pub draft: bool,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    pub prerelease: bool,
+    pub published_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "The name of the tag."]
+    pub tag_name: String,
+    pub tarball_url: Option<String>,
+    #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
+    pub target_commitish: String,
+    pub upload_url: String,
+    pub url: String,
+    pub zipball_url: Option<String>,
+}
+impl From<&ReleasePrereleasedRelease> for ReleasePrereleasedRelease {
+    fn from(value: &ReleasePrereleasedRelease) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReleasePublished {
     pub action: ReleasePublishedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub release: Release,
+    pub release: ReleasePublishedRelease,
     pub repository: Repository,
     pub sender: User,
 }
@@ -22318,6 +32475,37 @@ impl std::convert::TryFrom<String> for ReleasePublishedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleasePublishedRelease {
+    pub assets: Vec<ReleaseAsset>,
+    pub assets_url: String,
+    pub author: User,
+    pub body: String,
+    pub created_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "Wether the release is a draft or published"]
+    pub draft: bool,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the release is identified as a prerelease or a full release."]
+    pub prerelease: bool,
+    pub published_at: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The name of the tag."]
+    pub tag_name: String,
+    pub tarball_url: Option<String>,
+    #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
+    pub target_commitish: String,
+    pub upload_url: String,
+    pub url: String,
+    pub zipball_url: Option<String>,
+}
+impl From<&ReleasePublishedRelease> for ReleasePublishedRelease {
+    fn from(value: &ReleasePublishedRelease) -> Self {
+        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22389,7 +32577,7 @@ pub struct ReleaseUnpublished {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub release: Release,
+    pub release: ReleaseUnpublishedRelease,
     pub repository: Repository,
     pub sender: User,
 }
@@ -22440,6 +32628,37 @@ impl std::convert::TryFrom<String> for ReleaseUnpublishedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseUnpublishedRelease {
+    pub assets: Vec<ReleaseAsset>,
+    pub assets_url: String,
+    pub author: User,
+    pub body: String,
+    pub created_at: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[doc = "Wether the release is a draft or published"]
+    pub draft: bool,
+    pub html_url: String,
+    pub id: i64,
+    pub name: String,
+    pub node_id: String,
+    #[doc = "Whether the release is identified as a prerelease or a full release."]
+    pub prerelease: bool,
+    pub published_at: (),
+    #[doc = "The name of the tag."]
+    pub tag_name: String,
+    pub tarball_url: Option<String>,
+    #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
+    pub target_commitish: String,
+    pub upload_url: String,
+    pub url: String,
+    pub zipball_url: Option<String>,
+}
+impl From<&ReleaseUnpublishedRelease> for ReleaseUnpublishedRelease {
+    fn from(value: &ReleaseUnpublishedRelease) -> Self {
+        value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22584,7 +32803,7 @@ pub struct RepositoryArchived {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub repository: Repository,
+    pub repository: RepositoryArchivedRepository,
     pub sender: User,
 }
 impl From<&RepositoryArchived> for RepositoryArchived {
@@ -22634,6 +32853,223 @@ impl std::convert::TryFrom<String> for RepositoryArchivedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryArchivedRepository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: RepositoryArchivedRepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<RepositoryArchivedRepositoryPermissions>,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: RepositoryArchivedRepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&RepositoryArchivedRepository> for RepositoryArchivedRepository {
+    fn from(value: &RepositoryArchivedRepository) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryArchivedRepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&RepositoryArchivedRepositoryCreatedAt> for RepositoryArchivedRepositoryCreatedAt {
+    fn from(value: &RepositoryArchivedRepositoryCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryArchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryArchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for RepositoryArchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for RepositoryArchivedRepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for RepositoryArchivedRepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryArchivedRepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryArchivedRepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&RepositoryArchivedRepositoryPermissions> for RepositoryArchivedRepositoryPermissions {
+    fn from(value: &RepositoryArchivedRepositoryPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryArchivedRepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&RepositoryArchivedRepositoryPushedAt> for RepositoryArchivedRepositoryPushedAt {
+    fn from(value: &RepositoryArchivedRepositoryPushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for RepositoryArchivedRepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryArchivedRepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23218,7 +33654,7 @@ pub struct RepositoryPrivatized {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub repository: Repository,
+    pub repository: RepositoryPrivatizedRepository,
     pub sender: User,
 }
 impl From<&RepositoryPrivatized> for RepositoryPrivatized {
@@ -23272,13 +33708,232 @@ impl std::convert::TryFrom<String> for RepositoryPrivatizedAction {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct RepositoryPrivatizedRepository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: RepositoryPrivatizedRepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<RepositoryPrivatizedRepositoryPermissions>,
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: RepositoryPrivatizedRepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&RepositoryPrivatizedRepository> for RepositoryPrivatizedRepository {
+    fn from(value: &RepositoryPrivatizedRepository) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryPrivatizedRepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&RepositoryPrivatizedRepositoryCreatedAt> for RepositoryPrivatizedRepositoryCreatedAt {
+    fn from(value: &RepositoryPrivatizedRepositoryCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryPrivatizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryPrivatizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for RepositoryPrivatizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for RepositoryPrivatizedRepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for RepositoryPrivatizedRepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPrivatizedRepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPrivatizedRepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&RepositoryPrivatizedRepositoryPermissions>
+    for RepositoryPrivatizedRepositoryPermissions
+{
+    fn from(value: &RepositoryPrivatizedRepositoryPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryPrivatizedRepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&RepositoryPrivatizedRepositoryPushedAt> for RepositoryPrivatizedRepositoryPushedAt {
+    fn from(value: &RepositoryPrivatizedRepositoryPushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for RepositoryPrivatizedRepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPrivatizedRepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RepositoryPublicized {
     pub action: RepositoryPublicizedAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub repository: Repository,
+    pub repository: RepositoryPublicizedRepository,
     pub sender: User,
 }
 impl From<&RepositoryPublicized> for RepositoryPublicized {
@@ -23328,6 +33983,225 @@ impl std::convert::TryFrom<String> for RepositoryPublicizedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPublicizedRepository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    #[doc = "Whether the repository is archived."]
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: RepositoryPublicizedRepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<RepositoryPublicizedRepositoryPermissions>,
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: RepositoryPublicizedRepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&RepositoryPublicizedRepository> for RepositoryPublicizedRepository {
+    fn from(value: &RepositoryPublicizedRepository) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryPublicizedRepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&RepositoryPublicizedRepositoryCreatedAt> for RepositoryPublicizedRepositoryCreatedAt {
+    fn from(value: &RepositoryPublicizedRepositoryCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryPublicizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryPublicizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for RepositoryPublicizedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for RepositoryPublicizedRepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for RepositoryPublicizedRepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPublicizedRepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryPublicizedRepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&RepositoryPublicizedRepositoryPermissions>
+    for RepositoryPublicizedRepositoryPermissions
+{
+    fn from(value: &RepositoryPublicizedRepositoryPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryPublicizedRepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&RepositoryPublicizedRepositoryPushedAt> for RepositoryPublicizedRepositoryPushedAt {
+    fn from(value: &RepositoryPublicizedRepositoryPushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for RepositoryPublicizedRepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPublicizedRepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -23543,7 +34417,7 @@ pub struct RepositoryUnarchived {
     pub installation: Option<InstallationLite>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
-    pub repository: Repository,
+    pub repository: RepositoryUnarchivedRepository,
     pub sender: User,
 }
 impl From<&RepositoryUnarchived> for RepositoryUnarchived {
@@ -23593,6 +34467,225 @@ impl std::convert::TryFrom<String> for RepositoryUnarchivedAction {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryUnarchivedRepository {
+    #[doc = "Whether to allow auto-merge for pull requests."]
+    #[serde(default)]
+    pub allow_auto_merge: bool,
+    #[doc = "Whether to allow private forks"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_forking: Option<bool>,
+    #[doc = "Whether to allow merge commits for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_merge_commit: bool,
+    #[doc = "Whether to allow rebase merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_rebase_merge: bool,
+    #[doc = "Whether to allow squash merges for pull requests."]
+    #[serde(default = "defaults::default_bool::<true>")]
+    pub allow_squash_merge: bool,
+    pub archive_url: String,
+    pub archived: bool,
+    pub assignees_url: String,
+    pub blobs_url: String,
+    pub branches_url: String,
+    pub clone_url: String,
+    pub collaborators_url: String,
+    pub comments_url: String,
+    pub commits_url: String,
+    pub compare_url: String,
+    pub contents_url: String,
+    pub contributors_url: String,
+    pub created_at: RepositoryUnarchivedRepositoryCreatedAt,
+    #[doc = "The default branch of the repository."]
+    pub default_branch: String,
+    #[doc = "Whether to delete head branches when pull requests are merged"]
+    #[serde(default)]
+    pub delete_branch_on_merge: bool,
+    pub deployments_url: String,
+    pub description: Option<String>,
+    #[doc = "Returns whether or not this repository is disabled."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    pub downloads_url: String,
+    pub events_url: String,
+    pub fork: bool,
+    pub forks: i64,
+    pub forks_count: i64,
+    pub forks_url: String,
+    pub full_name: String,
+    pub git_commits_url: String,
+    pub git_refs_url: String,
+    pub git_tags_url: String,
+    pub git_url: String,
+    #[doc = "Whether downloads are enabled."]
+    pub has_downloads: bool,
+    #[doc = "Whether issues are enabled."]
+    pub has_issues: bool,
+    pub has_pages: bool,
+    #[doc = "Whether projects are enabled."]
+    pub has_projects: bool,
+    #[doc = "Whether the wiki is enabled."]
+    pub has_wiki: bool,
+    pub homepage: Option<String>,
+    pub hooks_url: String,
+    pub html_url: String,
+    #[doc = "Unique identifier of the repository"]
+    pub id: i64,
+    pub issue_comment_url: String,
+    pub issue_events_url: String,
+    pub issues_url: String,
+    pub keys_url: String,
+    pub labels_url: String,
+    pub language: Option<String>,
+    pub languages_url: String,
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_branch: Option<String>,
+    pub merges_url: String,
+    pub milestones_url: String,
+    pub mirror_url: Option<String>,
+    #[doc = "The name of the repository."]
+    pub name: String,
+    pub node_id: String,
+    pub notifications_url: String,
+    pub open_issues: i64,
+    pub open_issues_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    pub owner: User,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<RepositoryUnarchivedRepositoryPermissions>,
+    #[doc = "Whether the repository is private or public."]
+    pub private: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    pub pulls_url: String,
+    pub pushed_at: RepositoryUnarchivedRepositoryPushedAt,
+    pub releases_url: String,
+    pub size: i64,
+    pub ssh_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stargazers: Option<i64>,
+    pub stargazers_count: i64,
+    pub stargazers_url: String,
+    pub statuses_url: String,
+    pub subscribers_url: String,
+    pub subscription_url: String,
+    pub svn_url: String,
+    pub tags_url: String,
+    pub teams_url: String,
+    pub trees_url: String,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub watchers: i64,
+    pub watchers_count: i64,
+}
+impl From<&RepositoryUnarchivedRepository> for RepositoryUnarchivedRepository {
+    fn from(value: &RepositoryUnarchivedRepository) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryUnarchivedRepositoryCreatedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+}
+impl From<&RepositoryUnarchivedRepositoryCreatedAt> for RepositoryUnarchivedRepositoryCreatedAt {
+    fn from(value: &RepositoryUnarchivedRepositoryCreatedAt) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for RepositoryUnarchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for RepositoryUnarchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for RepositoryUnarchivedRepositoryCreatedAt {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for RepositoryUnarchivedRepositoryCreatedAt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<i64> for RepositoryUnarchivedRepositoryCreatedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryUnarchivedRepositoryCreatedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryUnarchivedRepositoryPermissions {
+    pub admin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maintain: Option<bool>,
+    pub pull: bool,
+    pub push: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<bool>,
+}
+impl From<&RepositoryUnarchivedRepositoryPermissions>
+    for RepositoryUnarchivedRepositoryPermissions
+{
+    fn from(value: &RepositoryUnarchivedRepositoryPermissions) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RepositoryUnarchivedRepositoryPushedAt {
+    Variant0(i64),
+    Variant1(chrono::DateTime<chrono::offset::Utc>),
+    Variant2,
+}
+impl From<&RepositoryUnarchivedRepositoryPushedAt> for RepositoryUnarchivedRepositoryPushedAt {
+    fn from(value: &RepositoryUnarchivedRepositoryPushedAt) -> Self {
+        value.clone()
+    }
+}
+impl From<i64> for RepositoryUnarchivedRepositoryPushedAt {
+    fn from(value: i64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryUnarchivedRepositoryPushedAt {
+    fn from(value: chrono::DateTime<chrono::offset::Utc>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25927,9 +37020,9 @@ impl From<&StatusEventCommit> for StatusEventCommit {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommit {
-    pub author: Committer,
+    pub author: StatusEventCommitCommitAuthor,
     pub comment_count: i64,
-    pub committer: Committer,
+    pub committer: StatusEventCommitCommitCommitter,
     pub message: String,
     pub tree: StatusEventCommitCommitTree,
     pub url: String,
@@ -25937,6 +37030,38 @@ pub struct StatusEventCommitCommit {
 }
 impl From<&StatusEventCommitCommit> for StatusEventCommitCommit {
     fn from(value: &StatusEventCommitCommit) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusEventCommitCommitAuthor {
+    pub date: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The git author's email address."]
+    pub email: Option<String>,
+    #[doc = "The git author's name."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+impl From<&StatusEventCommitCommitAuthor> for StatusEventCommitCommitAuthor {
+    fn from(value: &StatusEventCommitCommitAuthor) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusEventCommitCommitCommitter {
+    pub date: chrono::DateTime<chrono::offset::Utc>,
+    #[doc = "The git author's email address."]
+    pub email: Option<String>,
+    #[doc = "The git author's name."]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+impl From<&StatusEventCommitCommitCommitter> for StatusEventCommitCommitCommitter {
+    fn from(value: &StatusEventCommitCommitCommitter) -> Self {
         value.clone()
     }
 }
@@ -27220,7 +38345,7 @@ pub struct WorkflowJobCompleted {
     pub organization: Option<Organization>,
     pub repository: Repository,
     pub sender: User,
-    pub workflow_job: WorkflowJob,
+    pub workflow_job: WorkflowJobCompletedWorkflowJob,
 }
 impl From<&WorkflowJobCompleted> for WorkflowJobCompleted {
     fn from(value: &WorkflowJobCompleted) -> Self {
@@ -27266,6 +38391,132 @@ impl std::convert::TryFrom<&String> for WorkflowJobCompletedAction {
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobCompletedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobCompletedWorkflowJob {
+    pub check_run_url: String,
+    pub completed_at: Option<String>,
+    pub conclusion: WorkflowJobCompletedWorkflowJobConclusion,
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<String>,
+    pub name: String,
+    pub node_id: String,
+    pub run_id: f64,
+    pub run_url: String,
+    pub started_at: String,
+    pub status: WorkflowJobCompletedWorkflowJobStatus,
+    pub steps: Vec<WorkflowStep>,
+    pub url: String,
+}
+impl From<&WorkflowJobCompletedWorkflowJob> for WorkflowJobCompletedWorkflowJob {
+    fn from(value: &WorkflowJobCompletedWorkflowJob) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobCompletedWorkflowJobConclusion {
+    #[serde(rename = "success")]
+    Success,
+    #[serde(rename = "failure")]
+    Failure,
+}
+impl From<&WorkflowJobCompletedWorkflowJobConclusion>
+    for WorkflowJobCompletedWorkflowJobConclusion
+{
+    fn from(value: &WorkflowJobCompletedWorkflowJobConclusion) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowJobCompletedWorkflowJobConclusion {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Success => "success".to_string(),
+            Self::Failure => "failure".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobCompletedWorkflowJobConclusion {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "success" => Ok(Self::Success),
+            "failure" => Ok(Self::Failure),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobConclusion {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobCompletedWorkflowJobConclusion {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobConclusion {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobCompletedWorkflowJobStatus {
+    #[serde(rename = "queued")]
+    Queued,
+    #[serde(rename = "in_progress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+}
+impl From<&WorkflowJobCompletedWorkflowJobStatus> for WorkflowJobCompletedWorkflowJobStatus {
+    fn from(value: &WorkflowJobCompletedWorkflowJobStatus) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowJobCompletedWorkflowJobStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Queued => "queued".to_string(),
+            Self::InProgress => "in_progress".to_string(),
+            Self::Completed => "completed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobCompletedWorkflowJobStatus {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobStatus {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobCompletedWorkflowJobStatus {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobStatus {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -27485,7 +38736,7 @@ pub struct WorkflowJobStarted {
     pub organization: Option<Organization>,
     pub repository: Repository,
     pub sender: User,
-    pub workflow_job: WorkflowJob,
+    pub workflow_job: WorkflowJobStartedWorkflowJob,
 }
 impl From<&WorkflowJobStarted> for WorkflowJobStarted {
     fn from(value: &WorkflowJobStarted) -> Self {
@@ -27531,6 +38782,179 @@ impl std::convert::TryFrom<&String> for WorkflowJobStartedAction {
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobStartedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowJobStartedWorkflowJob {
+    pub check_run_url: String,
+    pub completed_at: (),
+    pub conclusion: WorkflowJobStartedWorkflowJobConclusion,
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub labels: Vec<String>,
+    pub name: String,
+    pub node_id: String,
+    pub run_id: f64,
+    pub run_url: String,
+    pub started_at: String,
+    pub status: WorkflowJobStartedWorkflowJobStatus,
+    pub steps: [WorkflowJobStartedWorkflowJobStepsItem; 1usize],
+    pub url: String,
+}
+impl From<&WorkflowJobStartedWorkflowJob> for WorkflowJobStartedWorkflowJob {
+    fn from(value: &WorkflowJobStartedWorkflowJob) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct WorkflowJobStartedWorkflowJobConclusion(());
+impl std::ops::Deref for WorkflowJobStartedWorkflowJobConclusion {
+    type Target = ();
+    fn deref(&self) -> &() {
+        &self.0
+    }
+}
+impl From<WorkflowJobStartedWorkflowJobConclusion> for () {
+    fn from(value: WorkflowJobStartedWorkflowJobConclusion) -> Self {
+        value.0
+    }
+}
+impl From<&WorkflowJobStartedWorkflowJobConclusion> for WorkflowJobStartedWorkflowJobConclusion {
+    fn from(value: &WorkflowJobStartedWorkflowJobConclusion) -> Self {
+        value.clone()
+    }
+}
+impl std::convert::TryFrom<()> for WorkflowJobStartedWorkflowJobConclusion {
+    type Error = &'static str;
+    fn try_from(value: ()) -> Result<Self, &'static str> {
+        if ![()].contains(&value) {
+            Err("invalid value")
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for WorkflowJobStartedWorkflowJobConclusion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::try_from(<()>::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobStartedWorkflowJobStatus {
+    #[serde(rename = "queued")]
+    Queued,
+    #[serde(rename = "in_progress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+}
+impl From<&WorkflowJobStartedWorkflowJobStatus> for WorkflowJobStartedWorkflowJobStatus {
+    fn from(value: &WorkflowJobStartedWorkflowJobStatus) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowJobStartedWorkflowJobStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Queued => "queued".to_string(),
+            Self::InProgress => "in_progress".to_string(),
+            Self::Completed => "completed".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobStartedWorkflowJobStatus {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobStartedWorkflowJobStatus {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobStartedWorkflowJobStatus {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowJobStartedWorkflowJobStatus {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WorkflowJobStartedWorkflowJobStepsItem {
+    pub completed_at: (),
+    pub conclusion: (),
+    pub name: String,
+    pub number: i64,
+    pub started_at: String,
+    pub status: WorkflowJobStartedWorkflowJobStepsItemStatus,
+}
+impl From<&WorkflowJobStartedWorkflowJobStepsItem> for WorkflowJobStartedWorkflowJobStepsItem {
+    fn from(value: &WorkflowJobStartedWorkflowJobStepsItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowJobStartedWorkflowJobStepsItemStatus {
+    #[serde(rename = "in_progress")]
+    InProgress,
+}
+impl From<&WorkflowJobStartedWorkflowJobStepsItemStatus>
+    for WorkflowJobStartedWorkflowJobStepsItemStatus
+{
+    fn from(value: &WorkflowJobStartedWorkflowJobStepsItemStatus) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowJobStartedWorkflowJobStepsItemStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::InProgress => "in_progress".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowJobStartedWorkflowJobStepsItemStatus {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "in_progress" => Ok(Self::InProgress),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowJobStartedWorkflowJobStepsItemStatus {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowJobStartedWorkflowJobStepsItemStatus {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowJobStartedWorkflowJobStepsItemStatus {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -27635,7 +39059,7 @@ pub struct WorkflowRunCompleted {
     pub repository: Repository,
     pub sender: User,
     pub workflow: Workflow,
-    pub workflow_run: WorkflowRun,
+    pub workflow_run: WorkflowRunCompletedWorkflowRun,
 }
 impl From<&WorkflowRunCompleted> for WorkflowRunCompleted {
     fn from(value: &WorkflowRunCompleted) -> Self {
@@ -27681,6 +39105,214 @@ impl std::convert::TryFrom<&String> for WorkflowRunCompletedAction {
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunCompletedAction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunCompletedWorkflowRun {
+    pub artifacts_url: String,
+    pub cancel_url: String,
+    pub check_suite_id: i64,
+    pub check_suite_node_id: String,
+    pub check_suite_url: String,
+    pub conclusion: WorkflowRunCompletedWorkflowRunConclusion,
+    pub created_at: chrono::DateTime<chrono::offset::Utc>,
+    pub event: String,
+    pub head_branch: String,
+    pub head_commit: CommitSimple,
+    pub head_repository: RepositoryLite,
+    pub head_sha: String,
+    pub html_url: String,
+    pub id: i64,
+    pub jobs_url: String,
+    pub logs_url: String,
+    pub name: String,
+    pub node_id: String,
+    pub pull_requests: Vec<WorkflowRunCompletedWorkflowRunPullRequestsItem>,
+    pub repository: RepositoryLite,
+    pub rerun_url: String,
+    pub run_number: i64,
+    pub status: WorkflowRunCompletedWorkflowRunStatus,
+    pub updated_at: chrono::DateTime<chrono::offset::Utc>,
+    pub url: String,
+    pub workflow_id: i64,
+    pub workflow_url: String,
+}
+impl From<&WorkflowRunCompletedWorkflowRun> for WorkflowRunCompletedWorkflowRun {
+    fn from(value: &WorkflowRunCompletedWorkflowRun) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowRunCompletedWorkflowRunConclusion {
+    #[serde(rename = "success")]
+    Success,
+    #[serde(rename = "failure")]
+    Failure,
+    #[serde(rename = "neutral")]
+    Neutral,
+    #[serde(rename = "cancelled")]
+    Cancelled,
+    #[serde(rename = "timed_out")]
+    TimedOut,
+    #[serde(rename = "action_required")]
+    ActionRequired,
+    #[serde(rename = "stale")]
+    Stale,
+}
+impl From<&WorkflowRunCompletedWorkflowRunConclusion>
+    for WorkflowRunCompletedWorkflowRunConclusion
+{
+    fn from(value: &WorkflowRunCompletedWorkflowRunConclusion) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowRunCompletedWorkflowRunConclusion {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Success => "success".to_string(),
+            Self::Failure => "failure".to_string(),
+            Self::Neutral => "neutral".to_string(),
+            Self::Cancelled => "cancelled".to_string(),
+            Self::TimedOut => "timed_out".to_string(),
+            Self::ActionRequired => "action_required".to_string(),
+            Self::Stale => "stale".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowRunCompletedWorkflowRunConclusion {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "success" => Ok(Self::Success),
+            "failure" => Ok(Self::Failure),
+            "neutral" => Ok(Self::Neutral),
+            "cancelled" => Ok(Self::Cancelled),
+            "timed_out" => Ok(Self::TimedOut),
+            "action_required" => Ok(Self::ActionRequired),
+            "stale" => Ok(Self::Stale),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunConclusion {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunCompletedWorkflowRunConclusion {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunConclusion {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunCompletedWorkflowRunPullRequestsItem {
+    pub base: WorkflowRunCompletedWorkflowRunPullRequestsItemBase,
+    pub head: WorkflowRunCompletedWorkflowRunPullRequestsItemHead,
+    pub id: f64,
+    pub number: f64,
+    pub url: String,
+}
+impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItem>
+    for WorkflowRunCompletedWorkflowRunPullRequestsItem
+{
+    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItem) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemBase {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: RepoRef,
+    pub sha: String,
+}
+impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItemBase>
+    for WorkflowRunCompletedWorkflowRunPullRequestsItemBase
+{
+    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItemBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemHead {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub repo: RepoRef,
+    pub sha: String,
+}
+impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItemHead>
+    for WorkflowRunCompletedWorkflowRunPullRequestsItemHead
+{
+    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItemHead) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum WorkflowRunCompletedWorkflowRunStatus {
+    #[serde(rename = "requested")]
+    Requested,
+    #[serde(rename = "in_progress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "queued")]
+    Queued,
+}
+impl From<&WorkflowRunCompletedWorkflowRunStatus> for WorkflowRunCompletedWorkflowRunStatus {
+    fn from(value: &WorkflowRunCompletedWorkflowRunStatus) -> Self {
+        value.clone()
+    }
+}
+impl ToString for WorkflowRunCompletedWorkflowRunStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Requested => "requested".to_string(),
+            Self::InProgress => "in_progress".to_string(),
+            Self::Completed => "completed".to_string(),
+            Self::Queued => "queued".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for WorkflowRunCompletedWorkflowRunStatus {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "requested" => Ok(Self::Requested),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            "queued" => Ok(Self::Queued),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunStatus {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for WorkflowRunCompletedWorkflowRunStatus {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunStatus {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -463,10 +463,14 @@ impl std::convert::TryFrom<String> for AggregateTransformType {
 pub enum AlignValue {
     Variant0(Vec<AlignValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: AlignValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<AlignValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<AlignValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<AlignValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<AlignValueVariant1Subtype3>,
     },
 }
 impl From<&AlignValue> for AlignValue {
@@ -481,10 +485,14 @@ impl From<Vec<AlignValueVariant0Item>> for AlignValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: AlignValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<AlignValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<AlignValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<AlignValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<AlignValueVariant0ItemSubtype3>,
 }
 impl From<&AlignValueVariant0Item> for AlignValueVariant0Item {
     fn from(value: &AlignValueVariant0Item) -> Self {
@@ -492,11 +500,162 @@ impl From<&AlignValueVariant0Item> for AlignValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AlignValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: AlignValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: AlignValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&AlignValueVariant0ItemSubtype0> for AlignValueVariant0ItemSubtype0 {
+    fn from(value: &AlignValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum AlignValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&AlignValueVariant0ItemSubtype0Variant1Value>
+    for AlignValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &AlignValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for AlignValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for AlignValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AlignValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AlignValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&AlignValueVariant0ItemSubtype0Variant3Range>
+    for AlignValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &AlignValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for AlignValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AlignValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for AlignValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for AlignValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AlignValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AlignValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&AlignValueVariant0ItemSubtype1> for AlignValueVariant0ItemSubtype1 {
     fn from(value: &AlignValueVariant0ItemSubtype1) -> Self {
@@ -504,49 +663,59 @@ impl From<&AlignValueVariant0ItemSubtype1> for AlignValueVariant0ItemSubtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AlignValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct AlignValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&AlignValueVariant0ItemSubtype1Subtype1> for AlignValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&AlignValueVariant0ItemSubtype2> for AlignValueVariant0ItemSubtype2 {
+    fn from(value: &AlignValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AlignValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&AlignValueVariant0ItemSubtype3> for AlignValueVariant0ItemSubtype3 {
+    fn from(value: &AlignValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum AlignValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: AlignValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: AlignValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype0>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&AlignValueVariant1Subtype0> for AlignValueVariant1Subtype0 {
+    fn from(value: &AlignValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for AlignValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum AlignValueVariant1Subtype0Variant1Value {
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -554,14 +723,12 @@ pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "center")]
     Center,
 }
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+impl From<&AlignValueVariant1Subtype0Variant1Value> for AlignValueVariant1Subtype0Variant1Value {
+    fn from(value: &AlignValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for AlignValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Left => "left".to_string(),
@@ -570,7 +737,7 @@ impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
         }
     }
 }
-impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for AlignValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -581,21 +748,19 @@ impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
-impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<String> for AlignValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -603,18 +768,16 @@ impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype1Subtype1Sub
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum AlignValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&AlignValueVariant1Subtype0Variant3Range> for AlignValueVariant1Subtype0Variant3Range {
+    fn from(value: &AlignValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for AlignValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -626,27 +789,25 @@ impl std::str::FromStr for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
-impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for AlignValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for AlignValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -654,53 +815,19 @@ impl ToString for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for AlignValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for AlignValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for AlignValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype1>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype2>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&AlignValueVariant0ItemSubtype1Subtype1Subtype3>
-    for AlignValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &AlignValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AlignValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AlignValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AlignValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AlignValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AlignValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&AlignValueVariant1Subtype1> for AlignValueVariant1Subtype1 {
     fn from(value: &AlignValueVariant1Subtype1) -> Self {
@@ -708,162 +835,21 @@ impl From<&AlignValueVariant1Subtype1> for AlignValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AlignValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: AlignValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: AlignValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct AlignValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&AlignValueVariant1Subtype1Subtype0> for AlignValueVariant1Subtype1Subtype0 {
-    fn from(value: &AlignValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for AlignValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum AlignValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "left")]
-    Left,
-    #[serde(rename = "right")]
-    Right,
-    #[serde(rename = "center")]
-    Center,
-}
-impl From<&AlignValueVariant1Subtype1Subtype0Variant1Value>
-    for AlignValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &AlignValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "left" => Ok(Self::Left),
-            "right" => Ok(Self::Right),
-            "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for AlignValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AlignValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&AlignValueVariant1Subtype1Subtype0Variant3Range>
-    for AlignValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AlignValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for AlignValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant1Subtype1Subtype1 {}
-impl From<&AlignValueVariant1Subtype1Subtype1> for AlignValueVariant1Subtype1Subtype1 {
-    fn from(value: &AlignValueVariant1Subtype1Subtype1) -> Self {
+impl From<&AlignValueVariant1Subtype2> for AlignValueVariant1Subtype2 {
+    fn from(value: &AlignValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant1Subtype1Subtype2 {}
-impl From<&AlignValueVariant1Subtype1Subtype2> for AlignValueVariant1Subtype1Subtype2 {
-    fn from(value: &AlignValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct AlignValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AlignValueVariant1Subtype1Subtype3 {}
-impl From<&AlignValueVariant1Subtype1Subtype3> for AlignValueVariant1Subtype1Subtype3 {
-    fn from(value: &AlignValueVariant1Subtype1Subtype3) -> Self {
+impl From<&AlignValueVariant1Subtype3> for AlignValueVariant1Subtype3 {
+    fn from(value: &AlignValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -872,10 +858,14 @@ impl From<&AlignValueVariant1Subtype1Subtype3> for AlignValueVariant1Subtype1Sub
 pub enum AnchorValue {
     Variant0(Vec<AnchorValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: AnchorValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<AnchorValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<AnchorValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<AnchorValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<AnchorValueVariant1Subtype3>,
     },
 }
 impl From<&AnchorValue> for AnchorValue {
@@ -890,10 +880,14 @@ impl From<Vec<AnchorValueVariant0Item>> for AnchorValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: AnchorValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<AnchorValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<AnchorValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<AnchorValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<AnchorValueVariant0ItemSubtype3>,
 }
 impl From<&AnchorValueVariant0Item> for AnchorValueVariant0Item {
     fn from(value: &AnchorValueVariant0Item) -> Self {
@@ -901,11 +895,162 @@ impl From<&AnchorValueVariant0Item> for AnchorValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AnchorValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: AnchorValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: AnchorValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&AnchorValueVariant0ItemSubtype0> for AnchorValueVariant0ItemSubtype0 {
+    fn from(value: &AnchorValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum AnchorValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&AnchorValueVariant0ItemSubtype0Variant1Value>
+    for AnchorValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &AnchorValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for AnchorValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for AnchorValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AnchorValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for AnchorValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AnchorValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&AnchorValueVariant0ItemSubtype0Variant3Range>
+    for AnchorValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &AnchorValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for AnchorValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AnchorValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for AnchorValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for AnchorValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for AnchorValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnchorValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AnchorValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&AnchorValueVariant0ItemSubtype1> for AnchorValueVariant0ItemSubtype1 {
     fn from(value: &AnchorValueVariant0ItemSubtype1) -> Self {
@@ -913,49 +1058,59 @@ impl From<&AnchorValueVariant0ItemSubtype1> for AnchorValueVariant0ItemSubtype1 
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AnchorValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct AnchorValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1> for AnchorValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&AnchorValueVariant0ItemSubtype2> for AnchorValueVariant0ItemSubtype2 {
+    fn from(value: &AnchorValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AnchorValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&AnchorValueVariant0ItemSubtype3> for AnchorValueVariant0ItemSubtype3 {
+    fn from(value: &AnchorValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum AnchorValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: AnchorValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: AnchorValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype0>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&AnchorValueVariant1Subtype0> for AnchorValueVariant1Subtype0 {
+    fn from(value: &AnchorValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum AnchorValueVariant1Subtype0Variant1Value {
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -963,14 +1118,12 @@ pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "end")]
     End,
 }
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+impl From<&AnchorValueVariant1Subtype0Variant1Value> for AnchorValueVariant1Subtype0Variant1Value {
+    fn from(value: &AnchorValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for AnchorValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Start => "start".to_string(),
@@ -979,7 +1132,7 @@ impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
         }
     }
 }
-impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for AnchorValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -990,23 +1143,19 @@ impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -1014,18 +1163,16 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum AnchorValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&AnchorValueVariant1Subtype0Variant3Range> for AnchorValueVariant1Subtype0Variant3Range {
+    fn from(value: &AnchorValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for AnchorValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -1037,29 +1184,25 @@ impl std::str::FromStr for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for AnchorValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -1067,53 +1210,19 @@ impl ToString for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for AnchorValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for AnchorValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for AnchorValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype1>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype2>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&AnchorValueVariant0ItemSubtype1Subtype1Subtype3>
-    for AnchorValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &AnchorValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnchorValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AnchorValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AnchorValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AnchorValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AnchorValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&AnchorValueVariant1Subtype1> for AnchorValueVariant1Subtype1 {
     fn from(value: &AnchorValueVariant1Subtype1) -> Self {
@@ -1121,162 +1230,21 @@ impl From<&AnchorValueVariant1Subtype1> for AnchorValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AnchorValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: AnchorValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: AnchorValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct AnchorValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&AnchorValueVariant1Subtype1Subtype0> for AnchorValueVariant1Subtype1Subtype0 {
-    fn from(value: &AnchorValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for AnchorValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "start")]
-    Start,
-    #[serde(rename = "middle")]
-    Middle,
-    #[serde(rename = "end")]
-    End,
-}
-impl From<&AnchorValueVariant1Subtype1Subtype0Variant1Value>
-    for AnchorValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &AnchorValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "start" => Ok(Self::Start),
-            "middle" => Ok(Self::Middle),
-            "end" => Ok(Self::End),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&AnchorValueVariant1Subtype1Subtype0Variant3Range>
-    for AnchorValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AnchorValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for AnchorValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant1Subtype1Subtype1 {}
-impl From<&AnchorValueVariant1Subtype1Subtype1> for AnchorValueVariant1Subtype1Subtype1 {
-    fn from(value: &AnchorValueVariant1Subtype1Subtype1) -> Self {
+impl From<&AnchorValueVariant1Subtype2> for AnchorValueVariant1Subtype2 {
+    fn from(value: &AnchorValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant1Subtype1Subtype2 {}
-impl From<&AnchorValueVariant1Subtype1Subtype2> for AnchorValueVariant1Subtype1Subtype2 {
-    fn from(value: &AnchorValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct AnchorValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnchorValueVariant1Subtype1Subtype3 {}
-impl From<&AnchorValueVariant1Subtype1Subtype3> for AnchorValueVariant1Subtype1Subtype3 {
-    fn from(value: &AnchorValueVariant1Subtype1Subtype3) -> Self {
+impl From<&AnchorValueVariant1Subtype3> for AnchorValueVariant1Subtype3 {
+    fn from(value: &AnchorValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -1285,10 +1253,14 @@ impl From<&AnchorValueVariant1Subtype1Subtype3> for AnchorValueVariant1Subtype1S
 pub enum AnyValue {
     Variant0(Vec<AnyValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: AnyValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<AnyValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<AnyValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<AnyValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<AnyValueVariant1Subtype3>,
     },
 }
 impl From<&AnyValue> for AnyValue {
@@ -1303,10 +1275,14 @@ impl From<Vec<AnyValueVariant0Item>> for AnyValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnyValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: AnyValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<AnyValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<AnyValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<AnyValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<AnyValueVariant0ItemSubtype3>,
 }
 impl From<&AnyValueVariant0Item> for AnyValueVariant0Item {
     fn from(value: &AnyValueVariant0Item) -> Self {
@@ -1314,11 +1290,108 @@ impl From<&AnyValueVariant0Item> for AnyValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AnyValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: serde_json::Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: AnyValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&AnyValueVariant0ItemSubtype0> for AnyValueVariant0ItemSubtype0 {
+    fn from(value: &AnyValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AnyValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&AnyValueVariant0ItemSubtype0Variant3Range>
+    for AnyValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &AnyValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for AnyValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for AnyValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for AnyValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for AnyValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for AnyValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for AnyValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for AnyValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnyValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: AnyValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&AnyValueVariant0ItemSubtype1> for AnyValueVariant0ItemSubtype1 {
     fn from(value: &AnyValueVariant0ItemSubtype1) -> Self {
@@ -1326,61 +1399,69 @@ impl From<&AnyValueVariant0ItemSubtype1> for AnyValueVariant0ItemSubtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AnyValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct AnyValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&AnyValueVariant0ItemSubtype1Subtype1> for AnyValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&AnyValueVariant0ItemSubtype2> for AnyValueVariant0ItemSubtype2 {
+    fn from(value: &AnyValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AnyValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&AnyValueVariant0ItemSubtype3> for AnyValueVariant0ItemSubtype3 {
+    fn from(value: &AnyValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum AnyValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: serde_json::Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: AnyValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype0>
-    for AnyValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&AnyValueVariant1Subtype0> for AnyValueVariant1Subtype0 {
+    fn from(value: &AnyValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for AnyValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum AnyValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&AnyValueVariant1Subtype0Variant3Range> for AnyValueVariant1Subtype0Variant3Range {
+    fn from(value: &AnyValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for AnyValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -1392,25 +1473,25 @@ impl std::str::FromStr for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3R
         }
     }
 }
-impl std::convert::TryFrom<&str> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for AnyValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&String> for AnyValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for AnyValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for AnyValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -1418,53 +1499,19 @@ impl ToString for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for AnyValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for AnyValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for AnyValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype1>
-    for AnyValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype2>
-    for AnyValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&AnyValueVariant0ItemSubtype1Subtype1Subtype3>
-    for AnyValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &AnyValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnyValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<AnyValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<AnyValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<AnyValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<AnyValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&AnyValueVariant1Subtype1> for AnyValueVariant1Subtype1 {
     fn from(value: &AnyValueVariant1Subtype1) -> Self {
@@ -1472,108 +1519,21 @@ impl From<&AnyValueVariant1Subtype1> for AnyValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AnyValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: serde_json::Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: AnyValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct AnyValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&AnyValueVariant1Subtype1Subtype0> for AnyValueVariant1Subtype1Subtype0 {
-    fn from(value: &AnyValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for AnyValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum AnyValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&AnyValueVariant1Subtype1Subtype0Variant3Range>
-    for AnyValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &AnyValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for AnyValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant1Subtype1Subtype1 {}
-impl From<&AnyValueVariant1Subtype1Subtype1> for AnyValueVariant1Subtype1Subtype1 {
-    fn from(value: &AnyValueVariant1Subtype1Subtype1) -> Self {
+impl From<&AnyValueVariant1Subtype2> for AnyValueVariant1Subtype2 {
+    fn from(value: &AnyValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant1Subtype1Subtype2 {}
-impl From<&AnyValueVariant1Subtype1Subtype2> for AnyValueVariant1Subtype1Subtype2 {
-    fn from(value: &AnyValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct AnyValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AnyValueVariant1Subtype1Subtype3 {}
-impl From<&AnyValueVariant1Subtype1Subtype3> for AnyValueVariant1Subtype1Subtype3 {
-    fn from(value: &AnyValueVariant1Subtype1Subtype3) -> Self {
+impl From<&AnyValueVariant1Subtype3> for AnyValueVariant1Subtype3 {
+    fn from(value: &AnyValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -1603,10 +1563,14 @@ impl From<SignalRef> for ArrayOrSignal {
 pub enum ArrayValue {
     Variant0(Vec<ArrayValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: ArrayValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<ArrayValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<ArrayValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<ArrayValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<ArrayValueVariant1Subtype3>,
     },
 }
 impl From<&ArrayValue> for ArrayValue {
@@ -1621,10 +1585,14 @@ impl From<Vec<ArrayValueVariant0Item>> for ArrayValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArrayValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: ArrayValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<ArrayValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<ArrayValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<ArrayValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<ArrayValueVariant0ItemSubtype3>,
 }
 impl From<&ArrayValueVariant0Item> for ArrayValueVariant0Item {
     fn from(value: &ArrayValueVariant0Item) -> Self {
@@ -1632,11 +1600,108 @@ impl From<&ArrayValueVariant0Item> for ArrayValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ArrayValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: Vec<serde_json::Value>,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: ArrayValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&ArrayValueVariant0ItemSubtype0> for ArrayValueVariant0ItemSubtype0 {
+    fn from(value: &ArrayValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ArrayValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&ArrayValueVariant0ItemSubtype0Variant3Range>
+    for ArrayValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &ArrayValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for ArrayValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for ArrayValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ArrayValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for ArrayValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for ArrayValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for ArrayValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for ArrayValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArrayValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: ArrayValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&ArrayValueVariant0ItemSubtype1> for ArrayValueVariant0ItemSubtype1 {
     fn from(value: &ArrayValueVariant0ItemSubtype1) -> Self {
@@ -1644,61 +1709,69 @@ impl From<&ArrayValueVariant0ItemSubtype1> for ArrayValueVariant0ItemSubtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<ArrayValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct ArrayValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1> for ArrayValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&ArrayValueVariant0ItemSubtype2> for ArrayValueVariant0ItemSubtype2 {
+    fn from(value: &ArrayValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArrayValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&ArrayValueVariant0ItemSubtype3> for ArrayValueVariant0ItemSubtype3 {
+    fn from(value: &ArrayValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum ArrayValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: Vec<serde_json::Value>,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: ArrayValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype0>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&ArrayValueVariant1Subtype0> for ArrayValueVariant1Subtype0 {
+    fn from(value: &ArrayValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum ArrayValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&ArrayValueVariant1Subtype0Variant3Range> for ArrayValueVariant1Subtype0Variant3Range {
+    fn from(value: &ArrayValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for ArrayValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -1710,27 +1783,25 @@ impl std::str::FromStr for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
-impl std::convert::TryFrom<&str> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for ArrayValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for ArrayValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for ArrayValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for ArrayValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -1738,53 +1809,19 @@ impl ToString for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for ArrayValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for ArrayValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for ArrayValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype1>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype2>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&ArrayValueVariant0ItemSubtype1Subtype1Subtype3>
-    for ArrayValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &ArrayValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ArrayValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<ArrayValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<ArrayValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<ArrayValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<ArrayValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&ArrayValueVariant1Subtype1> for ArrayValueVariant1Subtype1 {
     fn from(value: &ArrayValueVariant1Subtype1) -> Self {
@@ -1792,108 +1829,21 @@ impl From<&ArrayValueVariant1Subtype1> for ArrayValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum ArrayValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: Vec<serde_json::Value>,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: ArrayValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct ArrayValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&ArrayValueVariant1Subtype1Subtype0> for ArrayValueVariant1Subtype1Subtype0 {
-    fn from(value: &ArrayValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for ArrayValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&ArrayValueVariant1Subtype1Subtype0Variant3Range>
-    for ArrayValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &ArrayValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for ArrayValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant1Subtype1Subtype1 {}
-impl From<&ArrayValueVariant1Subtype1Subtype1> for ArrayValueVariant1Subtype1Subtype1 {
-    fn from(value: &ArrayValueVariant1Subtype1Subtype1) -> Self {
+impl From<&ArrayValueVariant1Subtype2> for ArrayValueVariant1Subtype2 {
+    fn from(value: &ArrayValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant1Subtype1Subtype2 {}
-impl From<&ArrayValueVariant1Subtype1Subtype2> for ArrayValueVariant1Subtype1Subtype2 {
-    fn from(value: &ArrayValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct ArrayValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ArrayValueVariant1Subtype1Subtype3 {}
-impl From<&ArrayValueVariant1Subtype1Subtype3> for ArrayValueVariant1Subtype1Subtype3 {
-    fn from(value: &ArrayValueVariant1Subtype1Subtype3) -> Self {
+impl From<&ArrayValueVariant1Subtype3> for ArrayValueVariant1Subtype3 {
+    fn from(value: &ArrayValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -4106,10 +4056,14 @@ impl From<StringOrSignal> for Background {
 #[serde(untagged, deny_unknown_fields)]
 pub enum BaseColorValue {
     Variant0 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: BaseColorValueVariant0Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<BaseColorValueVariant0Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<BaseColorValueVariant0Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<BaseColorValueVariant0Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<BaseColorValueVariant0Subtype3>,
     },
     Variant1 {
         value: LinearGradient,
@@ -4136,59 +4090,48 @@ impl From<&BaseColorValue> for BaseColorValue {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaseColorValueVariant0Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BaseColorValueVariant0Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BaseColorValueVariant0Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BaseColorValueVariant0Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BaseColorValueVariant0Subtype1Subtype3>,
-}
-impl From<&BaseColorValueVariant0Subtype1> for BaseColorValueVariant0Subtype1 {
-    fn from(value: &BaseColorValueVariant0Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BaseColorValueVariant0Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum BaseColorValueVariant0Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: Option<String>,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: BaseColorValueVariant0Subtype1Subtype0Variant3Range,
+        range: BaseColorValueVariant0Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&BaseColorValueVariant0Subtype1Subtype0> for BaseColorValueVariant0Subtype1Subtype0 {
-    fn from(value: &BaseColorValueVariant0Subtype1Subtype0) -> Self {
+impl From<&BaseColorValueVariant0Subtype0> for BaseColorValueVariant0Subtype0 {
+    fn from(value: &BaseColorValueVariant0Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for BaseColorValueVariant0Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+pub enum BaseColorValueVariant0Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&BaseColorValueVariant0Subtype1Subtype0Variant3Range>
-    for BaseColorValueVariant0Subtype1Subtype0Variant3Range
+impl From<&BaseColorValueVariant0Subtype0Variant3Range>
+    for BaseColorValueVariant0Subtype0Variant3Range
 {
-    fn from(value: &BaseColorValueVariant0Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &BaseColorValueVariant0Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for BaseColorValueVariant0Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -4200,25 +4143,25 @@ impl std::str::FromStr for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl std::convert::TryFrom<&str> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for BaseColorValueVariant0Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&String> for BaseColorValueVariant0Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for BaseColorValueVariant0Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl ToString for BaseColorValueVariant0Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -4226,34 +4169,41 @@ impl ToString for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl From<f64> for BaseColorValueVariant0Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for BaseColorValueVariant0Subtype1Subtype0Variant3Range {
+impl From<bool> for BaseColorValueVariant0Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaseColorValueVariant0Subtype1Subtype1 {}
-impl From<&BaseColorValueVariant0Subtype1Subtype1> for BaseColorValueVariant0Subtype1Subtype1 {
-    fn from(value: &BaseColorValueVariant0Subtype1Subtype1) -> Self {
+pub struct BaseColorValueVariant0Subtype1 {
+    pub scale: Field,
+}
+impl From<&BaseColorValueVariant0Subtype1> for BaseColorValueVariant0Subtype1 {
+    fn from(value: &BaseColorValueVariant0Subtype1) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaseColorValueVariant0Subtype1Subtype2 {}
-impl From<&BaseColorValueVariant0Subtype1Subtype2> for BaseColorValueVariant0Subtype1Subtype2 {
-    fn from(value: &BaseColorValueVariant0Subtype1Subtype2) -> Self {
+pub struct BaseColorValueVariant0Subtype2 {
+    pub scale: Field,
+}
+impl From<&BaseColorValueVariant0Subtype2> for BaseColorValueVariant0Subtype2 {
+    fn from(value: &BaseColorValueVariant0Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaseColorValueVariant0Subtype1Subtype3 {}
-impl From<&BaseColorValueVariant0Subtype1Subtype3> for BaseColorValueVariant0Subtype1Subtype3 {
-    fn from(value: &BaseColorValueVariant0Subtype1Subtype3) -> Self {
+pub struct BaseColorValueVariant0Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+}
+impl From<&BaseColorValueVariant0Subtype3> for BaseColorValueVariant0Subtype3 {
+    fn from(value: &BaseColorValueVariant0Subtype3) -> Self {
         value.clone()
     }
 }
@@ -4295,10 +4245,14 @@ impl From<ColorHcl> for BaseColorValueVariant4Color {
 pub enum BaselineValue {
     Variant0(Vec<BaselineValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: BaselineValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<BaselineValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<BaselineValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<BaselineValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<BaselineValueVariant1Subtype3>,
     },
 }
 impl From<&BaselineValue> for BaselineValue {
@@ -4313,10 +4267,14 @@ impl From<Vec<BaselineValueVariant0Item>> for BaselineValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaselineValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: BaselineValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<BaselineValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<BaselineValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<BaselineValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<BaselineValueVariant0ItemSubtype3>,
 }
 impl From<&BaselineValueVariant0Item> for BaselineValueVariant0Item {
     fn from(value: &BaselineValueVariant0Item) -> Self {
@@ -4324,11 +4282,166 @@ impl From<&BaselineValueVariant0Item> for BaselineValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BaselineValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: BaselineValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: BaselineValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&BaselineValueVariant0ItemSubtype0> for BaselineValueVariant0ItemSubtype0 {
+    fn from(value: &BaselineValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum BaselineValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+}
+impl From<&BaselineValueVariant0ItemSubtype0Variant1Value>
+    for BaselineValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &BaselineValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for BaselineValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for BaselineValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for BaselineValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BaselineValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for BaselineValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BaselineValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&BaselineValueVariant0ItemSubtype0Variant3Range>
+    for BaselineValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &BaselineValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for BaselineValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for BaselineValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BaselineValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for BaselineValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for BaselineValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for BaselineValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BaselineValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaselineValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BaselineValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&BaselineValueVariant0ItemSubtype1> for BaselineValueVariant0ItemSubtype1 {
     fn from(value: &BaselineValueVariant0ItemSubtype1) -> Self {
@@ -4336,51 +4449,59 @@ impl From<&BaselineValueVariant0ItemSubtype1> for BaselineValueVariant0ItemSubty
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BaselineValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct BaselineValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1>
-    for BaselineValueVariant0ItemSubtype1Subtype1
-{
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&BaselineValueVariant0ItemSubtype2> for BaselineValueVariant0ItemSubtype2 {
+    fn from(value: &BaselineValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BaselineValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&BaselineValueVariant0ItemSubtype3> for BaselineValueVariant0ItemSubtype3 {
+    fn from(value: &BaselineValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum BaselineValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: BaselineValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: BaselineValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype0>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&BaselineValueVariant1Subtype0> for BaselineValueVariant1Subtype0 {
+    fn from(value: &BaselineValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum BaselineValueVariant1Subtype0Variant1Value {
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -4390,14 +4511,14 @@ pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "alphabetic")]
     Alphabetic,
 }
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+impl From<&BaselineValueVariant1Subtype0Variant1Value>
+    for BaselineValueVariant1Subtype0Variant1Value
 {
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+    fn from(value: &BaselineValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for BaselineValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Top => "top".to_string(),
@@ -4407,7 +4528,7 @@ impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
         }
     }
 }
-impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for BaselineValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -4419,25 +4540,19 @@ impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Vari
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -4445,18 +4560,18 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum BaselineValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&BaselineValueVariant1Subtype0Variant3Range>
+    for BaselineValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &BaselineValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for BaselineValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -4468,31 +4583,25 @@ impl std::str::FromStr for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Vari
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for BaselineValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -4500,53 +4609,19 @@ impl ToString for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
         }
     }
 }
-impl From<f64> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for BaselineValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for BaselineValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for BaselineValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype1>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype2>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&BaselineValueVariant0ItemSubtype1Subtype1Subtype3>
-    for BaselineValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &BaselineValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BaselineValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BaselineValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BaselineValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BaselineValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BaselineValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&BaselineValueVariant1Subtype1> for BaselineValueVariant1Subtype1 {
     fn from(value: &BaselineValueVariant1Subtype1) -> Self {
@@ -4554,166 +4629,21 @@ impl From<&BaselineValueVariant1Subtype1> for BaselineValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BaselineValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: BaselineValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: BaselineValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct BaselineValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&BaselineValueVariant1Subtype1Subtype0> for BaselineValueVariant1Subtype1Subtype0 {
-    fn from(value: &BaselineValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for BaselineValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "top")]
-    Top,
-    #[serde(rename = "middle")]
-    Middle,
-    #[serde(rename = "bottom")]
-    Bottom,
-    #[serde(rename = "alphabetic")]
-    Alphabetic,
-}
-impl From<&BaselineValueVariant1Subtype1Subtype0Variant1Value>
-    for BaselineValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &BaselineValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "top" => Ok(Self::Top),
-            "middle" => Ok(Self::Middle),
-            "bottom" => Ok(Self::Bottom),
-            "alphabetic" => Ok(Self::Alphabetic),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&BaselineValueVariant1Subtype1Subtype0Variant3Range>
-    for BaselineValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &BaselineValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for BaselineValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant1Subtype1Subtype1 {}
-impl From<&BaselineValueVariant1Subtype1Subtype1> for BaselineValueVariant1Subtype1Subtype1 {
-    fn from(value: &BaselineValueVariant1Subtype1Subtype1) -> Self {
+impl From<&BaselineValueVariant1Subtype2> for BaselineValueVariant1Subtype2 {
+    fn from(value: &BaselineValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant1Subtype1Subtype2 {}
-impl From<&BaselineValueVariant1Subtype1Subtype2> for BaselineValueVariant1Subtype1Subtype2 {
-    fn from(value: &BaselineValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct BaselineValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BaselineValueVariant1Subtype1Subtype3 {}
-impl From<&BaselineValueVariant1Subtype1Subtype3> for BaselineValueVariant1Subtype1Subtype3 {
-    fn from(value: &BaselineValueVariant1Subtype1Subtype3) -> Self {
+impl From<&BaselineValueVariant1Subtype3> for BaselineValueVariant1Subtype3 {
+    fn from(value: &BaselineValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -5456,10 +5386,14 @@ impl<'de> serde::Deserialize<'de> for BindVariant3Input {
 pub enum BlendValue {
     Variant0(Vec<BlendValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: BlendValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<BlendValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<BlendValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<BlendValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<BlendValueVariant1Subtype3>,
     },
 }
 impl From<&BlendValue> for BlendValue {
@@ -5474,10 +5408,14 @@ impl From<Vec<BlendValueVariant0Item>> for BlendValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: BlendValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<BlendValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<BlendValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<BlendValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<BlendValueVariant0ItemSubtype3>,
 }
 impl From<&BlendValueVariant0Item> for BlendValueVariant0Item {
     fn from(value: &BlendValueVariant0Item) -> Self {
@@ -5485,11 +5423,210 @@ impl From<&BlendValueVariant0Item> for BlendValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BlendValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: Option<BlendValueVariant0ItemSubtype0Variant1Value>,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: BlendValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&BlendValueVariant0ItemSubtype0> for BlendValueVariant0ItemSubtype0 {
+    fn from(value: &BlendValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum BlendValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "multiply")]
+    Multiply,
+    #[serde(rename = "screen")]
+    Screen,
+    #[serde(rename = "overlay")]
+    Overlay,
+    #[serde(rename = "darken")]
+    Darken,
+    #[serde(rename = "lighten")]
+    Lighten,
+    #[serde(rename = "color-dodge")]
+    ColorDodge,
+    #[serde(rename = "color-burn")]
+    ColorBurn,
+    #[serde(rename = "hard-light")]
+    HardLight,
+    #[serde(rename = "soft-light")]
+    SoftLight,
+    #[serde(rename = "difference")]
+    Difference,
+    #[serde(rename = "exclusion")]
+    Exclusion,
+    #[serde(rename = "hue")]
+    Hue,
+    #[serde(rename = "saturation")]
+    Saturation,
+    #[serde(rename = "color")]
+    Color,
+    #[serde(rename = "luminosity")]
+    Luminosity,
+}
+impl From<&BlendValueVariant0ItemSubtype0Variant1Value>
+    for BlendValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &BlendValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for BlendValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Multiply => "multiply".to_string(),
+            Self::Screen => "screen".to_string(),
+            Self::Overlay => "overlay".to_string(),
+            Self::Darken => "darken".to_string(),
+            Self::Lighten => "lighten".to_string(),
+            Self::ColorDodge => "color-dodge".to_string(),
+            Self::ColorBurn => "color-burn".to_string(),
+            Self::HardLight => "hard-light".to_string(),
+            Self::SoftLight => "soft-light".to_string(),
+            Self::Difference => "difference".to_string(),
+            Self::Exclusion => "exclusion".to_string(),
+            Self::Hue => "hue".to_string(),
+            Self::Saturation => "saturation".to_string(),
+            Self::Color => "color".to_string(),
+            Self::Luminosity => "luminosity".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for BlendValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "multiply" => Ok(Self::Multiply),
+            "screen" => Ok(Self::Screen),
+            "overlay" => Ok(Self::Overlay),
+            "darken" => Ok(Self::Darken),
+            "lighten" => Ok(Self::Lighten),
+            "color-dodge" => Ok(Self::ColorDodge),
+            "color-burn" => Ok(Self::ColorBurn),
+            "hard-light" => Ok(Self::HardLight),
+            "soft-light" => Ok(Self::SoftLight),
+            "difference" => Ok(Self::Difference),
+            "exclusion" => Ok(Self::Exclusion),
+            "hue" => Ok(Self::Hue),
+            "saturation" => Ok(Self::Saturation),
+            "color" => Ok(Self::Color),
+            "luminosity" => Ok(Self::Luminosity),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BlendValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BlendValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&BlendValueVariant0ItemSubtype0Variant3Range>
+    for BlendValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &BlendValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for BlendValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BlendValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for BlendValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for BlendValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BlendValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BlendValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&BlendValueVariant0ItemSubtype1> for BlendValueVariant0ItemSubtype1 {
     fn from(value: &BlendValueVariant0ItemSubtype1) -> Self {
@@ -5497,49 +5634,59 @@ impl From<&BlendValueVariant0ItemSubtype1> for BlendValueVariant0ItemSubtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct BlendValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&BlendValueVariant0ItemSubtype1Subtype1> for BlendValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&BlendValueVariant0ItemSubtype2> for BlendValueVariant0ItemSubtype2 {
+    fn from(value: &BlendValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BlendValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&BlendValueVariant0ItemSubtype3> for BlendValueVariant0ItemSubtype3 {
+    fn from(value: &BlendValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum BlendValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: Option<BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: Option<BlendValueVariant1Subtype0Variant1Value>,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: BlendValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype0>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&BlendValueVariant1Subtype0> for BlendValueVariant1Subtype0 {
+    fn from(value: &BlendValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for BlendValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum BlendValueVariant1Subtype0Variant1Value {
     #[serde(rename = "multiply")]
     Multiply,
     #[serde(rename = "screen")]
@@ -5571,14 +5718,12 @@ pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "luminosity")]
     Luminosity,
 }
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+impl From<&BlendValueVariant1Subtype0Variant1Value> for BlendValueVariant1Subtype0Variant1Value {
+    fn from(value: &BlendValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for BlendValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Multiply => "multiply".to_string(),
@@ -5599,7 +5744,7 @@ impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
         }
     }
 }
-impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for BlendValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -5622,21 +5767,19 @@ impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
-impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<String> for BlendValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -5644,18 +5787,16 @@ impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype1Subtype1Sub
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum BlendValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&BlendValueVariant1Subtype0Variant3Range> for BlendValueVariant1Subtype0Variant3Range {
+    fn from(value: &BlendValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for BlendValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -5667,27 +5808,25 @@ impl std::str::FromStr for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant
         }
     }
 }
-impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for BlendValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for BlendValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -5695,53 +5834,19 @@ impl ToString for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for BlendValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for BlendValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for BlendValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype1>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype2>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&BlendValueVariant0ItemSubtype1Subtype1Subtype3>
-    for BlendValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &BlendValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlendValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BlendValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BlendValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BlendValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BlendValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&BlendValueVariant1Subtype1> for BlendValueVariant1Subtype1 {
     fn from(value: &BlendValueVariant1Subtype1) -> Self {
@@ -5749,210 +5854,21 @@ impl From<&BlendValueVariant1Subtype1> for BlendValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BlendValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: Option<BlendValueVariant1Subtype1Subtype0Variant1Value>,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: BlendValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct BlendValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&BlendValueVariant1Subtype1Subtype0> for BlendValueVariant1Subtype1Subtype0 {
-    fn from(value: &BlendValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for BlendValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum BlendValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "multiply")]
-    Multiply,
-    #[serde(rename = "screen")]
-    Screen,
-    #[serde(rename = "overlay")]
-    Overlay,
-    #[serde(rename = "darken")]
-    Darken,
-    #[serde(rename = "lighten")]
-    Lighten,
-    #[serde(rename = "color-dodge")]
-    ColorDodge,
-    #[serde(rename = "color-burn")]
-    ColorBurn,
-    #[serde(rename = "hard-light")]
-    HardLight,
-    #[serde(rename = "soft-light")]
-    SoftLight,
-    #[serde(rename = "difference")]
-    Difference,
-    #[serde(rename = "exclusion")]
-    Exclusion,
-    #[serde(rename = "hue")]
-    Hue,
-    #[serde(rename = "saturation")]
-    Saturation,
-    #[serde(rename = "color")]
-    Color,
-    #[serde(rename = "luminosity")]
-    Luminosity,
-}
-impl From<&BlendValueVariant1Subtype1Subtype0Variant1Value>
-    for BlendValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &BlendValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Multiply => "multiply".to_string(),
-            Self::Screen => "screen".to_string(),
-            Self::Overlay => "overlay".to_string(),
-            Self::Darken => "darken".to_string(),
-            Self::Lighten => "lighten".to_string(),
-            Self::ColorDodge => "color-dodge".to_string(),
-            Self::ColorBurn => "color-burn".to_string(),
-            Self::HardLight => "hard-light".to_string(),
-            Self::SoftLight => "soft-light".to_string(),
-            Self::Difference => "difference".to_string(),
-            Self::Exclusion => "exclusion".to_string(),
-            Self::Hue => "hue".to_string(),
-            Self::Saturation => "saturation".to_string(),
-            Self::Color => "color".to_string(),
-            Self::Luminosity => "luminosity".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "multiply" => Ok(Self::Multiply),
-            "screen" => Ok(Self::Screen),
-            "overlay" => Ok(Self::Overlay),
-            "darken" => Ok(Self::Darken),
-            "lighten" => Ok(Self::Lighten),
-            "color-dodge" => Ok(Self::ColorDodge),
-            "color-burn" => Ok(Self::ColorBurn),
-            "hard-light" => Ok(Self::HardLight),
-            "soft-light" => Ok(Self::SoftLight),
-            "difference" => Ok(Self::Difference),
-            "exclusion" => Ok(Self::Exclusion),
-            "hue" => Ok(Self::Hue),
-            "saturation" => Ok(Self::Saturation),
-            "color" => Ok(Self::Color),
-            "luminosity" => Ok(Self::Luminosity),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for BlendValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BlendValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&BlendValueVariant1Subtype1Subtype0Variant3Range>
-    for BlendValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &BlendValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for BlendValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant1Subtype1Subtype1 {}
-impl From<&BlendValueVariant1Subtype1Subtype1> for BlendValueVariant1Subtype1Subtype1 {
-    fn from(value: &BlendValueVariant1Subtype1Subtype1) -> Self {
+impl From<&BlendValueVariant1Subtype2> for BlendValueVariant1Subtype2 {
+    fn from(value: &BlendValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant1Subtype1Subtype2 {}
-impl From<&BlendValueVariant1Subtype1Subtype2> for BlendValueVariant1Subtype1Subtype2 {
-    fn from(value: &BlendValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct BlendValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlendValueVariant1Subtype1Subtype3 {}
-impl From<&BlendValueVariant1Subtype1Subtype3> for BlendValueVariant1Subtype1Subtype3 {
-    fn from(value: &BlendValueVariant1Subtype1Subtype3) -> Self {
+impl From<&BlendValueVariant1Subtype3> for BlendValueVariant1Subtype3 {
+    fn from(value: &BlendValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -5982,10 +5898,14 @@ impl From<SignalRef> for BooleanOrSignal {
 pub enum BooleanValue {
     Variant0(Vec<BooleanValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: BooleanValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<BooleanValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<BooleanValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<BooleanValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<BooleanValueVariant1Subtype3>,
     },
 }
 impl From<&BooleanValue> for BooleanValue {
@@ -6000,10 +5920,14 @@ impl From<Vec<BooleanValueVariant0Item>> for BooleanValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BooleanValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: BooleanValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<BooleanValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<BooleanValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<BooleanValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<BooleanValueVariant0ItemSubtype3>,
 }
 impl From<&BooleanValueVariant0Item> for BooleanValueVariant0Item {
     fn from(value: &BooleanValueVariant0Item) -> Self {
@@ -6011,11 +5935,108 @@ impl From<&BooleanValueVariant0Item> for BooleanValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BooleanValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: bool,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: BooleanValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&BooleanValueVariant0ItemSubtype0> for BooleanValueVariant0ItemSubtype0 {
+    fn from(value: &BooleanValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BooleanValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&BooleanValueVariant0ItemSubtype0Variant3Range>
+    for BooleanValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &BooleanValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for BooleanValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for BooleanValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for BooleanValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for BooleanValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for BooleanValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for BooleanValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for BooleanValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BooleanValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: BooleanValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&BooleanValueVariant0ItemSubtype1> for BooleanValueVariant0ItemSubtype1 {
     fn from(value: &BooleanValueVariant0ItemSubtype1) -> Self {
@@ -6023,61 +6044,71 @@ impl From<&BooleanValueVariant0ItemSubtype1> for BooleanValueVariant0ItemSubtype
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BooleanValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct BooleanValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1> for BooleanValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&BooleanValueVariant0ItemSubtype2> for BooleanValueVariant0ItemSubtype2 {
+    fn from(value: &BooleanValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BooleanValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&BooleanValueVariant0ItemSubtype3> for BooleanValueVariant0ItemSubtype3 {
+    fn from(value: &BooleanValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum BooleanValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: bool,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: BooleanValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype0>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&BooleanValueVariant1Subtype0> for BooleanValueVariant1Subtype0 {
+    fn from(value: &BooleanValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum BooleanValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&BooleanValueVariant1Subtype0Variant3Range>
+    for BooleanValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &BooleanValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for BooleanValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -6089,29 +6120,25 @@ impl std::str::FromStr for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Varia
         }
     }
 }
-impl std::convert::TryFrom<&str> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for BooleanValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for BooleanValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for BooleanValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for BooleanValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -6119,53 +6146,19 @@ impl ToString for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range 
         }
     }
 }
-impl From<f64> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for BooleanValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for BooleanValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for BooleanValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype1>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype2>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&BooleanValueVariant0ItemSubtype1Subtype1Subtype3>
-    for BooleanValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &BooleanValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BooleanValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<BooleanValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<BooleanValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<BooleanValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<BooleanValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&BooleanValueVariant1Subtype1> for BooleanValueVariant1Subtype1 {
     fn from(value: &BooleanValueVariant1Subtype1) -> Self {
@@ -6173,108 +6166,21 @@ impl From<&BooleanValueVariant1Subtype1> for BooleanValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BooleanValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: bool,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: BooleanValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct BooleanValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&BooleanValueVariant1Subtype1Subtype0> for BooleanValueVariant1Subtype1Subtype0 {
-    fn from(value: &BooleanValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for BooleanValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&BooleanValueVariant1Subtype1Subtype0Variant3Range>
-    for BooleanValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &BooleanValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for BooleanValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant1Subtype1Subtype1 {}
-impl From<&BooleanValueVariant1Subtype1Subtype1> for BooleanValueVariant1Subtype1Subtype1 {
-    fn from(value: &BooleanValueVariant1Subtype1Subtype1) -> Self {
+impl From<&BooleanValueVariant1Subtype2> for BooleanValueVariant1Subtype2 {
+    fn from(value: &BooleanValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant1Subtype1Subtype2 {}
-impl From<&BooleanValueVariant1Subtype1Subtype2> for BooleanValueVariant1Subtype1Subtype2 {
-    fn from(value: &BooleanValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct BooleanValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BooleanValueVariant1Subtype1Subtype3 {}
-impl From<&BooleanValueVariant1Subtype1Subtype3> for BooleanValueVariant1Subtype1Subtype3 {
-    fn from(value: &BooleanValueVariant1Subtype1Subtype3) -> Self {
+impl From<&BooleanValueVariant1Subtype3> for BooleanValueVariant1Subtype3 {
+    fn from(value: &BooleanValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -6403,15 +6309,205 @@ impl From<BaseColorValue> for ColorValue {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ColorValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: BaseColorValue,
+#[serde(untagged, deny_unknown_fields)]
+pub enum ColorValueVariant0Item {
+    Variant0 {
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<ColorValueVariant0ItemVariant0Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<ColorValueVariant0ItemVariant0Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<ColorValueVariant0ItemVariant0Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<ColorValueVariant0ItemVariant0Subtype3>,
+    },
+    Variant1 {
+        value: LinearGradient,
+    },
+    Variant2 {
+        value: RadialGradient,
+    },
+    Variant3 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        count: Option<f64>,
+        gradient: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start: Option<[f64; 2usize]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stop: Option<[f64; 2usize]>,
+    },
+    Variant4 {
+        color: ColorValueVariant0ItemVariant4Color,
+    },
 }
 impl From<&ColorValueVariant0Item> for ColorValueVariant0Item {
     fn from(value: &ColorValueVariant0Item) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ColorValueVariant0ItemVariant0Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: Option<String>,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: ColorValueVariant0ItemVariant0Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&ColorValueVariant0ItemVariant0Subtype0> for ColorValueVariant0ItemVariant0Subtype0 {
+    fn from(value: &ColorValueVariant0ItemVariant0Subtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&ColorValueVariant0ItemVariant0Subtype0Variant3Range>
+    for ColorValueVariant0ItemVariant0Subtype0Variant3Range
+{
+    fn from(value: &ColorValueVariant0ItemVariant0Subtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ColorValueVariant0ItemVariant0Subtype1 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&ColorValueVariant0ItemVariant0Subtype1> for ColorValueVariant0ItemVariant0Subtype1 {
+    fn from(value: &ColorValueVariant0ItemVariant0Subtype1) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ColorValueVariant0ItemVariant0Subtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&ColorValueVariant0ItemVariant0Subtype2> for ColorValueVariant0ItemVariant0Subtype2 {
+    fn from(value: &ColorValueVariant0ItemVariant0Subtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ColorValueVariant0ItemVariant0Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&ColorValueVariant0ItemVariant0Subtype3> for ColorValueVariant0ItemVariant0Subtype3 {
+    fn from(value: &ColorValueVariant0ItemVariant0Subtype3) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ColorValueVariant0ItemVariant4Color {
+    Rgb(ColorRgb),
+    Hsl(ColorHsl),
+    Lab(ColorLab),
+    Hcl(ColorHcl),
+}
+impl From<&ColorValueVariant0ItemVariant4Color> for ColorValueVariant0ItemVariant4Color {
+    fn from(value: &ColorValueVariant0ItemVariant4Color) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorRgb> for ColorValueVariant0ItemVariant4Color {
+    fn from(value: ColorRgb) -> Self {
+        Self::Rgb(value)
+    }
+}
+impl From<ColorHsl> for ColorValueVariant0ItemVariant4Color {
+    fn from(value: ColorHsl) -> Self {
+        Self::Hsl(value)
+    }
+}
+impl From<ColorLab> for ColorValueVariant0ItemVariant4Color {
+    fn from(value: ColorLab) -> Self {
+        Self::Lab(value)
+    }
+}
+impl From<ColorHcl> for ColorValueVariant0ItemVariant4Color {
+    fn from(value: ColorHcl) -> Self {
+        Self::Hcl(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11232,10 +11328,14 @@ impl std::convert::TryFrom<String> for DensityTransformType {
 pub enum DirectionValue {
     Variant0(Vec<DirectionValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: DirectionValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<DirectionValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<DirectionValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<DirectionValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<DirectionValueVariant1Subtype3>,
     },
 }
 impl From<&DirectionValue> for DirectionValue {
@@ -11250,10 +11350,14 @@ impl From<Vec<DirectionValueVariant0Item>> for DirectionValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DirectionValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: DirectionValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<DirectionValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<DirectionValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<DirectionValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<DirectionValueVariant0ItemSubtype3>,
 }
 impl From<&DirectionValueVariant0Item> for DirectionValueVariant0Item {
     fn from(value: &DirectionValueVariant0Item) -> Self {
@@ -11261,11 +11365,158 @@ impl From<&DirectionValueVariant0Item> for DirectionValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum DirectionValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: DirectionValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: DirectionValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&DirectionValueVariant0ItemSubtype0> for DirectionValueVariant0ItemSubtype0 {
+    fn from(value: &DirectionValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum DirectionValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "horizontal")]
+    Horizontal,
+    #[serde(rename = "vertical")]
+    Vertical,
+}
+impl From<&DirectionValueVariant0ItemSubtype0Variant1Value>
+    for DirectionValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &DirectionValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for DirectionValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => "vertical".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for DirectionValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "horizontal" => Ok(Self::Horizontal),
+            "vertical" => Ok(Self::Vertical),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DirectionValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DirectionValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DirectionValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum DirectionValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&DirectionValueVariant0ItemSubtype0Variant3Range>
+    for DirectionValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &DirectionValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for DirectionValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for DirectionValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for DirectionValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for DirectionValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for DirectionValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for DirectionValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for DirectionValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DirectionValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: DirectionValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&DirectionValueVariant0ItemSubtype1> for DirectionValueVariant0ItemSubtype1 {
     fn from(value: &DirectionValueVariant0ItemSubtype1) -> Self {
@@ -11273,64 +11524,72 @@ impl From<&DirectionValueVariant0ItemSubtype1> for DirectionValueVariant0ItemSub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<DirectionValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct DirectionValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1>
-    for DirectionValueVariant0ItemSubtype1Subtype1
-{
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&DirectionValueVariant0ItemSubtype2> for DirectionValueVariant0ItemSubtype2 {
+    fn from(value: &DirectionValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DirectionValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&DirectionValueVariant0ItemSubtype3> for DirectionValueVariant0ItemSubtype3 {
+    fn from(value: &DirectionValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum DirectionValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: DirectionValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: DirectionValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype0>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&DirectionValueVariant1Subtype0> for DirectionValueVariant1Subtype0 {
+    fn from(value: &DirectionValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum DirectionValueVariant1Subtype0Variant1Value {
     #[serde(rename = "horizontal")]
     Horizontal,
     #[serde(rename = "vertical")]
     Vertical,
 }
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+impl From<&DirectionValueVariant1Subtype0Variant1Value>
+    for DirectionValueVariant1Subtype0Variant1Value
 {
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+    fn from(value: &DirectionValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for DirectionValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Horizontal => "horizontal".to_string(),
@@ -11338,7 +11597,7 @@ impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Valu
         }
     }
 }
-impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for DirectionValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -11348,25 +11607,19 @@ impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -11374,18 +11627,18 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum DirectionValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&DirectionValueVariant1Subtype0Variant3Range>
+    for DirectionValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &DirectionValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for DirectionValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -11397,31 +11650,25 @@ impl std::str::FromStr for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for DirectionValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -11429,53 +11676,19 @@ impl ToString for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Rang
         }
     }
 }
-impl From<f64> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for DirectionValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for DirectionValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for DirectionValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype1>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype2>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&DirectionValueVariant0ItemSubtype1Subtype1Subtype3>
-    for DirectionValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &DirectionValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DirectionValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<DirectionValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<DirectionValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<DirectionValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<DirectionValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&DirectionValueVariant1Subtype1> for DirectionValueVariant1Subtype1 {
     fn from(value: &DirectionValueVariant1Subtype1) -> Self {
@@ -11483,158 +11696,21 @@ impl From<&DirectionValueVariant1Subtype1> for DirectionValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum DirectionValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: DirectionValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: DirectionValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct DirectionValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&DirectionValueVariant1Subtype1Subtype0> for DirectionValueVariant1Subtype1Subtype0 {
-    fn from(value: &DirectionValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for DirectionValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "horizontal")]
-    Horizontal,
-    #[serde(rename = "vertical")]
-    Vertical,
-}
-impl From<&DirectionValueVariant1Subtype1Subtype0Variant1Value>
-    for DirectionValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &DirectionValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Horizontal => "horizontal".to_string(),
-            Self::Vertical => "vertical".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "horizontal" => Ok(Self::Horizontal),
-            "vertical" => Ok(Self::Vertical),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&DirectionValueVariant1Subtype1Subtype0Variant3Range>
-    for DirectionValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &DirectionValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for DirectionValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant1Subtype1Subtype1 {}
-impl From<&DirectionValueVariant1Subtype1Subtype1> for DirectionValueVariant1Subtype1Subtype1 {
-    fn from(value: &DirectionValueVariant1Subtype1Subtype1) -> Self {
+impl From<&DirectionValueVariant1Subtype2> for DirectionValueVariant1Subtype2 {
+    fn from(value: &DirectionValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant1Subtype1Subtype2 {}
-impl From<&DirectionValueVariant1Subtype1Subtype2> for DirectionValueVariant1Subtype1Subtype2 {
-    fn from(value: &DirectionValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct DirectionValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DirectionValueVariant1Subtype1Subtype3 {}
-impl From<&DirectionValueVariant1Subtype1Subtype3> for DirectionValueVariant1Subtype1Subtype3 {
-    fn from(value: &DirectionValueVariant1Subtype1Subtype3) -> Self {
+impl From<&DirectionValueVariant1Subtype3> for DirectionValueVariant1Subtype3 {
+    fn from(value: &DirectionValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -12112,10 +12188,46 @@ impl From<&EncodeEntry> for EncodeEntry {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Everything {
-    #[serde(flatten)]
-    pub subtype_0: Scope,
-    #[serde(flatten)]
-    pub subtype_1: EverythingSubtype1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub autosize: Option<Autosize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub axes: Vec<Axis>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background: Option<Background>,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub config: serde_json::Map<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<Data>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout: Option<Layout>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub legends: Vec<Legend>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub marks: Vec<EverythingMarksItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<Padding>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub projections: Vec<Projection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scales: Vec<Scale>,
+    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub signals: Vec<Signal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<Style>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<Title>,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub usermeta: serde_json::Map<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<NumberOrSignal>,
 }
 impl From<&Everything> for Everything {
     fn from(value: &Everything) -> Self {
@@ -12123,29 +12235,24 @@ impl From<&Everything> for Everything {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct EverythingSubtype1 {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub autosize: Option<Autosize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub background: Option<Background>,
-    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
-    pub config: serde_json::Map<String, serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub height: Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub padding: Option<Padding>,
-    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
-    pub schema: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub style: Option<Style>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub width: Option<NumberOrSignal>,
+#[serde(untagged)]
+pub enum EverythingMarksItem {
+    Group(MarkGroup),
+    Visual(MarkVisual),
 }
-impl From<&EverythingSubtype1> for EverythingSubtype1 {
-    fn from(value: &EverythingSubtype1) -> Self {
+impl From<&EverythingMarksItem> for EverythingMarksItem {
+    fn from(value: &EverythingMarksItem) -> Self {
         value.clone()
+    }
+}
+impl From<MarkGroup> for EverythingMarksItem {
+    fn from(value: MarkGroup) -> Self {
+        Self::Group(value)
+    }
+}
+impl From<MarkVisual> for EverythingMarksItem {
+    fn from(value: MarkVisual) -> Self {
+        Self::Visual(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -12752,10 +12859,14 @@ impl std::convert::TryFrom<String> for FoldTransformType {
 pub enum FontWeightValue {
     Variant0(Vec<FontWeightValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: FontWeightValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<FontWeightValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<FontWeightValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<FontWeightValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<FontWeightValueVariant1Subtype3>,
     },
 }
 impl From<&FontWeightValue> for FontWeightValue {
@@ -12770,10 +12881,14 @@ impl From<Vec<FontWeightValueVariant0Item>> for FontWeightValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: FontWeightValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<FontWeightValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<FontWeightValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<FontWeightValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<FontWeightValueVariant0ItemSubtype3>,
 }
 impl From<&FontWeightValueVariant0Item> for FontWeightValueVariant0Item {
     fn from(value: &FontWeightValueVariant0Item) -> Self {
@@ -12781,11 +12896,108 @@ impl From<&FontWeightValueVariant0Item> for FontWeightValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FontWeightValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: MyEnum,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: FontWeightValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&FontWeightValueVariant0ItemSubtype0> for FontWeightValueVariant0ItemSubtype0 {
+    fn from(value: &FontWeightValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FontWeightValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&FontWeightValueVariant0ItemSubtype0Variant3Range>
+    for FontWeightValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &FontWeightValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for FontWeightValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FontWeightValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: FontWeightValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&FontWeightValueVariant0ItemSubtype1> for FontWeightValueVariant0ItemSubtype1 {
     fn from(value: &FontWeightValueVariant0ItemSubtype1) -> Self {
@@ -12793,63 +13005,71 @@ impl From<&FontWeightValueVariant0ItemSubtype1> for FontWeightValueVariant0ItemS
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<FontWeightValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct FontWeightValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1>
-    for FontWeightValueVariant0ItemSubtype1Subtype1
-{
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&FontWeightValueVariant0ItemSubtype2> for FontWeightValueVariant0ItemSubtype2 {
+    fn from(value: &FontWeightValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FontWeightValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&FontWeightValueVariant0ItemSubtype3> for FontWeightValueVariant0ItemSubtype3 {
+    fn from(value: &FontWeightValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum FontWeightValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: MyEnum,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: FontWeightValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype0>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&FontWeightValueVariant1Subtype0> for FontWeightValueVariant1Subtype0 {
+    fn from(value: &FontWeightValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum FontWeightValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&FontWeightValueVariant1Subtype0Variant3Range>
+    for FontWeightValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &FontWeightValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for FontWeightValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -12861,31 +13081,25 @@ impl std::str::FromStr for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Va
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&str> for FontWeightValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for FontWeightValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for FontWeightValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for FontWeightValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -12893,53 +13107,19 @@ impl ToString for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Ran
         }
     }
 }
-impl From<f64> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for FontWeightValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for FontWeightValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for FontWeightValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype1>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype2>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&FontWeightValueVariant0ItemSubtype1Subtype1Subtype3>
-    for FontWeightValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &FontWeightValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FontWeightValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<FontWeightValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<FontWeightValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<FontWeightValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<FontWeightValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&FontWeightValueVariant1Subtype1> for FontWeightValueVariant1Subtype1 {
     fn from(value: &FontWeightValueVariant1Subtype1) -> Self {
@@ -12947,108 +13127,21 @@ impl From<&FontWeightValueVariant1Subtype1> for FontWeightValueVariant1Subtype1 
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum FontWeightValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: MyEnum,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: FontWeightValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct FontWeightValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&FontWeightValueVariant1Subtype1Subtype0> for FontWeightValueVariant1Subtype1Subtype0 {
-    fn from(value: &FontWeightValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for FontWeightValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&FontWeightValueVariant1Subtype1Subtype0Variant3Range>
-    for FontWeightValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &FontWeightValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for FontWeightValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant1Subtype1Subtype1 {}
-impl From<&FontWeightValueVariant1Subtype1Subtype1> for FontWeightValueVariant1Subtype1Subtype1 {
-    fn from(value: &FontWeightValueVariant1Subtype1Subtype1) -> Self {
+impl From<&FontWeightValueVariant1Subtype2> for FontWeightValueVariant1Subtype2 {
+    fn from(value: &FontWeightValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant1Subtype1Subtype2 {}
-impl From<&FontWeightValueVariant1Subtype1Subtype2> for FontWeightValueVariant1Subtype1Subtype2 {
-    fn from(value: &FontWeightValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct FontWeightValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FontWeightValueVariant1Subtype1Subtype3 {}
-impl From<&FontWeightValueVariant1Subtype1Subtype3> for FontWeightValueVariant1Subtype1Subtype3 {
-    fn from(value: &FontWeightValueVariant1Subtype1Subtype3) -> Self {
+impl From<&FontWeightValueVariant1Subtype3> for FontWeightValueVariant1Subtype3 {
+    fn from(value: &FontWeightValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -18701,10 +18794,20 @@ impl From<NumberOrSignal> for LayoutVariant0TitleBand {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Legend {
-    #[serde(flatten)]
-    pub subtype_0: LegendSubtype0,
-    #[serde(flatten)]
-    pub subtype_1: LegendSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<LegendSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<LegendSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<LegendSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<LegendSubtype3>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_4: Option<LegendSubtype4>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_5: Option<LegendSubtype5>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_6: Option<LegendSubtype6>,
 }
 impl From<&Legend> for Legend {
     fn from(value: &Legend) -> Self {
@@ -18874,8 +18977,7 @@ pub struct LegendSubtype0 {
     pub row_padding: Option<NumberOrSignal>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size: Option<String>,
+    pub size: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     #[serde(
@@ -20620,19 +20722,11439 @@ impl std::convert::TryFrom<String> for LegendSubtype0Type {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum LegendSubtype1 {
-    Variant0 {},
-    Variant1 {},
-    Variant2 {},
-    Variant3 {},
-    Variant4 {},
-    Variant5 {},
-    Variant6 {},
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype1 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype1CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype1Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype1Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype1FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype1Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype1FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype1GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype1GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype1GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype1GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype1LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype1LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype1LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype1LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype1LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype1LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype1LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype1LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype1LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype1LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype1LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype1LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype1Offset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype1Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype1Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    pub shape: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke: Option<String>,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype1StrokeColor>,
+    #[serde(
+        rename = "strokeDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_dash: Option<String>,
+    #[serde(
+        rename = "strokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_width: Option<String>,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype1SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype1SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype1SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype1SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype1SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype1SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype1SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype1SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype1SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype1TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype1TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype1TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype1TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype1TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype1TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype1TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype1TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype1TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype1TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype1TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype1TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype1TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype1Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
 }
 impl From<&LegendSubtype1> for LegendSubtype1 {
     fn from(value: &LegendSubtype1) -> Self {
         value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1CornerRadius> for LegendSubtype1CornerRadius {
+    fn from(value: &LegendSubtype1CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype1Direction> for LegendSubtype1Direction {
+    fn from(value: &LegendSubtype1Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype1Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype1Encode> for LegendSubtype1Encode {
+    fn from(value: &LegendSubtype1Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1FillColor> for LegendSubtype1FillColor {
+    fn from(value: &LegendSubtype1FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype1Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype1Format> for LegendSubtype1Format {
+    fn from(value: &LegendSubtype1Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype1Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1FormatType {
+    Variant0(LegendSubtype1FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype1FormatType> for LegendSubtype1FormatType {
+    fn from(value: &LegendSubtype1FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1FormatTypeVariant0> for LegendSubtype1FormatType {
+    fn from(value: LegendSubtype1FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype1FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype1FormatTypeVariant0> for LegendSubtype1FormatTypeVariant0 {
+    fn from(value: &LegendSubtype1FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1GradientOpacity> for LegendSubtype1GradientOpacity {
+    fn from(value: &LegendSubtype1GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1GradientStrokeColor> for LegendSubtype1GradientStrokeColor {
+    fn from(value: &LegendSubtype1GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1GradientStrokeWidth> for LegendSubtype1GradientStrokeWidth {
+    fn from(value: &LegendSubtype1GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1GridAlign {
+    Variant0(LegendSubtype1GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype1GridAlign> for LegendSubtype1GridAlign {
+    fn from(value: &LegendSubtype1GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1GridAlignVariant0> for LegendSubtype1GridAlign {
+    fn from(value: LegendSubtype1GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype1GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype1GridAlignVariant0> for LegendSubtype1GridAlignVariant0 {
+    fn from(value: &LegendSubtype1GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelAlign {
+    Variant0(LegendSubtype1LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype1LabelAlign> for LegendSubtype1LabelAlign {
+    fn from(value: &LegendSubtype1LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1LabelAlignVariant0> for LegendSubtype1LabelAlign {
+    fn from(value: LegendSubtype1LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype1LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype1LabelAlignVariant0> for LegendSubtype1LabelAlignVariant0 {
+    fn from(value: &LegendSubtype1LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelBaseline {
+    Variant0(LegendSubtype1LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype1LabelBaseline> for LegendSubtype1LabelBaseline {
+    fn from(value: &LegendSubtype1LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1LabelBaselineVariant0> for LegendSubtype1LabelBaseline {
+    fn from(value: LegendSubtype1LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype1LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype1LabelBaselineVariant0> for LegendSubtype1LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype1LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1LabelColor> for LegendSubtype1LabelColor {
+    fn from(value: &LegendSubtype1LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype1LabelFont> for LegendSubtype1LabelFont {
+    fn from(value: &LegendSubtype1LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype1LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LabelFontSize> for LegendSubtype1LabelFontSize {
+    fn from(value: &LegendSubtype1LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype1LabelFontStyle> for LegendSubtype1LabelFontStyle {
+    fn from(value: &LegendSubtype1LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype1LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype1LabelFontWeight> for LegendSubtype1LabelFontWeight {
+    fn from(value: &LegendSubtype1LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype1LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype1LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LabelLimit> for LegendSubtype1LabelLimit {
+    fn from(value: &LegendSubtype1LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LabelOffset> for LegendSubtype1LabelOffset {
+    fn from(value: &LegendSubtype1LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LabelOpacity> for LegendSubtype1LabelOpacity {
+    fn from(value: &LegendSubtype1LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LegendX> for LegendSubtype1LegendX {
+    fn from(value: &LegendSubtype1LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1LegendY> for LegendSubtype1LegendY {
+    fn from(value: &LegendSubtype1LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1Offset> for LegendSubtype1Offset {
+    fn from(value: &LegendSubtype1Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1Orient {
+    Variant0(LegendSubtype1OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype1Orient> for LegendSubtype1Orient {
+    fn from(value: &LegendSubtype1Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1OrientVariant0> for LegendSubtype1Orient {
+    fn from(value: LegendSubtype1OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype1Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype1OrientVariant0> for LegendSubtype1OrientVariant0 {
+    fn from(value: &LegendSubtype1OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1Padding> for LegendSubtype1Padding {
+    fn from(value: &LegendSubtype1Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1StrokeColor> for LegendSubtype1StrokeColor {
+    fn from(value: &LegendSubtype1StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype1SymbolDash> for LegendSubtype1SymbolDash {
+    fn from(value: &LegendSubtype1SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype1SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype1SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1SymbolDashOffset> for LegendSubtype1SymbolDashOffset {
+    fn from(value: &LegendSubtype1SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1SymbolFillColor> for LegendSubtype1SymbolFillColor {
+    fn from(value: &LegendSubtype1SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1SymbolOffset> for LegendSubtype1SymbolOffset {
+    fn from(value: &LegendSubtype1SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1SymbolOpacity> for LegendSubtype1SymbolOpacity {
+    fn from(value: &LegendSubtype1SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1SymbolSize> for LegendSubtype1SymbolSize {
+    fn from(value: &LegendSubtype1SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1SymbolStrokeColor> for LegendSubtype1SymbolStrokeColor {
+    fn from(value: &LegendSubtype1SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1SymbolStrokeWidth> for LegendSubtype1SymbolStrokeWidth {
+    fn from(value: &LegendSubtype1SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype1SymbolType> for LegendSubtype1SymbolType {
+    fn from(value: &LegendSubtype1SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype1SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleAlign {
+    Variant0(LegendSubtype1TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype1TitleAlign> for LegendSubtype1TitleAlign {
+    fn from(value: &LegendSubtype1TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1TitleAlignVariant0> for LegendSubtype1TitleAlign {
+    fn from(value: LegendSubtype1TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype1TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype1TitleAlignVariant0> for LegendSubtype1TitleAlignVariant0 {
+    fn from(value: &LegendSubtype1TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleAnchor {
+    Variant0(Option<LegendSubtype1TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype1TitleAnchor> for LegendSubtype1TitleAnchor {
+    fn from(value: &LegendSubtype1TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype1TitleAnchorVariant0>> for LegendSubtype1TitleAnchor {
+    fn from(value: Option<LegendSubtype1TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype1TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype1TitleAnchorVariant0> for LegendSubtype1TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype1TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleBaseline {
+    Variant0(LegendSubtype1TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype1TitleBaseline> for LegendSubtype1TitleBaseline {
+    fn from(value: &LegendSubtype1TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1TitleBaselineVariant0> for LegendSubtype1TitleBaseline {
+    fn from(value: LegendSubtype1TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype1TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype1TitleBaselineVariant0> for LegendSubtype1TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype1TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype1TitleColor> for LegendSubtype1TitleColor {
+    fn from(value: &LegendSubtype1TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype1TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype1TitleFont> for LegendSubtype1TitleFont {
+    fn from(value: &LegendSubtype1TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype1TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1TitleFontSize> for LegendSubtype1TitleFontSize {
+    fn from(value: &LegendSubtype1TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype1TitleFontStyle> for LegendSubtype1TitleFontStyle {
+    fn from(value: &LegendSubtype1TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype1TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype1TitleFontWeight> for LegendSubtype1TitleFontWeight {
+    fn from(value: &LegendSubtype1TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype1TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype1TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1TitleLimit> for LegendSubtype1TitleLimit {
+    fn from(value: &LegendSubtype1TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1TitleLineHeight> for LegendSubtype1TitleLineHeight {
+    fn from(value: &LegendSubtype1TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1TitleOpacity> for LegendSubtype1TitleOpacity {
+    fn from(value: &LegendSubtype1TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitleOrient {
+    Variant0(LegendSubtype1TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype1TitleOrient> for LegendSubtype1TitleOrient {
+    fn from(value: &LegendSubtype1TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype1TitleOrientVariant0> for LegendSubtype1TitleOrient {
+    fn from(value: LegendSubtype1TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype1TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype1TitleOrientVariant0> for LegendSubtype1TitleOrientVariant0 {
+    fn from(value: &LegendSubtype1TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype1TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype1TitlePadding> for LegendSubtype1TitlePadding {
+    fn from(value: &LegendSubtype1TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype1TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype1TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype1Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype1Type> for LegendSubtype1Type {
+    fn from(value: &LegendSubtype1Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype1Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype1Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype1Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype1Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype1Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype2 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype2CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype2Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype2Encode>,
+    pub fill: String,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype2FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype2Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype2FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype2GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype2GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype2GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype2GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype2LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype2LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype2LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype2LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype2LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype2LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype2LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype2LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype2LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype2LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype2LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype2LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype2Offset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype2Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype2Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shape: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke: Option<String>,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype2StrokeColor>,
+    #[serde(
+        rename = "strokeDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_dash: Option<String>,
+    #[serde(
+        rename = "strokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_width: Option<String>,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype2SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype2SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype2SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype2SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype2SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype2SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype2SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype2SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype2SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype2TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype2TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype2TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype2TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype2TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype2TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype2TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype2TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype2TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype2TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype2TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype2TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype2TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype2Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
+}
+impl From<&LegendSubtype2> for LegendSubtype2 {
+    fn from(value: &LegendSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2CornerRadius> for LegendSubtype2CornerRadius {
+    fn from(value: &LegendSubtype2CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype2Direction> for LegendSubtype2Direction {
+    fn from(value: &LegendSubtype2Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype2Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype2Encode> for LegendSubtype2Encode {
+    fn from(value: &LegendSubtype2Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2FillColor> for LegendSubtype2FillColor {
+    fn from(value: &LegendSubtype2FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype2Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype2Format> for LegendSubtype2Format {
+    fn from(value: &LegendSubtype2Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype2Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2FormatType {
+    Variant0(LegendSubtype2FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype2FormatType> for LegendSubtype2FormatType {
+    fn from(value: &LegendSubtype2FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2FormatTypeVariant0> for LegendSubtype2FormatType {
+    fn from(value: LegendSubtype2FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype2FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype2FormatTypeVariant0> for LegendSubtype2FormatTypeVariant0 {
+    fn from(value: &LegendSubtype2FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2GradientOpacity> for LegendSubtype2GradientOpacity {
+    fn from(value: &LegendSubtype2GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2GradientStrokeColor> for LegendSubtype2GradientStrokeColor {
+    fn from(value: &LegendSubtype2GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2GradientStrokeWidth> for LegendSubtype2GradientStrokeWidth {
+    fn from(value: &LegendSubtype2GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2GridAlign {
+    Variant0(LegendSubtype2GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype2GridAlign> for LegendSubtype2GridAlign {
+    fn from(value: &LegendSubtype2GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2GridAlignVariant0> for LegendSubtype2GridAlign {
+    fn from(value: LegendSubtype2GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype2GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype2GridAlignVariant0> for LegendSubtype2GridAlignVariant0 {
+    fn from(value: &LegendSubtype2GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelAlign {
+    Variant0(LegendSubtype2LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype2LabelAlign> for LegendSubtype2LabelAlign {
+    fn from(value: &LegendSubtype2LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2LabelAlignVariant0> for LegendSubtype2LabelAlign {
+    fn from(value: LegendSubtype2LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype2LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype2LabelAlignVariant0> for LegendSubtype2LabelAlignVariant0 {
+    fn from(value: &LegendSubtype2LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelBaseline {
+    Variant0(LegendSubtype2LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype2LabelBaseline> for LegendSubtype2LabelBaseline {
+    fn from(value: &LegendSubtype2LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2LabelBaselineVariant0> for LegendSubtype2LabelBaseline {
+    fn from(value: LegendSubtype2LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype2LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype2LabelBaselineVariant0> for LegendSubtype2LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype2LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2LabelColor> for LegendSubtype2LabelColor {
+    fn from(value: &LegendSubtype2LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype2LabelFont> for LegendSubtype2LabelFont {
+    fn from(value: &LegendSubtype2LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype2LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LabelFontSize> for LegendSubtype2LabelFontSize {
+    fn from(value: &LegendSubtype2LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype2LabelFontStyle> for LegendSubtype2LabelFontStyle {
+    fn from(value: &LegendSubtype2LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype2LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype2LabelFontWeight> for LegendSubtype2LabelFontWeight {
+    fn from(value: &LegendSubtype2LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype2LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype2LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LabelLimit> for LegendSubtype2LabelLimit {
+    fn from(value: &LegendSubtype2LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LabelOffset> for LegendSubtype2LabelOffset {
+    fn from(value: &LegendSubtype2LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LabelOpacity> for LegendSubtype2LabelOpacity {
+    fn from(value: &LegendSubtype2LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LegendX> for LegendSubtype2LegendX {
+    fn from(value: &LegendSubtype2LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2LegendY> for LegendSubtype2LegendY {
+    fn from(value: &LegendSubtype2LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2Offset> for LegendSubtype2Offset {
+    fn from(value: &LegendSubtype2Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2Orient {
+    Variant0(LegendSubtype2OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype2Orient> for LegendSubtype2Orient {
+    fn from(value: &LegendSubtype2Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2OrientVariant0> for LegendSubtype2Orient {
+    fn from(value: LegendSubtype2OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype2Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype2OrientVariant0> for LegendSubtype2OrientVariant0 {
+    fn from(value: &LegendSubtype2OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2Padding> for LegendSubtype2Padding {
+    fn from(value: &LegendSubtype2Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2StrokeColor> for LegendSubtype2StrokeColor {
+    fn from(value: &LegendSubtype2StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype2SymbolDash> for LegendSubtype2SymbolDash {
+    fn from(value: &LegendSubtype2SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype2SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype2SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2SymbolDashOffset> for LegendSubtype2SymbolDashOffset {
+    fn from(value: &LegendSubtype2SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2SymbolFillColor> for LegendSubtype2SymbolFillColor {
+    fn from(value: &LegendSubtype2SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2SymbolOffset> for LegendSubtype2SymbolOffset {
+    fn from(value: &LegendSubtype2SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2SymbolOpacity> for LegendSubtype2SymbolOpacity {
+    fn from(value: &LegendSubtype2SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2SymbolSize> for LegendSubtype2SymbolSize {
+    fn from(value: &LegendSubtype2SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2SymbolStrokeColor> for LegendSubtype2SymbolStrokeColor {
+    fn from(value: &LegendSubtype2SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2SymbolStrokeWidth> for LegendSubtype2SymbolStrokeWidth {
+    fn from(value: &LegendSubtype2SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype2SymbolType> for LegendSubtype2SymbolType {
+    fn from(value: &LegendSubtype2SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype2SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleAlign {
+    Variant0(LegendSubtype2TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype2TitleAlign> for LegendSubtype2TitleAlign {
+    fn from(value: &LegendSubtype2TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2TitleAlignVariant0> for LegendSubtype2TitleAlign {
+    fn from(value: LegendSubtype2TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype2TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype2TitleAlignVariant0> for LegendSubtype2TitleAlignVariant0 {
+    fn from(value: &LegendSubtype2TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleAnchor {
+    Variant0(Option<LegendSubtype2TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype2TitleAnchor> for LegendSubtype2TitleAnchor {
+    fn from(value: &LegendSubtype2TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype2TitleAnchorVariant0>> for LegendSubtype2TitleAnchor {
+    fn from(value: Option<LegendSubtype2TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype2TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype2TitleAnchorVariant0> for LegendSubtype2TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype2TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleBaseline {
+    Variant0(LegendSubtype2TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype2TitleBaseline> for LegendSubtype2TitleBaseline {
+    fn from(value: &LegendSubtype2TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2TitleBaselineVariant0> for LegendSubtype2TitleBaseline {
+    fn from(value: LegendSubtype2TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype2TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype2TitleBaselineVariant0> for LegendSubtype2TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype2TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype2TitleColor> for LegendSubtype2TitleColor {
+    fn from(value: &LegendSubtype2TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype2TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype2TitleFont> for LegendSubtype2TitleFont {
+    fn from(value: &LegendSubtype2TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype2TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2TitleFontSize> for LegendSubtype2TitleFontSize {
+    fn from(value: &LegendSubtype2TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype2TitleFontStyle> for LegendSubtype2TitleFontStyle {
+    fn from(value: &LegendSubtype2TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype2TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype2TitleFontWeight> for LegendSubtype2TitleFontWeight {
+    fn from(value: &LegendSubtype2TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype2TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype2TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2TitleLimit> for LegendSubtype2TitleLimit {
+    fn from(value: &LegendSubtype2TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2TitleLineHeight> for LegendSubtype2TitleLineHeight {
+    fn from(value: &LegendSubtype2TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2TitleOpacity> for LegendSubtype2TitleOpacity {
+    fn from(value: &LegendSubtype2TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitleOrient {
+    Variant0(LegendSubtype2TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype2TitleOrient> for LegendSubtype2TitleOrient {
+    fn from(value: &LegendSubtype2TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype2TitleOrientVariant0> for LegendSubtype2TitleOrient {
+    fn from(value: LegendSubtype2TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype2TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype2TitleOrientVariant0> for LegendSubtype2TitleOrientVariant0 {
+    fn from(value: &LegendSubtype2TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype2TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype2TitlePadding> for LegendSubtype2TitlePadding {
+    fn from(value: &LegendSubtype2TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype2TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype2TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype2Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype2Type> for LegendSubtype2Type {
+    fn from(value: &LegendSubtype2Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype2Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype2Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype2Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype2Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype2Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype3CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype3Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype3Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype3FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype3Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype3FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype3GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype3GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype3GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype3GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype3LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype3LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype3LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype3LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype3LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype3LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype3LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype3LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype3LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype3LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype3LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype3LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype3Offset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype3Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype3Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shape: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    pub stroke: String,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype3StrokeColor>,
+    #[serde(
+        rename = "strokeDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_dash: Option<String>,
+    #[serde(
+        rename = "strokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_width: Option<String>,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype3SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype3SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype3SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype3SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype3SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype3SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype3SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype3SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype3SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype3TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype3TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype3TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype3TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype3TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype3TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype3TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype3TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype3TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype3TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype3TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype3TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype3TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype3Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
+}
+impl From<&LegendSubtype3> for LegendSubtype3 {
+    fn from(value: &LegendSubtype3) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3CornerRadius> for LegendSubtype3CornerRadius {
+    fn from(value: &LegendSubtype3CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype3Direction> for LegendSubtype3Direction {
+    fn from(value: &LegendSubtype3Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype3Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype3Encode> for LegendSubtype3Encode {
+    fn from(value: &LegendSubtype3Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3FillColor> for LegendSubtype3FillColor {
+    fn from(value: &LegendSubtype3FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype3Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype3Format> for LegendSubtype3Format {
+    fn from(value: &LegendSubtype3Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype3Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3FormatType {
+    Variant0(LegendSubtype3FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype3FormatType> for LegendSubtype3FormatType {
+    fn from(value: &LegendSubtype3FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3FormatTypeVariant0> for LegendSubtype3FormatType {
+    fn from(value: LegendSubtype3FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype3FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype3FormatTypeVariant0> for LegendSubtype3FormatTypeVariant0 {
+    fn from(value: &LegendSubtype3FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3GradientOpacity> for LegendSubtype3GradientOpacity {
+    fn from(value: &LegendSubtype3GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3GradientStrokeColor> for LegendSubtype3GradientStrokeColor {
+    fn from(value: &LegendSubtype3GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3GradientStrokeWidth> for LegendSubtype3GradientStrokeWidth {
+    fn from(value: &LegendSubtype3GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3GridAlign {
+    Variant0(LegendSubtype3GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype3GridAlign> for LegendSubtype3GridAlign {
+    fn from(value: &LegendSubtype3GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3GridAlignVariant0> for LegendSubtype3GridAlign {
+    fn from(value: LegendSubtype3GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype3GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype3GridAlignVariant0> for LegendSubtype3GridAlignVariant0 {
+    fn from(value: &LegendSubtype3GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelAlign {
+    Variant0(LegendSubtype3LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype3LabelAlign> for LegendSubtype3LabelAlign {
+    fn from(value: &LegendSubtype3LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3LabelAlignVariant0> for LegendSubtype3LabelAlign {
+    fn from(value: LegendSubtype3LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype3LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype3LabelAlignVariant0> for LegendSubtype3LabelAlignVariant0 {
+    fn from(value: &LegendSubtype3LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelBaseline {
+    Variant0(LegendSubtype3LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype3LabelBaseline> for LegendSubtype3LabelBaseline {
+    fn from(value: &LegendSubtype3LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3LabelBaselineVariant0> for LegendSubtype3LabelBaseline {
+    fn from(value: LegendSubtype3LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype3LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype3LabelBaselineVariant0> for LegendSubtype3LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype3LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3LabelColor> for LegendSubtype3LabelColor {
+    fn from(value: &LegendSubtype3LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype3LabelFont> for LegendSubtype3LabelFont {
+    fn from(value: &LegendSubtype3LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype3LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LabelFontSize> for LegendSubtype3LabelFontSize {
+    fn from(value: &LegendSubtype3LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype3LabelFontStyle> for LegendSubtype3LabelFontStyle {
+    fn from(value: &LegendSubtype3LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype3LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype3LabelFontWeight> for LegendSubtype3LabelFontWeight {
+    fn from(value: &LegendSubtype3LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype3LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype3LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LabelLimit> for LegendSubtype3LabelLimit {
+    fn from(value: &LegendSubtype3LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LabelOffset> for LegendSubtype3LabelOffset {
+    fn from(value: &LegendSubtype3LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LabelOpacity> for LegendSubtype3LabelOpacity {
+    fn from(value: &LegendSubtype3LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LegendX> for LegendSubtype3LegendX {
+    fn from(value: &LegendSubtype3LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3LegendY> for LegendSubtype3LegendY {
+    fn from(value: &LegendSubtype3LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3Offset> for LegendSubtype3Offset {
+    fn from(value: &LegendSubtype3Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3Orient {
+    Variant0(LegendSubtype3OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype3Orient> for LegendSubtype3Orient {
+    fn from(value: &LegendSubtype3Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3OrientVariant0> for LegendSubtype3Orient {
+    fn from(value: LegendSubtype3OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype3Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype3OrientVariant0> for LegendSubtype3OrientVariant0 {
+    fn from(value: &LegendSubtype3OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3Padding> for LegendSubtype3Padding {
+    fn from(value: &LegendSubtype3Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3StrokeColor> for LegendSubtype3StrokeColor {
+    fn from(value: &LegendSubtype3StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype3SymbolDash> for LegendSubtype3SymbolDash {
+    fn from(value: &LegendSubtype3SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype3SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype3SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3SymbolDashOffset> for LegendSubtype3SymbolDashOffset {
+    fn from(value: &LegendSubtype3SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3SymbolFillColor> for LegendSubtype3SymbolFillColor {
+    fn from(value: &LegendSubtype3SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3SymbolOffset> for LegendSubtype3SymbolOffset {
+    fn from(value: &LegendSubtype3SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3SymbolOpacity> for LegendSubtype3SymbolOpacity {
+    fn from(value: &LegendSubtype3SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3SymbolSize> for LegendSubtype3SymbolSize {
+    fn from(value: &LegendSubtype3SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3SymbolStrokeColor> for LegendSubtype3SymbolStrokeColor {
+    fn from(value: &LegendSubtype3SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3SymbolStrokeWidth> for LegendSubtype3SymbolStrokeWidth {
+    fn from(value: &LegendSubtype3SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype3SymbolType> for LegendSubtype3SymbolType {
+    fn from(value: &LegendSubtype3SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype3SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleAlign {
+    Variant0(LegendSubtype3TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype3TitleAlign> for LegendSubtype3TitleAlign {
+    fn from(value: &LegendSubtype3TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3TitleAlignVariant0> for LegendSubtype3TitleAlign {
+    fn from(value: LegendSubtype3TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype3TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype3TitleAlignVariant0> for LegendSubtype3TitleAlignVariant0 {
+    fn from(value: &LegendSubtype3TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleAnchor {
+    Variant0(Option<LegendSubtype3TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype3TitleAnchor> for LegendSubtype3TitleAnchor {
+    fn from(value: &LegendSubtype3TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype3TitleAnchorVariant0>> for LegendSubtype3TitleAnchor {
+    fn from(value: Option<LegendSubtype3TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype3TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype3TitleAnchorVariant0> for LegendSubtype3TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype3TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleBaseline {
+    Variant0(LegendSubtype3TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype3TitleBaseline> for LegendSubtype3TitleBaseline {
+    fn from(value: &LegendSubtype3TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3TitleBaselineVariant0> for LegendSubtype3TitleBaseline {
+    fn from(value: LegendSubtype3TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype3TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype3TitleBaselineVariant0> for LegendSubtype3TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype3TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype3TitleColor> for LegendSubtype3TitleColor {
+    fn from(value: &LegendSubtype3TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype3TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype3TitleFont> for LegendSubtype3TitleFont {
+    fn from(value: &LegendSubtype3TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype3TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3TitleFontSize> for LegendSubtype3TitleFontSize {
+    fn from(value: &LegendSubtype3TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype3TitleFontStyle> for LegendSubtype3TitleFontStyle {
+    fn from(value: &LegendSubtype3TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype3TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype3TitleFontWeight> for LegendSubtype3TitleFontWeight {
+    fn from(value: &LegendSubtype3TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype3TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype3TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3TitleLimit> for LegendSubtype3TitleLimit {
+    fn from(value: &LegendSubtype3TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3TitleLineHeight> for LegendSubtype3TitleLineHeight {
+    fn from(value: &LegendSubtype3TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3TitleOpacity> for LegendSubtype3TitleOpacity {
+    fn from(value: &LegendSubtype3TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitleOrient {
+    Variant0(LegendSubtype3TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype3TitleOrient> for LegendSubtype3TitleOrient {
+    fn from(value: &LegendSubtype3TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype3TitleOrientVariant0> for LegendSubtype3TitleOrient {
+    fn from(value: LegendSubtype3TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype3TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype3TitleOrientVariant0> for LegendSubtype3TitleOrientVariant0 {
+    fn from(value: &LegendSubtype3TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype3TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype3TitlePadding> for LegendSubtype3TitlePadding {
+    fn from(value: &LegendSubtype3TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype3TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype3TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype3Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype3Type> for LegendSubtype3Type {
+    fn from(value: &LegendSubtype3Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype3Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype3Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype3Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype3Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype3Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype4 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype4CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype4Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype4Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype4FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype4Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype4FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype4GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype4GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype4GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype4GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype4LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype4LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype4LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype4LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype4LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype4LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype4LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype4LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype4LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype4LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype4LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype4LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype4Offset>,
+    pub opacity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype4Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype4Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shape: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke: Option<String>,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype4StrokeColor>,
+    #[serde(
+        rename = "strokeDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_dash: Option<String>,
+    #[serde(
+        rename = "strokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_width: Option<String>,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype4SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype4SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype4SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype4SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype4SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype4SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype4SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype4SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype4SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype4TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype4TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype4TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype4TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype4TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype4TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype4TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype4TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype4TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype4TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype4TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype4TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype4TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype4Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
+}
+impl From<&LegendSubtype4> for LegendSubtype4 {
+    fn from(value: &LegendSubtype4) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4CornerRadius> for LegendSubtype4CornerRadius {
+    fn from(value: &LegendSubtype4CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype4Direction> for LegendSubtype4Direction {
+    fn from(value: &LegendSubtype4Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype4Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype4Encode> for LegendSubtype4Encode {
+    fn from(value: &LegendSubtype4Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4FillColor> for LegendSubtype4FillColor {
+    fn from(value: &LegendSubtype4FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype4Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype4Format> for LegendSubtype4Format {
+    fn from(value: &LegendSubtype4Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype4Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4FormatType {
+    Variant0(LegendSubtype4FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype4FormatType> for LegendSubtype4FormatType {
+    fn from(value: &LegendSubtype4FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4FormatTypeVariant0> for LegendSubtype4FormatType {
+    fn from(value: LegendSubtype4FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype4FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype4FormatTypeVariant0> for LegendSubtype4FormatTypeVariant0 {
+    fn from(value: &LegendSubtype4FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4GradientOpacity> for LegendSubtype4GradientOpacity {
+    fn from(value: &LegendSubtype4GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4GradientStrokeColor> for LegendSubtype4GradientStrokeColor {
+    fn from(value: &LegendSubtype4GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4GradientStrokeWidth> for LegendSubtype4GradientStrokeWidth {
+    fn from(value: &LegendSubtype4GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4GridAlign {
+    Variant0(LegendSubtype4GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype4GridAlign> for LegendSubtype4GridAlign {
+    fn from(value: &LegendSubtype4GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4GridAlignVariant0> for LegendSubtype4GridAlign {
+    fn from(value: LegendSubtype4GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype4GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype4GridAlignVariant0> for LegendSubtype4GridAlignVariant0 {
+    fn from(value: &LegendSubtype4GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelAlign {
+    Variant0(LegendSubtype4LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype4LabelAlign> for LegendSubtype4LabelAlign {
+    fn from(value: &LegendSubtype4LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4LabelAlignVariant0> for LegendSubtype4LabelAlign {
+    fn from(value: LegendSubtype4LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype4LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype4LabelAlignVariant0> for LegendSubtype4LabelAlignVariant0 {
+    fn from(value: &LegendSubtype4LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelBaseline {
+    Variant0(LegendSubtype4LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype4LabelBaseline> for LegendSubtype4LabelBaseline {
+    fn from(value: &LegendSubtype4LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4LabelBaselineVariant0> for LegendSubtype4LabelBaseline {
+    fn from(value: LegendSubtype4LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype4LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype4LabelBaselineVariant0> for LegendSubtype4LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype4LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4LabelColor> for LegendSubtype4LabelColor {
+    fn from(value: &LegendSubtype4LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype4LabelFont> for LegendSubtype4LabelFont {
+    fn from(value: &LegendSubtype4LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype4LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LabelFontSize> for LegendSubtype4LabelFontSize {
+    fn from(value: &LegendSubtype4LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype4LabelFontStyle> for LegendSubtype4LabelFontStyle {
+    fn from(value: &LegendSubtype4LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype4LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype4LabelFontWeight> for LegendSubtype4LabelFontWeight {
+    fn from(value: &LegendSubtype4LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype4LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype4LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LabelLimit> for LegendSubtype4LabelLimit {
+    fn from(value: &LegendSubtype4LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LabelOffset> for LegendSubtype4LabelOffset {
+    fn from(value: &LegendSubtype4LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LabelOpacity> for LegendSubtype4LabelOpacity {
+    fn from(value: &LegendSubtype4LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LegendX> for LegendSubtype4LegendX {
+    fn from(value: &LegendSubtype4LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4LegendY> for LegendSubtype4LegendY {
+    fn from(value: &LegendSubtype4LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4Offset> for LegendSubtype4Offset {
+    fn from(value: &LegendSubtype4Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4Orient {
+    Variant0(LegendSubtype4OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype4Orient> for LegendSubtype4Orient {
+    fn from(value: &LegendSubtype4Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4OrientVariant0> for LegendSubtype4Orient {
+    fn from(value: LegendSubtype4OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype4Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype4OrientVariant0> for LegendSubtype4OrientVariant0 {
+    fn from(value: &LegendSubtype4OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4Padding> for LegendSubtype4Padding {
+    fn from(value: &LegendSubtype4Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4StrokeColor> for LegendSubtype4StrokeColor {
+    fn from(value: &LegendSubtype4StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype4SymbolDash> for LegendSubtype4SymbolDash {
+    fn from(value: &LegendSubtype4SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype4SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype4SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4SymbolDashOffset> for LegendSubtype4SymbolDashOffset {
+    fn from(value: &LegendSubtype4SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4SymbolFillColor> for LegendSubtype4SymbolFillColor {
+    fn from(value: &LegendSubtype4SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4SymbolOffset> for LegendSubtype4SymbolOffset {
+    fn from(value: &LegendSubtype4SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4SymbolOpacity> for LegendSubtype4SymbolOpacity {
+    fn from(value: &LegendSubtype4SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4SymbolSize> for LegendSubtype4SymbolSize {
+    fn from(value: &LegendSubtype4SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4SymbolStrokeColor> for LegendSubtype4SymbolStrokeColor {
+    fn from(value: &LegendSubtype4SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4SymbolStrokeWidth> for LegendSubtype4SymbolStrokeWidth {
+    fn from(value: &LegendSubtype4SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype4SymbolType> for LegendSubtype4SymbolType {
+    fn from(value: &LegendSubtype4SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype4SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleAlign {
+    Variant0(LegendSubtype4TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype4TitleAlign> for LegendSubtype4TitleAlign {
+    fn from(value: &LegendSubtype4TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4TitleAlignVariant0> for LegendSubtype4TitleAlign {
+    fn from(value: LegendSubtype4TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype4TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype4TitleAlignVariant0> for LegendSubtype4TitleAlignVariant0 {
+    fn from(value: &LegendSubtype4TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleAnchor {
+    Variant0(Option<LegendSubtype4TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype4TitleAnchor> for LegendSubtype4TitleAnchor {
+    fn from(value: &LegendSubtype4TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype4TitleAnchorVariant0>> for LegendSubtype4TitleAnchor {
+    fn from(value: Option<LegendSubtype4TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype4TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype4TitleAnchorVariant0> for LegendSubtype4TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype4TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleBaseline {
+    Variant0(LegendSubtype4TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype4TitleBaseline> for LegendSubtype4TitleBaseline {
+    fn from(value: &LegendSubtype4TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4TitleBaselineVariant0> for LegendSubtype4TitleBaseline {
+    fn from(value: LegendSubtype4TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype4TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype4TitleBaselineVariant0> for LegendSubtype4TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype4TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype4TitleColor> for LegendSubtype4TitleColor {
+    fn from(value: &LegendSubtype4TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype4TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype4TitleFont> for LegendSubtype4TitleFont {
+    fn from(value: &LegendSubtype4TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype4TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4TitleFontSize> for LegendSubtype4TitleFontSize {
+    fn from(value: &LegendSubtype4TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype4TitleFontStyle> for LegendSubtype4TitleFontStyle {
+    fn from(value: &LegendSubtype4TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype4TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype4TitleFontWeight> for LegendSubtype4TitleFontWeight {
+    fn from(value: &LegendSubtype4TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype4TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype4TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4TitleLimit> for LegendSubtype4TitleLimit {
+    fn from(value: &LegendSubtype4TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4TitleLineHeight> for LegendSubtype4TitleLineHeight {
+    fn from(value: &LegendSubtype4TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4TitleOpacity> for LegendSubtype4TitleOpacity {
+    fn from(value: &LegendSubtype4TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitleOrient {
+    Variant0(LegendSubtype4TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype4TitleOrient> for LegendSubtype4TitleOrient {
+    fn from(value: &LegendSubtype4TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype4TitleOrientVariant0> for LegendSubtype4TitleOrient {
+    fn from(value: LegendSubtype4TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype4TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype4TitleOrientVariant0> for LegendSubtype4TitleOrientVariant0 {
+    fn from(value: &LegendSubtype4TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype4TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype4TitlePadding> for LegendSubtype4TitlePadding {
+    fn from(value: &LegendSubtype4TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype4TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype4TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype4Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype4Type> for LegendSubtype4Type {
+    fn from(value: &LegendSubtype4Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype4Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype4Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype4Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype4Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype4Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype5 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype5CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype5Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype5Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype5FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype5Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype5FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype5GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype5GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype5GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype5GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype5LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype5LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype5LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype5LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype5LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype5LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype5LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype5LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype5LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype5LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype5LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype5LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype5Offset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype5Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype5Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shape: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke: Option<String>,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype5StrokeColor>,
+    #[serde(rename = "strokeDash")]
+    pub stroke_dash: String,
+    #[serde(
+        rename = "strokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_width: Option<String>,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype5SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype5SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype5SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype5SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype5SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype5SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype5SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype5SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype5SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype5TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype5TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype5TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype5TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype5TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype5TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype5TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype5TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype5TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype5TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype5TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype5TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype5TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype5Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
+}
+impl From<&LegendSubtype5> for LegendSubtype5 {
+    fn from(value: &LegendSubtype5) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5CornerRadius> for LegendSubtype5CornerRadius {
+    fn from(value: &LegendSubtype5CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype5Direction> for LegendSubtype5Direction {
+    fn from(value: &LegendSubtype5Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype5Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype5Encode> for LegendSubtype5Encode {
+    fn from(value: &LegendSubtype5Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5FillColor> for LegendSubtype5FillColor {
+    fn from(value: &LegendSubtype5FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype5Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype5Format> for LegendSubtype5Format {
+    fn from(value: &LegendSubtype5Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype5Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5FormatType {
+    Variant0(LegendSubtype5FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype5FormatType> for LegendSubtype5FormatType {
+    fn from(value: &LegendSubtype5FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5FormatTypeVariant0> for LegendSubtype5FormatType {
+    fn from(value: LegendSubtype5FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype5FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype5FormatTypeVariant0> for LegendSubtype5FormatTypeVariant0 {
+    fn from(value: &LegendSubtype5FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5GradientOpacity> for LegendSubtype5GradientOpacity {
+    fn from(value: &LegendSubtype5GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5GradientStrokeColor> for LegendSubtype5GradientStrokeColor {
+    fn from(value: &LegendSubtype5GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5GradientStrokeWidth> for LegendSubtype5GradientStrokeWidth {
+    fn from(value: &LegendSubtype5GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5GridAlign {
+    Variant0(LegendSubtype5GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype5GridAlign> for LegendSubtype5GridAlign {
+    fn from(value: &LegendSubtype5GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5GridAlignVariant0> for LegendSubtype5GridAlign {
+    fn from(value: LegendSubtype5GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype5GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype5GridAlignVariant0> for LegendSubtype5GridAlignVariant0 {
+    fn from(value: &LegendSubtype5GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelAlign {
+    Variant0(LegendSubtype5LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype5LabelAlign> for LegendSubtype5LabelAlign {
+    fn from(value: &LegendSubtype5LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5LabelAlignVariant0> for LegendSubtype5LabelAlign {
+    fn from(value: LegendSubtype5LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype5LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype5LabelAlignVariant0> for LegendSubtype5LabelAlignVariant0 {
+    fn from(value: &LegendSubtype5LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelBaseline {
+    Variant0(LegendSubtype5LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype5LabelBaseline> for LegendSubtype5LabelBaseline {
+    fn from(value: &LegendSubtype5LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5LabelBaselineVariant0> for LegendSubtype5LabelBaseline {
+    fn from(value: LegendSubtype5LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype5LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype5LabelBaselineVariant0> for LegendSubtype5LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype5LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5LabelColor> for LegendSubtype5LabelColor {
+    fn from(value: &LegendSubtype5LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype5LabelFont> for LegendSubtype5LabelFont {
+    fn from(value: &LegendSubtype5LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype5LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LabelFontSize> for LegendSubtype5LabelFontSize {
+    fn from(value: &LegendSubtype5LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype5LabelFontStyle> for LegendSubtype5LabelFontStyle {
+    fn from(value: &LegendSubtype5LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype5LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype5LabelFontWeight> for LegendSubtype5LabelFontWeight {
+    fn from(value: &LegendSubtype5LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype5LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype5LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LabelLimit> for LegendSubtype5LabelLimit {
+    fn from(value: &LegendSubtype5LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LabelOffset> for LegendSubtype5LabelOffset {
+    fn from(value: &LegendSubtype5LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LabelOpacity> for LegendSubtype5LabelOpacity {
+    fn from(value: &LegendSubtype5LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LegendX> for LegendSubtype5LegendX {
+    fn from(value: &LegendSubtype5LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5LegendY> for LegendSubtype5LegendY {
+    fn from(value: &LegendSubtype5LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5Offset> for LegendSubtype5Offset {
+    fn from(value: &LegendSubtype5Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5Orient {
+    Variant0(LegendSubtype5OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype5Orient> for LegendSubtype5Orient {
+    fn from(value: &LegendSubtype5Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5OrientVariant0> for LegendSubtype5Orient {
+    fn from(value: LegendSubtype5OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype5Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype5OrientVariant0> for LegendSubtype5OrientVariant0 {
+    fn from(value: &LegendSubtype5OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5Padding> for LegendSubtype5Padding {
+    fn from(value: &LegendSubtype5Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5StrokeColor> for LegendSubtype5StrokeColor {
+    fn from(value: &LegendSubtype5StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype5SymbolDash> for LegendSubtype5SymbolDash {
+    fn from(value: &LegendSubtype5SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype5SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype5SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5SymbolDashOffset> for LegendSubtype5SymbolDashOffset {
+    fn from(value: &LegendSubtype5SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5SymbolFillColor> for LegendSubtype5SymbolFillColor {
+    fn from(value: &LegendSubtype5SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5SymbolOffset> for LegendSubtype5SymbolOffset {
+    fn from(value: &LegendSubtype5SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5SymbolOpacity> for LegendSubtype5SymbolOpacity {
+    fn from(value: &LegendSubtype5SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5SymbolSize> for LegendSubtype5SymbolSize {
+    fn from(value: &LegendSubtype5SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5SymbolStrokeColor> for LegendSubtype5SymbolStrokeColor {
+    fn from(value: &LegendSubtype5SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5SymbolStrokeWidth> for LegendSubtype5SymbolStrokeWidth {
+    fn from(value: &LegendSubtype5SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype5SymbolType> for LegendSubtype5SymbolType {
+    fn from(value: &LegendSubtype5SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype5SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleAlign {
+    Variant0(LegendSubtype5TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype5TitleAlign> for LegendSubtype5TitleAlign {
+    fn from(value: &LegendSubtype5TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5TitleAlignVariant0> for LegendSubtype5TitleAlign {
+    fn from(value: LegendSubtype5TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype5TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype5TitleAlignVariant0> for LegendSubtype5TitleAlignVariant0 {
+    fn from(value: &LegendSubtype5TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleAnchor {
+    Variant0(Option<LegendSubtype5TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype5TitleAnchor> for LegendSubtype5TitleAnchor {
+    fn from(value: &LegendSubtype5TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype5TitleAnchorVariant0>> for LegendSubtype5TitleAnchor {
+    fn from(value: Option<LegendSubtype5TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype5TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype5TitleAnchorVariant0> for LegendSubtype5TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype5TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleBaseline {
+    Variant0(LegendSubtype5TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype5TitleBaseline> for LegendSubtype5TitleBaseline {
+    fn from(value: &LegendSubtype5TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5TitleBaselineVariant0> for LegendSubtype5TitleBaseline {
+    fn from(value: LegendSubtype5TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype5TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype5TitleBaselineVariant0> for LegendSubtype5TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype5TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype5TitleColor> for LegendSubtype5TitleColor {
+    fn from(value: &LegendSubtype5TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype5TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype5TitleFont> for LegendSubtype5TitleFont {
+    fn from(value: &LegendSubtype5TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype5TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5TitleFontSize> for LegendSubtype5TitleFontSize {
+    fn from(value: &LegendSubtype5TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype5TitleFontStyle> for LegendSubtype5TitleFontStyle {
+    fn from(value: &LegendSubtype5TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype5TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype5TitleFontWeight> for LegendSubtype5TitleFontWeight {
+    fn from(value: &LegendSubtype5TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype5TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype5TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5TitleLimit> for LegendSubtype5TitleLimit {
+    fn from(value: &LegendSubtype5TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5TitleLineHeight> for LegendSubtype5TitleLineHeight {
+    fn from(value: &LegendSubtype5TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5TitleOpacity> for LegendSubtype5TitleOpacity {
+    fn from(value: &LegendSubtype5TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitleOrient {
+    Variant0(LegendSubtype5TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype5TitleOrient> for LegendSubtype5TitleOrient {
+    fn from(value: &LegendSubtype5TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype5TitleOrientVariant0> for LegendSubtype5TitleOrient {
+    fn from(value: LegendSubtype5TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype5TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype5TitleOrientVariant0> for LegendSubtype5TitleOrientVariant0 {
+    fn from(value: &LegendSubtype5TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype5TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype5TitlePadding> for LegendSubtype5TitlePadding {
+    fn from(value: &LegendSubtype5TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype5TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype5TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype5Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype5Type> for LegendSubtype5Type {
+    fn from(value: &LegendSubtype5Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype5Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype5Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype5Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype5Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype5Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype6 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(
+        rename = "clipHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clip_height: Option<NumberOrSignal>,
+    #[serde(
+        rename = "columnPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub column_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<NumberOrSignal>,
+    #[serde(
+        rename = "cornerRadius",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub corner_radius: Option<LegendSubtype6CornerRadius>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<LegendSubtype6Direction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<LegendSubtype6Encode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    #[serde(rename = "fillColor", default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<LegendSubtype6FillColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<LegendSubtype6Format>,
+    #[serde(
+        rename = "formatType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_type: Option<LegendSubtype6FormatType>,
+    #[serde(
+        rename = "gradientLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_length: Option<NumberOrSignal>,
+    #[serde(
+        rename = "gradientOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_opacity: Option<LegendSubtype6GradientOpacity>,
+    #[serde(
+        rename = "gradientStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_color: Option<LegendSubtype6GradientStrokeColor>,
+    #[serde(
+        rename = "gradientStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_stroke_width: Option<LegendSubtype6GradientStrokeWidth>,
+    #[serde(
+        rename = "gradientThickness",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gradient_thickness: Option<NumberOrSignal>,
+    #[serde(rename = "gridAlign", default, skip_serializing_if = "Option::is_none")]
+    pub grid_align: Option<LegendSubtype6GridAlign>,
+    #[serde(
+        rename = "labelAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_align: Option<LegendSubtype6LabelAlign>,
+    #[serde(
+        rename = "labelBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_baseline: Option<LegendSubtype6LabelBaseline>,
+    #[serde(
+        rename = "labelColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_color: Option<LegendSubtype6LabelColor>,
+    #[serde(rename = "labelFont", default, skip_serializing_if = "Option::is_none")]
+    pub label_font: Option<LegendSubtype6LabelFont>,
+    #[serde(
+        rename = "labelFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_size: Option<LegendSubtype6LabelFontSize>,
+    #[serde(
+        rename = "labelFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_style: Option<LegendSubtype6LabelFontStyle>,
+    #[serde(
+        rename = "labelFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_font_weight: Option<LegendSubtype6LabelFontWeight>,
+    #[serde(
+        rename = "labelLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_limit: Option<LegendSubtype6LabelLimit>,
+    #[serde(
+        rename = "labelOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_offset: Option<LegendSubtype6LabelOffset>,
+    #[serde(
+        rename = "labelOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_opacity: Option<LegendSubtype6LabelOpacity>,
+    #[serde(
+        rename = "labelOverlap",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_overlap: Option<LabelOverlap>,
+    #[serde(
+        rename = "labelSeparation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub label_separation: Option<NumberOrSignal>,
+    #[serde(rename = "legendX", default, skip_serializing_if = "Option::is_none")]
+    pub legend_x: Option<LegendSubtype6LegendX>,
+    #[serde(rename = "legendY", default, skip_serializing_if = "Option::is_none")]
+    pub legend_y: Option<LegendSubtype6LegendY>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<LegendSubtype6Offset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orient: Option<LegendSubtype6Orient>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding: Option<LegendSubtype6Padding>,
+    #[serde(
+        rename = "rowPadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub row_padding: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shape: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke: Option<String>,
+    #[serde(
+        rename = "strokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_color: Option<LegendSubtype6StrokeColor>,
+    #[serde(
+        rename = "strokeDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stroke_dash: Option<String>,
+    #[serde(rename = "strokeWidth")]
+    pub stroke_width: String,
+    #[serde(
+        rename = "symbolDash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash: Option<LegendSubtype6SymbolDash>,
+    #[serde(
+        rename = "symbolDashOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_dash_offset: Option<LegendSubtype6SymbolDashOffset>,
+    #[serde(
+        rename = "symbolFillColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_fill_color: Option<LegendSubtype6SymbolFillColor>,
+    #[serde(
+        rename = "symbolLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_limit: Option<NumberOrSignal>,
+    #[serde(
+        rename = "symbolOffset",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_offset: Option<LegendSubtype6SymbolOffset>,
+    #[serde(
+        rename = "symbolOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_opacity: Option<LegendSubtype6SymbolOpacity>,
+    #[serde(
+        rename = "symbolSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_size: Option<LegendSubtype6SymbolSize>,
+    #[serde(
+        rename = "symbolStrokeColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_color: Option<LegendSubtype6SymbolStrokeColor>,
+    #[serde(
+        rename = "symbolStrokeWidth",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_stroke_width: Option<LegendSubtype6SymbolStrokeWidth>,
+    #[serde(
+        rename = "symbolType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub symbol_type: Option<LegendSubtype6SymbolType>,
+    #[serde(rename = "tickCount", default, skip_serializing_if = "Option::is_none")]
+    pub tick_count: Option<TickCount>,
+    #[serde(
+        rename = "tickMinStep",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tick_min_step: Option<NumberOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<TextOrSignal>,
+    #[serde(
+        rename = "titleAlign",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_align: Option<LegendSubtype6TitleAlign>,
+    #[serde(
+        rename = "titleAnchor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_anchor: Option<LegendSubtype6TitleAnchor>,
+    #[serde(
+        rename = "titleBaseline",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_baseline: Option<LegendSubtype6TitleBaseline>,
+    #[serde(
+        rename = "titleColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_color: Option<LegendSubtype6TitleColor>,
+    #[serde(rename = "titleFont", default, skip_serializing_if = "Option::is_none")]
+    pub title_font: Option<LegendSubtype6TitleFont>,
+    #[serde(
+        rename = "titleFontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_size: Option<LegendSubtype6TitleFontSize>,
+    #[serde(
+        rename = "titleFontStyle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_style: Option<LegendSubtype6TitleFontStyle>,
+    #[serde(
+        rename = "titleFontWeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_font_weight: Option<LegendSubtype6TitleFontWeight>,
+    #[serde(
+        rename = "titleLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_limit: Option<LegendSubtype6TitleLimit>,
+    #[serde(
+        rename = "titleLineHeight",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_line_height: Option<LegendSubtype6TitleLineHeight>,
+    #[serde(
+        rename = "titleOpacity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_opacity: Option<LegendSubtype6TitleOpacity>,
+    #[serde(
+        rename = "titleOrient",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_orient: Option<LegendSubtype6TitleOrient>,
+    #[serde(
+        rename = "titlePadding",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub title_padding: Option<LegendSubtype6TitlePadding>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub type_: Option<LegendSubtype6Type>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<ArrayOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zindex: Option<f64>,
+}
+impl From<&LegendSubtype6> for LegendSubtype6 {
+    fn from(value: &LegendSubtype6) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6CornerRadius {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6CornerRadius> for LegendSubtype6CornerRadius {
+    fn from(value: &LegendSubtype6CornerRadius) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6CornerRadius {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6CornerRadius {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6Direction {
+    #[serde(rename = "vertical")]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+}
+impl From<&LegendSubtype6Direction> for LegendSubtype6Direction {
+    fn from(value: &LegendSubtype6Direction) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => "horizontal".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6Direction {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "vertical" => Ok(Self::Vertical),
+            "horizontal" => Ok(Self::Horizontal),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6Direction {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6Direction {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6Direction {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegendSubtype6Encode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<GuideEncode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<GuideEncode>,
+}
+impl From<&LegendSubtype6Encode> for LegendSubtype6Encode {
+    fn from(value: &LegendSubtype6Encode) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6FillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6FillColor> for LegendSubtype6FillColor {
+    fn from(value: &LegendSubtype6FillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6FillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum LegendSubtype6Format {
+    Variant0(String),
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        date: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        day: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hours: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        milliseconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minutes: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        month: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        quarter: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seconds: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        week: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        year: Option<String>,
+    },
+    Variant2(SignalRef),
+}
+impl From<&LegendSubtype6Format> for LegendSubtype6Format {
+    fn from(value: &LegendSubtype6Format) -> Self {
+        value.clone()
+    }
+}
+impl From<SignalRef> for LegendSubtype6Format {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6FormatType {
+    Variant0(LegendSubtype6FormatTypeVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype6FormatType> for LegendSubtype6FormatType {
+    fn from(value: &LegendSubtype6FormatType) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6FormatTypeVariant0> for LegendSubtype6FormatType {
+    fn from(value: LegendSubtype6FormatTypeVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype6FormatType {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6FormatTypeVariant0 {
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "time")]
+    Time,
+    #[serde(rename = "utc")]
+    Utc,
+}
+impl From<&LegendSubtype6FormatTypeVariant0> for LegendSubtype6FormatTypeVariant0 {
+    fn from(value: &LegendSubtype6FormatTypeVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6FormatTypeVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Number => "number".to_string(),
+            Self::Time => "time".to_string(),
+            Self::Utc => "utc".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6FormatTypeVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "number" => Ok(Self::Number),
+            "time" => Ok(Self::Time),
+            "utc" => Ok(Self::Utc),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6FormatTypeVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6GradientOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6GradientOpacity> for LegendSubtype6GradientOpacity {
+    fn from(value: &LegendSubtype6GradientOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6GradientOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6GradientOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6GradientStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6GradientStrokeColor> for LegendSubtype6GradientStrokeColor {
+    fn from(value: &LegendSubtype6GradientStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6GradientStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6GradientStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6GradientStrokeWidth> for LegendSubtype6GradientStrokeWidth {
+    fn from(value: &LegendSubtype6GradientStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6GradientStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6GradientStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6GridAlign {
+    Variant0(LegendSubtype6GridAlignVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype6GridAlign> for LegendSubtype6GridAlign {
+    fn from(value: &LegendSubtype6GridAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6GridAlignVariant0> for LegendSubtype6GridAlign {
+    fn from(value: LegendSubtype6GridAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype6GridAlign {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6GridAlignVariant0 {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "each")]
+    Each,
+    #[serde(rename = "none")]
+    None,
+}
+impl From<&LegendSubtype6GridAlignVariant0> for LegendSubtype6GridAlignVariant0 {
+    fn from(value: &LegendSubtype6GridAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6GridAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::All => "all".to_string(),
+            Self::Each => "each".to_string(),
+            Self::None => "none".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6GridAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "all" => Ok(Self::All),
+            "each" => Ok(Self::Each),
+            "none" => Ok(Self::None),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6GridAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelAlign {
+    Variant0(LegendSubtype6LabelAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype6LabelAlign> for LegendSubtype6LabelAlign {
+    fn from(value: &LegendSubtype6LabelAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6LabelAlignVariant0> for LegendSubtype6LabelAlign {
+    fn from(value: LegendSubtype6LabelAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype6LabelAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6LabelAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype6LabelAlignVariant0> for LegendSubtype6LabelAlignVariant0 {
+    fn from(value: &LegendSubtype6LabelAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6LabelAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6LabelAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6LabelAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelBaseline {
+    Variant0(LegendSubtype6LabelBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype6LabelBaseline> for LegendSubtype6LabelBaseline {
+    fn from(value: &LegendSubtype6LabelBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6LabelBaselineVariant0> for LegendSubtype6LabelBaseline {
+    fn from(value: LegendSubtype6LabelBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype6LabelBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6LabelBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype6LabelBaselineVariant0> for LegendSubtype6LabelBaselineVariant0 {
+    fn from(value: &LegendSubtype6LabelBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6LabelBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6LabelBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6LabelBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6LabelColor> for LegendSubtype6LabelColor {
+    fn from(value: &LegendSubtype6LabelColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6LabelColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype6LabelFont> for LegendSubtype6LabelFont {
+    fn from(value: &LegendSubtype6LabelFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype6LabelFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LabelFontSize> for LegendSubtype6LabelFontSize {
+    fn from(value: &LegendSubtype6LabelFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LabelFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LabelFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype6LabelFontStyle> for LegendSubtype6LabelFontStyle {
+    fn from(value: &LegendSubtype6LabelFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype6LabelFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype6LabelFontWeight> for LegendSubtype6LabelFontWeight {
+    fn from(value: &LegendSubtype6LabelFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype6LabelFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype6LabelFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LabelLimit> for LegendSubtype6LabelLimit {
+    fn from(value: &LegendSubtype6LabelLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LabelLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LabelLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LabelOffset> for LegendSubtype6LabelOffset {
+    fn from(value: &LegendSubtype6LabelOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LabelOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LabelOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LabelOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LabelOpacity> for LegendSubtype6LabelOpacity {
+    fn from(value: &LegendSubtype6LabelOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LabelOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LabelOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LegendX {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LegendX> for LegendSubtype6LegendX {
+    fn from(value: &LegendSubtype6LegendX) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LegendX {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LegendX {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6LegendY {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6LegendY> for LegendSubtype6LegendY {
+    fn from(value: &LegendSubtype6LegendY) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6LegendY {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6LegendY {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6Offset> for LegendSubtype6Offset {
+    fn from(value: &LegendSubtype6Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6Orient {
+    Variant0(LegendSubtype6OrientVariant0),
+    Variant1(SignalRef),
+}
+impl From<&LegendSubtype6Orient> for LegendSubtype6Orient {
+    fn from(value: &LegendSubtype6Orient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6OrientVariant0> for LegendSubtype6Orient {
+    fn from(value: LegendSubtype6OrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<SignalRef> for LegendSubtype6Orient {
+    fn from(value: SignalRef) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6OrientVariant0 {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "top-left")]
+    TopLeft,
+    #[serde(rename = "top-right")]
+    TopRight,
+    #[serde(rename = "bottom-left")]
+    BottomLeft,
+    #[serde(rename = "bottom-right")]
+    BottomRight,
+}
+impl From<&LegendSubtype6OrientVariant0> for LegendSubtype6OrientVariant0 {
+    fn from(value: &LegendSubtype6OrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6OrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::None => "none".to_string(),
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::TopLeft => "top-left".to_string(),
+            Self::TopRight => "top-right".to_string(),
+            Self::BottomLeft => "bottom-left".to_string(),
+            Self::BottomRight => "bottom-right".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6OrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "none" => Ok(Self::None),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            "top-left" => Ok(Self::TopLeft),
+            "top-right" => Ok(Self::TopRight),
+            "bottom-left" => Ok(Self::BottomLeft),
+            "bottom-right" => Ok(Self::BottomRight),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6OrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6Padding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6Padding> for LegendSubtype6Padding {
+    fn from(value: &LegendSubtype6Padding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6Padding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6Padding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6StrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6StrokeColor> for LegendSubtype6StrokeColor {
+    fn from(value: &LegendSubtype6StrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6StrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolDash {
+    Variant0(Vec<f64>),
+    Variant1(ArrayValue),
+}
+impl From<&LegendSubtype6SymbolDash> for LegendSubtype6SymbolDash {
+    fn from(value: &LegendSubtype6SymbolDash) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<f64>> for LegendSubtype6SymbolDash {
+    fn from(value: Vec<f64>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<ArrayValue> for LegendSubtype6SymbolDash {
+    fn from(value: ArrayValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolDashOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6SymbolDashOffset> for LegendSubtype6SymbolDashOffset {
+    fn from(value: &LegendSubtype6SymbolDashOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6SymbolDashOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6SymbolDashOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolFillColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6SymbolFillColor> for LegendSubtype6SymbolFillColor {
+    fn from(value: &LegendSubtype6SymbolFillColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6SymbolFillColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolOffset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6SymbolOffset> for LegendSubtype6SymbolOffset {
+    fn from(value: &LegendSubtype6SymbolOffset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6SymbolOffset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6SymbolOffset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6SymbolOpacity> for LegendSubtype6SymbolOpacity {
+    fn from(value: &LegendSubtype6SymbolOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6SymbolOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6SymbolOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6SymbolSize> for LegendSubtype6SymbolSize {
+    fn from(value: &LegendSubtype6SymbolSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6SymbolSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6SymbolSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolStrokeColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6SymbolStrokeColor> for LegendSubtype6SymbolStrokeColor {
+    fn from(value: &LegendSubtype6SymbolStrokeColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6SymbolStrokeColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolStrokeWidth {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6SymbolStrokeWidth> for LegendSubtype6SymbolStrokeWidth {
+    fn from(value: &LegendSubtype6SymbolStrokeWidth) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6SymbolStrokeWidth {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6SymbolStrokeWidth {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6SymbolType {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype6SymbolType> for LegendSubtype6SymbolType {
+    fn from(value: &LegendSubtype6SymbolType) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype6SymbolType {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleAlign {
+    Variant0(LegendSubtype6TitleAlignVariant0),
+    Variant1(AlignValue),
+}
+impl From<&LegendSubtype6TitleAlign> for LegendSubtype6TitleAlign {
+    fn from(value: &LegendSubtype6TitleAlign) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6TitleAlignVariant0> for LegendSubtype6TitleAlign {
+    fn from(value: LegendSubtype6TitleAlignVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AlignValue> for LegendSubtype6TitleAlign {
+    fn from(value: AlignValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6TitleAlignVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "center")]
+    Center,
+}
+impl From<&LegendSubtype6TitleAlignVariant0> for LegendSubtype6TitleAlignVariant0 {
+    fn from(value: &LegendSubtype6TitleAlignVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6TitleAlignVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Center => "center".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6TitleAlignVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" => Ok(Self::Center),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6TitleAlignVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleAnchor {
+    Variant0(Option<LegendSubtype6TitleAnchorVariant0>),
+    Variant1(AnchorValue),
+}
+impl From<&LegendSubtype6TitleAnchor> for LegendSubtype6TitleAnchor {
+    fn from(value: &LegendSubtype6TitleAnchor) -> Self {
+        value.clone()
+    }
+}
+impl From<Option<LegendSubtype6TitleAnchorVariant0>> for LegendSubtype6TitleAnchor {
+    fn from(value: Option<LegendSubtype6TitleAnchorVariant0>) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<AnchorValue> for LegendSubtype6TitleAnchor {
+    fn from(value: AnchorValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6TitleAnchorVariant0 {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "end")]
+    End,
+}
+impl From<&LegendSubtype6TitleAnchorVariant0> for LegendSubtype6TitleAnchorVariant0 {
+    fn from(value: &LegendSubtype6TitleAnchorVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6TitleAnchorVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Start => "start".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::End => "end".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6TitleAnchorVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "start" => Ok(Self::Start),
+            "middle" => Ok(Self::Middle),
+            "end" => Ok(Self::End),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6TitleAnchorVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleBaseline {
+    Variant0(LegendSubtype6TitleBaselineVariant0),
+    Variant1(BaselineValue),
+}
+impl From<&LegendSubtype6TitleBaseline> for LegendSubtype6TitleBaseline {
+    fn from(value: &LegendSubtype6TitleBaseline) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6TitleBaselineVariant0> for LegendSubtype6TitleBaseline {
+    fn from(value: LegendSubtype6TitleBaselineVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<BaselineValue> for LegendSubtype6TitleBaseline {
+    fn from(value: BaselineValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6TitleBaselineVariant0 {
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "middle")]
+    Middle,
+    #[serde(rename = "bottom")]
+    Bottom,
+    #[serde(rename = "alphabetic")]
+    Alphabetic,
+    #[serde(rename = "line-top")]
+    LineTop,
+    #[serde(rename = "line-bottom")]
+    LineBottom,
+}
+impl From<&LegendSubtype6TitleBaselineVariant0> for LegendSubtype6TitleBaselineVariant0 {
+    fn from(value: &LegendSubtype6TitleBaselineVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6TitleBaselineVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Top => "top".to_string(),
+            Self::Middle => "middle".to_string(),
+            Self::Bottom => "bottom".to_string(),
+            Self::Alphabetic => "alphabetic".to_string(),
+            Self::LineTop => "line-top".to_string(),
+            Self::LineBottom => "line-bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6TitleBaselineVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "top" => Ok(Self::Top),
+            "middle" => Ok(Self::Middle),
+            "bottom" => Ok(Self::Bottom),
+            "alphabetic" => Ok(Self::Alphabetic),
+            "line-top" => Ok(Self::LineTop),
+            "line-bottom" => Ok(Self::LineBottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6TitleBaselineVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleColor {
+    Variant0,
+    Variant1(String),
+    Variant2(ColorValue),
+}
+impl From<&LegendSubtype6TitleColor> for LegendSubtype6TitleColor {
+    fn from(value: &LegendSubtype6TitleColor) -> Self {
+        value.clone()
+    }
+}
+impl From<ColorValue> for LegendSubtype6TitleColor {
+    fn from(value: ColorValue) -> Self {
+        Self::Variant2(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleFont {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype6TitleFont> for LegendSubtype6TitleFont {
+    fn from(value: &LegendSubtype6TitleFont) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype6TitleFont {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleFontSize {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6TitleFontSize> for LegendSubtype6TitleFontSize {
+    fn from(value: &LegendSubtype6TitleFontSize) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6TitleFontSize {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6TitleFontSize {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleFontStyle {
+    Variant0(String),
+    Variant1(StringValue),
+}
+impl From<&LegendSubtype6TitleFontStyle> for LegendSubtype6TitleFontStyle {
+    fn from(value: &LegendSubtype6TitleFontStyle) -> Self {
+        value.clone()
+    }
+}
+impl From<StringValue> for LegendSubtype6TitleFontStyle {
+    fn from(value: StringValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleFontWeight {
+    Variant0(MyEnum),
+    Variant1(FontWeightValue),
+}
+impl From<&LegendSubtype6TitleFontWeight> for LegendSubtype6TitleFontWeight {
+    fn from(value: &LegendSubtype6TitleFontWeight) -> Self {
+        value.clone()
+    }
+}
+impl From<MyEnum> for LegendSubtype6TitleFontWeight {
+    fn from(value: MyEnum) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<FontWeightValue> for LegendSubtype6TitleFontWeight {
+    fn from(value: FontWeightValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleLimit {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6TitleLimit> for LegendSubtype6TitleLimit {
+    fn from(value: &LegendSubtype6TitleLimit) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6TitleLimit {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6TitleLimit {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleLineHeight {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6TitleLineHeight> for LegendSubtype6TitleLineHeight {
+    fn from(value: &LegendSubtype6TitleLineHeight) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6TitleLineHeight {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6TitleLineHeight {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleOpacity {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6TitleOpacity> for LegendSubtype6TitleOpacity {
+    fn from(value: &LegendSubtype6TitleOpacity) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6TitleOpacity {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6TitleOpacity {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitleOrient {
+    Variant0(LegendSubtype6TitleOrientVariant0),
+    Variant1(OrientValue),
+}
+impl From<&LegendSubtype6TitleOrient> for LegendSubtype6TitleOrient {
+    fn from(value: &LegendSubtype6TitleOrient) -> Self {
+        value.clone()
+    }
+}
+impl From<LegendSubtype6TitleOrientVariant0> for LegendSubtype6TitleOrient {
+    fn from(value: LegendSubtype6TitleOrientVariant0) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<OrientValue> for LegendSubtype6TitleOrient {
+    fn from(value: OrientValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6TitleOrientVariant0 {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&LegendSubtype6TitleOrientVariant0> for LegendSubtype6TitleOrientVariant0 {
+    fn from(value: &LegendSubtype6TitleOrientVariant0) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6TitleOrientVariant0 {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6TitleOrientVariant0 {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6TitleOrientVariant0 {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum LegendSubtype6TitlePadding {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&LegendSubtype6TitlePadding> for LegendSubtype6TitlePadding {
+    fn from(value: &LegendSubtype6TitlePadding) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for LegendSubtype6TitlePadding {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for LegendSubtype6TitlePadding {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum LegendSubtype6Type {
+    #[serde(rename = "gradient")]
+    Gradient,
+    #[serde(rename = "symbol")]
+    Symbol,
+}
+impl From<&LegendSubtype6Type> for LegendSubtype6Type {
+    fn from(value: &LegendSubtype6Type) -> Self {
+        value.clone()
+    }
+}
+impl ToString for LegendSubtype6Type {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Gradient => "gradient".to_string(),
+            Self::Symbol => "symbol".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for LegendSubtype6Type {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "gradient" => Ok(Self::Gradient),
+            "symbol" => Ok(Self::Symbol),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegendSubtype6Type {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for LegendSubtype6Type {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for LegendSubtype6Type {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -21608,14 +33130,54 @@ impl From<&Mark> for Mark {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MarkGroup {
-    #[serde(flatten)]
-    pub mark: Mark,
-    #[serde(flatten)]
-    pub scope: Scope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub axes: Vec<Axis>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clip: Option<Markclip>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<Data>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub encode: serde_json::Map<String, serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<MarkGroupFrom>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<BooleanOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout: Option<Layout>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub legends: Vec<Legend>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub marks: Vec<MarkGroupMarksItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on: Option<OnMarkTrigger>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub projections: Vec<Projection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scales: Vec<Scale>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub signals: Vec<Signal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sort: Option<Compare>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<Style>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<Title>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transform: Vec<TransformMark>,
     #[serde(rename = "type")]
     pub type_: MarkGroupType,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub usermeta: serde_json::Map<String, serde_json::Value>,
 }
 impl From<&MarkGroup> for MarkGroup {
     fn from(value: &MarkGroup) -> Self {
@@ -21641,6 +33203,27 @@ impl From<From> for MarkGroupFrom {
 impl From<Facet> for MarkGroupFrom {
     fn from(value: Facet) -> Self {
         Self::Facet(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MarkGroupMarksItem {
+    Group(MarkGroup),
+    Visual(MarkVisual),
+}
+impl From<&MarkGroupMarksItem> for MarkGroupMarksItem {
+    fn from(value: &MarkGroupMarksItem) -> Self {
+        value.clone()
+    }
+}
+impl From<MarkGroup> for MarkGroupMarksItem {
+    fn from(value: MarkGroup) -> Self {
+        Self::Group(value)
+    }
+}
+impl From<MarkVisual> for MarkGroupMarksItem {
+    fn from(value: MarkVisual) -> Self {
+        Self::Visual(value)
     }
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -21689,12 +33272,34 @@ impl std::convert::TryFrom<String> for MarkGroupType {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MarkVisual {
-    #[serde(flatten)]
-    pub mark: Mark,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aria: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clip: Option<Markclip>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encode: Option<Encode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<From>,
-    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub type_: Option<MarkVisualType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<BooleanOrSignal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on: Option<OnMarkTrigger>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sort: Option<Compare>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<Style>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transform: Vec<TransformMark>,
+    #[serde(rename = "type")]
+    pub type_: MarkVisualType,
 }
 impl From<&MarkVisual> for MarkVisual {
     fn from(value: &MarkVisual) -> Self {
@@ -22004,7 +33609,7 @@ impl From<bool> for NumberModifiersBand {
 #[serde(untagged)]
 pub enum NumberModifiersExponent {
     Variant0(f64),
-    Variant1(Box<NumberValue>),
+    Variant1(NumberValue),
 }
 impl From<&NumberModifiersExponent> for NumberModifiersExponent {
     fn from(value: &NumberModifiersExponent) -> Self {
@@ -22016,8 +33621,8 @@ impl From<f64> for NumberModifiersExponent {
         Self::Variant0(value)
     }
 }
-impl From<Box<NumberValue>> for NumberModifiersExponent {
-    fn from(value: Box<NumberValue>) -> Self {
+impl From<NumberValue> for NumberModifiersExponent {
+    fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
@@ -22025,7 +33630,7 @@ impl From<Box<NumberValue>> for NumberModifiersExponent {
 #[serde(untagged)]
 pub enum NumberModifiersMult {
     Variant0(f64),
-    Variant1(Box<NumberValue>),
+    Variant1(NumberValue),
 }
 impl From<&NumberModifiersMult> for NumberModifiersMult {
     fn from(value: &NumberModifiersMult) -> Self {
@@ -22037,8 +33642,8 @@ impl From<f64> for NumberModifiersMult {
         Self::Variant0(value)
     }
 }
-impl From<Box<NumberValue>> for NumberModifiersMult {
-    fn from(value: Box<NumberValue>) -> Self {
+impl From<NumberValue> for NumberModifiersMult {
+    fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
@@ -22046,7 +33651,7 @@ impl From<Box<NumberValue>> for NumberModifiersMult {
 #[serde(untagged)]
 pub enum NumberModifiersOffset {
     Variant0(f64),
-    Variant1(Box<NumberValue>),
+    Variant1(NumberValue),
 }
 impl From<&NumberModifiersOffset> for NumberModifiersOffset {
     fn from(value: &NumberModifiersOffset) -> Self {
@@ -22058,8 +33663,8 @@ impl From<f64> for NumberModifiersOffset {
         Self::Variant0(value)
     }
 }
-impl From<Box<NumberValue>> for NumberModifiersOffset {
-    fn from(value: Box<NumberValue>) -> Self {
+impl From<NumberValue> for NumberModifiersOffset {
+    fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
@@ -22089,10 +33694,14 @@ impl From<SignalRef> for NumberOrSignal {
 pub enum NumberValue {
     Variant0(Vec<NumberValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: NumberModifiers,
-        #[serde(flatten)]
-        subtype_1: NumberValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<NumberValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<NumberValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<NumberValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<NumberValueVariant1Subtype3>,
     },
 }
 impl From<&NumberValue> for NumberValue {
@@ -22107,10 +33716,14 @@ impl From<Vec<NumberValueVariant0Item>> for NumberValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NumberValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: NumberValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<NumberValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<NumberValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<NumberValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<NumberValueVariant0ItemSubtype3>,
 }
 impl From<&NumberValueVariant0Item> for NumberValueVariant0Item {
     fn from(value: &NumberValueVariant0Item) -> Self {
@@ -22118,73 +33731,104 @@ impl From<&NumberValueVariant0Item> for NumberValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: NumberModifiers,
-    #[serde(flatten)]
-    pub subtype_1: NumberValueVariant0ItemSubtype1Subtype1,
-}
-impl From<&NumberValueVariant0ItemSubtype1> for NumberValueVariant0ItemSubtype1 {
-    fn from(value: &NumberValueVariant0ItemSubtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<NumberValueVariant0ItemSubtype1Subtype1Subtype3>,
-}
-impl From<&NumberValueVariant0ItemSubtype1Subtype1> for NumberValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum NumberValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant0ItemSubtype0Variant0Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant0ItemSubtype0Variant0Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant0ItemSubtype0Variant0Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant0ItemSubtype0Variant0Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant0ItemSubtype0Variant1Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant0ItemSubtype0Variant1Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant0ItemSubtype0Variant1Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant0ItemSubtype0Variant1Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
         value: f64,
     },
     Variant2 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant0ItemSubtype0Variant2Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant0ItemSubtype0Variant2Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant0ItemSubtype0Variant2Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant0ItemSubtype0Variant2Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
     },
     Variant3 {
-        range: NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant0ItemSubtype0Variant3Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant0ItemSubtype0Variant3Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant0ItemSubtype0Variant3Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant0ItemSubtype0Variant3Offset>,
+        range: NumberValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
     },
 }
-impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype0>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&NumberValueVariant0ItemSubtype0> for NumberValueVariant0ItemSubtype0 {
+    fn from(value: &NumberValueVariant0ItemSubtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for NumberValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum NumberValueVariant0ItemSubtype0Variant0Band {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&NumberValueVariant0ItemSubtype0Variant0Band>
+    for NumberValueVariant0ItemSubtype0Variant0Band
 {
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant0Band) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant0Band {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -22196,29 +33840,25 @@ impl std::str::FromStr for NumberValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant0Band {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant0Band {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant0Band {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for NumberValueVariant0ItemSubtype0Variant0Band {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -22226,53 +33866,1625 @@ impl ToString for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant0Band {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for NumberValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for NumberValueVariant0ItemSubtype0Variant0Band {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype1>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype1
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant0Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant0Exponent>
+    for NumberValueVariant0ItemSubtype0Variant0Exponent
 {
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant0Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant0Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant0Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant0Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant0Mult>
+    for NumberValueVariant0ItemSubtype0Variant0Mult
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant0Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant0Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant0Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant0Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant0Offset>
+    for NumberValueVariant0ItemSubtype0Variant0Offset
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant0Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant0Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant0Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant1Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant1Band>
+    for NumberValueVariant0ItemSubtype0Variant1Band
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant1Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant1Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype0Variant1Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant1Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype0Variant1Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant1Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant1Exponent>
+    for NumberValueVariant0ItemSubtype0Variant1Exponent
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant1Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant1Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant1Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant1Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant1Mult>
+    for NumberValueVariant0ItemSubtype0Variant1Mult
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant1Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant1Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant1Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant1Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant1Offset>
+    for NumberValueVariant0ItemSubtype0Variant1Offset
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant1Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant1Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant2Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant2Band>
+    for NumberValueVariant0ItemSubtype0Variant2Band
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant2Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant2Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype0Variant2Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant2Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype0Variant2Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant2Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant2Exponent>
+    for NumberValueVariant0ItemSubtype0Variant2Exponent
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant2Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant2Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant2Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant2Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant2Mult>
+    for NumberValueVariant0ItemSubtype0Variant2Mult
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant2Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant2Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant2Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant2Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant2Offset>
+    for NumberValueVariant0ItemSubtype0Variant2Offset
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant2Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant2Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant2Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant3Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant3Band>
+    for NumberValueVariant0ItemSubtype0Variant3Band
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant3Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant3Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype0Variant3Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant3Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype0Variant3Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant3Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant3Exponent>
+    for NumberValueVariant0ItemSubtype0Variant3Exponent
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant3Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant3Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant3Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant3Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant3Mult>
+    for NumberValueVariant0ItemSubtype0Variant3Mult
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant3Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant3Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant3Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant3Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant3Offset>
+    for NumberValueVariant0ItemSubtype0Variant3Offset
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant3Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant3Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype0Variant3Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype0Variant3Range>
+    for NumberValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &NumberValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NumberValueVariant0ItemSubtype1 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub band: Option<NumberValueVariant0ItemSubtype1Band>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant0ItemSubtype1Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant0ItemSubtype1Mult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<NumberValueVariant0ItemSubtype1Offset>,
+    #[serde(default)]
+    pub round: bool,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&NumberValueVariant0ItemSubtype1> for NumberValueVariant0ItemSubtype1 {
+    fn from(value: &NumberValueVariant0ItemSubtype1) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype2>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype1Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype1Band> for NumberValueVariant0ItemSubtype1Band {
+    fn from(value: &NumberValueVariant0ItemSubtype1Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype1Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype1Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype1Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype1Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype1Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype1Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype1Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype1Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype1Exponent> for NumberValueVariant0ItemSubtype1Exponent {
+    fn from(value: &NumberValueVariant0ItemSubtype1Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype1Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype1Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype1Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype1Mult> for NumberValueVariant0ItemSubtype1Mult {
+    fn from(value: &NumberValueVariant0ItemSubtype1Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype1Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype1Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype1Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype1Offset> for NumberValueVariant0ItemSubtype1Offset {
+    fn from(value: &NumberValueVariant0ItemSubtype1Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype1Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NumberValueVariant0ItemSubtype2 {
+    pub band: NumberValueVariant0ItemSubtype2Band,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant0ItemSubtype2Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant0ItemSubtype2Mult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<NumberValueVariant0ItemSubtype2Offset>,
+    #[serde(default)]
+    pub round: bool,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&NumberValueVariant0ItemSubtype2> for NumberValueVariant0ItemSubtype2 {
+    fn from(value: &NumberValueVariant0ItemSubtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&NumberValueVariant0ItemSubtype1Subtype1Subtype3>
-    for NumberValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &NumberValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype2Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype2Band> for NumberValueVariant0ItemSubtype2Band {
+    fn from(value: &NumberValueVariant0ItemSubtype2Band) -> Self {
         value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype2Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype2Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype2Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype2Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype2Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype2Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype2Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype2Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype2Exponent> for NumberValueVariant0ItemSubtype2Exponent {
+    fn from(value: &NumberValueVariant0ItemSubtype2Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype2Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype2Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype2Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype2Mult> for NumberValueVariant0ItemSubtype2Mult {
+    fn from(value: &NumberValueVariant0ItemSubtype2Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype2Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype2Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype2Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype2Offset> for NumberValueVariant0ItemSubtype2Offset {
+    fn from(value: &NumberValueVariant0ItemSubtype2Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype2Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype2Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NumberValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub band: Option<NumberValueVariant0ItemSubtype3Band>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant0ItemSubtype3Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant0ItemSubtype3Mult>,
+    pub offset: NumberValueVariant0ItemSubtype3Offset,
+    #[serde(default)]
+    pub round: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&NumberValueVariant0ItemSubtype3> for NumberValueVariant0ItemSubtype3 {
+    fn from(value: &NumberValueVariant0ItemSubtype3) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype3Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant0ItemSubtype3Band> for NumberValueVariant0ItemSubtype3Band {
+    fn from(value: &NumberValueVariant0ItemSubtype3Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant0ItemSubtype3Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype3Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype3Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype3Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant0ItemSubtype3Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype3Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant0ItemSubtype3Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype3Exponent {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype3Exponent> for NumberValueVariant0ItemSubtype3Exponent {
+    fn from(value: &NumberValueVariant0ItemSubtype3Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype3Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype3Exponent {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype3Mult {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype3Mult> for NumberValueVariant0ItemSubtype3Mult {
+    fn from(value: &NumberValueVariant0ItemSubtype3Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype3Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype3Mult {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant0ItemSubtype3Offset {
+    Variant0(f64),
+    Variant1(NumberValue),
+}
+impl From<&NumberValueVariant0ItemSubtype3Offset> for NumberValueVariant0ItemSubtype3Offset {
+    fn from(value: &NumberValueVariant0ItemSubtype3Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant0ItemSubtype3Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<NumberValue> for NumberValueVariant0ItemSubtype3Offset {
+    fn from(value: NumberValue) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant1Subtype0Variant0Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant1Subtype0Variant0Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant1Subtype0Variant0Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant1Subtype0Variant0Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant1Subtype0Variant1Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant1Subtype0Variant1Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant1Subtype0Variant1Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant1Subtype0Variant1Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: f64,
+    },
+    Variant2 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant1Subtype0Variant2Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant1Subtype0Variant2Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant1Subtype0Variant2Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant1Subtype0Variant2Offset>,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+    },
+    Variant3 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        band: Option<NumberValueVariant1Subtype0Variant3Band>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exponent: Option<NumberValueVariant1Subtype0Variant3Exponent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mult: Option<NumberValueVariant1Subtype0Variant3Mult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<NumberValueVariant1Subtype0Variant3Offset>,
+        range: NumberValueVariant1Subtype0Variant3Range,
+        #[serde(default)]
+        round: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+    },
+}
+impl From<&NumberValueVariant1Subtype0> for NumberValueVariant1Subtype0 {
+    fn from(value: &NumberValueVariant1Subtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant0Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype0Variant0Band> for NumberValueVariant1Subtype0Variant0Band {
+    fn from(value: &NumberValueVariant1Subtype0Variant0Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype0Variant0Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant0Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant0Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant0Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype0Variant0Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant0Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype0Variant0Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant0Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant0Exponent>
+    for NumberValueVariant1Subtype0Variant0Exponent
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant0Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant0Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant0Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant0Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant0Mult> for NumberValueVariant1Subtype0Variant0Mult {
+    fn from(value: &NumberValueVariant1Subtype0Variant0Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant0Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant0Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant0Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant0Offset>
+    for NumberValueVariant1Subtype0Variant0Offset
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant0Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant0Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant0Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant1Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype0Variant1Band> for NumberValueVariant1Subtype0Variant1Band {
+    fn from(value: &NumberValueVariant1Subtype0Variant1Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype0Variant1Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant1Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype0Variant1Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant1Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype0Variant1Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant1Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant1Exponent>
+    for NumberValueVariant1Subtype0Variant1Exponent
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant1Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant1Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant1Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant1Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant1Mult> for NumberValueVariant1Subtype0Variant1Mult {
+    fn from(value: &NumberValueVariant1Subtype0Variant1Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant1Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant1Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant1Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant1Offset>
+    for NumberValueVariant1Subtype0Variant1Offset
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant1Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant1Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant2Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype0Variant2Band> for NumberValueVariant1Subtype0Variant2Band {
+    fn from(value: &NumberValueVariant1Subtype0Variant2Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype0Variant2Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant2Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype0Variant2Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant2Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype0Variant2Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant2Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant2Exponent>
+    for NumberValueVariant1Subtype0Variant2Exponent
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant2Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant2Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant2Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant2Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant2Mult> for NumberValueVariant1Subtype0Variant2Mult {
+    fn from(value: &NumberValueVariant1Subtype0Variant2Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant2Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant2Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant2Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant2Offset>
+    for NumberValueVariant1Subtype0Variant2Offset
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant2Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant2Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant2Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant3Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype0Variant3Band> for NumberValueVariant1Subtype0Variant3Band {
+    fn from(value: &NumberValueVariant1Subtype0Variant3Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype0Variant3Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant3Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype0Variant3Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant3Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype0Variant3Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant3Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant3Exponent>
+    for NumberValueVariant1Subtype0Variant3Exponent
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant3Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant3Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant3Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant3Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant3Mult> for NumberValueVariant1Subtype0Variant3Mult {
+    fn from(value: &NumberValueVariant1Subtype0Variant3Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant3Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant3Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant3Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype0Variant3Offset>
+    for NumberValueVariant1Subtype0Variant3Offset
+{
+    fn from(value: &NumberValueVariant1Subtype0Variant3Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant3Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype0Variant3Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype0Variant3Range> for NumberValueVariant1Subtype0Variant3Range {
+    fn from(value: &NumberValueVariant1Subtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NumberValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<NumberValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<NumberValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<NumberValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<NumberValueVariant1Subtype1Subtype3>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub band: Option<NumberValueVariant1Subtype1Band>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant1Subtype1Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant1Subtype1Mult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<NumberValueVariant1Subtype1Offset>,
+    #[serde(default)]
+    pub round: bool,
+    pub scale: Field,
 }
 impl From<&NumberValueVariant1Subtype1> for NumberValueVariant1Subtype1 {
     fn from(value: &NumberValueVariant1Subtype1) -> Self {
@@ -22281,42 +35493,16 @@ impl From<&NumberValueVariant1Subtype1> for NumberValueVariant1Subtype1 {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum NumberValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: f64,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: NumberValueVariant1Subtype1Subtype0Variant3Range,
-    },
-}
-impl From<&NumberValueVariant1Subtype1Subtype0> for NumberValueVariant1Subtype1Subtype0 {
-    fn from(value: &NumberValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for NumberValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum NumberValueVariant1Subtype1Subtype0Variant3Range {
+pub enum NumberValueVariant1Subtype1Band {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&NumberValueVariant1Subtype1Subtype0Variant3Range>
-    for NumberValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &NumberValueVariant1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&NumberValueVariant1Subtype1Band> for NumberValueVariant1Subtype1Band {
+    fn from(value: &NumberValueVariant1Subtype1Band) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for NumberValueVariant1Subtype1Band {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -22328,25 +35514,25 @@ impl std::str::FromStr for NumberValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype1Band {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype1Band {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype1Band {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl ToString for NumberValueVariant1Subtype1Band {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -22354,35 +35540,362 @@ impl ToString for NumberValueVariant1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl From<f64> for NumberValueVariant1Subtype1Band {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for NumberValueVariant1Subtype1Subtype0Variant3Range {
+impl From<bool> for NumberValueVariant1Subtype1Band {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant1Subtype1Subtype1 {}
-impl From<&NumberValueVariant1Subtype1Subtype1> for NumberValueVariant1Subtype1Subtype1 {
-    fn from(value: &NumberValueVariant1Subtype1Subtype1) -> Self {
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype1Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype1Exponent> for NumberValueVariant1Subtype1Exponent {
+    fn from(value: &NumberValueVariant1Subtype1Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype1Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype1Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype1Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype1Mult> for NumberValueVariant1Subtype1Mult {
+    fn from(value: &NumberValueVariant1Subtype1Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype1Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype1Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype1Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype1Offset> for NumberValueVariant1Subtype1Offset {
+    fn from(value: &NumberValueVariant1Subtype1Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype1Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype1Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NumberValueVariant1Subtype2 {
+    pub band: NumberValueVariant1Subtype2Band,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant1Subtype2Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant1Subtype2Mult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<NumberValueVariant1Subtype2Offset>,
+    #[serde(default)]
+    pub round: bool,
+    pub scale: Field,
+}
+impl From<&NumberValueVariant1Subtype2> for NumberValueVariant1Subtype2 {
+    fn from(value: &NumberValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant1Subtype1Subtype2 {}
-impl From<&NumberValueVariant1Subtype1Subtype2> for NumberValueVariant1Subtype1Subtype2 {
-    fn from(value: &NumberValueVariant1Subtype1Subtype2) -> Self {
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype2Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype2Band> for NumberValueVariant1Subtype2Band {
+    fn from(value: &NumberValueVariant1Subtype2Band) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype2Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype2Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype2Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype2Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype2Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype2Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype2Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype2Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype2Exponent> for NumberValueVariant1Subtype2Exponent {
+    fn from(value: &NumberValueVariant1Subtype2Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype2Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype2Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype2Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype2Mult> for NumberValueVariant1Subtype2Mult {
+    fn from(value: &NumberValueVariant1Subtype2Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype2Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype2Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype2Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype2Offset> for NumberValueVariant1Subtype2Offset {
+    fn from(value: &NumberValueVariant1Subtype2Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype2Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype2Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NumberValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub band: Option<NumberValueVariant1Subtype3Band>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exponent: Option<NumberValueVariant1Subtype3Exponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mult: Option<NumberValueVariant1Subtype3Mult>,
+    pub offset: NumberValueVariant1Subtype3Offset,
+    #[serde(default)]
+    pub round: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+}
+impl From<&NumberValueVariant1Subtype3> for NumberValueVariant1Subtype3 {
+    fn from(value: &NumberValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NumberValueVariant1Subtype1Subtype3 {}
-impl From<&NumberValueVariant1Subtype1Subtype3> for NumberValueVariant1Subtype1Subtype3 {
-    fn from(value: &NumberValueVariant1Subtype1Subtype3) -> Self {
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype3Band {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&NumberValueVariant1Subtype3Band> for NumberValueVariant1Subtype3Band {
+    fn from(value: &NumberValueVariant1Subtype3Band) -> Self {
         value.clone()
+    }
+}
+impl std::str::FromStr for NumberValueVariant1Subtype3Band {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype3Band {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype3Band {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NumberValueVariant1Subtype3Band {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for NumberValueVariant1Subtype3Band {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype3Band {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for NumberValueVariant1Subtype3Band {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype3Exponent {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype3Exponent> for NumberValueVariant1Subtype3Exponent {
+    fn from(value: &NumberValueVariant1Subtype3Exponent) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype3Exponent {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype3Exponent {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype3Mult {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype3Mult> for NumberValueVariant1Subtype3Mult {
+    fn from(value: &NumberValueVariant1Subtype3Mult) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype3Mult {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype3Mult {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NumberValueVariant1Subtype3Offset {
+    Variant0(f64),
+    Variant1(Box<NumberValue>),
+}
+impl From<&NumberValueVariant1Subtype3Offset> for NumberValueVariant1Subtype3Offset {
+    fn from(value: &NumberValueVariant1Subtype3Offset) -> Self {
+        value.clone()
+    }
+}
+impl From<f64> for NumberValueVariant1Subtype3Offset {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Box<NumberValue>> for NumberValueVariant1Subtype3Offset {
+    fn from(value: Box<NumberValue>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22409,11 +35922,20 @@ impl From<Vec<OnEventsItem>> for OnEvents {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OnEventsItem {
-    #[serde(flatten)]
-    pub subtype_0: OnEventsItemSubtype0,
-    #[serde(flatten)]
-    pub subtype_1: OnEventsItemSubtype1,
+#[serde(untagged)]
+pub enum OnEventsItem {
+    Variant0 {
+        encode: String,
+        events: OnEventsItemVariant0Events,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        force: Option<bool>,
+    },
+    Variant1 {
+        events: OnEventsItemVariant1Events,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        force: Option<bool>,
+        update: OnEventsItemVariant1Update,
+    },
 }
 impl From<&OnEventsItem> for OnEventsItem {
     fn from(value: &OnEventsItem) -> Self {
@@ -22421,84 +35943,83 @@ impl From<&OnEventsItem> for OnEventsItem {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OnEventsItemSubtype0 {
-    pub events: OnEventsItemSubtype0Events,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub force: Option<bool>,
-}
-impl From<&OnEventsItemSubtype0> for OnEventsItemSubtype0 {
-    fn from(value: &OnEventsItemSubtype0) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum OnEventsItemSubtype0Events {
+pub enum OnEventsItemVariant0Events {
     Variant0(Selector),
     Variant1(Listener),
     Variant2(Vec<Listener>),
 }
-impl From<&OnEventsItemSubtype0Events> for OnEventsItemSubtype0Events {
-    fn from(value: &OnEventsItemSubtype0Events) -> Self {
+impl From<&OnEventsItemVariant0Events> for OnEventsItemVariant0Events {
+    fn from(value: &OnEventsItemVariant0Events) -> Self {
         value.clone()
     }
 }
-impl From<Selector> for OnEventsItemSubtype0Events {
+impl From<Selector> for OnEventsItemVariant0Events {
     fn from(value: Selector) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<Listener> for OnEventsItemSubtype0Events {
+impl From<Listener> for OnEventsItemVariant0Events {
     fn from(value: Listener) -> Self {
         Self::Variant1(value)
     }
 }
-impl From<Vec<Listener>> for OnEventsItemSubtype0Events {
+impl From<Vec<Listener>> for OnEventsItemVariant0Events {
     fn from(value: Vec<Listener>) -> Self {
         Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum OnEventsItemSubtype1 {
-    #[serde(rename = "encode")]
-    Encode(String),
-    #[serde(rename = "update")]
-    Update(OnEventsItemSubtype1Update),
+#[serde(untagged)]
+pub enum OnEventsItemVariant1Events {
+    Variant0(Selector),
+    Variant1(Listener),
+    Variant2(Vec<Listener>),
 }
-impl From<&OnEventsItemSubtype1> for OnEventsItemSubtype1 {
-    fn from(value: &OnEventsItemSubtype1) -> Self {
+impl From<&OnEventsItemVariant1Events> for OnEventsItemVariant1Events {
+    fn from(value: &OnEventsItemVariant1Events) -> Self {
         value.clone()
     }
 }
-impl From<OnEventsItemSubtype1Update> for OnEventsItemSubtype1 {
-    fn from(value: OnEventsItemSubtype1Update) -> Self {
-        Self::Update(value)
+impl From<Selector> for OnEventsItemVariant1Events {
+    fn from(value: Selector) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Listener> for OnEventsItemVariant1Events {
+    fn from(value: Listener) -> Self {
+        Self::Variant1(value)
+    }
+}
+impl From<Vec<Listener>> for OnEventsItemVariant1Events {
+    fn from(value: Vec<Listener>) -> Self {
+        Self::Variant2(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum OnEventsItemSubtype1Update {
+pub enum OnEventsItemVariant1Update {
     Variant0(ExprString),
     Variant1(Expr),
     Variant2(SignalRef),
     Variant3 { value: serde_json::Value },
 }
-impl From<&OnEventsItemSubtype1Update> for OnEventsItemSubtype1Update {
-    fn from(value: &OnEventsItemSubtype1Update) -> Self {
+impl From<&OnEventsItemVariant1Update> for OnEventsItemVariant1Update {
+    fn from(value: &OnEventsItemVariant1Update) -> Self {
         value.clone()
     }
 }
-impl From<ExprString> for OnEventsItemSubtype1Update {
+impl From<ExprString> for OnEventsItemVariant1Update {
     fn from(value: ExprString) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<Expr> for OnEventsItemSubtype1Update {
+impl From<Expr> for OnEventsItemVariant1Update {
     fn from(value: Expr) -> Self {
         Self::Variant1(value)
     }
 }
-impl From<SignalRef> for OnEventsItemSubtype1Update {
+impl From<SignalRef> for OnEventsItemVariant1Update {
     fn from(value: SignalRef) -> Self {
         Self::Variant2(value)
     }
@@ -22647,10 +36168,14 @@ impl From<ExprString> for OnTriggerItemRemove {
 pub enum OrientValue {
     Variant0(Vec<OrientValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: OrientValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<OrientValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<OrientValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<OrientValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<OrientValueVariant1Subtype3>,
     },
 }
 impl From<&OrientValue> for OrientValue {
@@ -22665,10 +36190,14 @@ impl From<Vec<OrientValueVariant0Item>> for OrientValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: OrientValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<OrientValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<OrientValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<OrientValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<OrientValueVariant0ItemSubtype3>,
 }
 impl From<&OrientValueVariant0Item> for OrientValueVariant0Item {
     fn from(value: &OrientValueVariant0Item) -> Self {
@@ -22676,11 +36205,166 @@ impl From<&OrientValueVariant0Item> for OrientValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OrientValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: OrientValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: OrientValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&OrientValueVariant0ItemSubtype0> for OrientValueVariant0ItemSubtype0 {
+    fn from(value: &OrientValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum OrientValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "top")]
+    Top,
+    #[serde(rename = "bottom")]
+    Bottom,
+}
+impl From<&OrientValueVariant0ItemSubtype0Variant1Value>
+    for OrientValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &OrientValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for OrientValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Left => "left".to_string(),
+            Self::Right => "right".to_string(),
+            Self::Top => "top".to_string(),
+            Self::Bottom => "bottom".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for OrientValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "top" => Ok(Self::Top),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrientValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for OrientValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OrientValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&OrientValueVariant0ItemSubtype0Variant3Range>
+    for OrientValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &OrientValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for OrientValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for OrientValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for OrientValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for OrientValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for OrientValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for OrientValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: OrientValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&OrientValueVariant0ItemSubtype1> for OrientValueVariant0ItemSubtype1 {
     fn from(value: &OrientValueVariant0ItemSubtype1) -> Self {
@@ -22688,49 +36372,59 @@ impl From<&OrientValueVariant0ItemSubtype1> for OrientValueVariant0ItemSubtype1 
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<OrientValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct OrientValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&OrientValueVariant0ItemSubtype1Subtype1> for OrientValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&OrientValueVariant0ItemSubtype2> for OrientValueVariant0ItemSubtype2 {
+    fn from(value: &OrientValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OrientValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&OrientValueVariant0ItemSubtype3> for OrientValueVariant0ItemSubtype3 {
+    fn from(value: &OrientValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum OrientValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: OrientValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: OrientValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype0>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&OrientValueVariant1Subtype0> for OrientValueVariant1Subtype0 {
+    fn from(value: &OrientValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for OrientValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum OrientValueVariant1Subtype0Variant1Value {
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -22740,14 +36434,12 @@ pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "bottom")]
     Bottom,
 }
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+impl From<&OrientValueVariant1Subtype0Variant1Value> for OrientValueVariant1Subtype0Variant1Value {
+    fn from(value: &OrientValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for OrientValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Left => "left".to_string(),
@@ -22757,7 +36449,7 @@ impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
         }
     }
 }
-impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for OrientValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -22769,23 +36461,19 @@ impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for OrientValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -22793,18 +36481,16 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum OrientValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&OrientValueVariant1Subtype0Variant3Range> for OrientValueVariant1Subtype0Variant3Range {
+    fn from(value: &OrientValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for OrientValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -22816,29 +36502,25 @@ impl std::str::FromStr for OrientValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for OrientValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for OrientValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -22846,53 +36528,19 @@ impl ToString for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for OrientValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for OrientValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for OrientValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype1>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype2>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&OrientValueVariant0ItemSubtype1Subtype1Subtype3>
-    for OrientValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &OrientValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrientValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<OrientValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<OrientValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<OrientValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<OrientValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&OrientValueVariant1Subtype1> for OrientValueVariant1Subtype1 {
     fn from(value: &OrientValueVariant1Subtype1) -> Self {
@@ -22900,166 +36548,21 @@ impl From<&OrientValueVariant1Subtype1> for OrientValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum OrientValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: OrientValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: OrientValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct OrientValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&OrientValueVariant1Subtype1Subtype0> for OrientValueVariant1Subtype1Subtype0 {
-    fn from(value: &OrientValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for OrientValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum OrientValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "left")]
-    Left,
-    #[serde(rename = "right")]
-    Right,
-    #[serde(rename = "top")]
-    Top,
-    #[serde(rename = "bottom")]
-    Bottom,
-}
-impl From<&OrientValueVariant1Subtype1Subtype0Variant1Value>
-    for OrientValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &OrientValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "left" => Ok(Self::Left),
-            "right" => Ok(Self::Right),
-            "top" => Ok(Self::Top),
-            "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for OrientValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum OrientValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&OrientValueVariant1Subtype1Subtype0Variant3Range>
-    for OrientValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &OrientValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for OrientValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant1Subtype1Subtype1 {}
-impl From<&OrientValueVariant1Subtype1Subtype1> for OrientValueVariant1Subtype1Subtype1 {
-    fn from(value: &OrientValueVariant1Subtype1Subtype1) -> Self {
+impl From<&OrientValueVariant1Subtype2> for OrientValueVariant1Subtype2 {
+    fn from(value: &OrientValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant1Subtype1Subtype2 {}
-impl From<&OrientValueVariant1Subtype1Subtype2> for OrientValueVariant1Subtype1Subtype2 {
-    fn from(value: &OrientValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct OrientValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct OrientValueVariant1Subtype1Subtype3 {}
-impl From<&OrientValueVariant1Subtype1Subtype3> for OrientValueVariant1Subtype1Subtype3 {
-    fn from(value: &OrientValueVariant1Subtype1Subtype3) -> Self {
+impl From<&OrientValueVariant1Subtype3> for OrientValueVariant1Subtype3 {
+    fn from(value: &OrientValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -31400,11 +44903,62 @@ impl std::convert::TryFrom<String> for StratifyTransformType {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Stream {
-    #[serde(flatten)]
-    pub subtype_0: StreamSubtype0,
-    #[serde(flatten)]
-    pub subtype_1: StreamSubtype1,
+#[serde(untagged)]
+pub enum Stream {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        between: Option<[Box<Stream>; 2usize]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        consume: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        debounce: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<StreamVariant0Filter>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        markname: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        marktype: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        throttle: Option<f64>,
+        #[serde(rename = "type")]
+        type_: String,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        between: Option<[Box<Stream>; 2usize]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        consume: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        debounce: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<StreamVariant1Filter>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        markname: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        marktype: Option<String>,
+        stream: Box<Stream>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        throttle: Option<f64>,
+    },
+    Variant2 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        between: Option<[Box<Stream>; 2usize]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        consume: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        debounce: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<StreamVariant2Filter>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        markname: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        marktype: Option<String>,
+        merge: Vec<Stream>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        throttle: Option<f64>,
+    },
 }
 impl From<&Stream> for Stream {
     fn from(value: &Stream) -> Self {
@@ -31412,67 +44966,66 @@ impl From<&Stream> for Stream {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StreamSubtype0 {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub between: Option<[Box<Stream>; 2usize]>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub consume: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub debounce: Option<f64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub filter: Option<StreamSubtype0Filter>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub markname: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub marktype: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub throttle: Option<f64>,
-}
-impl From<&StreamSubtype0> for StreamSubtype0 {
-    fn from(value: &StreamSubtype0) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StreamSubtype0Filter {
+pub enum StreamVariant0Filter {
     Variant0(ExprString),
     Variant1(Vec<ExprString>),
 }
-impl From<&StreamSubtype0Filter> for StreamSubtype0Filter {
-    fn from(value: &StreamSubtype0Filter) -> Self {
+impl From<&StreamVariant0Filter> for StreamVariant0Filter {
+    fn from(value: &StreamVariant0Filter) -> Self {
         value.clone()
     }
 }
-impl From<ExprString> for StreamSubtype0Filter {
+impl From<ExprString> for StreamVariant0Filter {
     fn from(value: ExprString) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<Vec<ExprString>> for StreamSubtype0Filter {
+impl From<Vec<ExprString>> for StreamVariant0Filter {
     fn from(value: Vec<ExprString>) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StreamSubtype1 {
-    Variant0 {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        source: Option<String>,
-        #[serde(rename = "type")]
-        type_: String,
-    },
-    Variant1 {
-        stream: Box<Stream>,
-    },
-    Variant2 {
-        merge: Vec<Stream>,
-    },
+pub enum StreamVariant1Filter {
+    Variant0(ExprString),
+    Variant1(Vec<ExprString>),
 }
-impl From<&StreamSubtype1> for StreamSubtype1 {
-    fn from(value: &StreamSubtype1) -> Self {
+impl From<&StreamVariant1Filter> for StreamVariant1Filter {
+    fn from(value: &StreamVariant1Filter) -> Self {
         value.clone()
+    }
+}
+impl From<ExprString> for StreamVariant1Filter {
+    fn from(value: ExprString) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ExprString>> for StreamVariant1Filter {
+    fn from(value: Vec<ExprString>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StreamVariant2Filter {
+    Variant0(ExprString),
+    Variant1(Vec<ExprString>),
+}
+impl From<&StreamVariant2Filter> for StreamVariant2Filter {
+    fn from(value: &StreamVariant2Filter) -> Self {
+        value.clone()
+    }
+}
+impl From<ExprString> for StreamVariant2Filter {
+    fn from(value: ExprString) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<Vec<ExprString>> for StreamVariant2Filter {
+    fn from(value: Vec<ExprString>) -> Self {
+        Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -31506,10 +45059,14 @@ impl From<SignalRef> for StringOrSignal {
 pub enum StringValue {
     Variant0(Vec<StringValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: StringValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<StringValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<StringValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<StringValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<StringValueVariant1Subtype3>,
     },
 }
 impl From<&StringValue> for StringValue {
@@ -31524,10 +45081,14 @@ impl From<Vec<StringValueVariant0Item>> for StringValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StringValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: StringValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<StringValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<StringValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<StringValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<StringValueVariant0ItemSubtype3>,
 }
 impl From<&StringValueVariant0Item> for StringValueVariant0Item {
     fn from(value: &StringValueVariant0Item) -> Self {
@@ -31535,11 +45096,108 @@ impl From<&StringValueVariant0Item> for StringValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StringValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: String,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: StringValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&StringValueVariant0ItemSubtype0> for StringValueVariant0ItemSubtype0 {
+    fn from(value: &StringValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StringValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&StringValueVariant0ItemSubtype0Variant3Range>
+    for StringValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &StringValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for StringValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for StringValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StringValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for StringValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for StringValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for StringValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StringValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StringValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StringValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&StringValueVariant0ItemSubtype1> for StringValueVariant0ItemSubtype1 {
     fn from(value: &StringValueVariant0ItemSubtype1) -> Self {
@@ -31547,61 +45205,69 @@ impl From<&StringValueVariant0ItemSubtype1> for StringValueVariant0ItemSubtype1 
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StringValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StringValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StringValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StringValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct StringValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&StringValueVariant0ItemSubtype1Subtype1> for StringValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&StringValueVariant0ItemSubtype2> for StringValueVariant0ItemSubtype2 {
+    fn from(value: &StringValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StringValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&StringValueVariant0ItemSubtype3> for StringValueVariant0ItemSubtype3 {
+    fn from(value: &StringValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum StringValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
         value: String,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: StringValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype0>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&StringValueVariant1Subtype0> for StringValueVariant1Subtype0 {
+    fn from(value: &StringValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for StringValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum StringValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&StringValueVariant1Subtype0Variant3Range> for StringValueVariant1Subtype0Variant3Range {
+    fn from(value: &StringValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for StringValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -31613,29 +45279,25 @@ impl std::str::FromStr for StringValueVariant0ItemSubtype1Subtype1Subtype0Varian
         }
     }
 }
-impl std::convert::TryFrom<&str> for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for StringValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for StringValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for StringValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for StringValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -31643,53 +45305,19 @@ impl ToString for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for StringValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for StringValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for StringValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype1>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype2>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&StringValueVariant0ItemSubtype1Subtype1Subtype3>
-    for StringValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &StringValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StringValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StringValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StringValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StringValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StringValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&StringValueVariant1Subtype1> for StringValueVariant1Subtype1 {
     fn from(value: &StringValueVariant1Subtype1) -> Self {
@@ -31697,108 +45325,21 @@ impl From<&StringValueVariant1Subtype1> for StringValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StringValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: String,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: StringValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct StringValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&StringValueVariant1Subtype1Subtype0> for StringValueVariant1Subtype1Subtype0 {
-    fn from(value: &StringValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for StringValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StringValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&StringValueVariant1Subtype1Subtype0Variant3Range>
-    for StringValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &StringValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for StringValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for StringValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for StringValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for StringValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for StringValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for StringValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for StringValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant1Subtype1Subtype1 {}
-impl From<&StringValueVariant1Subtype1Subtype1> for StringValueVariant1Subtype1Subtype1 {
-    fn from(value: &StringValueVariant1Subtype1Subtype1) -> Self {
+impl From<&StringValueVariant1Subtype2> for StringValueVariant1Subtype2 {
+    fn from(value: &StringValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant1Subtype1Subtype2 {}
-impl From<&StringValueVariant1Subtype1Subtype2> for StringValueVariant1Subtype1Subtype2 {
-    fn from(value: &StringValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct StringValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StringValueVariant1Subtype1Subtype3 {}
-impl From<&StringValueVariant1Subtype1Subtype3> for StringValueVariant1Subtype1Subtype3 {
-    fn from(value: &StringValueVariant1Subtype1Subtype3) -> Self {
+impl From<&StringValueVariant1Subtype3> for StringValueVariant1Subtype3 {
+    fn from(value: &StringValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -31807,10 +45348,14 @@ impl From<&StringValueVariant1Subtype1Subtype3> for StringValueVariant1Subtype1S
 pub enum StrokeCapValue {
     Variant0(Vec<StrokeCapValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: StrokeCapValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<StrokeCapValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<StrokeCapValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<StrokeCapValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<StrokeCapValueVariant1Subtype3>,
     },
 }
 impl From<&StrokeCapValue> for StrokeCapValue {
@@ -31825,10 +45370,14 @@ impl From<Vec<StrokeCapValueVariant0Item>> for StrokeCapValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: StrokeCapValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<StrokeCapValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<StrokeCapValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<StrokeCapValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<StrokeCapValueVariant0ItemSubtype3>,
 }
 impl From<&StrokeCapValueVariant0Item> for StrokeCapValueVariant0Item {
     fn from(value: &StrokeCapValueVariant0Item) -> Self {
@@ -31836,11 +45385,162 @@ impl From<&StrokeCapValueVariant0Item> for StrokeCapValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StrokeCapValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: StrokeCapValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: StrokeCapValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&StrokeCapValueVariant0ItemSubtype0> for StrokeCapValueVariant0ItemSubtype0 {
+    fn from(value: &StrokeCapValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "butt")]
+    Butt,
+    #[serde(rename = "round")]
+    Round,
+    #[serde(rename = "square")]
+    Square,
+}
+impl From<&StrokeCapValueVariant0ItemSubtype0Variant1Value>
+    for StrokeCapValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &StrokeCapValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Butt => "butt".to_string(),
+            Self::Round => "round".to_string(),
+            Self::Square => "square".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "butt" => Ok(Self::Butt),
+            "round" => Ok(Self::Round),
+            "square" => Ok(Self::Square),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&StrokeCapValueVariant0ItemSubtype0Variant3Range>
+    for StrokeCapValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &StrokeCapValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StrokeCapValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&StrokeCapValueVariant0ItemSubtype1> for StrokeCapValueVariant0ItemSubtype1 {
     fn from(value: &StrokeCapValueVariant0ItemSubtype1) -> Self {
@@ -31848,51 +45548,59 @@ impl From<&StrokeCapValueVariant0ItemSubtype1> for StrokeCapValueVariant0ItemSub
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct StrokeCapValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1
-{
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&StrokeCapValueVariant0ItemSubtype2> for StrokeCapValueVariant0ItemSubtype2 {
+    fn from(value: &StrokeCapValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StrokeCapValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&StrokeCapValueVariant0ItemSubtype3> for StrokeCapValueVariant0ItemSubtype3 {
+    fn from(value: &StrokeCapValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum StrokeCapValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: StrokeCapValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: StrokeCapValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&StrokeCapValueVariant1Subtype0> for StrokeCapValueVariant1Subtype0 {
+    fn from(value: &StrokeCapValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum StrokeCapValueVariant1Subtype0Variant1Value {
     #[serde(rename = "butt")]
     Butt,
     #[serde(rename = "round")]
@@ -31900,14 +45608,14 @@ pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "square")]
     Square,
 }
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+impl From<&StrokeCapValueVariant1Subtype0Variant1Value>
+    for StrokeCapValueVariant1Subtype0Variant1Value
 {
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+    fn from(value: &StrokeCapValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for StrokeCapValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Butt => "butt".to_string(),
@@ -31916,7 +45624,7 @@ impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Valu
         }
     }
 }
-impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for StrokeCapValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -31927,25 +45635,19 @@ impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -31953,18 +45655,18 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum StrokeCapValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&StrokeCapValueVariant1Subtype0Variant3Range>
+    for StrokeCapValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &StrokeCapValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for StrokeCapValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -31976,31 +45678,25 @@ impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Var
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for StrokeCapValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -32008,53 +45704,19 @@ impl ToString for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Rang
         }
     }
 }
-impl From<f64> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for StrokeCapValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for StrokeCapValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3>
-    for StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &StrokeCapValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeCapValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StrokeCapValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StrokeCapValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StrokeCapValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StrokeCapValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&StrokeCapValueVariant1Subtype1> for StrokeCapValueVariant1Subtype1 {
     fn from(value: &StrokeCapValueVariant1Subtype1) -> Self {
@@ -32062,162 +45724,21 @@ impl From<&StrokeCapValueVariant1Subtype1> for StrokeCapValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StrokeCapValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: StrokeCapValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: StrokeCapValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct StrokeCapValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&StrokeCapValueVariant1Subtype1Subtype0> for StrokeCapValueVariant1Subtype1Subtype0 {
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for StrokeCapValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "butt")]
-    Butt,
-    #[serde(rename = "round")]
-    Round,
-    #[serde(rename = "square")]
-    Square,
-}
-impl From<&StrokeCapValueVariant1Subtype1Subtype0Variant1Value>
-    for StrokeCapValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Butt => "butt".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Square => "square".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "butt" => Ok(Self::Butt),
-            "round" => Ok(Self::Round),
-            "square" => Ok(Self::Square),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&StrokeCapValueVariant1Subtype1Subtype0Variant3Range>
-    for StrokeCapValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for StrokeCapValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant1Subtype1Subtype1 {}
-impl From<&StrokeCapValueVariant1Subtype1Subtype1> for StrokeCapValueVariant1Subtype1Subtype1 {
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype1) -> Self {
+impl From<&StrokeCapValueVariant1Subtype2> for StrokeCapValueVariant1Subtype2 {
+    fn from(value: &StrokeCapValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant1Subtype1Subtype2 {}
-impl From<&StrokeCapValueVariant1Subtype1Subtype2> for StrokeCapValueVariant1Subtype1Subtype2 {
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct StrokeCapValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeCapValueVariant1Subtype1Subtype3 {}
-impl From<&StrokeCapValueVariant1Subtype1Subtype3> for StrokeCapValueVariant1Subtype1Subtype3 {
-    fn from(value: &StrokeCapValueVariant1Subtype1Subtype3) -> Self {
+impl From<&StrokeCapValueVariant1Subtype3> for StrokeCapValueVariant1Subtype3 {
+    fn from(value: &StrokeCapValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -32226,10 +45747,14 @@ impl From<&StrokeCapValueVariant1Subtype1Subtype3> for StrokeCapValueVariant1Sub
 pub enum StrokeJoinValue {
     Variant0(Vec<StrokeJoinValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: StrokeJoinValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<StrokeJoinValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<StrokeJoinValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<StrokeJoinValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<StrokeJoinValueVariant1Subtype3>,
     },
 }
 impl From<&StrokeJoinValue> for StrokeJoinValue {
@@ -32244,10 +45769,14 @@ impl From<Vec<StrokeJoinValueVariant0Item>> for StrokeJoinValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: StrokeJoinValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<StrokeJoinValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<StrokeJoinValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<StrokeJoinValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<StrokeJoinValueVariant0ItemSubtype3>,
 }
 impl From<&StrokeJoinValueVariant0Item> for StrokeJoinValueVariant0Item {
     fn from(value: &StrokeJoinValueVariant0Item) -> Self {
@@ -32255,11 +45784,162 @@ impl From<&StrokeJoinValueVariant0Item> for StrokeJoinValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StrokeJoinValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: StrokeJoinValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: StrokeJoinValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&StrokeJoinValueVariant0ItemSubtype0> for StrokeJoinValueVariant0ItemSubtype0 {
+    fn from(value: &StrokeJoinValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    #[serde(rename = "miter")]
+    Miter,
+    #[serde(rename = "round")]
+    Round,
+    #[serde(rename = "bevel")]
+    Bevel,
+}
+impl From<&StrokeJoinValueVariant0ItemSubtype0Variant1Value>
+    for StrokeJoinValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &StrokeJoinValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl ToString for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Miter => "miter".to_string(),
+            Self::Round => "round".to_string(),
+            Self::Bevel => "bevel".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "miter" => Ok(Self::Miter),
+            "round" => Ok(Self::Round),
+            "bevel" => Ok(Self::Bevel),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&StrokeJoinValueVariant0ItemSubtype0Variant3Range>
+    for StrokeJoinValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &StrokeJoinValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: StrokeJoinValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&StrokeJoinValueVariant0ItemSubtype1> for StrokeJoinValueVariant0ItemSubtype1 {
     fn from(value: &StrokeJoinValueVariant0ItemSubtype1) -> Self {
@@ -32267,51 +45947,59 @@ impl From<&StrokeJoinValueVariant0ItemSubtype1> for StrokeJoinValueVariant0ItemS
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct StrokeJoinValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1
-{
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&StrokeJoinValueVariant0ItemSubtype2> for StrokeJoinValueVariant0ItemSubtype2 {
+    fn from(value: &StrokeJoinValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StrokeJoinValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&StrokeJoinValueVariant0ItemSubtype3> for StrokeJoinValueVariant0ItemSubtype3 {
+    fn from(value: &StrokeJoinValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum StrokeJoinValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: StrokeJoinValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: StrokeJoinValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&StrokeJoinValueVariant1Subtype0> for StrokeJoinValueVariant1Subtype0 {
+    fn from(value: &StrokeJoinValueVariant1Subtype0) -> Self {
         value.clone()
     }
 }
-impl From<SignalRef> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum StrokeJoinValueVariant1Subtype0Variant1Value {
     #[serde(rename = "miter")]
     Miter,
     #[serde(rename = "round")]
@@ -32319,14 +46007,14 @@ pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
     #[serde(rename = "bevel")]
     Bevel,
 }
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
+impl From<&StrokeJoinValueVariant1Subtype0Variant1Value>
+    for StrokeJoinValueVariant1Subtype0Variant1Value
 {
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+    fn from(value: &StrokeJoinValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl ToString for StrokeJoinValueVariant1Subtype0Variant1Value {
     fn to_string(&self) -> String {
         match *self {
             Self::Miter => "miter".to_string(),
@@ -32335,7 +46023,7 @@ impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Val
         }
     }
 }
-impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl std::str::FromStr for StrokeJoinValueVariant1Subtype0Variant1Value {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -32346,25 +46034,19 @@ impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Va
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
+impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype0Variant1Value {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -32372,18 +46054,18 @@ impl std::convert::TryFrom<String>
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum StrokeJoinValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
+impl From<&StrokeJoinValueVariant1Subtype0Variant3Range>
+    for StrokeJoinValueVariant1Subtype0Variant3Range
 {
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+    fn from(value: &StrokeJoinValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for StrokeJoinValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -32395,31 +46077,25 @@ impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Va
         }
     }
 }
-impl std::convert::TryFrom<&str>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
+impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for StrokeJoinValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -32427,53 +46103,19 @@ impl ToString for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Ran
         }
     }
 }
-impl From<f64> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for StrokeJoinValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for StrokeJoinValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3>
-    for StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &StrokeJoinValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StrokeJoinValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<StrokeJoinValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<StrokeJoinValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<StrokeJoinValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<StrokeJoinValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&StrokeJoinValueVariant1Subtype1> for StrokeJoinValueVariant1Subtype1 {
     fn from(value: &StrokeJoinValueVariant1Subtype1) -> Self {
@@ -32481,162 +46123,21 @@ impl From<&StrokeJoinValueVariant1Subtype1> for StrokeJoinValueVariant1Subtype1 
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StrokeJoinValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: StrokeJoinValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: StrokeJoinValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct StrokeJoinValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&StrokeJoinValueVariant1Subtype1Subtype0> for StrokeJoinValueVariant1Subtype1Subtype0 {
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for StrokeJoinValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    #[serde(rename = "miter")]
-    Miter,
-    #[serde(rename = "round")]
-    Round,
-    #[serde(rename = "bevel")]
-    Bevel,
-}
-impl From<&StrokeJoinValueVariant1Subtype1Subtype0Variant1Value>
-    for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl ToString for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    fn to_string(&self) -> String {
-        match *self {
-            Self::Miter => "miter".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Bevel => "bevel".to_string(),
-        }
-    }
-}
-impl std::str::FromStr for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        match value {
-            "miter" => Ok(Self::Miter),
-            "round" => Ok(Self::Round),
-            "bevel" => Ok(Self::Bevel),
-            _ => Err("invalid value"),
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&StrokeJoinValueVariant1Subtype1Subtype0Variant3Range>
-    for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for StrokeJoinValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant1Subtype1Subtype1 {}
-impl From<&StrokeJoinValueVariant1Subtype1Subtype1> for StrokeJoinValueVariant1Subtype1Subtype1 {
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype1) -> Self {
+impl From<&StrokeJoinValueVariant1Subtype2> for StrokeJoinValueVariant1Subtype2 {
+    fn from(value: &StrokeJoinValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant1Subtype1Subtype2 {}
-impl From<&StrokeJoinValueVariant1Subtype1Subtype2> for StrokeJoinValueVariant1Subtype1Subtype2 {
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct StrokeJoinValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StrokeJoinValueVariant1Subtype1Subtype3 {}
-impl From<&StrokeJoinValueVariant1Subtype1Subtype3> for StrokeJoinValueVariant1Subtype1Subtype3 {
-    fn from(value: &StrokeJoinValueVariant1Subtype1Subtype3) -> Self {
+impl From<&StrokeJoinValueVariant1Subtype3> for StrokeJoinValueVariant1Subtype3 {
+    fn from(value: &StrokeJoinValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }
@@ -32698,10 +46199,14 @@ impl From<Vec<String>> for TextOrSignalVariant0 {
 pub enum TextValue {
     Variant0(Vec<TextValueVariant0Item>),
     Variant1 {
-        #[serde(flatten)]
-        subtype_0: StringModifiers,
-        #[serde(flatten)]
-        subtype_1: TextValueVariant1Subtype1,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_0: Option<TextValueVariant1Subtype0>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_1: Option<TextValueVariant1Subtype1>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_2: Option<TextValueVariant1Subtype2>,
+        #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+        subtype_3: Option<TextValueVariant1Subtype3>,
     },
 }
 impl From<&TextValue> for TextValue {
@@ -32716,10 +46221,14 @@ impl From<Vec<TextValueVariant0Item>> for TextValue {
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TextValueVariant0Item {
-    #[serde(flatten)]
-    pub subtype_0: Rule,
-    #[serde(flatten)]
-    pub subtype_1: TextValueVariant0ItemSubtype1,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<TextValueVariant0ItemSubtype0>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<TextValueVariant0ItemSubtype1>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_2: Option<TextValueVariant0ItemSubtype2>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_3: Option<TextValueVariant0ItemSubtype3>,
 }
 impl From<&TextValueVariant0Item> for TextValueVariant0Item {
     fn from(value: &TextValueVariant0Item) -> Self {
@@ -32727,11 +46236,126 @@ impl From<&TextValueVariant0Item> for TextValueVariant0Item {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TextValueVariant0ItemSubtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+        value: TextValueVariant0ItemSubtype0Variant1Value,
+    },
+    Variant2 {
+        field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+    Variant3 {
+        range: TextValueVariant0ItemSubtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        test: Option<String>,
+    },
+}
+impl From<&TextValueVariant0ItemSubtype0> for TextValueVariant0ItemSubtype0 {
+    fn from(value: &TextValueVariant0ItemSubtype0) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TextValueVariant0ItemSubtype0Variant1Value {
+    Variant0(String),
+    Variant1(Vec<String>),
+}
+impl From<&TextValueVariant0ItemSubtype0Variant1Value>
+    for TextValueVariant0ItemSubtype0Variant1Value
+{
+    fn from(value: &TextValueVariant0ItemSubtype0Variant1Value) -> Self {
+        value.clone()
+    }
+}
+impl From<Vec<String>> for TextValueVariant0ItemSubtype0Variant1Value {
+    fn from(value: Vec<String>) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TextValueVariant0ItemSubtype0Variant3Range {
+    Variant0(f64),
+    Variant1(bool),
+}
+impl From<&TextValueVariant0ItemSubtype0Variant3Range>
+    for TextValueVariant0ItemSubtype0Variant3Range
+{
+    fn from(value: &TextValueVariant0ItemSubtype0Variant3Range) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for TextValueVariant0ItemSubtype0Variant3Range {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::Variant0(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Variant1(v))
+        } else {
+            Err("string conversion failed for all variants")
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for TextValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for TextValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for TextValueVariant0ItemSubtype0Variant3Range {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl ToString for TextValueVariant0ItemSubtype0Variant3Range {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Variant0(x) => x.to_string(),
+            Self::Variant1(x) => x.to_string(),
+        }
+    }
+}
+impl From<f64> for TextValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: f64) -> Self {
+        Self::Variant0(value)
+    }
+}
+impl From<bool> for TextValueVariant0ItemSubtype0Variant3Range {
+    fn from(value: bool) -> Self {
+        Self::Variant1(value)
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TextValueVariant0ItemSubtype1 {
-    #[serde(flatten)]
-    pub subtype_0: StringModifiers,
-    #[serde(flatten)]
-    pub subtype_1: TextValueVariant0ItemSubtype1Subtype1,
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
 impl From<&TextValueVariant0ItemSubtype1> for TextValueVariant0ItemSubtype1 {
     fn from(value: &TextValueVariant0ItemSubtype1) -> Self {
@@ -32739,79 +46363,85 @@ impl From<&TextValueVariant0ItemSubtype1> for TextValueVariant0ItemSubtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant0ItemSubtype1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<TextValueVariant0ItemSubtype1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<TextValueVariant0ItemSubtype1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<TextValueVariant0ItemSubtype1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<TextValueVariant0ItemSubtype1Subtype1Subtype3>,
+pub struct TextValueVariant0ItemSubtype2 {
+    pub scale: Field,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
 }
-impl From<&TextValueVariant0ItemSubtype1Subtype1> for TextValueVariant0ItemSubtype1Subtype1 {
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1) -> Self {
+impl From<&TextValueVariant0ItemSubtype2> for TextValueVariant0ItemSubtype2 {
+    fn from(value: &TextValueVariant0ItemSubtype2) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TextValueVariant0ItemSubtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test: Option<String>,
+}
+impl From<&TextValueVariant0ItemSubtype3> for TextValueVariant0ItemSubtype3 {
+    fn from(value: &TextValueVariant0ItemSubtype3) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0 {
-    Variant0(SignalRef),
+pub enum TextValueVariant1Subtype0 {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        signal: String,
+    },
     Variant1 {
-        value: TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
+        value: TextValueVariant1Subtype0Variant1Value,
     },
     Variant2 {
         field: Field,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
     Variant3 {
-        range: TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range,
+        range: TextValueVariant1Subtype0Variant3Range,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<Field>,
     },
 }
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype0>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype0
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype0) -> Self {
+impl From<&TextValueVariant1Subtype0> for TextValueVariant1Subtype0 {
+    fn from(value: &TextValueVariant1Subtype0) -> Self {
         value.clone()
-    }
-}
-impl From<SignalRef> for TextValueVariant0ItemSubtype1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+pub enum TextValueVariant1Subtype0Variant1Value {
     Variant0(String),
     Variant1(Vec<String>),
 }
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value) -> Self {
+impl From<&TextValueVariant1Subtype0Variant1Value> for TextValueVariant1Subtype0Variant1Value {
+    fn from(value: &TextValueVariant1Subtype0Variant1Value) -> Self {
         value.clone()
     }
 }
-impl From<Vec<String>> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant1Value {
+impl From<Vec<String>> for TextValueVariant1Subtype0Variant1Value {
     fn from(value: Vec<String>) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+pub enum TextValueVariant1Subtype0Variant3Range {
     Variant0(f64),
     Variant1(bool),
 }
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range) -> Self {
+impl From<&TextValueVariant1Subtype0Variant3Range> for TextValueVariant1Subtype0Variant3Range {
+    fn from(value: &TextValueVariant1Subtype0Variant3Range) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::str::FromStr for TextValueVariant1Subtype0Variant3Range {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if let Ok(v) = value.parse() {
@@ -32823,25 +46453,25 @@ impl std::str::FromStr for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3
         }
     }
 }
-impl std::convert::TryFrom<&str> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&str> for TextValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<&String> for TextValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl std::convert::TryFrom<String> for TextValueVariant1Subtype0Variant3Range {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl ToString for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl ToString for TextValueVariant1Subtype0Variant3Range {
     fn to_string(&self) -> String {
         match self {
             Self::Variant0(x) => x.to_string(),
@@ -32849,53 +46479,19 @@ impl ToString for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
         }
     }
 }
-impl From<f64> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<f64> for TextValueVariant1Subtype0Variant3Range {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl From<bool> for TextValueVariant0ItemSubtype1Subtype1Subtype0Variant3Range {
+impl From<bool> for TextValueVariant1Subtype0Variant3Range {
     fn from(value: bool) -> Self {
         Self::Variant1(value)
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant0ItemSubtype1Subtype1Subtype1 {}
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype1>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype1
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype1) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant0ItemSubtype1Subtype1Subtype2 {}
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype2>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype2
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant0ItemSubtype1Subtype1Subtype3 {}
-impl From<&TextValueVariant0ItemSubtype1Subtype1Subtype3>
-    for TextValueVariant0ItemSubtype1Subtype1Subtype3
-{
-    fn from(value: &TextValueVariant0ItemSubtype1Subtype1Subtype3) -> Self {
-        value.clone()
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TextValueVariant1Subtype1 {
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_0: Option<TextValueVariant1Subtype1Subtype0>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_1: Option<TextValueVariant1Subtype1Subtype1>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_2: Option<TextValueVariant1Subtype1Subtype2>,
-    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
-    pub subtype_3: Option<TextValueVariant1Subtype1Subtype3>,
+    pub scale: Field,
 }
 impl From<&TextValueVariant1Subtype1> for TextValueVariant1Subtype1 {
     fn from(value: &TextValueVariant1Subtype1) -> Self {
@@ -32903,126 +46499,21 @@ impl From<&TextValueVariant1Subtype1> for TextValueVariant1Subtype1 {
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum TextValueVariant1Subtype1Subtype0 {
-    Variant0(SignalRef),
-    Variant1 {
-        value: TextValueVariant1Subtype1Subtype0Variant1Value,
-    },
-    Variant2 {
-        field: Field,
-    },
-    Variant3 {
-        range: TextValueVariant1Subtype1Subtype0Variant3Range,
-    },
+pub struct TextValueVariant1Subtype2 {
+    pub scale: Field,
 }
-impl From<&TextValueVariant1Subtype1Subtype0> for TextValueVariant1Subtype1Subtype0 {
-    fn from(value: &TextValueVariant1Subtype1Subtype0) -> Self {
-        value.clone()
-    }
-}
-impl From<SignalRef> for TextValueVariant1Subtype1Subtype0 {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum TextValueVariant1Subtype1Subtype0Variant1Value {
-    Variant0(String),
-    Variant1(Vec<String>),
-}
-impl From<&TextValueVariant1Subtype1Subtype0Variant1Value>
-    for TextValueVariant1Subtype1Subtype0Variant1Value
-{
-    fn from(value: &TextValueVariant1Subtype1Subtype0Variant1Value) -> Self {
-        value.clone()
-    }
-}
-impl From<Vec<String>> for TextValueVariant1Subtype1Subtype0Variant1Value {
-    fn from(value: Vec<String>) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum TextValueVariant1Subtype1Subtype0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
-}
-impl From<&TextValueVariant1Subtype1Subtype0Variant3Range>
-    for TextValueVariant1Subtype1Subtype0Variant3Range
-{
-    fn from(value: &TextValueVariant1Subtype1Subtype0Variant3Range) -> Self {
-        value.clone()
-    }
-}
-impl std::str::FromStr for TextValueVariant1Subtype1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
-        } else {
-            Err("string conversion failed for all variants")
-        }
-    }
-}
-impl std::convert::TryFrom<&str> for TextValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for TextValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<String> for TextValueVariant1Subtype1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl ToString for TextValueVariant1Subtype1Subtype0Variant3Range {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-        }
-    }
-}
-impl From<f64> for TextValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl From<bool> for TextValueVariant1Subtype1Subtype0Variant3Range {
-    fn from(value: bool) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant1Subtype1Subtype1 {}
-impl From<&TextValueVariant1Subtype1Subtype1> for TextValueVariant1Subtype1Subtype1 {
-    fn from(value: &TextValueVariant1Subtype1Subtype1) -> Self {
+impl From<&TextValueVariant1Subtype2> for TextValueVariant1Subtype2 {
+    fn from(value: &TextValueVariant1Subtype2) -> Self {
         value.clone()
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant1Subtype1Subtype2 {}
-impl From<&TextValueVariant1Subtype1Subtype2> for TextValueVariant1Subtype1Subtype2 {
-    fn from(value: &TextValueVariant1Subtype1Subtype2) -> Self {
-        value.clone()
-    }
+pub struct TextValueVariant1Subtype3 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<Field>,
 }
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TextValueVariant1Subtype1Subtype3 {}
-impl From<&TextValueVariant1Subtype1Subtype3> for TextValueVariant1Subtype1Subtype3 {
-    fn from(value: &TextValueVariant1Subtype1Subtype3) -> Self {
+impl From<&TextValueVariant1Subtype3> for TextValueVariant1Subtype3 {
+    fn from(value: &TextValueVariant1Subtype3) -> Self {
         value.clone()
     }
 }

--- a/typify/tests/schemas/maps.json
+++ b/typify/tests/schemas/maps.json
@@ -28,5 +28,8 @@
         "format": "date-time"
       }
     }
-  }
+  },
+  "$comment": "usual case of a map whose name must come from its title",
+  "title": "DeadSimple",
+  "type": "object"
 }

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -1,5 +1,28 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DeadSimple(pub serde_json::Map<String, serde_json::Value>);
+impl std::ops::Deref for DeadSimple {
+    type Target = serde_json::Map<String, serde_json::Value>;
+    fn deref(&self) -> &serde_json::Map<String, serde_json::Value> {
+        &self.0
+    }
+}
+impl From<DeadSimple> for serde_json::Map<String, serde_json::Value> {
+    fn from(value: DeadSimple) -> Self {
+        value.0
+    }
+}
+impl From<&DeadSimple> for DeadSimple {
+    fn from(value: &DeadSimple) -> Self {
+        value.clone()
+    }
+}
+impl From<serde_json::Map<String, serde_json::Value>> for DeadSimple {
+    fn from(value: serde_json::Map<String, serde_json::Value>) -> Self {
+        Self(value)
+    }
+}
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Eh(pub String);
 impl std::ops::Deref for Eh {

--- a/typify/tests/schemas/merged-schemas.json
+++ b/typify/tests/schemas/merged-schemas.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "narrow-number": {
+      "allOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "minimum": 1
+        }
+      ]
+    },
+    "JsonResponseBase": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    "JsonSuccessBase": {
+      "description": "x",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/JsonResponseBase"
+        },
+        {
+          "required": [
+            "result",
+            "msg"
+          ],
+          "properties": {
+            "result": {
+              "enum": [
+                "success"
+              ]
+            },
+            "msg": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "JsonSuccess": {
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/JsonSuccessBase"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "result": {},
+            "msg": {}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1,0 +1,175 @@
+#[allow(unused_imports)]
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct JsonResponseBase {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+impl From<&JsonResponseBase> for JsonResponseBase {
+    fn from(value: &JsonResponseBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JsonSuccess {
+    pub msg: String,
+    pub result: JsonSuccessResult,
+}
+impl From<&JsonSuccess> for JsonSuccess {
+    fn from(value: &JsonSuccess) -> Self {
+        value.clone()
+    }
+}
+#[doc = "x"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct JsonSuccessBase {
+    pub msg: String,
+    pub result: JsonSuccessBaseResult,
+}
+impl From<&JsonSuccessBase> for JsonSuccessBase {
+    fn from(value: &JsonSuccessBase) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum JsonSuccessBaseResult {
+    #[serde(rename = "success")]
+    Success,
+}
+impl From<&JsonSuccessBaseResult> for JsonSuccessBaseResult {
+    fn from(value: &JsonSuccessBaseResult) -> Self {
+        value.clone()
+    }
+}
+impl ToString for JsonSuccessBaseResult {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Success => "success".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for JsonSuccessBaseResult {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "success" => Ok(Self::Success),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for JsonSuccessBaseResult {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for JsonSuccessBaseResult {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for JsonSuccessBaseResult {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum JsonSuccessResult {
+    #[serde(rename = "success")]
+    Success,
+}
+impl From<&JsonSuccessResult> for JsonSuccessResult {
+    fn from(value: &JsonSuccessResult) -> Self {
+        value.clone()
+    }
+}
+impl ToString for JsonSuccessResult {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Success => "success".to_string(),
+        }
+    }
+}
+impl std::str::FromStr for JsonSuccessResult {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, &'static str> {
+        match value {
+            "success" => Ok(Self::Success),
+            _ => Err("invalid value"),
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for JsonSuccessResult {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for JsonSuccessResult {
+    type Error = &'static str;
+    fn try_from(value: &String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for JsonSuccessResult {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, &'static str> {
+        value.parse()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NarrowNumber(pub std::num::NonZeroU64);
+impl std::ops::Deref for NarrowNumber {
+    type Target = std::num::NonZeroU64;
+    fn deref(&self) -> &std::num::NonZeroU64 {
+        &self.0
+    }
+}
+impl From<NarrowNumber> for std::num::NonZeroU64 {
+    fn from(value: NarrowNumber) -> Self {
+        value.0
+    }
+}
+impl From<&NarrowNumber> for NarrowNumber {
+    fn from(value: &NarrowNumber) -> Self {
+        value.clone()
+    }
+}
+impl From<std::num::NonZeroU64> for NarrowNumber {
+    fn from(value: std::num::NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for NarrowNumber {
+    type Err = <std::num::NonZeroU64 as std::str::FromStr>::Err;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.parse()?))
+    }
+}
+impl std::convert::TryFrom<&str> for NarrowNumber {
+    type Error = <std::num::NonZeroU64 as std::str::FromStr>::Err;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for NarrowNumber {
+    type Error = <std::num::NonZeroU64 as std::str::FromStr>::Err;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for NarrowNumber {
+    type Error = <std::num::NonZeroU64 as std::str::FromStr>::Err;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl ToString for NarrowNumber {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+fn main() {}


### PR DESCRIPTION
Before this PR, the handling of `allOf` was basically wrong. It worked in a small number of cases, but on the whole it was flawed in concept.  Most of the time, it would result in a `struct` with all subschemas embedded with a `#[serde(flatten)]` directive. This was broken in many ways, but in particular because `allOf` constructs are often used to augment, narrow, and expand other types.

This PR instead "merges" the subschemas of an `allOf` construction. This results in many more types, but also (per our testing), types that compile and are usable which was often not the case previously.

This implements much of what is discussed in #176, but doesn't include the `impl From` that issue imagines to go from the "merged" type to the component type (i.e. the type that appeared in the `allOf` array). 

Fixes #315 and #370 

---

In addition, there are several cleanups: adding `env_logger` to `cargo-typify`, improved logs and docs, start of a schema validator for Values, etc.