### PR TITLE
unsatisfiable `allOf` construction panics

### DIFF
--- a/typify/tests/schemas/merged-schemas.json
+++ b/typify/tests/schemas/merged-schemas.json
@@ -208,6 +208,50 @@
           }
         }
       ]
+    },
+    "unsatisfiable-1": {
+      "allOf": [
+        {
+          "type": "string",
+          "enum": [
+            "foo"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bar": {}
+          }
+        }
+      ]
+    },
+    "unsatisfiable-2": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "foo"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "bar"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -191,6 +191,22 @@ impl From<&TrimFat> for TrimFat {
         value.clone()
     }
 }
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum Unsatisfiable1 {}
+impl From<&Unsatisfiable1> for Unsatisfiable1 {
+    fn from(value: &Unsatisfiable1) -> Self {
+        value.clone()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Unsatisfiable2 {}
+impl From<&Unsatisfiable2> for Unsatisfiable2 {
+    fn from(value: &Unsatisfiable2) -> Self {
+        value.clone()
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WeirdEnum {


### PR DESCRIPTION
If the merged result of an `allOf` is unsatisfiable (i.e. false) we should produce a Never-like type.

Closes #443 