### PR TITLE
fix example-build/Cargo.toml

### DIFF
--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.109"
 
 [build-dependencies]


### PR DESCRIPTION
The generated code relies on the `serde` derive macro, but this is an optional feature and must be explicitly opted in to.

See the [serde derive docs](https://serde.rs/derive.html).


Without this change, using the structure in `example/build` results in errors like the following:

```
error: cannot find derive macro `Deserialize` in this scope
   --> packages/test-cli/src/manifest/codegen.rs:304:24
    |
304 | #[derive(Clone, Debug, Deserialize, Serialize)]
    |                        ^^^^^^^^^^^
    |
note: `Deserialize` is imported here, but it is only a trait, without a derive macro
   --> packages/test-cli/src/manifest/codegen.rs:1:13
    |
1   | use serde::{Deserialize, Serialize};
    |             ^^^^^^^^^^^


```