### PR TITLE
fix stack overflow; improve `not` subschema handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ name = "typify"
 version = "0.0.13"
 dependencies = [
  "chrono",
+ "env_logger",
  "expectorate",
  "glob",
  "quote",

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1237,6 +1237,16 @@ impl TypeSpace {
         metadata: &'a Option<Box<schemars::schema::Metadata>>,
         subschemas: &'a [Schema],
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
+        // TODO it would probably be smart to do a pass through the schema
+        // given to us and either put it into some canonical form or move to
+        // some sort of intermediate representation.
+        //
+        // Each of the enum types does some similar exploration of each
+        // variant-schema--it should be possible to do that once. In addition
+        // the various enum types rely on some heuristics around how schemas
+        // are laid out; it would be nice to eliminate some of the guesswork,
+        // but putting schemas into a predictable form.
+
         let ty = self
             .maybe_option(type_name.clone(), metadata, subschemas)
             .or_else(|| self.maybe_externally_tagged_enum(type_name.clone(), metadata, subschemas))

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -19,6 +19,7 @@ typify-impl = { version = "0.0.13", path = "../typify-impl" }
 
 [dev-dependencies]
 chrono = { version = "0.4.30", features = ["serde"] }
+env_logger = "0.10.0"
 expectorate = "1.0.7"
 glob = "0.3.1"
 quote = "1.0.33"

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -12,6 +12,7 @@ use typify_impl::TypeSpaceImpl;
 
 #[test]
 fn test_schemas() {
+    env_logger::init();
     // Make sure output is up to date.
     for entry in glob("tests/schemas/*.json").expect("Failed to read glob pattern") {
         validate_schema(entry.unwrap()).unwrap();

--- a/typify/tests/schemas/merged-schemas.json
+++ b/typify/tests/schemas/merged-schemas.json
@@ -56,6 +56,27 @@
           }
         }
       ]
+    },
+    "nyet": {
+      "type": "object",
+      "properties": {
+        "a": {},
+        "b": {}
+      },
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "a"
+            ]
+          },
+          {
+            "required": [
+              "b"
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/typify/tests/schemas/merged-schemas.json
+++ b/typify/tests/schemas/merged-schemas.json
@@ -57,26 +57,157 @@
         }
       ]
     },
-    "nyet": {
+    "but-not-that": {
+      "type": "object",
+      "properties": {
+        "this": {},
+        "that": {}
+      },
+      "not": {
+        "required": [
+          "that"
+        ]
+      }
+    },
+    "trim-fat": {
       "type": "object",
       "properties": {
         "a": {},
-        "b": {}
+        "b": {},
+        "c": {}
       },
+      "required": [
+        "a"
+      ],
       "not": {
         "anyOf": [
           {
             "required": [
-              "a"
+              "b"
             ]
           },
           {
             "required": [
-              "b"
+              "c"
             ]
           }
         ]
       }
+    },
+    "weird-enum": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string"
+        },
+        "pattern-regex": {
+          "type": "string"
+        },
+        "patterns": {
+          "type": "string"
+        },
+        "pattern-either": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "pattern"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "patterns"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-either"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-regex"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "patterns"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "pattern"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-either"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-regex"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "pattern-either"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "pattern"
+                ]
+              },
+              {
+                "required": [
+                  "patterns"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-regex"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "required": [
+            "pattern-regex"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "pattern"
+                ]
+              },
+              {
+                "required": [
+                  "patterns"
+                ]
+              },
+              {
+                "required": [
+                  "pattern-either"
+                ]
+              }
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1,6 +1,16 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ButNotThat {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub this: Option<serde_json::Value>,
+}
+impl From<&ButNotThat> for ButNotThat {
+    fn from(value: &ButNotThat) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct JsonResponseBase {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
@@ -170,6 +180,38 @@ impl std::convert::TryFrom<String> for NarrowNumber {
 impl ToString for NarrowNumber {
     fn to_string(&self) -> String {
         self.0.to_string()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrimFat {
+    pub a: serde_json::Value,
+}
+impl From<&TrimFat> for TrimFat {
+    fn from(value: &TrimFat) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum WeirdEnum {
+    Variant0 {
+        pattern: String,
+    },
+    Variant1 {
+        patterns: String,
+    },
+    Variant2 {
+        #[serde(rename = "pattern-either")]
+        pattern_either: String,
+    },
+    Variant3 {
+        #[serde(rename = "pattern-regex")]
+        pattern_regex: String,
+    },
+}
+impl From<&WeirdEnum> for WeirdEnum {
+    fn from(value: &WeirdEnum) -> Self {
+        value.clone()
     }
 }
 fn main() {}


### PR DESCRIPTION
A schema like this will recur infinitely:

```json
    {
      "type": "object",
      "properties": {
        "this": {},
        "that": {}
      },
      "not": {
        "required": [
          "that"
        ]
      }
    }
```

This includes logic to handle this type of `not` by "subtracting" it out from the other schema.

In addition, we now handle constructs like this:

```json
    {
      "type": "object",
      "properties": {
        "a": {},
        "b": {},
        "c": {}
      },
      "required": [
        "a"
      ],
      "not": {
        "anyOf": [
          {
            "required": [
              "b"
            ]
          },
          {
            "required": [
              "c"
            ]
          }
        ]
      }
    }
```

We reduce a `not` of `anyOf` to an `allOf` of `not` which we can then "subtract" out as above.