### PR TITLE
introduce a proper Error type for various conversions

### DIFF
--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -5,6 +5,31 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "Fruit"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -210,8 +235,8 @@ pub mod builder {
         }
     }
     impl std::convert::TryFrom<Veggie> for super::Veggie {
-        type Error = String;
-        fn try_from(value: Veggie) -> Result<Self, String> {
+        type Error = super::error::ConversionError;
+        fn try_from(value: Veggie) -> Result<Self, super::error::ConversionError> {
             Ok(Self {
                 veggie_like: value.veggie_like?,
                 veggie_name: value.veggie_name?,
@@ -262,8 +287,8 @@ pub mod builder {
         }
     }
     impl std::convert::TryFrom<Veggies> for super::Veggies {
-        type Error = String;
-        fn try_from(value: Veggies) -> Result<Self, String> {
+        type Error = super::error::ConversionError;
+        fn try_from(value: Veggies) -> Result<Self, super::error::ConversionError> {
             Ok(Self {
                 fruits: value.fruits?,
                 vegetables: value.vegetables?,

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -5,6 +5,31 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "Fruit"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -5,6 +5,31 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "Fruit"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -5,6 +5,31 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "Fruit"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1790,7 +1790,7 @@ mod tests {
     use std::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8};
 
     use paste::paste;
-    use quote::quote;
+    use quote::{quote, ToTokens};
     use schema::Schema;
     use schemars::{
         schema::{InstanceType, Metadata, NumberValidation, RootSchema, SchemaObject},
@@ -1997,8 +1997,11 @@ mod tests {
         let _ = type_space.add_type(&schema.schema.into()).unwrap();
 
         let actual = type_space.to_stream();
-        let expected = quote! {};
-        assert_eq!(actual.to_string(), expected.to_string());
+        let file = syn::parse2::<syn::File>(actual).expect("type space should emit a valid file");
+        match file.items.as_slice() {
+            [syn::Item::Mod(error)] if error.ident == "error" => {}
+            _ => panic!("unexpected file contents {}", file.to_token_stream()),
+        }
     }
 
     #[test]

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -669,6 +669,44 @@ impl TypeSpace {
     pub fn to_stream(&self) -> TokenStream {
         let mut output = OutputSpace::default();
 
+        // Add the error type we use for conversions; it's fine if this is
+        // unused.
+        output.add_item(
+            output::OutputSpaceMod::Error,
+            "",
+            quote! {
+                /// Error from a TryFrom or FromStr implementation.
+                pub struct ConversionError(std::borrow::Cow<'static, str>);
+
+                impl std::error::Error for ConversionError {}
+                impl std::fmt::Display for ConversionError {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>)
+                        -> Result<(), std::fmt::Error>
+                    {
+                        std::fmt::Display::fmt(&self.0, f)
+                    }
+                }
+
+                impl std::fmt::Debug for ConversionError {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>)
+                        -> Result<(), std::fmt::Error>
+                    {
+                        std::fmt::Debug::fmt(&self.0, f)
+                    }
+                }
+                impl From<&'static str> for ConversionError {
+                    fn from(value: &'static str) -> Self {
+                        Self(value.into())
+                    }
+                }
+                impl From<String> for ConversionError {
+                    fn from(value: String) -> Self {
+                        Self(value.into())
+                    }
+                }
+            },
+        );
+
         // Add all types.
         self.id_to_entry
             .values()

--- a/typify-impl/src/output.rs
+++ b/typify-impl/src/output.rs
@@ -12,6 +12,7 @@ pub struct OutputSpace {
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OutputSpaceMod {
+    Error,
     Crate,
     Builder,
     Defaults,
@@ -53,6 +54,11 @@ impl OutputSpace {
             },
             OutputSpaceMod::Defaults => quote! {
                 pub mod defaults {
+                    #items
+                }
+            },
+            OutputSpaceMod::Error => quote! {
+                pub mod error {
                     #items
                 }
             },

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -732,33 +732,33 @@ impl TypeEntry {
                         }
                     }
                     impl std::str::FromStr for #type_name {
-                        type Err = &'static str;
+                        type Err = self::error::ConversionError;
 
-                        fn from_str(value: &str) -> Result<Self, &'static str> {
+                        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
                             match value {
                                 #(#match_strs => Ok(Self::#match_variants),)*
-                                _ => Err("invalid value"),
+                                _ => Err("invalid value".into()),
                             }
                         }
                     }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
-                        fn try_from(value: &str) -> Result<Self, &'static str> {
+                        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
-                        fn try_from(value: &String) -> Result<Self, &'static str> {
+                        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
-                        fn try_from(value: String) -> Result<Self, &'static str> {
+                        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
                             value.parse()
                         }
                     }
@@ -785,10 +785,10 @@ impl TypeEntry {
 
                 quote! {
                     impl std::str::FromStr for #type_name {
-                        type Err = &'static str;
+                        type Err = self::error::ConversionError;
 
                         fn from_str(value: &str) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             #(
                                 // Try to parse() into each variant.
@@ -797,33 +797,33 @@ impl TypeEntry {
                                 } else
                             )*
                             {
-                                Err("string conversion failed for all variants")
+                                Err("string conversion failed for all variants".into())
                             }
                         }
                     }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: &str) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: &String) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: String) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
@@ -1154,10 +1154,10 @@ impl TypeEntry {
                     impl std::convert::TryFrom<#type_name>
                         for super::#type_name
                     {
-                        type Error = String;
+                        type Error = super::error::ConversionError;
 
                         fn try_from(value: #type_name)
-                            -> Result<Self, String>
+                            -> Result<Self, super::error::ConversionError>
                         {
                             Ok(Self {
                                 #(
@@ -1336,16 +1336,16 @@ impl TypeEntry {
                 quote! {
                     // This is effectively the constructor for this type.
                     impl std::convert::TryFrom<#inner_type_name> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(
                             value: #inner_type_name
-                        ) -> Result<Self, &'static str>
+                        ) -> Result<Self, self::error::ConversionError>
                         {
                             if #not [
                                 #(#value_output,)*
                             ].contains(&value) {
-                                Err("invalid value")
+                                Err("invalid value".into())
                             } else {
                                 Ok(Self(value))
                             }
@@ -1382,7 +1382,7 @@ impl TypeEntry {
                     let err = format!("longer than {} characters", v);
                     quote! {
                         if value.len() > #v {
-                            return Err(#err);
+                            return Err(#err.into());
                         }
                     }
                 });
@@ -1391,7 +1391,7 @@ impl TypeEntry {
                     let err = format!("shorter than {} characters", v);
                     quote! {
                         if value.len() < #v {
-                            return Err(#err);
+                            return Err(#err.into());
                         }
                     }
                 });
@@ -1399,7 +1399,7 @@ impl TypeEntry {
                     let err = format!("doesn't match pattern \"{}\"", p);
                     quote! {
                         if regress::Regex::new(#p).unwrap().find(value).is_none() {
-                            return Err(#err);
+                            return Err(#err.into());
                         }
                     }
                 });
@@ -1412,9 +1412,9 @@ impl TypeEntry {
                 // wouldn't be accurate.
                 quote! {
                     impl std::str::FromStr for #type_name {
-                        type Err = &'static str;
+                        type Err = self::error::ConversionError;
 
-                        fn from_str(value: &str) -> Result<Self, &'static str> {
+                        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
                             #max
                             #min
                             #pat
@@ -1423,28 +1423,28 @@ impl TypeEntry {
                         }
                     }
                     impl std::convert::TryFrom<&str> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: &str) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<&String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: &String) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
                     }
                     impl std::convert::TryFrom<String> for #type_name {
-                        type Error = &'static str;
+                        type Error = self::error::ConversionError;
 
                         fn try_from(value: String) ->
-                            Result<Self, &'static str>
+                            Result<Self, self::error::ConversionError>
                         {
                             value.parse()
                         }
@@ -1459,7 +1459,7 @@ impl TypeEntry {
                         {
                             String::deserialize(deserializer)?
                                 .parse()
-                                .map_err(|e: &'static str| {
+                                .map_err(|e: self::error::ConversionError| {
                                     <D::Error as serde::de::Error>::custom(
                                         e.to_string(),
                                     )

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,4 +1,29 @@
 mod types {
+    pub mod error {
+        #[doc = r" Error from a TryFrom or FromStr implementation."]
+        pub struct ConversionError(std::borrow::Cow<'static, str>);
+        impl std::error::Error for ConversionError {}
+        impl std::fmt::Display for ConversionError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+        impl std::fmt::Debug for ConversionError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
+        }
+    }
     #[doc = "AllTheTraits"]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
@@ -150,31 +175,31 @@ mod types {
         }
     }
     impl std::str::FromStr for StringEnum {
-        type Err = &'static str;
-        fn from_str(value: &str) -> Result<Self, &'static str> {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
             match value {
                 "One" => Ok(Self::One),
                 "Two" => Ok(Self::Two),
                 "BuckleMyShoe" => Ok(Self::BuckleMyShoe),
-                _ => Err("invalid value"),
+                _ => Err("invalid value".into()),
             }
         }
     }
     impl std::convert::TryFrom<&str> for StringEnum {
-        type Error = &'static str;
-        fn try_from(value: &str) -> Result<Self, &'static str> {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
     impl std::convert::TryFrom<&String> for StringEnum {
-        type Error = &'static str;
-        fn try_from(value: &String) -> Result<Self, &'static str> {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
     impl std::convert::TryFrom<String> for StringEnum {
-        type Error = &'static str;
-        fn try_from(value: String) -> Result<Self, &'static str> {
+        type Error = self::error::ConversionError;
+        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
             value.parse()
         }
     }
@@ -203,8 +228,8 @@ mod types {
             }
         }
         impl std::convert::TryFrom<AllTheTraits> for super::AllTheTraits {
-            type Error = String;
-            fn try_from(value: AllTheTraits) -> Result<Self, String> {
+            type Error = super::error::ConversionError;
+            fn try_from(value: AllTheTraits) -> Result<Self, super::error::ConversionError> {
                 Ok(Self { ok: value.ok? })
             }
         }
@@ -249,8 +274,8 @@ mod types {
             }
         }
         impl std::convert::TryFrom<CompoundType> for super::CompoundType {
-            type Error = String;
-            fn try_from(value: CompoundType) -> Result<Self, String> {
+            type Error = super::error::ConversionError;
+            fn try_from(value: CompoundType) -> Result<Self, super::error::ConversionError> {
                 Ok(Self {
                     value1: value.value1?,
                     value2: value.value2?,
@@ -301,8 +326,8 @@ mod types {
             }
         }
         impl std::convert::TryFrom<Pair> for super::Pair {
-            type Error = String;
-            fn try_from(value: Pair) -> Result<Self, String> {
+            type Error = super::error::ConversionError;
+            fn try_from(value: Pair) -> Result<Self, super::error::ConversionError> {
                 Ok(Self {
                     a: value.a?,
                     b: value.b?,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -1,3 +1,28 @@
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "AlertInstance"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -219,31 +244,31 @@ impl ToString for AlertInstanceState {
     }
 }
 impl std::str::FromStr for AlertInstanceState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlertInstanceState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlertInstanceState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlertInstanceState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -843,8 +868,8 @@ impl ToString for AppEventsItem {
     }
 }
 impl std::str::FromStr for AppEventsItem {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -890,25 +915,25 @@ impl std::str::FromStr for AppEventsItem {
             "watch" => Ok(Self::Watch),
             "workflow_dispatch" => Ok(Self::WorkflowDispatch),
             "workflow_run" => Ok(Self::WorkflowRun),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppEventsItem {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1276,30 +1301,30 @@ impl ToString for AppPermissionsActions {
     }
 }
 impl std::str::FromStr for AppPermissionsActions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1338,30 +1363,30 @@ impl ToString for AppPermissionsAdministration {
     }
 }
 impl std::str::FromStr for AppPermissionsAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1400,30 +1425,30 @@ impl ToString for AppPermissionsChecks {
     }
 }
 impl std::str::FromStr for AppPermissionsChecks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1462,30 +1487,30 @@ impl ToString for AppPermissionsContentReferences {
     }
 }
 impl std::str::FromStr for AppPermissionsContentReferences {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1524,30 +1549,30 @@ impl ToString for AppPermissionsContents {
     }
 }
 impl std::str::FromStr for AppPermissionsContents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1586,30 +1611,30 @@ impl ToString for AppPermissionsDeployments {
     }
 }
 impl std::str::FromStr for AppPermissionsDeployments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1648,30 +1673,30 @@ impl ToString for AppPermissionsDiscussions {
     }
 }
 impl std::str::FromStr for AppPermissionsDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1710,30 +1735,30 @@ impl ToString for AppPermissionsEmails {
     }
 }
 impl std::str::FromStr for AppPermissionsEmails {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1772,30 +1797,30 @@ impl ToString for AppPermissionsEnvironments {
     }
 }
 impl std::str::FromStr for AppPermissionsEnvironments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1834,30 +1859,30 @@ impl ToString for AppPermissionsIssues {
     }
 }
 impl std::str::FromStr for AppPermissionsIssues {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1896,30 +1921,30 @@ impl ToString for AppPermissionsMembers {
     }
 }
 impl std::str::FromStr for AppPermissionsMembers {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1958,30 +1983,30 @@ impl ToString for AppPermissionsMetadata {
     }
 }
 impl std::str::FromStr for AppPermissionsMetadata {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2020,30 +2045,30 @@ impl ToString for AppPermissionsOrganizationAdministration {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2082,30 +2107,30 @@ impl ToString for AppPermissionsOrganizationHooks {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2144,30 +2169,30 @@ impl ToString for AppPermissionsOrganizationPackages {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2206,30 +2231,30 @@ impl ToString for AppPermissionsOrganizationPlan {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationPlan {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2268,30 +2293,30 @@ impl ToString for AppPermissionsOrganizationProjects {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2330,30 +2355,30 @@ impl ToString for AppPermissionsOrganizationSecrets {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2394,30 +2419,30 @@ impl ToString for AppPermissionsOrganizationSelfHostedRunners {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationSelfHostedRunners {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2456,30 +2481,30 @@ impl ToString for AppPermissionsOrganizationUserBlocking {
     }
 }
 impl std::str::FromStr for AppPermissionsOrganizationUserBlocking {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2518,30 +2543,30 @@ impl ToString for AppPermissionsPackages {
     }
 }
 impl std::str::FromStr for AppPermissionsPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2580,30 +2605,30 @@ impl ToString for AppPermissionsPages {
     }
 }
 impl std::str::FromStr for AppPermissionsPages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2642,30 +2667,30 @@ impl ToString for AppPermissionsPullRequests {
     }
 }
 impl std::str::FromStr for AppPermissionsPullRequests {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2704,30 +2729,30 @@ impl ToString for AppPermissionsRepositoryHooks {
     }
 }
 impl std::str::FromStr for AppPermissionsRepositoryHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2766,30 +2791,30 @@ impl ToString for AppPermissionsRepositoryProjects {
     }
 }
 impl std::str::FromStr for AppPermissionsRepositoryProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2828,30 +2853,30 @@ impl ToString for AppPermissionsSecretScanningAlerts {
     }
 }
 impl std::str::FromStr for AppPermissionsSecretScanningAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2890,30 +2915,30 @@ impl ToString for AppPermissionsSecrets {
     }
 }
 impl std::str::FromStr for AppPermissionsSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2952,30 +2977,30 @@ impl ToString for AppPermissionsSecurityEvents {
     }
 }
 impl std::str::FromStr for AppPermissionsSecurityEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3014,30 +3039,30 @@ impl ToString for AppPermissionsSecurityScanningAlert {
     }
 }
 impl std::str::FromStr for AppPermissionsSecurityScanningAlert {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3076,30 +3101,30 @@ impl ToString for AppPermissionsSingleFile {
     }
 }
 impl std::str::FromStr for AppPermissionsSingleFile {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3138,30 +3163,30 @@ impl ToString for AppPermissionsStatuses {
     }
 }
 impl std::str::FromStr for AppPermissionsStatuses {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3200,30 +3225,30 @@ impl ToString for AppPermissionsTeamDiscussions {
     }
 }
 impl std::str::FromStr for AppPermissionsTeamDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3262,30 +3287,30 @@ impl ToString for AppPermissionsVulnerabilityAlerts {
     }
 }
 impl std::str::FromStr for AppPermissionsVulnerabilityAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3324,30 +3349,30 @@ impl ToString for AppPermissionsWorkflows {
     }
 }
 impl std::str::FromStr for AppPermissionsWorkflows {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AppPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AppPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AppPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3413,8 +3438,8 @@ impl ToString for AuthorAssociation {
     }
 }
 impl std::str::FromStr for AuthorAssociation {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "COLLABORATOR" => Ok(Self::Collaborator),
             "CONTRIBUTOR" => Ok(Self::Contributor),
@@ -3424,25 +3449,25 @@ impl std::str::FromStr for AuthorAssociation {
             "MEMBER" => Ok(Self::Member),
             "NONE" => Ok(Self::None),
             "OWNER" => Ok(Self::Owner),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AuthorAssociation {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AuthorAssociation {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AuthorAssociation {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3693,31 +3718,31 @@ impl ToString for BranchProtectionRuleAllowDeletionsEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3762,31 +3787,31 @@ impl ToString for BranchProtectionRuleAllowForcePushesEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3881,29 +3906,29 @@ impl ToString for BranchProtectionRuleCreatedAction {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3998,29 +4023,29 @@ impl ToString for BranchProtectionRuleDeletedAction {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4151,29 +4176,29 @@ impl ToString for BranchProtectionRuleEditedAction {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4384,35 +4409,35 @@ impl ToString for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4457,31 +4482,31 @@ impl ToString for BranchProtectionRuleMergeQueueEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4526,31 +4551,31 @@ impl ToString for BranchProtectionRulePullRequestReviewsEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4595,31 +4620,31 @@ impl ToString for BranchProtectionRuleRequiredConversationResolutionLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4664,31 +4689,31 @@ impl ToString for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4733,31 +4758,31 @@ impl ToString for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4802,31 +4827,31 @@ impl ToString for BranchProtectionRuleSignatureRequirementEnforcementLevel {
     }
 }
 impl std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "off" => Ok(Self::Off),
             "non_admins" => Ok(Self::NonAdmins),
             "everyone" => Ok(Self::Everyone),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5164,29 +5189,29 @@ impl ToString for CheckRunCompletedAction {
     }
 }
 impl std::str::FromStr for CheckRunCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5651,8 +5676,8 @@ impl ToString for CheckRunCompletedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -5661,25 +5686,25 @@ impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5724,31 +5749,31 @@ impl ToString for CheckRunCompletedCheckRunCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5812,8 +5837,8 @@ impl ToString for CheckRunCompletedCheckRunConclusion {
     }
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -5823,25 +5848,25 @@ impl std::str::FromStr for CheckRunCompletedCheckRunConclusion {
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
             "skipped" => Ok(Self::Skipped),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5936,29 +5961,29 @@ impl ToString for CheckRunCompletedCheckRunStatus {
     }
 }
 impl std::str::FromStr for CheckRunCompletedCheckRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCompletedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCompletedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6331,29 +6356,29 @@ impl ToString for CheckRunCreatedAction {
     }
 }
 impl std::str::FromStr for CheckRunCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6823,8 +6848,8 @@ impl ToString for CheckRunCreatedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -6833,25 +6858,25 @@ impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6894,31 +6919,31 @@ impl ToString for CheckRunCreatedCheckRunCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6982,8 +7007,8 @@ impl ToString for CheckRunCreatedCheckRunConclusion {
     }
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -6993,25 +7018,25 @@ impl std::str::FromStr for CheckRunCreatedCheckRunConclusion {
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
             "skipped" => Ok(Self::Skipped),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7114,31 +7139,31 @@ impl ToString for CheckRunCreatedCheckRunStatus {
     }
 }
 impl std::str::FromStr for CheckRunCreatedCheckRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunCreatedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunCreatedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7819,29 +7844,29 @@ impl ToString for CheckRunRequestedActionAction {
     }
 }
 impl std::str::FromStr for CheckRunRequestedActionAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested_action" => Ok(Self::RequestedAction),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRequestedActionAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8313,8 +8338,8 @@ impl ToString for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -8323,25 +8348,25 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8386,31 +8411,31 @@ impl ToString for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8476,8 +8501,8 @@ impl ToString for CheckRunRequestedActionCheckRunConclusion {
     }
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -8487,25 +8512,25 @@ impl std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
             "skipped" => Ok(Self::Skipped),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8608,31 +8633,31 @@ impl ToString for CheckRunRequestedActionCheckRunStatus {
     }
 }
 impl std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRequestedActionCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8994,29 +9019,29 @@ impl ToString for CheckRunRerequestedAction {
     }
 }
 impl std::str::FromStr for CheckRunRerequestedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "rerequested" => Ok(Self::Rerequested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9469,8 +9494,8 @@ impl ToString for CheckRunRerequestedCheckRunCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -9479,25 +9504,25 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9534,29 +9559,29 @@ impl ToString for CheckRunRerequestedCheckRunCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9620,8 +9645,8 @@ impl ToString for CheckRunRerequestedCheckRunConclusion {
     }
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -9631,25 +9656,25 @@ impl std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
             "skipped" => Ok(Self::Skipped),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9744,29 +9769,29 @@ impl ToString for CheckRunRerequestedCheckRunStatus {
     }
 }
 impl std::str::FromStr for CheckRunRerequestedCheckRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckRunRerequestedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10002,29 +10027,29 @@ impl ToString for CheckSuiteCompletedAction {
     }
 }
 impl std::str::FromStr for CheckSuiteCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10237,8 +10262,8 @@ impl ToString for CheckSuiteCompletedCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckSuiteCompletedCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -10247,25 +10272,25 @@ impl std::str::FromStr for CheckSuiteCompletedCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10313,32 +10338,32 @@ impl ToString for CheckSuiteCompletedCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10591,29 +10616,29 @@ impl ToString for CheckSuiteRequestedAction {
     }
 }
 impl std::str::FromStr for CheckSuiteRequestedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10826,8 +10851,8 @@ impl ToString for CheckSuiteRequestedCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckSuiteRequestedCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -10836,25 +10861,25 @@ impl std::str::FromStr for CheckSuiteRequestedCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10902,32 +10927,32 @@ impl ToString for CheckSuiteRequestedCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11133,29 +11158,29 @@ impl ToString for CheckSuiteRerequestedAction {
     }
 }
 impl std::str::FromStr for CheckSuiteRerequestedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "rerequested" => Ok(Self::Rerequested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRerequestedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11370,8 +11395,8 @@ impl ToString for CheckSuiteRerequestedCheckSuiteConclusion {
     }
 }
 impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -11380,25 +11405,25 @@ impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11446,32 +11471,32 @@ impl ToString for CheckSuiteRerequestedCheckSuiteStatus {
     }
 }
 impl std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11718,29 +11743,29 @@ impl ToString for CodeScanningAlertAppearedInBranchAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "appeared_in_branch" => Ok(Self::AppearedInBranch),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11962,31 +11987,31 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertDismissedReason {
     }
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
             "used in tests" => Ok(Self::UsedInTests),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12093,32 +12118,32 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12164,31 +12189,31 @@ impl ToString for CodeScanningAlertAppearedInBranchAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertAppearedInBranchAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertAppearedInBranchAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12500,29 +12525,29 @@ impl ToString for CodeScanningAlertClosedByUserAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed_by_user" => Ok(Self::ClosedByUser),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12767,31 +12792,31 @@ impl ToString for CodeScanningAlertClosedByUserAlertDismissedReason {
     }
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
             "used in tests" => Ok(Self::UsedInTests),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12962,29 +12987,29 @@ impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13109,32 +13134,32 @@ impl ToString for CodeScanningAlertClosedByUserAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13170,29 +13195,29 @@ impl ToString for CodeScanningAlertClosedByUserAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertClosedByUserAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertClosedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13505,29 +13530,29 @@ impl ToString for CodeScanningAlertCreatedAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13896,30 +13921,30 @@ impl ToString for CodeScanningAlertCreatedAlertInstancesItemState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAlertInstancesItemState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14044,32 +14069,32 @@ impl ToString for CodeScanningAlertCreatedAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14109,30 +14134,30 @@ impl ToString for CodeScanningAlertCreatedAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertCreatedAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertCreatedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14541,29 +14566,29 @@ impl ToString for CodeScanningAlertFixedAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertFixedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14826,31 +14851,31 @@ impl ToString for CodeScanningAlertFixedAlertDismissedReason {
     }
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertDismissedReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "false positive" => Ok(Self::FalsePositive),
             "won't fix" => Ok(Self::WontFix),
             "used in tests" => Ok(Self::UsedInTests),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertDismissedReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15019,29 +15044,29 @@ impl ToString for CodeScanningAlertFixedAlertInstancesItemState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertInstancesItemState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15164,32 +15189,32 @@ impl ToString for CodeScanningAlertFixedAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15225,29 +15250,29 @@ impl ToString for CodeScanningAlertFixedAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertFixedAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertFixedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15560,29 +15585,29 @@ impl ToString for CodeScanningAlertReopenedAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15946,29 +15971,29 @@ impl ToString for CodeScanningAlertReopenedAlertInstancesItemState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAlertInstancesItemState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16093,32 +16118,32 @@ impl ToString for CodeScanningAlertReopenedAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16162,31 +16187,31 @@ impl ToString for CodeScanningAlertReopenedAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "dismissed" => Ok(Self::Dismissed),
             "fixed" => Ok(Self::Fixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16479,29 +16504,29 @@ impl ToString for CodeScanningAlertReopenedByUserAction {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened_by_user" => Ok(Self::ReopenedByUser),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16845,29 +16870,29 @@ impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16972,32 +16997,32 @@ impl ToString for CodeScanningAlertReopenedByUserAlertRuleSeverity {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "note" => Ok(Self::Note),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17035,29 +17060,29 @@ impl ToString for CodeScanningAlertReopenedByUserAlertState {
     }
 }
 impl std::str::FromStr for CodeScanningAlertReopenedByUserAlertState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17377,29 +17402,29 @@ impl ToString for CommitCommentCreatedAction {
     }
 }
 impl std::str::FromStr for CommitCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CommitCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CommitCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CommitCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17779,29 +17804,29 @@ impl ToString for ContentReferenceCreatedAction {
     }
 }
 impl std::str::FromStr for ContentReferenceCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ContentReferenceCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ContentReferenceCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ContentReferenceCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18008,30 +18033,30 @@ impl ToString for CreateEventRefType {
     }
 }
 impl std::str::FromStr for CreateEventRefType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "tag" => Ok(Self::Tag),
             "branch" => Ok(Self::Branch),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CreateEventRefType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CreateEventRefType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CreateEventRefType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18144,30 +18169,30 @@ impl ToString for DeleteEventRefType {
     }
 }
 impl std::str::FromStr for DeleteEventRefType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "tag" => Ok(Self::Tag),
             "branch" => Ok(Self::Branch),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DeleteEventRefType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeleteEventRefType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DeleteEventRefType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18296,29 +18321,29 @@ impl ToString for DeployKeyCreatedAction {
     }
 }
 impl std::str::FromStr for DeployKeyCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DeployKeyCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeployKeyCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DeployKeyCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18508,29 +18533,29 @@ impl ToString for DeployKeyDeletedAction {
     }
 }
 impl std::str::FromStr for DeployKeyDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DeployKeyDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeployKeyDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DeployKeyDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18813,29 +18838,29 @@ impl ToString for DeploymentCreatedAction {
     }
 }
 impl std::str::FromStr for DeploymentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DeploymentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeploymentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DeploymentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19258,29 +19283,29 @@ impl ToString for DeploymentStatusCreatedAction {
     }
 }
 impl std::str::FromStr for DeploymentStatusCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DeploymentStatusCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DeploymentStatusCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DeploymentStatusCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19941,29 +19966,29 @@ impl ToString for DiscussionAnsweredAction {
     }
 }
 impl std::str::FromStr for DiscussionAnsweredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "answered" => Ok(Self::Answered),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionAnsweredAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionAnsweredAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionAnsweredAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20325,31 +20350,31 @@ impl ToString for DiscussionAnsweredDiscussionAnswerChosenByType {
     }
 }
 impl std::str::FromStr for DiscussionAnsweredDiscussionAnswerChosenByType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionAnswerChosenByType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionAnsweredDiscussionAnswerChosenByType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionAnswerChosenByType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20465,31 +20490,31 @@ impl ToString for DiscussionAnsweredDiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionAnsweredDiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "locked" => Ok(Self::Locked),
             "converting" => Ok(Self::Converting),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionAnsweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20718,29 +20743,29 @@ impl ToString for DiscussionCategoryChangedAction {
     }
 }
 impl std::str::FromStr for DiscussionCategoryChangedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "category_changed" => Ok(Self::CategoryChanged),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCategoryChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCategoryChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCategoryChangedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21118,29 +21143,29 @@ impl ToString for DiscussionCommentCreatedAction {
     }
 }
 impl std::str::FromStr for DiscussionCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21382,29 +21407,29 @@ impl ToString for DiscussionCommentDeletedAction {
     }
 }
 impl std::str::FromStr for DiscussionCommentDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21669,29 +21694,29 @@ impl ToString for DiscussionCommentEditedAction {
     }
 }
 impl std::str::FromStr for DiscussionCommentEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22025,29 +22050,29 @@ impl ToString for DiscussionCreatedAction {
     }
 }
 impl std::str::FromStr for DiscussionCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22233,30 +22258,30 @@ impl ToString for DiscussionCreatedDiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionCreatedDiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "converting" => Ok(Self::Converting),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionCreatedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionCreatedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionCreatedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22350,29 +22375,29 @@ impl ToString for DiscussionDeletedAction {
     }
 }
 impl std::str::FromStr for DiscussionDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22498,29 +22523,29 @@ impl ToString for DiscussionEditedAction {
     }
 }
 impl std::str::FromStr for DiscussionEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22864,29 +22889,29 @@ impl ToString for DiscussionLabeledAction {
     }
 }
 impl std::str::FromStr for DiscussionLabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "labeled" => Ok(Self::Labeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23006,29 +23031,29 @@ impl ToString for DiscussionLockedAction {
     }
 }
 impl std::str::FromStr for DiscussionLockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionLockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23197,29 +23222,29 @@ impl ToString for DiscussionLockedDiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionLockedDiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionLockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionLockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionLockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23313,29 +23338,29 @@ impl ToString for DiscussionPinnedAction {
     }
 }
 impl std::str::FromStr for DiscussionPinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pinned" => Ok(Self::Pinned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23378,31 +23403,31 @@ impl ToString for DiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "locked" => Ok(Self::Locked),
             "converting" => Ok(Self::Converting),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23514,29 +23539,29 @@ impl ToString for DiscussionTransferredAction {
     }
 }
 impl std::str::FromStr for DiscussionTransferredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "transferred" => Ok(Self::Transferred),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23764,29 +23789,29 @@ impl ToString for DiscussionUnansweredAction {
     }
 }
 impl std::str::FromStr for DiscussionUnansweredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unanswered" => Ok(Self::Unanswered),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnansweredAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnansweredAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnansweredAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23980,31 +24005,31 @@ impl ToString for DiscussionUnansweredDiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionUnansweredDiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "locked" => Ok(Self::Locked),
             "converting" => Ok(Self::Converting),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnansweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnansweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnansweredDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24189,29 +24214,29 @@ impl ToString for DiscussionUnlabeledAction {
     }
 }
 impl std::str::FromStr for DiscussionUnlabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24331,29 +24356,29 @@ impl ToString for DiscussionUnlockedAction {
     }
 }
 impl std::str::FromStr for DiscussionUnlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24522,29 +24547,29 @@ impl ToString for DiscussionUnlockedDiscussionState {
     }
 }
 impl std::str::FromStr for DiscussionUnlockedDiscussionState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnlockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnlockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnlockedDiscussionState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24638,29 +24663,29 @@ impl ToString for DiscussionUnpinnedAction {
     }
 }
 impl std::str::FromStr for DiscussionUnpinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unpinned" => Ok(Self::Unpinned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiscussionUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiscussionUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiscussionUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25425,32 +25450,32 @@ impl From<&ForkEventForkeeCreatedAt> for ForkEventForkeeCreatedAt {
     }
 }
 impl std::str::FromStr for ForkEventForkeeCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForkEventForkeeCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForkEventForkeeCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForkEventForkeeCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25671,29 +25696,29 @@ impl ToString for GithubAppAuthorizationRevokedAction {
     }
 }
 impl std::str::FromStr for GithubAppAuthorizationRevokedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "revoked" => Ok(Self::Revoked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GithubAppAuthorizationRevokedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GithubAppAuthorizationRevokedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GithubAppAuthorizationRevokedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26056,30 +26081,30 @@ impl ToString for GollumEventPagesItemAction {
     }
 }
 impl std::str::FromStr for GollumEventPagesItemAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GollumEventPagesItemAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GollumEventPagesItemAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GollumEventPagesItemAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26671,29 +26696,29 @@ impl ToString for InstallationCreatedAction {
     }
 }
 impl std::str::FromStr for InstallationCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26727,32 +26752,32 @@ impl From<&InstallationCreatedAt> for InstallationCreatedAt {
     }
 }
 impl std::str::FromStr for InstallationCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26947,29 +26972,29 @@ impl ToString for InstallationDeletedAction {
     }
 }
 impl std::str::FromStr for InstallationDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27300,8 +27325,8 @@ impl ToString for InstallationEventsItem {
     }
 }
 impl std::str::FromStr for InstallationEventsItem {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -27348,25 +27373,25 @@ impl std::str::FromStr for InstallationEventsItem {
             "watch" => Ok(Self::Watch),
             "workflow_dispatch" => Ok(Self::WorkflowDispatch),
             "workflow_run" => Ok(Self::WorkflowRun),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27527,29 +27552,29 @@ impl ToString for InstallationNewPermissionsAcceptedAction {
     }
 }
 impl std::str::FromStr for InstallationNewPermissionsAcceptedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "new_permissions_accepted" => Ok(Self::NewPermissionsAccepted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationNewPermissionsAcceptedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationNewPermissionsAcceptedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationNewPermissionsAcceptedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27983,30 +28008,30 @@ impl ToString for InstallationPermissionsActions {
     }
 }
 impl std::str::FromStr for InstallationPermissionsActions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28045,30 +28070,30 @@ impl ToString for InstallationPermissionsAdministration {
     }
 }
 impl std::str::FromStr for InstallationPermissionsAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28107,30 +28132,30 @@ impl ToString for InstallationPermissionsChecks {
     }
 }
 impl std::str::FromStr for InstallationPermissionsChecks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28169,30 +28194,30 @@ impl ToString for InstallationPermissionsContentReferences {
     }
 }
 impl std::str::FromStr for InstallationPermissionsContentReferences {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28231,30 +28256,30 @@ impl ToString for InstallationPermissionsContents {
     }
 }
 impl std::str::FromStr for InstallationPermissionsContents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28293,30 +28318,30 @@ impl ToString for InstallationPermissionsDeployments {
     }
 }
 impl std::str::FromStr for InstallationPermissionsDeployments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28355,30 +28380,30 @@ impl ToString for InstallationPermissionsDiscussions {
     }
 }
 impl std::str::FromStr for InstallationPermissionsDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28417,30 +28442,30 @@ impl ToString for InstallationPermissionsEmails {
     }
 }
 impl std::str::FromStr for InstallationPermissionsEmails {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28479,30 +28504,30 @@ impl ToString for InstallationPermissionsEnvironments {
     }
 }
 impl std::str::FromStr for InstallationPermissionsEnvironments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28541,30 +28566,30 @@ impl ToString for InstallationPermissionsIssues {
     }
 }
 impl std::str::FromStr for InstallationPermissionsIssues {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28603,30 +28628,30 @@ impl ToString for InstallationPermissionsMembers {
     }
 }
 impl std::str::FromStr for InstallationPermissionsMembers {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28665,30 +28690,30 @@ impl ToString for InstallationPermissionsMetadata {
     }
 }
 impl std::str::FromStr for InstallationPermissionsMetadata {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28729,30 +28754,30 @@ impl ToString for InstallationPermissionsOrganizationAdministration {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28793,30 +28818,30 @@ impl ToString for InstallationPermissionsOrganizationEvents {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationEvents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationEvents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28855,30 +28880,30 @@ impl ToString for InstallationPermissionsOrganizationHooks {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28919,30 +28944,30 @@ impl ToString for InstallationPermissionsOrganizationPackages {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28981,30 +29006,30 @@ impl ToString for InstallationPermissionsOrganizationPlan {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationPlan {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29045,30 +29070,30 @@ impl ToString for InstallationPermissionsOrganizationProjects {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationProjects {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29109,30 +29134,30 @@ impl ToString for InstallationPermissionsOrganizationSecrets {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29173,30 +29198,30 @@ impl ToString for InstallationPermissionsOrganizationSelfHostedRunners {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationSelfHostedRunners {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29237,30 +29262,30 @@ impl ToString for InstallationPermissionsOrganizationUserBlocking {
     }
 }
 impl std::str::FromStr for InstallationPermissionsOrganizationUserBlocking {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationUserBlocking {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29299,30 +29324,30 @@ impl ToString for InstallationPermissionsPackages {
     }
 }
 impl std::str::FromStr for InstallationPermissionsPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29361,30 +29386,30 @@ impl ToString for InstallationPermissionsPages {
     }
 }
 impl std::str::FromStr for InstallationPermissionsPages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29423,30 +29448,30 @@ impl ToString for InstallationPermissionsPullRequests {
     }
 }
 impl std::str::FromStr for InstallationPermissionsPullRequests {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29485,30 +29510,30 @@ impl ToString for InstallationPermissionsRepositoryHooks {
     }
 }
 impl std::str::FromStr for InstallationPermissionsRepositoryHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29549,30 +29574,30 @@ impl ToString for InstallationPermissionsRepositoryProjects {
     }
 }
 impl std::str::FromStr for InstallationPermissionsRepositoryProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29613,30 +29638,30 @@ impl ToString for InstallationPermissionsSecretScanningAlerts {
     }
 }
 impl std::str::FromStr for InstallationPermissionsSecretScanningAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsSecretScanningAlerts {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29675,30 +29700,30 @@ impl ToString for InstallationPermissionsSecrets {
     }
 }
 impl std::str::FromStr for InstallationPermissionsSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29737,30 +29762,30 @@ impl ToString for InstallationPermissionsSecurityEvents {
     }
 }
 impl std::str::FromStr for InstallationPermissionsSecurityEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29801,30 +29826,30 @@ impl ToString for InstallationPermissionsSecurityScanningAlert {
     }
 }
 impl std::str::FromStr for InstallationPermissionsSecurityScanningAlert {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsSecurityScanningAlert {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29863,30 +29888,30 @@ impl ToString for InstallationPermissionsSingleFile {
     }
 }
 impl std::str::FromStr for InstallationPermissionsSingleFile {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29925,30 +29950,30 @@ impl ToString for InstallationPermissionsStatuses {
     }
 }
 impl std::str::FromStr for InstallationPermissionsStatuses {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29987,30 +30012,30 @@ impl ToString for InstallationPermissionsTeamDiscussions {
     }
 }
 impl std::str::FromStr for InstallationPermissionsTeamDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30051,30 +30076,30 @@ impl ToString for InstallationPermissionsVulnerabilityAlerts {
     }
 }
 impl std::str::FromStr for InstallationPermissionsVulnerabilityAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30113,30 +30138,30 @@ impl ToString for InstallationPermissionsWorkflows {
     }
 }
 impl std::str::FromStr for InstallationPermissionsWorkflows {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30308,29 +30333,29 @@ impl ToString for InstallationRepositoriesAddedAction {
     }
 }
 impl std::str::FromStr for InstallationRepositoriesAddedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "added" => Ok(Self::Added),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationRepositoriesAddedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30484,30 +30509,30 @@ impl ToString for InstallationRepositoriesAddedRepositorySelection {
     }
 }
 impl std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesAddedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesAddedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationRepositoriesAddedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30724,29 +30749,29 @@ impl ToString for InstallationRepositoriesRemovedAction {
     }
 }
 impl std::str::FromStr for InstallationRepositoriesRemovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "removed" => Ok(Self::Removed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationRepositoriesRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30902,30 +30927,30 @@ impl ToString for InstallationRepositoriesRemovedRepositorySelection {
     }
 }
 impl std::str::FromStr for InstallationRepositoriesRemovedRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositoriesRemovedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositoriesRemovedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationRepositoriesRemovedRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30965,30 +30990,30 @@ impl ToString for InstallationRepositorySelection {
     }
 }
 impl std::str::FromStr for InstallationRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31131,29 +31156,29 @@ impl ToString for InstallationSuspendAction {
     }
 }
 impl std::str::FromStr for InstallationSuspendAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "suspend" => Ok(Self::Suspend),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31252,32 +31277,32 @@ impl From<&InstallationSuspendInstallationCreatedAt> for InstallationSuspendInst
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31508,8 +31533,8 @@ impl ToString for InstallationSuspendInstallationEventsItem {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationEventsItem {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -31556,25 +31581,25 @@ impl std::str::FromStr for InstallationSuspendInstallationEventsItem {
             "watch" => Ok(Self::Watch),
             "workflow_dispatch" => Ok(Self::WorkflowDispatch),
             "workflow_run" => Ok(Self::WorkflowRun),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31961,30 +31986,30 @@ impl ToString for InstallationSuspendInstallationPermissionsActions {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsActions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32025,30 +32050,30 @@ impl ToString for InstallationSuspendInstallationPermissionsAdministration {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32089,30 +32114,30 @@ impl ToString for InstallationSuspendInstallationPermissionsChecks {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsChecks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32153,32 +32178,32 @@ impl ToString for InstallationSuspendInstallationPermissionsContentReferences {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsContentReferences {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsContentReferences
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32219,30 +32244,30 @@ impl ToString for InstallationSuspendInstallationPermissionsContents {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsContents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32283,30 +32308,30 @@ impl ToString for InstallationSuspendInstallationPermissionsDeployments {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsDeployments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32347,30 +32372,30 @@ impl ToString for InstallationSuspendInstallationPermissionsDiscussions {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32411,30 +32436,30 @@ impl ToString for InstallationSuspendInstallationPermissionsEmails {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsEmails {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32475,30 +32500,30 @@ impl ToString for InstallationSuspendInstallationPermissionsEnvironments {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsEnvironments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32539,30 +32564,30 @@ impl ToString for InstallationSuspendInstallationPermissionsIssues {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsIssues {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32603,30 +32628,30 @@ impl ToString for InstallationSuspendInstallationPermissionsMembers {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsMembers {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32667,30 +32692,30 @@ impl ToString for InstallationSuspendInstallationPermissionsMetadata {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsMetadata {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32731,36 +32756,36 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationAdminist
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32801,34 +32826,34 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationEvents {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationEvents
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationEvents
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32869,32 +32894,32 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationHooks {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationHooks
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32935,36 +32960,36 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationPackages
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33005,30 +33030,30 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationPlan {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33069,36 +33094,36 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationProjects
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33139,34 +33164,34 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationSecrets 
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationSecrets
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationSecrets
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33209,36 +33234,36 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationSelfHost
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33279,36 +33304,36 @@ impl ToString for InstallationSuspendInstallationPermissionsOrganizationUserBloc
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33349,30 +33374,30 @@ impl ToString for InstallationSuspendInstallationPermissionsPackages {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33413,30 +33438,30 @@ impl ToString for InstallationSuspendInstallationPermissionsPages {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsPages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33477,30 +33502,30 @@ impl ToString for InstallationSuspendInstallationPermissionsPullRequests {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsPullRequests {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33541,30 +33566,30 @@ impl ToString for InstallationSuspendInstallationPermissionsRepositoryHooks {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33605,34 +33630,34 @@ impl ToString for InstallationSuspendInstallationPermissionsRepositoryProjects {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsRepositoryProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsRepositoryProjects {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsRepositoryProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsRepositoryProjects
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33673,36 +33698,36 @@ impl ToString for InstallationSuspendInstallationPermissionsSecretScanningAlerts
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33743,30 +33768,30 @@ impl ToString for InstallationSuspendInstallationPermissionsSecrets {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33807,30 +33832,30 @@ impl ToString for InstallationSuspendInstallationPermissionsSecurityEvents {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecurityEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33871,36 +33896,36 @@ impl ToString for InstallationSuspendInstallationPermissionsSecurityScanningAler
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationSuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33941,30 +33966,30 @@ impl ToString for InstallationSuspendInstallationPermissionsSingleFile {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsSingleFile {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34005,30 +34030,30 @@ impl ToString for InstallationSuspendInstallationPermissionsStatuses {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsStatuses {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34069,30 +34094,30 @@ impl ToString for InstallationSuspendInstallationPermissionsTeamDiscussions {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34133,34 +34158,34 @@ impl ToString for InstallationSuspendInstallationPermissionsVulnerabilityAlerts 
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34201,30 +34226,30 @@ impl ToString for InstallationSuspendInstallationPermissionsWorkflows {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationPermissionsWorkflows {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34266,30 +34291,30 @@ impl ToString for InstallationSuspendInstallationRepositorySelection {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34485,31 +34510,31 @@ impl ToString for InstallationSuspendInstallationSuspendedByType {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationSuspendedByType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationSuspendedByType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationSuspendedByType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationSuspendedByType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34548,30 +34573,30 @@ impl ToString for InstallationSuspendInstallationTargetType {
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationTargetType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34605,32 +34630,32 @@ impl From<&InstallationSuspendInstallationUpdatedAt> for InstallationSuspendInst
     }
 }
 impl std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationSuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationSuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationSuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34740,30 +34765,30 @@ impl ToString for InstallationTargetType {
     }
 }
 impl std::str::FromStr for InstallationTargetType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34905,29 +34930,29 @@ impl ToString for InstallationUnsuspendAction {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unsuspend" => Ok(Self::Unsuspend),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35027,32 +35052,32 @@ impl From<&InstallationUnsuspendInstallationCreatedAt>
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35283,8 +35308,8 @@ impl ToString for InstallationUnsuspendInstallationEventsItem {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationEventsItem {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -35331,25 +35356,25 @@ impl std::str::FromStr for InstallationUnsuspendInstallationEventsItem {
             "watch" => Ok(Self::Watch),
             "workflow_dispatch" => Ok(Self::WorkflowDispatch),
             "workflow_run" => Ok(Self::WorkflowRun),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationEventsItem {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35738,30 +35763,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsActions {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsActions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsActions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35802,30 +35827,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsAdministration {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsAdministration {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35866,30 +35891,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsChecks {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsChecks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsChecks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35930,34 +35955,34 @@ impl ToString for InstallationUnsuspendInstallationPermissionsContentReferences 
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsContentReferences {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsContentReferences {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsContentReferences
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsContentReferences
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35998,30 +36023,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsContents {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsContents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsContents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36062,30 +36087,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsDeployments {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsDeployments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsDeployments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36126,30 +36151,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsDiscussions {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36190,30 +36215,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsEmails {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsEmails {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsEmails {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36254,30 +36279,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsEnvironments {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsEnvironments {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsEnvironments {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36318,30 +36343,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsIssues {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsIssues {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsIssues {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36382,30 +36407,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsMembers {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsMembers {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsMembers {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36446,30 +36471,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsMetadata {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsMetadata {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsMetadata {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36512,36 +36537,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationAdmini
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36582,36 +36607,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationEvents
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationEvents
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationEvents
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationEvents
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36652,34 +36677,34 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationHooks 
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationHooks
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationHooks
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36720,36 +36745,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPackag
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationPackages
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36790,34 +36815,34 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationPlan
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationPlan
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36858,36 +36883,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationProjec
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationProjects
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36928,36 +36953,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSecret
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37002,36 +37027,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSelfHo
 impl std::str::FromStr
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37072,36 +37097,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationUserBl
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37142,30 +37167,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsPackages {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPackages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPackages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37206,30 +37231,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsPages {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPages {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPages {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37270,30 +37295,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsPullRequests {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsPullRequests {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsPullRequests {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37334,32 +37359,32 @@ impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsRepositoryHooks
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37400,36 +37425,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryProjects
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsRepositoryProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsRepositoryProjects
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsRepositoryProjects
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37470,36 +37495,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsSecretScanningAler
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37540,30 +37565,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsSecrets {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecrets {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSecrets {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37604,30 +37629,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsSecurityEvents {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37668,36 +37693,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsSecurityScanningAl
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37738,30 +37763,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsSingleFile {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsSingleFile {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsSingleFile {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37802,30 +37827,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsStatuses {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsStatuses {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsStatuses {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37866,32 +37891,32 @@ impl ToString for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsTeamDiscussions
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37932,36 +37957,36 @@ impl ToString for InstallationUnsuspendInstallationPermissionsVulnerabilityAlert
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str>
     for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38002,30 +38027,30 @@ impl ToString for InstallationUnsuspendInstallationPermissionsWorkflows {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationPermissionsWorkflows {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "read" => Ok(Self::Read),
             "write" => Ok(Self::Write),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissionsWorkflows {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38067,30 +38092,30 @@ impl ToString for InstallationUnsuspendInstallationRepositorySelection {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationRepositorySelection {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "selected" => Ok(Self::Selected),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationRepositorySelection {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38129,30 +38154,30 @@ impl ToString for InstallationUnsuspendInstallationTargetType {
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationTargetType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationTargetType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38188,32 +38213,32 @@ impl From<&InstallationUnsuspendInstallationUpdatedAt>
     }
 }
 impl std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUnsuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUnsuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38320,32 +38345,32 @@ impl From<&InstallationUpdatedAt> for InstallationUpdatedAt {
     }
 }
 impl std::str::FromStr for InstallationUpdatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for InstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for InstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for InstallationUpdatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38650,32 +38675,32 @@ impl ToString for IssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38946,29 +38971,29 @@ impl ToString for IssueCommentCreatedAction {
     }
 }
 impl std::str::FromStr for IssueCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39137,32 +39162,32 @@ impl ToString for IssueCommentCreatedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssueCommentCreatedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentCreatedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39258,31 +39283,31 @@ impl ToString for IssueCommentCreatedIssueAssigneeType {
     }
 }
 impl std::str::FromStr for IssueCommentCreatedIssueAssigneeType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentCreatedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39369,30 +39394,30 @@ impl ToString for IssueCommentCreatedIssueState {
     }
 }
 impl std::str::FromStr for IssueCommentCreatedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentCreatedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentCreatedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentCreatedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39563,29 +39588,29 @@ impl ToString for IssueCommentDeletedAction {
     }
 }
 impl std::str::FromStr for IssueCommentDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39754,32 +39779,32 @@ impl ToString for IssueCommentDeletedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssueCommentDeletedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentDeletedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39875,31 +39900,31 @@ impl ToString for IssueCommentDeletedIssueAssigneeType {
     }
 }
 impl std::str::FromStr for IssueCommentDeletedIssueAssigneeType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentDeletedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39986,30 +40011,30 @@ impl ToString for IssueCommentDeletedIssueState {
     }
 }
 impl std::str::FromStr for IssueCommentDeletedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentDeletedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentDeletedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentDeletedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40202,29 +40227,29 @@ impl ToString for IssueCommentEditedAction {
     }
 }
 impl std::str::FromStr for IssueCommentEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40462,32 +40487,32 @@ impl ToString for IssueCommentEditedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssueCommentEditedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentEditedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentEditedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentEditedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40583,31 +40608,31 @@ impl ToString for IssueCommentEditedIssueAssigneeType {
     }
 }
 impl std::str::FromStr for IssueCommentEditedIssueAssigneeType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentEditedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentEditedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentEditedIssueAssigneeType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40694,30 +40719,30 @@ impl ToString for IssueCommentEditedIssueState {
     }
 }
 impl std::str::FromStr for IssueCommentEditedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueCommentEditedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueCommentEditedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueCommentEditedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40850,30 +40875,30 @@ impl ToString for IssueState {
     }
 }
 impl std::str::FromStr for IssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40985,29 +41010,29 @@ impl ToString for IssuesAssignedAction {
     }
 }
 impl std::str::FromStr for IssuesAssignedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "assigned" => Ok(Self::Assigned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41128,29 +41153,29 @@ impl ToString for IssuesClosedAction {
     }
 }
 impl std::str::FromStr for IssuesClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesClosedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41274,32 +41299,32 @@ impl ToString for IssuesClosedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesClosedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesClosedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesClosedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesClosedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41380,29 +41405,29 @@ impl ToString for IssuesClosedIssueState {
     }
 }
 impl std::str::FromStr for IssuesClosedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesClosedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesClosedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesClosedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41496,29 +41521,29 @@ impl ToString for IssuesDeletedAction {
     }
 }
 impl std::str::FromStr for IssuesDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41633,29 +41658,29 @@ impl ToString for IssuesDemilestonedAction {
     }
 }
 impl std::str::FromStr for IssuesDemilestonedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "demilestoned" => Ok(Self::Demilestoned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDemilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDemilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesDemilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41773,32 +41798,32 @@ impl ToString for IssuesDemilestonedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesDemilestonedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDemilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDemilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesDemilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41884,30 +41909,30 @@ impl ToString for IssuesDemilestonedIssueState {
     }
 }
 impl std::str::FromStr for IssuesDemilestonedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesDemilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesDemilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesDemilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42041,29 +42066,29 @@ impl ToString for IssuesEditedAction {
     }
 }
 impl std::str::FromStr for IssuesEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42443,29 +42468,29 @@ impl ToString for IssuesLabeledAction {
     }
 }
 impl std::str::FromStr for IssuesLabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "labeled" => Ok(Self::Labeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42592,29 +42617,29 @@ impl ToString for IssuesLockedAction {
     }
 }
 impl std::str::FromStr for IssuesLockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesLockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42748,32 +42773,32 @@ impl ToString for IssuesLockedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesLockedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLockedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLockedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesLockedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42859,30 +42884,30 @@ impl ToString for IssuesLockedIssueState {
     }
 }
 impl std::str::FromStr for IssuesLockedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesLockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesLockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesLockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42997,29 +43022,29 @@ impl ToString for IssuesMilestonedAction {
     }
 }
 impl std::str::FromStr for IssuesMilestonedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "milestoned" => Ok(Self::Milestoned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesMilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesMilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesMilestonedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43137,32 +43162,32 @@ impl ToString for IssuesMilestonedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesMilestonedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesMilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesMilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesMilestonedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43335,30 +43360,30 @@ impl ToString for IssuesMilestonedIssueMilestoneState {
     }
 }
 impl std::str::FromStr for IssuesMilestonedIssueMilestoneState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesMilestonedIssueMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesMilestonedIssueMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesMilestonedIssueMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43444,30 +43469,30 @@ impl ToString for IssuesMilestonedIssueState {
     }
 }
 impl std::str::FromStr for IssuesMilestonedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesMilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesMilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesMilestonedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43602,29 +43627,29 @@ impl ToString for IssuesOpenedAction {
     }
 }
 impl std::str::FromStr for IssuesOpenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "opened" => Ok(Self::Opened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43781,32 +43806,32 @@ impl ToString for IssuesOpenedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesOpenedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesOpenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesOpenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesOpenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43887,29 +43912,29 @@ impl ToString for IssuesOpenedIssueState {
     }
 }
 impl std::str::FromStr for IssuesOpenedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesOpenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesOpenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesOpenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44003,29 +44028,29 @@ impl ToString for IssuesPinnedAction {
     }
 }
 impl std::str::FromStr for IssuesPinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pinned" => Ok(Self::Pinned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesPinnedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44138,29 +44163,29 @@ impl ToString for IssuesReopenedAction {
     }
 }
 impl std::str::FromStr for IssuesReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44279,32 +44304,32 @@ impl ToString for IssuesReopenedIssueActiveLockReason {
     }
 }
 impl std::str::FromStr for IssuesReopenedIssueActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesReopenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesReopenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesReopenedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44385,29 +44410,29 @@ impl ToString for IssuesReopenedIssueState {
     }
 }
 impl std::str::FromStr for IssuesReopenedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesReopenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesReopenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesReopenedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44519,29 +44544,29 @@ impl ToString for IssuesTransferredAction {
     }
 }
 impl std::str::FromStr for IssuesTransferredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "transferred" => Ok(Self::Transferred),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44686,29 +44711,29 @@ impl ToString for IssuesUnassignedAction {
     }
 }
 impl std::str::FromStr for IssuesUnassignedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unassigned" => Ok(Self::Unassigned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44809,29 +44834,29 @@ impl ToString for IssuesUnlabeledAction {
     }
 }
 impl std::str::FromStr for IssuesUnlabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44948,29 +44973,29 @@ impl ToString for IssuesUnlockedAction {
     }
 }
 impl std::str::FromStr for IssuesUnlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45083,10 +45108,10 @@ impl From<&IssuesUnlockedIssueActiveLockReason> for IssuesUnlockedIssueActiveLoc
     }
 }
 impl std::convert::TryFrom<()> for IssuesUnlockedIssueActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: ()) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: ()) -> Result<Self, self::error::ConversionError> {
         if ![()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -45183,30 +45208,30 @@ impl ToString for IssuesUnlockedIssueState {
     }
 }
 impl std::str::FromStr for IssuesUnlockedIssueState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnlockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnlockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnlockedIssueState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45300,29 +45325,29 @@ impl ToString for IssuesUnpinnedAction {
     }
 }
 impl std::str::FromStr for IssuesUnpinnedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unpinned" => Ok(Self::Unpinned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IssuesUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IssuesUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IssuesUnpinnedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45489,29 +45514,29 @@ impl ToString for LabelCreatedAction {
     }
 }
 impl std::str::FromStr for LabelCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LabelCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LabelCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45607,29 +45632,29 @@ impl ToString for LabelDeletedAction {
     }
 }
 impl std::str::FromStr for LabelDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LabelDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LabelDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45773,29 +45798,29 @@ impl ToString for LabelEditedAction {
     }
 }
 impl std::str::FromStr for LabelEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LabelEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LabelEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46467,29 +46492,29 @@ impl ToString for MarketplacePurchaseCancelledAction {
     }
 }
 impl std::str::FromStr for MarketplacePurchaseCancelledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "cancelled" => Ok(Self::Cancelled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchaseCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchaseCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarketplacePurchaseCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46983,29 +47008,29 @@ impl ToString for MarketplacePurchaseChangedAction {
     }
 }
 impl std::str::FromStr for MarketplacePurchaseChangedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "changed" => Ok(Self::Changed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchaseChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchaseChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarketplacePurchaseChangedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47564,29 +47589,29 @@ impl ToString for MarketplacePurchasePendingChangeAction {
     }
 }
 impl std::str::FromStr for MarketplacePurchasePendingChangeAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pending_change" => Ok(Self::PendingChange),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47784,29 +47809,29 @@ impl ToString for MarketplacePurchasePendingChangeCancelledAction {
     }
 }
 impl std::str::FromStr for MarketplacePurchasePendingChangeCancelledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pending_change_cancelled" => Ok(Self::PendingChangeCancelled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePendingChangeCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48677,29 +48702,29 @@ impl ToString for MarketplacePurchasePurchasedAction {
     }
 }
 impl std::str::FromStr for MarketplacePurchasePurchasedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "purchased" => Ok(Self::Purchased),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarketplacePurchasePurchasedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarketplacePurchasePurchasedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarketplacePurchasePurchasedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49115,29 +49140,29 @@ impl ToString for MemberAddedAction {
     }
 }
 impl std::str::FromStr for MemberAddedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "added" => Ok(Self::Added),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49249,30 +49274,30 @@ impl ToString for MemberAddedChangesPermissionTo {
     }
 }
 impl std::str::FromStr for MemberAddedChangesPermissionTo {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "write" => Ok(Self::Write),
             "admin" => Ok(Self::Admin),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MemberAddedChangesPermissionTo {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberAddedChangesPermissionTo {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MemberAddedChangesPermissionTo {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49388,29 +49413,29 @@ impl ToString for MemberEditedAction {
     }
 }
 impl std::str::FromStr for MemberEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MemberEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MemberEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49619,29 +49644,29 @@ impl ToString for MemberRemovedAction {
     }
 }
 impl std::str::FromStr for MemberRemovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "removed" => Ok(Self::Removed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49803,29 +49828,29 @@ impl ToString for MembershipAddedAction {
     }
 }
 impl std::str::FromStr for MembershipAddedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "added" => Ok(Self::Added),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MembershipAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MembershipAddedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49861,29 +49886,29 @@ impl ToString for MembershipAddedScope {
     }
 }
 impl std::str::FromStr for MembershipAddedScope {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "team" => Ok(Self::Team),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MembershipAddedScope {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipAddedScope {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MembershipAddedScope {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50053,29 +50078,29 @@ impl ToString for MembershipRemovedAction {
     }
 }
 impl std::str::FromStr for MembershipRemovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "removed" => Ok(Self::Removed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MembershipRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MembershipRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50115,30 +50140,30 @@ impl ToString for MembershipRemovedScope {
     }
 }
 impl std::str::FromStr for MembershipRemovedScope {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "team" => Ok(Self::Team),
             "organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MembershipRemovedScope {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MembershipRemovedScope {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MembershipRemovedScope {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50344,29 +50369,29 @@ impl ToString for MetaDeletedAction {
     }
 }
 impl std::str::FromStr for MetaDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MetaDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MetaDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MetaDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50537,30 +50562,30 @@ impl ToString for MetaDeletedHookConfigContentType {
     }
 }
 impl std::str::FromStr for MetaDeletedHookConfigContentType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "json" => Ok(Self::Json),
             "form" => Ok(Self::Form),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MetaDeletedHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MetaDeletedHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MetaDeletedHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50847,29 +50872,29 @@ impl ToString for MilestoneClosedAction {
     }
 }
 impl std::str::FromStr for MilestoneClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneClosedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50964,29 +50989,29 @@ impl ToString for MilestoneClosedMilestoneState {
     }
 }
 impl std::str::FromStr for MilestoneClosedMilestoneState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneClosedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneClosedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneClosedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51103,29 +51128,29 @@ impl ToString for MilestoneCreatedAction {
     }
 }
 impl std::str::FromStr for MilestoneCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51220,29 +51245,29 @@ impl ToString for MilestoneCreatedMilestoneState {
     }
 }
 impl std::str::FromStr for MilestoneCreatedMilestoneState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneCreatedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneCreatedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneCreatedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51336,29 +51361,29 @@ impl ToString for MilestoneDeletedAction {
     }
 }
 impl std::str::FromStr for MilestoneDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51500,29 +51525,29 @@ impl ToString for MilestoneEditedAction {
     }
 }
 impl std::str::FromStr for MilestoneEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51865,29 +51890,29 @@ impl ToString for MilestoneOpenedAction {
     }
 }
 impl std::str::FromStr for MilestoneOpenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "opened" => Ok(Self::Opened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51982,29 +52007,29 @@ impl ToString for MilestoneOpenedMilestoneState {
     }
 }
 impl std::str::FromStr for MilestoneOpenedMilestoneState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneOpenedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneOpenedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneOpenedMilestoneState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52044,30 +52069,30 @@ impl ToString for MilestoneState {
     }
 }
 impl std::str::FromStr for MilestoneState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MilestoneState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MilestoneState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52158,29 +52183,29 @@ impl ToString for OrgBlockBlockedAction {
     }
 }
 impl std::str::FromStr for OrgBlockBlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "blocked" => Ok(Self::Blocked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrgBlockBlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrgBlockBlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrgBlockBlockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52309,29 +52334,29 @@ impl ToString for OrgBlockUnblockedAction {
     }
 }
 impl std::str::FromStr for OrgBlockUnblockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unblocked" => Ok(Self::Unblocked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrgBlockUnblockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrgBlockUnblockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrgBlockUnblockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52523,29 +52548,29 @@ impl ToString for OrganizationDeletedAction {
     }
 }
 impl std::str::FromStr for OrganizationDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrganizationDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52699,29 +52724,29 @@ impl ToString for OrganizationMemberAddedAction {
     }
 }
 impl std::str::FromStr for OrganizationMemberAddedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "member_added" => Ok(Self::MemberAdded),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrganizationMemberAddedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52881,29 +52906,29 @@ impl ToString for OrganizationMemberInvitedAction {
     }
 }
 impl std::str::FromStr for OrganizationMemberInvitedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "member_invited" => Ok(Self::MemberInvited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberInvitedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberInvitedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrganizationMemberInvitedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53088,29 +53113,29 @@ impl ToString for OrganizationMemberRemovedAction {
     }
 }
 impl std::str::FromStr for OrganizationMemberRemovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "member_removed" => Ok(Self::MemberRemoved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationMemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationMemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrganizationMemberRemovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53199,29 +53224,29 @@ impl ToString for OrganizationRenamedAction {
     }
 }
 impl std::str::FromStr for OrganizationRenamedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "renamed" => Ok(Self::Renamed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrganizationRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrganizationRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrganizationRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53637,29 +53662,29 @@ impl ToString for PackagePublishedAction {
     }
 }
 impl std::str::FromStr for PackagePublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "published" => Ok(Self::Published),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PackagePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackagePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PackagePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54821,29 +54846,29 @@ impl ToString for PackageUpdatedAction {
     }
 }
 impl std::str::FromStr for PackageUpdatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "updated" => Ok(Self::Updated),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PackageUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackageUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PackageUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56231,30 +56256,30 @@ impl ToString for PingEventHookConfigContentType {
     }
 }
 impl std::str::FromStr for PingEventHookConfigContentType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "json" => Ok(Self::Json),
             "form" => Ok(Self::Form),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PingEventHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PingEventHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PingEventHookConfigContentType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56624,29 +56649,29 @@ impl ToString for ProjectCardConvertedAction {
     }
 }
 impl std::str::FromStr for ProjectCardConvertedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "converted" => Ok(Self::Converted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardConvertedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardConvertedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCardConvertedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56807,29 +56832,29 @@ impl ToString for ProjectCardCreatedAction {
     }
 }
 impl std::str::FromStr for ProjectCardCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCardCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56923,29 +56948,29 @@ impl ToString for ProjectCardDeletedAction {
     }
 }
 impl std::str::FromStr for ProjectCardDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCardDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57062,29 +57087,29 @@ impl ToString for ProjectCardEditedAction {
     }
 }
 impl std::str::FromStr for ProjectCardEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCardEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57352,29 +57377,29 @@ impl ToString for ProjectCardMovedAction {
     }
 }
 impl std::str::FromStr for ProjectCardMovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "moved" => Ok(Self::Moved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCardMovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCardMovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCardMovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57589,29 +57614,29 @@ impl ToString for ProjectClosedAction {
     }
 }
 impl std::str::FromStr for ProjectClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectClosedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57780,29 +57805,29 @@ impl ToString for ProjectColumnCreatedAction {
     }
 }
 impl std::str::FromStr for ProjectColumnCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectColumnCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57896,29 +57921,29 @@ impl ToString for ProjectColumnDeletedAction {
     }
 }
 impl std::str::FromStr for ProjectColumnDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectColumnDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58032,29 +58057,29 @@ impl ToString for ProjectColumnEditedAction {
     }
 }
 impl std::str::FromStr for ProjectColumnEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectColumnEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58269,29 +58294,29 @@ impl ToString for ProjectColumnMovedAction {
     }
 }
 impl std::str::FromStr for ProjectColumnMovedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "moved" => Ok(Self::Moved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectColumnMovedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectColumnMovedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectColumnMovedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58385,29 +58410,29 @@ impl ToString for ProjectCreatedAction {
     }
 }
 impl std::str::FromStr for ProjectCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58501,29 +58526,29 @@ impl ToString for ProjectDeletedAction {
     }
 }
 impl std::str::FromStr for ProjectDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58652,29 +58677,29 @@ impl ToString for ProjectEditedAction {
     }
 }
 impl std::str::FromStr for ProjectEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58948,29 +58973,29 @@ impl ToString for ProjectReopenedAction {
     }
 }
 impl std::str::FromStr for ProjectReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59010,30 +59035,30 @@ impl ToString for ProjectState {
     }
 }
 impl std::str::FromStr for ProjectState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59282,32 +59307,32 @@ impl From<&PublicEventRepositoryCreatedAt> for PublicEventRepositoryCreatedAt {
     }
 }
 impl std::str::FromStr for PublicEventRepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for PublicEventRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PublicEventRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PublicEventRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59917,32 +59942,32 @@ impl ToString for PullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60048,29 +60073,29 @@ impl ToString for PullRequestAssignedAction {
     }
 }
 impl std::str::FromStr for PullRequestAssignedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "assigned" => Ok(Self::Assigned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestAssignedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60169,29 +60194,29 @@ impl ToString for PullRequestAutoMergeDisabledAction {
     }
 }
 impl std::str::FromStr for PullRequestAutoMergeDisabledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto_merge_disabled" => Ok(Self::AutoMergeDisabled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAutoMergeDisabledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAutoMergeDisabledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestAutoMergeDisabledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60290,29 +60315,29 @@ impl ToString for PullRequestAutoMergeEnabledAction {
     }
 }
 impl std::str::FromStr for PullRequestAutoMergeEnabledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto_merge_enabled" => Ok(Self::AutoMergeEnabled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestAutoMergeEnabledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestAutoMergeEnabledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestAutoMergeEnabledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60492,29 +60517,29 @@ impl ToString for PullRequestClosedAction {
     }
 }
 impl std::str::FromStr for PullRequestClosedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestClosedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestClosedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60664,32 +60689,32 @@ impl ToString for PullRequestClosedPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestClosedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestClosedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestClosedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestClosedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60929,29 +60954,29 @@ impl ToString for PullRequestClosedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestClosedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestClosedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestClosedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestClosedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61091,29 +61116,29 @@ impl ToString for PullRequestConvertedToDraftAction {
     }
 }
 impl std::str::FromStr for PullRequestConvertedToDraftAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "converted_to_draft" => Ok(Self::ConvertedToDraft),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestConvertedToDraftAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61273,32 +61298,32 @@ impl ToString for PullRequestConvertedToDraftPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61551,30 +61576,30 @@ impl ToString for PullRequestConvertedToDraftPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestConvertedToDraftPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestConvertedToDraftPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61710,29 +61735,29 @@ impl ToString for PullRequestEditedAction {
     }
 }
 impl std::str::FromStr for PullRequestEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62176,29 +62201,29 @@ impl ToString for PullRequestLabeledAction {
     }
 }
 impl std::str::FromStr for PullRequestLabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "labeled" => Ok(Self::Labeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestLabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62364,29 +62389,29 @@ impl ToString for PullRequestLockedAction {
     }
 }
 impl std::str::FromStr for PullRequestLockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "locked" => Ok(Self::Locked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestLockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestLockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62526,29 +62551,29 @@ impl ToString for PullRequestOpenedAction {
     }
 }
 impl std::str::FromStr for PullRequestOpenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "opened" => Ok(Self::Opened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestOpenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62697,10 +62722,10 @@ impl From<&PullRequestOpenedPullRequestActiveLockReason>
     }
 }
 impl std::convert::TryFrom<()> for PullRequestOpenedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: ()) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: ()) -> Result<Self, self::error::ConversionError> {
         if ![()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -62951,29 +62976,29 @@ impl ToString for PullRequestOpenedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestOpenedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestOpenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestOpenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestOpenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63117,29 +63142,29 @@ impl ToString for PullRequestReadyForReviewAction {
     }
 }
 impl std::str::FromStr for PullRequestReadyForReviewAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "ready_for_review" => Ok(Self::ReadyForReview),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReadyForReviewAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReadyForReviewAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReadyForReviewAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63302,32 +63327,32 @@ impl ToString for PullRequestReadyForReviewPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestReadyForReviewPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReadyForReviewPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63571,29 +63596,29 @@ impl ToString for PullRequestReadyForReviewPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestReadyForReviewPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReadyForReviewPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63733,29 +63758,29 @@ impl ToString for PullRequestReopenedAction {
     }
 }
 impl std::str::FromStr for PullRequestReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63915,32 +63940,32 @@ impl ToString for PullRequestReopenedPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestReopenedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReopenedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReopenedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64180,29 +64205,29 @@ impl ToString for PullRequestReopenedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestReopenedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReopenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReopenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64879,29 +64904,29 @@ impl ToString for PullRequestReviewCommentCreatedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65310,32 +65335,32 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65587,30 +65612,30 @@ impl ToString for PullRequestReviewCommentCreatedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentCreatedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66009,29 +66034,29 @@ impl ToString for PullRequestReviewCommentDeletedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66440,32 +66465,32 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66717,30 +66742,30 @@ impl ToString for PullRequestReviewCommentDeletedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentDeletedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67161,29 +67186,29 @@ impl ToString for PullRequestReviewCommentEditedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67663,32 +67688,32 @@ impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67940,30 +67965,30 @@ impl ToString for PullRequestReviewCommentEditedPullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentEditedPullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentEditedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedPullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68090,30 +68115,30 @@ impl ToString for PullRequestReviewCommentSide {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentSide {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "LEFT" => Ok(Self::Left),
             "RIGHT" => Ok(Self::Right),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentSide {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentSide {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentSide {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68154,30 +68179,30 @@ impl ToString for PullRequestReviewCommentStartSide {
     }
 }
 impl std::str::FromStr for PullRequestReviewCommentStartSide {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "LEFT" => Ok(Self::Left),
             "RIGHT" => Ok(Self::Right),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewCommentStartSide {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewCommentStartSide {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewCommentStartSide {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68351,29 +68376,29 @@ impl ToString for PullRequestReviewDismissedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewDismissedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewDismissedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewDismissedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewDismissedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68551,29 +68576,29 @@ impl ToString for PullRequestReviewDismissedReviewState {
     }
 }
 impl std::str::FromStr for PullRequestReviewDismissedReviewState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dismissed" => Ok(Self::Dismissed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewDismissedReviewState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewDismissedReviewState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewDismissedReviewState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68765,29 +68790,29 @@ impl ToString for PullRequestReviewEditedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69211,29 +69236,29 @@ impl ToString for PullRequestReviewRequestRemovedVariant0Action {
     }
 }
 impl std::str::FromStr for PullRequestReviewRequestRemovedVariant0Action {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "review_request_removed" => Ok(Self::ReviewRequestRemoved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewRequestRemovedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69270,29 +69295,29 @@ impl ToString for PullRequestReviewRequestRemovedVariant1Action {
     }
 }
 impl std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "review_request_removed" => Ok(Self::ReviewRequestRemoved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestRemovedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewRequestRemovedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69459,29 +69484,29 @@ impl ToString for PullRequestReviewRequestedVariant0Action {
     }
 }
 impl std::str::FromStr for PullRequestReviewRequestedVariant0Action {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "review_requested" => Ok(Self::ReviewRequested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewRequestedVariant0Action {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69516,29 +69541,29 @@ impl ToString for PullRequestReviewRequestedVariant1Action {
     }
 }
 impl std::str::FromStr for PullRequestReviewRequestedVariant1Action {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "review_requested" => Ok(Self::ReviewRequested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewRequestedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewRequestedVariant1Action {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69709,29 +69734,29 @@ impl ToString for PullRequestReviewSubmittedAction {
     }
 }
 impl std::str::FromStr for PullRequestReviewSubmittedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "submitted" => Ok(Self::Submitted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestReviewSubmittedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestReviewSubmittedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestReviewSubmittedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69911,30 +69936,30 @@ impl ToString for PullRequestState {
     }
 }
 impl std::str::FromStr for PullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70045,29 +70070,29 @@ impl ToString for PullRequestSynchronizeAction {
     }
 }
 impl std::str::FromStr for PullRequestSynchronizeAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "synchronize" => Ok(Self::Synchronize),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestSynchronizeAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestSynchronizeAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestSynchronizeAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70173,29 +70198,29 @@ impl ToString for PullRequestUnassignedAction {
     }
 }
 impl std::str::FromStr for PullRequestUnassignedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unassigned" => Ok(Self::Unassigned),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestUnassignedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70301,29 +70326,29 @@ impl ToString for PullRequestUnlabeledAction {
     }
 }
 impl std::str::FromStr for PullRequestUnlabeledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlabeled" => Ok(Self::Unlabeled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestUnlabeledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70424,29 +70449,29 @@ impl ToString for PullRequestUnlockedAction {
     }
 }
 impl std::str::FromStr for PullRequestUnlockedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unlocked" => Ok(Self::Unlocked),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PullRequestUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PullRequestUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PullRequestUnlockedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70859,29 +70884,29 @@ impl ToString for ReleaseAssetState {
     }
 }
 impl std::str::FromStr for ReleaseAssetState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "uploaded" => Ok(Self::Uploaded),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseAssetState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseAssetState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseAssetState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70975,29 +71000,29 @@ impl ToString for ReleaseCreatedAction {
     }
 }
 impl std::str::FromStr for ReleaseCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71091,29 +71116,29 @@ impl ToString for ReleaseDeletedAction {
     }
 }
 impl std::str::FromStr for ReleaseDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71241,29 +71266,29 @@ impl ToString for ReleaseEditedAction {
     }
 }
 impl std::str::FromStr for ReleaseEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71574,29 +71599,29 @@ impl ToString for ReleasePrereleasedAction {
     }
 }
 impl std::str::FromStr for ReleasePrereleasedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "prereleased" => Ok(Self::Prereleased),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleasePrereleasedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleasePrereleasedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleasePrereleasedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71767,29 +71792,29 @@ impl ToString for ReleasePublishedAction {
     }
 }
 impl std::str::FromStr for ReleasePublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "published" => Ok(Self::Published),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleasePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleasePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleasePublishedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71941,29 +71966,29 @@ impl ToString for ReleaseReleasedAction {
     }
 }
 impl std::str::FromStr for ReleaseReleasedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "released" => Ok(Self::Released),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseReleasedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseReleasedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseReleasedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72073,29 +72098,29 @@ impl ToString for ReleaseUnpublishedAction {
     }
 }
 impl std::str::FromStr for ReleaseUnpublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unpublished" => Ok(Self::Unpublished),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReleaseUnpublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReleaseUnpublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReleaseUnpublishedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72897,29 +72922,29 @@ impl ToString for RepositoryArchivedAction {
     }
 }
 impl std::str::FromStr for RepositoryArchivedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "archived" => Ok(Self::Archived),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryArchivedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryArchivedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryArchivedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73104,32 +73129,32 @@ impl From<&RepositoryArchivedRepositoryCreatedAt> for RepositoryArchivedReposito
     }
 }
 impl std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryArchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryArchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryArchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73328,29 +73353,29 @@ impl ToString for RepositoryCreatedAction {
     }
 }
 impl std::str::FromStr for RepositoryCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73384,32 +73409,32 @@ impl From<&RepositoryCreatedAt> for RepositoryCreatedAt {
     }
 }
 impl std::str::FromStr for RepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73516,29 +73541,29 @@ impl ToString for RepositoryDeletedAction {
     }
 }
 impl std::str::FromStr for RepositoryDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73675,29 +73700,29 @@ impl ToString for RepositoryDispatchOnDemandTestAction {
     }
 }
 impl std::str::FromStr for RepositoryDispatchOnDemandTestAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "on-demand-test" => Ok(Self::OnDemandTest),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryDispatchOnDemandTestAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryDispatchOnDemandTestAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryDispatchOnDemandTestAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73836,29 +73861,29 @@ impl ToString for RepositoryEditedAction {
     }
 }
 impl std::str::FromStr for RepositoryEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74221,31 +74246,31 @@ impl ToString for RepositoryImportEventStatus {
     }
 }
 impl std::str::FromStr for RepositoryImportEventStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "cancelled" => Ok(Self::Cancelled),
             "failure" => Ok(Self::Failure),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryImportEventStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryImportEventStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryImportEventStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74706,29 +74731,29 @@ impl ToString for RepositoryPrivatizedAction {
     }
 }
 impl std::str::FromStr for RepositoryPrivatizedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "privatized" => Ok(Self::Privatized),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPrivatizedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPrivatizedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryPrivatizedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74912,32 +74937,32 @@ impl From<&RepositoryPrivatizedRepositoryCreatedAt> for RepositoryPrivatizedRepo
     }
 }
 impl std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPrivatizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPrivatizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryPrivatizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75158,29 +75183,29 @@ impl ToString for RepositoryPublicizedAction {
     }
 }
 impl std::str::FromStr for RepositoryPublicizedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "publicized" => Ok(Self::Publicized),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPublicizedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPublicizedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryPublicizedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75364,32 +75389,32 @@ impl From<&RepositoryPublicizedRepositoryCreatedAt> for RepositoryPublicizedRepo
     }
 }
 impl std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryPublicizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryPublicizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryPublicizedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75665,29 +75690,29 @@ impl ToString for RepositoryRenamedAction {
     }
 }
 impl std::str::FromStr for RepositoryRenamedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "renamed" => Ok(Self::Renamed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryRenamedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75919,29 +75944,29 @@ impl ToString for RepositoryTransferredAction {
     }
 }
 impl std::str::FromStr for RepositoryTransferredAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "transferred" => Ok(Self::Transferred),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryTransferredAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76157,29 +76182,29 @@ impl ToString for RepositoryUnarchivedAction {
     }
 }
 impl std::str::FromStr for RepositoryUnarchivedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "unarchived" => Ok(Self::Unarchived),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryUnarchivedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryUnarchivedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryUnarchivedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76364,32 +76389,32 @@ impl From<&RepositoryUnarchivedRepositoryCreatedAt> for RepositoryUnarchivedRepo
     }
 }
 impl std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryUnarchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryUnarchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryUnarchivedRepositoryCreatedAt {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76639,29 +76664,29 @@ impl ToString for RepositoryVulnerabilityAlertCreateAction {
     }
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertCreateAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "create" => Ok(Self::Create),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76890,29 +76915,29 @@ impl ToString for RepositoryVulnerabilityAlertDismissAction {
     }
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertDismissAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dismiss" => Ok(Self::Dismiss),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77185,29 +77210,29 @@ impl ToString for RepositoryVulnerabilityAlertResolveAction {
     }
 }
 impl std::str::FromStr for RepositoryVulnerabilityAlertResolveAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolve" => Ok(Self::Resolve),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77408,29 +77433,29 @@ impl ToString for SecretScanningAlertCreatedAction {
     }
 }
 impl std::str::FromStr for SecretScanningAlertCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecretScanningAlertCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77647,29 +77672,29 @@ impl ToString for SecretScanningAlertReopenedAction {
     }
 }
 impl std::str::FromStr for SecretScanningAlertReopenedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "reopened" => Ok(Self::Reopened),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecretScanningAlertReopenedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77845,29 +77870,29 @@ impl ToString for SecretScanningAlertResolvedAction {
     }
 }
 impl std::str::FromStr for SecretScanningAlertResolvedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecretScanningAlertResolvedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77972,32 +77997,32 @@ impl ToString for SecretScanningAlertResolvedAlertResolution {
     }
 }
 impl std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "false_positive" => Ok(Self::FalsePositive),
             "wontfix" => Ok(Self::Wontfix),
             "revoked" => Ok(Self::Revoked),
             "used_in_tests" => Ok(Self::UsedInTests),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecretScanningAlertResolvedAlertResolution {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecretScanningAlertResolvedAlertResolution {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecretScanningAlertResolvedAlertResolution {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -78294,29 +78319,29 @@ impl ToString for SecurityAdvisoryPerformedAction {
     }
 }
 impl std::str::FromStr for SecurityAdvisoryPerformedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "performed" => Ok(Self::Performed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryPerformedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryPerformedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecurityAdvisoryPerformedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79042,29 +79067,29 @@ impl ToString for SecurityAdvisoryPublishedAction {
     }
 }
 impl std::str::FromStr for SecurityAdvisoryPublishedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "published" => Ok(Self::Published),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryPublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryPublishedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecurityAdvisoryPublishedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79790,29 +79815,29 @@ impl ToString for SecurityAdvisoryUpdatedAction {
     }
 }
 impl std::str::FromStr for SecurityAdvisoryUpdatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "updated" => Ok(Self::Updated),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecurityAdvisoryUpdatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -80533,29 +80558,29 @@ impl ToString for SecurityAdvisoryWithdrawnAction {
     }
 }
 impl std::str::FromStr for SecurityAdvisoryWithdrawnAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "withdrawn" => Ok(Self::Withdrawn),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SecurityAdvisoryWithdrawnAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SecurityAdvisoryWithdrawnAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SecurityAdvisoryWithdrawnAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81444,32 +81469,32 @@ impl ToString for SimplePullRequestActiveLockReason {
     }
 }
 impl std::str::FromStr for SimplePullRequestActiveLockReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolved" => Ok(Self::Resolved),
             "off-topic" => Ok(Self::OffTopic),
             "too heated" => Ok(Self::TooHeated),
             "spam" => Ok(Self::Spam),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SimplePullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SimplePullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SimplePullRequestActiveLockReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81711,30 +81736,30 @@ impl ToString for SimplePullRequestState {
     }
 }
 impl std::str::FromStr for SimplePullRequestState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SimplePullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SimplePullRequestState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SimplePullRequestState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81842,29 +81867,29 @@ impl ToString for SponsorshipCancelledAction {
     }
 }
 impl std::str::FromStr for SponsorshipCancelledAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "cancelled" => Ok(Self::Cancelled),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipCancelledAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82026,29 +82051,29 @@ impl ToString for SponsorshipCreatedAction {
     }
 }
 impl std::str::FromStr for SponsorshipCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82231,29 +82256,29 @@ impl ToString for SponsorshipEditedAction {
     }
 }
 impl std::str::FromStr for SponsorshipEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82564,29 +82589,29 @@ impl ToString for SponsorshipPendingCancellationAction {
     }
 }
 impl std::str::FromStr for SponsorshipPendingCancellationAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pending_cancellation" => Ok(Self::PendingCancellation),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipPendingCancellationAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipPendingCancellationAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipPendingCancellationAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82780,29 +82805,29 @@ impl ToString for SponsorshipPendingTierChangeAction {
     }
 }
 impl std::str::FromStr for SponsorshipPendingTierChangeAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pending_tier_change" => Ok(Self::PendingTierChange),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipPendingTierChangeAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipPendingTierChangeAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipPendingTierChangeAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83121,29 +83146,29 @@ impl ToString for SponsorshipTierChangedAction {
     }
 }
 impl std::str::FromStr for SponsorshipTierChangedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "tier_changed" => Ok(Self::TierChanged),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SponsorshipTierChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SponsorshipTierChangedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SponsorshipTierChangedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83360,29 +83385,29 @@ impl ToString for StarCreatedAction {
     }
 }
 impl std::str::FromStr for StarCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StarCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StarCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StarCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83478,29 +83503,29 @@ impl ToString for StarDeletedAction {
     }
 }
 impl std::str::FromStr for StarDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StarDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StarDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StarDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84643,8 +84668,8 @@ impl ToString for StatusEventCommitCommitVerificationReason {
     }
 }
 impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "expired_key" => Ok(Self::ExpiredKey),
             "not_signing_key" => Ok(Self::NotSigningKey),
@@ -84659,25 +84684,25 @@ impl std::str::FromStr for StatusEventCommitCommitVerificationReason {
             "malformed_signature" => Ok(Self::MalformedSignature),
             "invalid" => Ok(Self::Invalid),
             "valid" => Ok(Self::Valid),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StatusEventCommitCommitVerificationReason {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StatusEventCommitCommitVerificationReason {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StatusEventCommitCommitVerificationReason {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84766,32 +84791,32 @@ impl ToString for StatusEventState {
     }
 }
 impl std::str::FromStr for StatusEventState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pending" => Ok(Self::Pending),
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
             "error" => Ok(Self::Error),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StatusEventState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StatusEventState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StatusEventState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85114,29 +85139,29 @@ impl ToString for TeamAddedToRepositoryAction {
     }
 }
 impl std::str::FromStr for TeamAddedToRepositoryAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "added_to_repository" => Ok(Self::AddedToRepository),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamAddedToRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamAddedToRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamAddedToRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85230,29 +85255,29 @@ impl ToString for TeamCreatedAction {
     }
 }
 impl std::str::FromStr for TeamCreatedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "created" => Ok(Self::Created),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamCreatedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85346,29 +85371,29 @@ impl ToString for TeamDeletedAction {
     }
 }
 impl std::str::FromStr for TeamDeletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "deleted" => Ok(Self::Deleted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamDeletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85546,29 +85571,29 @@ impl ToString for TeamEditedAction {
     }
 }
 impl std::str::FromStr for TeamEditedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "edited" => Ok(Self::Edited),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamEditedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamEditedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86118,31 +86143,31 @@ impl ToString for TeamParentPrivacy {
     }
 }
 impl std::str::FromStr for TeamParentPrivacy {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
             "secret" => Ok(Self::Secret),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamParentPrivacy {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamParentPrivacy {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamParentPrivacy {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86185,31 +86210,31 @@ impl ToString for TeamPrivacy {
     }
 }
 impl std::str::FromStr for TeamPrivacy {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "open" => Ok(Self::Open),
             "closed" => Ok(Self::Closed),
             "secret" => Ok(Self::Secret),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamPrivacy {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamPrivacy {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamPrivacy {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86303,29 +86328,29 @@ impl ToString for TeamRemovedFromRepositoryAction {
     }
 }
 impl std::str::FromStr for TeamRemovedFromRepositoryAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "removed_from_repository" => Ok(Self::RemovedFromRepository),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TeamRemovedFromRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TeamRemovedFromRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TeamRemovedFromRepositoryAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86512,31 +86537,31 @@ impl ToString for UserType {
     }
 }
 impl std::str::FromStr for UserType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Bot" => Ok(Self::Bot),
             "User" => Ok(Self::User),
             "Organization" => Ok(Self::Organization),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for UserType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for UserType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for UserType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86662,29 +86687,29 @@ impl ToString for WatchStartedAction {
     }
 }
 impl std::str::FromStr for WatchStartedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "started" => Ok(Self::Started),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WatchStartedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WatchStartedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WatchStartedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87001,8 +87026,8 @@ impl ToString for WebhookEventsVariant0Item {
     }
 }
 impl std::str::FromStr for WebhookEventsVariant0Item {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "check_run" => Ok(Self::CheckRun),
             "check_suite" => Ok(Self::CheckSuite),
@@ -87051,25 +87076,25 @@ impl std::str::FromStr for WebhookEventsVariant0Item {
             "watch" => Ok(Self::Watch),
             "workflow_dispatch" => Ok(Self::WorkflowDispatch),
             "workflow_run" => Ok(Self::WorkflowRun),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WebhookEventsVariant0Item {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WebhookEventsVariant0Item {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WebhookEventsVariant0Item {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87460,29 +87485,29 @@ impl ToString for WorkflowJobCompletedAction {
     }
 }
 impl std::str::FromStr for WorkflowJobCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87577,30 +87602,30 @@ impl ToString for WorkflowJobCompletedWorkflowJobConclusion {
     }
 }
 impl std::str::FromStr for WorkflowJobCompletedWorkflowJobConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobCompletedWorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87643,31 +87668,31 @@ impl ToString for WorkflowJobCompletedWorkflowJobStatus {
     }
 }
 impl std::str::FromStr for WorkflowJobCompletedWorkflowJobStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobCompletedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87706,30 +87731,30 @@ impl ToString for WorkflowJobConclusion {
     }
 }
 impl std::str::FromStr for WorkflowJobConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87949,29 +87974,29 @@ impl ToString for WorkflowJobQueuedAction {
     }
 }
 impl std::str::FromStr for WorkflowJobQueuedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobQueuedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobQueuedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobQueuedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88119,29 +88144,29 @@ impl ToString for WorkflowJobQueuedWorkflowJobStatus {
     }
 }
 impl std::str::FromStr for WorkflowJobQueuedWorkflowJobStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88264,29 +88289,29 @@ impl ToString for WorkflowJobStartedAction {
     }
 }
 impl std::str::FromStr for WorkflowJobStartedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "started" => Ok(Self::Started),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobStartedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobStartedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobStartedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88385,10 +88410,10 @@ impl From<&WorkflowJobStartedWorkflowJobConclusion> for WorkflowJobStartedWorkfl
     }
 }
 impl std::convert::TryFrom<()> for WorkflowJobStartedWorkflowJobConclusion {
-    type Error = &'static str;
-    fn try_from(value: ()) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: ()) -> Result<Self, self::error::ConversionError> {
         if ![()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -88442,31 +88467,31 @@ impl ToString for WorkflowJobStartedWorkflowJobStatus {
     }
 }
 impl std::str::FromStr for WorkflowJobStartedWorkflowJobStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobStartedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobStartedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobStartedWorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88509,31 +88534,31 @@ impl ToString for WorkflowJobStatus {
     }
 }
 impl std::str::FromStr for WorkflowJobStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "queued" => Ok(Self::Queued),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowJobStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88911,29 +88936,29 @@ impl ToString for WorkflowRunCompletedAction {
     }
 }
 impl std::str::FromStr for WorkflowRunCompletedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunCompletedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89065,8 +89090,8 @@ impl ToString for WorkflowRunCompletedWorkflowRunConclusion {
     }
 }
 impl std::str::FromStr for WorkflowRunCompletedWorkflowRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -89075,25 +89100,25 @@ impl std::str::FromStr for WorkflowRunCompletedWorkflowRunConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunCompletedWorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89310,32 +89335,32 @@ impl ToString for WorkflowRunCompletedWorkflowRunStatus {
     }
 }
 impl std::str::FromStr for WorkflowRunCompletedWorkflowRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunCompletedWorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89394,8 +89419,8 @@ impl ToString for WorkflowRunConclusion {
     }
 }
 impl std::str::FromStr for WorkflowRunConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
@@ -89404,25 +89429,25 @@ impl std::str::FromStr for WorkflowRunConclusion {
             "timed_out" => Ok(Self::TimedOut),
             "action_required" => Ok(Self::ActionRequired),
             "stale" => Ok(Self::Stale),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89723,29 +89748,29 @@ impl ToString for WorkflowRunRequestedAction {
     }
 }
 impl std::str::FromStr for WorkflowRunRequestedAction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunRequestedAction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89792,32 +89817,32 @@ impl ToString for WorkflowRunStatus {
     }
 }
 impl std::str::FromStr for WorkflowRunStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "requested" => Ok(Self::Requested),
             "in_progress" => Ok(Self::InProgress),
             "completed" => Ok(Self::Completed),
             "queued" => Ok(Self::Queued),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowRunStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89965,31 +89990,31 @@ impl ToString for WorkflowStepCompletedConclusion {
     }
 }
 impl std::str::FromStr for WorkflowStepCompletedConclusion {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "failure" => Ok(Self::Failure),
             "skipped" => Ok(Self::Skipped),
             "success" => Ok(Self::Success),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepCompletedConclusion {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepCompletedConclusion {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowStepCompletedConclusion {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90024,29 +90049,29 @@ impl ToString for WorkflowStepCompletedStatus {
     }
 }
 impl std::str::FromStr for WorkflowStepCompletedStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "completed" => Ok(Self::Completed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepCompletedStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepCompletedStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowStepCompletedStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90140,29 +90165,29 @@ impl ToString for WorkflowStepInProgressStatus {
     }
 }
 impl std::str::FromStr for WorkflowStepInProgressStatus {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "in_progress" => Ok(Self::InProgress),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WorkflowStepInProgressStatus {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WorkflowStepInProgressStatus {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WorkflowStepInProgressStatus {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -1,3 +1,28 @@
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "AggregateTransform"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -880,8 +905,8 @@ impl ToString for AggregateTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -907,25 +932,25 @@ impl std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
             "max" => Ok(Self::Max),
             "argmin" => Ok(Self::Argmin),
             "argmax" => Ok(Self::Argmax),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -959,29 +984,29 @@ impl ToString for AggregateTransformType {
     }
 }
 impl std::str::FromStr for AggregateTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "aggregate" => Ok(Self::Aggregate),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1457,31 +1482,31 @@ impl ToString for AlignValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for AlignValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlignValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1516,32 +1541,32 @@ impl From<&AlignValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for AlignValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlignValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlignValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1820,31 +1845,31 @@ impl ToString for AlignValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for AlignValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlignValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1877,32 +1902,32 @@ impl From<&AlignValueVariant1Subtype0Variant3Range> for AlignValueVariant1Subtyp
     }
 }
 impl std::str::FromStr for AlignValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlignValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlignValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlignValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2501,31 +2526,31 @@ impl ToString for AnchorValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for AnchorValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnchorValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnchorValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2560,32 +2585,32 @@ impl From<&AnchorValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for AnchorValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnchorValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnchorValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2864,31 +2889,31 @@ impl ToString for AnchorValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for AnchorValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2921,32 +2946,32 @@ impl From<&AnchorValueVariant1Subtype0Variant3Range> for AnchorValueVariant1Subt
     }
 }
 impl std::str::FromStr for AnchorValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnchorValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnchorValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnchorValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3512,32 +3537,32 @@ impl From<&AnyValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for AnyValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnyValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnyValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnyValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3801,32 +3826,32 @@ impl From<&AnyValueVariant1Subtype0Variant3Range> for AnyValueVariant1Subtype0Va
     }
 }
 impl std::str::FromStr for AnyValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for AnyValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AnyValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AnyValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4438,32 +4463,32 @@ impl From<&ArrayValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for ArrayValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ArrayValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ArrayValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ArrayValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4729,32 +4754,32 @@ impl From<&ArrayValueVariant1Subtype0Variant3Range> for ArrayValueVariant1Subtyp
     }
 }
 impl std::str::FromStr for ArrayValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ArrayValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ArrayValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ArrayValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5009,33 +5034,33 @@ impl ToString for AutosizeVariant0 {
     }
 }
 impl std::str::FromStr for AutosizeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pad" => Ok(Self::Pad),
             "fit" => Ok(Self::Fit),
             "fit-x" => Ok(Self::FitX),
             "fit-y" => Ok(Self::FitY),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AutosizeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5073,30 +5098,30 @@ impl ToString for AutosizeVariant1Contains {
     }
 }
 impl std::str::FromStr for AutosizeVariant1Contains {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "content" => Ok(Self::Content),
             "padding" => Ok(Self::Padding),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant1Contains {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant1Contains {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AutosizeVariant1Contains {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5147,33 +5172,33 @@ impl ToString for AutosizeVariant1Type {
     }
 }
 impl std::str::FromStr for AutosizeVariant1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pad" => Ok(Self::Pad),
             "fit" => Ok(Self::Fit),
             "fit-x" => Ok(Self::FitX),
             "fit-y" => Ok(Self::FitY),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AutosizeVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AutosizeVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AutosizeVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6846,31 +6871,31 @@ impl ToString for AxisFormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for AxisFormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisFormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisFormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisFormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7179,31 +7204,31 @@ impl ToString for AxisLabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for AxisLabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisLabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisLabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisLabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7340,8 +7365,8 @@ impl ToString for AxisLabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for AxisLabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -7349,25 +7374,25 @@ impl std::str::FromStr for AxisLabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisLabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisLabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisLabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8057,32 +8082,32 @@ impl ToString for AxisOrientVariant0 {
     }
 }
 impl std::str::FromStr for AxisOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8543,31 +8568,31 @@ impl ToString for AxisTitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for AxisTitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisTitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8653,31 +8678,31 @@ impl ToString for AxisTitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for AxisTitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisTitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8814,8 +8839,8 @@ impl ToString for AxisTitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for AxisTitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -8823,25 +8848,25 @@ impl std::str::FromStr for AxisTitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AxisTitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AxisTitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AxisTitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9693,32 +9718,32 @@ impl From<&BaseColorValueVariant0Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BaseColorValueVariant0Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BaseColorValueVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaseColorValueVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BaseColorValueVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10381,32 +10406,32 @@ impl ToString for BaselineValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for BaselineValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
             "bottom" => Ok(Self::Bottom),
             "alphabetic" => Ok(Self::Alphabetic),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BaselineValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaselineValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BaselineValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10441,32 +10466,32 @@ impl From<&BaselineValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BaselineValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BaselineValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaselineValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BaselineValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10752,32 +10777,32 @@ impl ToString for BaselineValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for BaselineValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
             "bottom" => Ok(Self::Bottom),
             "alphabetic" => Ok(Self::Alphabetic),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10812,32 +10837,32 @@ impl From<&BaselineValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BaselineValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BaselineValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BaselineValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BaselineValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12033,29 +12058,29 @@ impl ToString for BinTransformType {
     }
 }
 impl std::str::FromStr for BinTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "bin" => Ok(Self::Bin),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BinTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BinTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BinTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12296,29 +12321,29 @@ impl ToString for BindVariant0Input {
     }
 }
 impl std::str::FromStr for BindVariant0Input {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "checkbox" => Ok(Self::Checkbox),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant0Input {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant0Input {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BindVariant0Input {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12356,30 +12381,30 @@ impl ToString for BindVariant1Input {
     }
 }
 impl std::str::FromStr for BindVariant1Input {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "radio" => Ok(Self::Radio),
             "select" => Ok(Self::Select),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant1Input {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant1Input {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BindVariant1Input {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12413,29 +12438,29 @@ impl ToString for BindVariant2Input {
     }
 }
 impl std::str::FromStr for BindVariant2Input {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "range" => Ok(Self::Range),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BindVariant2Input {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BindVariant2Input {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BindVariant2Input {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12475,8 +12500,8 @@ impl From<&BindVariant3Input> for BindVariant3Input {
     }
 }
 impl std::convert::TryFrom<String> for BindVariant3Input {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         if [
             "checkbox".to_string(),
             "radio".to_string(),
@@ -12485,7 +12510,7 @@ impl std::convert::TryFrom<String> for BindVariant3Input {
         ]
         .contains(&value)
         {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -13073,8 +13098,8 @@ impl ToString for BlendValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for BlendValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "multiply" => Ok(Self::Multiply),
             "screen" => Ok(Self::Screen),
@@ -13091,25 +13116,25 @@ impl std::str::FromStr for BlendValueVariant0ItemSubtype0Variant1Value {
             "saturation" => Ok(Self::Saturation),
             "color" => Ok(Self::Color),
             "luminosity" => Ok(Self::Luminosity),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BlendValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13144,32 +13169,32 @@ impl From<&BlendValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BlendValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BlendValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BlendValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13510,8 +13535,8 @@ impl ToString for BlendValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for BlendValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "multiply" => Ok(Self::Multiply),
             "screen" => Ok(Self::Screen),
@@ -13528,25 +13553,25 @@ impl std::str::FromStr for BlendValueVariant1Subtype0Variant1Value {
             "saturation" => Ok(Self::Saturation),
             "color" => Ok(Self::Color),
             "luminosity" => Ok(Self::Luminosity),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BlendValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13579,32 +13604,32 @@ impl From<&BlendValueVariant1Subtype0Variant3Range> for BlendValueVariant1Subtyp
     }
 }
 impl std::str::FromStr for BlendValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BlendValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BlendValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BlendValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14216,32 +14241,32 @@ impl From<&BooleanValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BooleanValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BooleanValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BooleanValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BooleanValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14509,32 +14534,32 @@ impl From<&BooleanValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for BooleanValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for BooleanValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for BooleanValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for BooleanValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14733,29 +14758,29 @@ impl ToString for CollectTransformType {
     }
 }
 impl std::str::FromStr for CollectTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "collect" => Ok(Self::Collect),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CollectTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CollectTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CollectTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15153,32 +15178,32 @@ impl From<&ColorValueVariant0ItemVariant0Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ColorValueVariant0ItemVariant0Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16139,29 +16164,29 @@ impl ToString for ContourTransformType {
     }
 }
 impl std::str::FromStr for ContourTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "contour" => Ok(Self::Contour),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ContourTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ContourTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ContourTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16695,31 +16720,31 @@ impl ToString for CountpatternTransformCaseVariant0 {
     }
 }
 impl std::str::FromStr for CountpatternTransformCaseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "upper" => Ok(Self::Upper),
             "lower" => Ok(Self::Lower),
             "mixed" => Ok(Self::Mixed),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CountpatternTransformCaseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CountpatternTransformCaseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CountpatternTransformCaseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16872,29 +16897,29 @@ impl ToString for CountpatternTransformType {
     }
 }
 impl std::str::FromStr for CountpatternTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "countpattern" => Ok(Self::Countpattern),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CountpatternTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CountpatternTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CountpatternTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17093,29 +17118,29 @@ impl ToString for CrossTransformType {
     }
 }
 impl std::str::FromStr for CrossTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "cross" => Ok(Self::Cross),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CrossTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CrossTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CrossTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17361,29 +17386,29 @@ impl ToString for CrossfilterTransformType {
     }
 }
 impl std::str::FromStr for CrossfilterTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "crossfilter" => Ok(Self::Crossfilter),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for CrossfilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for CrossfilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for CrossfilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18575,29 +18600,29 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18638,32 +18663,32 @@ impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18733,36 +18758,36 @@ impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18798,37 +18823,37 @@ impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18839,7 +18864,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype0ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant2FormatVariant0Subtype1"]
@@ -19022,29 +19049,29 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19085,32 +19112,32 @@ impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19180,36 +19207,36 @@ impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19245,37 +19272,37 @@ impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19286,7 +19313,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype1ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant2FormatVariant0Subtype1Type"]
@@ -19319,29 +19348,29 @@ impl ToString for DataVariant2FormatVariant0Subtype1Type {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "json" => Ok(Self::Json),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19527,29 +19556,29 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19590,32 +19619,32 @@ impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19685,36 +19714,36 @@ impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19750,37 +19779,37 @@ impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19791,7 +19820,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype2ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant2FormatVariant0Subtype2Type"]
@@ -19828,30 +19859,30 @@ impl ToString for DataVariant2FormatVariant0Subtype2Type {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype2Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "csv" => Ok(Self::Csv),
             "tsv" => Ok(Self::Tsv),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20041,29 +20072,29 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20104,32 +20135,32 @@ impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20199,36 +20230,36 @@ impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20264,37 +20295,37 @@ impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20305,7 +20336,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype3ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant2FormatVariant0Subtype3Type"]
@@ -20338,29 +20371,29 @@ impl ToString for DataVariant2FormatVariant0Subtype3Type {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype3Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dsv" => Ok(Self::Dsv),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20481,29 +20514,29 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant0Type {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "topojson" => Ok(Self::Topojson),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20544,30 +20577,30 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant1Filter {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "interior" => Ok(Self::Interior),
             "exterior" => Ok(Self::Exterior),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20603,29 +20636,29 @@ impl ToString for DataVariant2FormatVariant0Subtype4Variant1Type {
     }
 }
 impl std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "topojson" => Ok(Self::Topojson),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21087,29 +21120,29 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21150,32 +21183,32 @@ impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21245,36 +21278,36 @@ impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21310,37 +21343,37 @@ impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21351,7 +21384,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype0ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant3FormatVariant0Subtype1"]
@@ -21534,29 +21569,29 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21597,32 +21632,32 @@ impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21692,36 +21727,36 @@ impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21757,37 +21792,37 @@ impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21798,7 +21833,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype1ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant3FormatVariant0Subtype1Type"]
@@ -21831,29 +21868,29 @@ impl ToString for DataVariant3FormatVariant0Subtype1Type {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "json" => Ok(Self::Json),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22039,29 +22076,29 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22102,32 +22139,32 @@ impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22197,36 +22234,36 @@ impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22262,37 +22299,37 @@ impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22303,7 +22340,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype2ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant3FormatVariant0Subtype2Type"]
@@ -22340,30 +22379,30 @@ impl ToString for DataVariant3FormatVariant0Subtype2Type {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype2Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "csv" => Ok(Self::Csv),
             "tsv" => Ok(Self::Tsv),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22553,29 +22592,29 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "auto" => Ok(Self::Auto),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22616,32 +22655,32 @@ impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1Value>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22711,36 +22750,36 @@ impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "boolean" => Ok(Self::Boolean),
             "number" => Ok(Self::Number),
             "date" => Ok(Self::Date),
             "string" => Ok(Self::String),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22776,37 +22815,37 @@ impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1>
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("^(date|utc):.*$")
             .unwrap()
             .find(value)
             .is_none()
         {
-            return Err("doesn't match pattern \"^(date|utc):.*$\"");
+            return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22817,7 +22856,9 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype3ParseVar
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "DataVariant3FormatVariant0Subtype3Type"]
@@ -22850,29 +22891,29 @@ impl ToString for DataVariant3FormatVariant0Subtype3Type {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype3Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dsv" => Ok(Self::Dsv),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22993,29 +23034,29 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant0Type {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "topojson" => Ok(Self::Topojson),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23056,30 +23097,30 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant1Filter {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "interior" => Ok(Self::Interior),
             "exterior" => Ok(Self::Exterior),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23115,29 +23156,29 @@ impl ToString for DataVariant3FormatVariant0Subtype4Variant1Type {
     }
 }
 impl std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "topojson" => Ok(Self::Topojson),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23884,29 +23925,29 @@ impl ToString for DensityTransformDistributionVariant0Function {
     }
 }
 impl std::str::FromStr for DensityTransformDistributionVariant0Function {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "normal" => Ok(Self::Normal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant0Function {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant0Function {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformDistributionVariant0Function {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24026,29 +24067,29 @@ impl ToString for DensityTransformDistributionVariant1Function {
     }
 }
 impl std::str::FromStr for DensityTransformDistributionVariant1Function {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "lognormal" => Ok(Self::Lognormal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant1Function {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant1Function {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformDistributionVariant1Function {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24168,29 +24209,29 @@ impl ToString for DensityTransformDistributionVariant2Function {
     }
 }
 impl std::str::FromStr for DensityTransformDistributionVariant2Function {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "uniform" => Ok(Self::Uniform),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant2Function {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant2Function {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformDistributionVariant2Function {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24397,29 +24438,29 @@ impl ToString for DensityTransformDistributionVariant3Function {
     }
 }
 impl std::str::FromStr for DensityTransformDistributionVariant3Function {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "kde" => Ok(Self::Kde),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant3Function {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant3Function {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformDistributionVariant3Function {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24496,29 +24537,29 @@ impl ToString for DensityTransformDistributionVariant4Function {
     }
 }
 impl std::str::FromStr for DensityTransformDistributionVariant4Function {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "mixture" => Ok(Self::Mixture),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformDistributionVariant4Function {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformDistributionVariant4Function {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformDistributionVariant4Function {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24897,29 +24938,29 @@ impl ToString for DensityTransformType {
     }
 }
 impl std::str::FromStr for DensityTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "density" => Ok(Self::Density),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DensityTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DensityTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DensityTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25387,30 +25428,30 @@ impl ToString for DirectionValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for DirectionValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DirectionValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DirectionValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DirectionValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25445,32 +25486,32 @@ impl From<&DirectionValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for DirectionValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DirectionValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DirectionValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DirectionValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25746,30 +25787,30 @@ impl ToString for DirectionValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for DirectionValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25804,32 +25845,32 @@ impl From<&DirectionValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for DirectionValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for DirectionValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DirectionValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DirectionValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26360,29 +26401,29 @@ impl ToString for DotbinTransformType {
     }
 }
 impl std::str::FromStr for DotbinTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "dotbin" => Ok(Self::Dotbin),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DotbinTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DotbinTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DotbinTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27239,29 +27280,29 @@ impl ToString for ExtentTransformType {
     }
 }
 impl std::str::FromStr for ExtentTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "extent" => Ok(Self::Extent),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ExtentTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ExtentTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ExtentTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27733,29 +27774,29 @@ impl ToString for FilterTransformType {
     }
 }
 impl std::str::FromStr for FilterTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "filter" => Ok(Self::Filter),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for FilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28097,29 +28138,29 @@ impl ToString for FlattenTransformType {
     }
 }
 impl std::str::FromStr for FlattenTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "flatten" => Ok(Self::Flatten),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for FlattenTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FlattenTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FlattenTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28436,29 +28477,29 @@ impl ToString for FoldTransformType {
     }
 }
 impl std::str::FromStr for FoldTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "fold" => Ok(Self::Fold),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for FoldTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FoldTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FoldTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29005,32 +29046,32 @@ impl From<&FontWeightValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for FontWeightValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for FontWeightValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FontWeightValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FontWeightValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29322,32 +29363,32 @@ impl From<&FontWeightValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for FontWeightValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for FontWeightValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FontWeightValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FontWeightValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30563,29 +30604,29 @@ impl ToString for ForceTransformForcesItemVariant0Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant0Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant0Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant0Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant0Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30695,29 +30736,29 @@ impl ToString for ForceTransformForcesItemVariant1Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant1Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "collide" => Ok(Self::Collide),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant1Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant1Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant1Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30983,29 +31024,29 @@ impl ToString for ForceTransformForcesItemVariant2Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant2Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "nbody" => Ok(Self::Nbody),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant2Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant2Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant2Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31189,29 +31230,29 @@ impl ToString for ForceTransformForcesItemVariant3Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant3Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "link" => Ok(Self::Link),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant3Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant3Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant3Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31394,29 +31435,29 @@ impl ToString for ForceTransformForcesItemVariant4Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant4Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "x" => Ok(Self::X),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant4Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant4Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant4Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31541,29 +31582,29 @@ impl ToString for ForceTransformForcesItemVariant5Force {
     }
 }
 impl std::str::FromStr for ForceTransformForcesItemVariant5Force {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "y" => Ok(Self::Y),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformForcesItemVariant5Force {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformForcesItemVariant5Force {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformForcesItemVariant5Force {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31808,29 +31849,29 @@ impl ToString for ForceTransformType {
     }
 }
 impl std::str::FromStr for ForceTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "force" => Ok(Self::Force),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ForceTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ForceTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ForceTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32046,29 +32087,29 @@ impl ToString for FormulaTransformType {
     }
 }
 impl std::str::FromStr for FormulaTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "formula" => Ok(Self::Formula),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for FormulaTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for FormulaTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for FormulaTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32355,29 +32396,29 @@ impl ToString for GeojsonTransformType {
     }
 }
 impl std::str::FromStr for GeojsonTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "geojson" => Ok(Self::Geojson),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GeojsonTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeojsonTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GeojsonTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32645,29 +32686,29 @@ impl ToString for GeopathTransformType {
     }
 }
 impl std::str::FromStr for GeopathTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "geopath" => Ok(Self::Geopath),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GeopathTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeopathTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GeopathTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32993,29 +33034,29 @@ impl ToString for GeopointTransformType {
     }
 }
 impl std::str::FromStr for GeopointTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "geopoint" => Ok(Self::Geopoint),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GeopointTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeopointTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GeopointTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33292,29 +33333,29 @@ impl ToString for GeoshapeTransformType {
     }
 }
 impl std::str::FromStr for GeoshapeTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "geoshape" => Ok(Self::Geoshape),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GeoshapeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GeoshapeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GeoshapeTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34075,29 +34116,29 @@ impl ToString for GraticuleTransformType {
     }
 }
 impl std::str::FromStr for GraticuleTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "graticule" => Ok(Self::Graticule),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for GraticuleTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for GraticuleTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for GraticuleTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34535,30 +34576,30 @@ impl ToString for HeatmapTransformResolveVariant0 {
     }
 }
 impl std::str::FromStr for HeatmapTransformResolveVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for HeatmapTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for HeatmapTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for HeatmapTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34592,29 +34633,29 @@ impl ToString for HeatmapTransformType {
     }
 }
 impl std::str::FromStr for HeatmapTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for HeatmapTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for HeatmapTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for HeatmapTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34731,29 +34772,29 @@ impl ToString for IdentifierTransformType {
     }
 }
 impl std::str::FromStr for IdentifierTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "identifier" => Ok(Self::Identifier),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IdentifierTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdentifierTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IdentifierTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35211,33 +35252,33 @@ impl ToString for ImputeTransformMethodVariant0 {
     }
 }
 impl std::str::FromStr for ImputeTransformMethodVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "value" => Ok(Self::Value),
             "mean" => Ok(Self::Mean),
             "median" => Ok(Self::Median),
             "max" => Ok(Self::Max),
             "min" => Ok(Self::Min),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ImputeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ImputeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ImputeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35271,29 +35312,29 @@ impl ToString for ImputeTransformType {
     }
 }
 impl std::str::FromStr for ImputeTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "impute" => Ok(Self::Impute),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ImputeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ImputeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ImputeTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35746,30 +35787,30 @@ impl ToString for IsocontourTransformResolveVariant0 {
     }
 }
 impl std::str::FromStr for IsocontourTransformResolveVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IsocontourTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IsocontourTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IsocontourTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36101,29 +36142,29 @@ impl ToString for IsocontourTransformType {
     }
 }
 impl std::str::FromStr for IsocontourTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "isocontour" => Ok(Self::Isocontour),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for IsocontourTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IsocontourTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IsocontourTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36948,8 +36989,8 @@ impl ToString for JoinaggregateTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -36975,25 +37016,25 @@ impl std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
             "max" => Ok(Self::Max),
             "argmin" => Ok(Self::Argmin),
             "argmax" => Ok(Self::Argmax),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37027,29 +37068,29 @@ impl ToString for JoinaggregateTransformType {
     }
 }
 impl std::str::FromStr for JoinaggregateTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "joinaggregate" => Ok(Self::Joinaggregate),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for JoinaggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JoinaggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for JoinaggregateTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37664,29 +37705,29 @@ impl ToString for Kde2dTransformType {
     }
 }
 impl std::str::FromStr for Kde2dTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "kde2d" => Ok(Self::Kde2d),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for Kde2dTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Kde2dTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for Kde2dTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38657,30 +38698,30 @@ impl ToString for KdeTransformResolveVariant0 {
     }
 }
 impl std::str::FromStr for KdeTransformResolveVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "shared" => Ok(Self::Shared),
             "independent" => Ok(Self::Independent),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for KdeTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for KdeTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for KdeTransformResolveVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38752,29 +38793,29 @@ impl ToString for KdeTransformType {
     }
 }
 impl std::str::FromStr for KdeTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "kde" => Ok(Self::Kde),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for KdeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for KdeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for KdeTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38862,30 +38903,30 @@ impl ToString for LabelOverlapVariant1 {
     }
 }
 impl std::str::FromStr for LabelOverlapVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "parity" => Ok(Self::Parity),
             "greedy" => Ok(Self::Greedy),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LabelOverlapVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelOverlapVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LabelOverlapVariant1 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39795,29 +39836,29 @@ impl ToString for LabelTransformType {
     }
 }
 impl std::str::FromStr for LabelTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "label" => Ok(Self::Label),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LabelTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LabelTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LabelTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40311,31 +40352,31 @@ impl ToString for LayoutVariant0AlignVariant0Variant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40421,31 +40462,31 @@ impl ToString for LayoutVariant0AlignVariant1ColumnVariant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40529,31 +40570,31 @@ impl ToString for LayoutVariant0AlignVariant1RowVariant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0AlignVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40632,30 +40673,30 @@ impl ToString for LayoutVariant0BoundsVariant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0BoundsVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "full" => Ok(Self::Full),
             "flush" => Ok(Self::Flush),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0BoundsVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0BoundsVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0BoundsVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41115,30 +41156,30 @@ impl ToString for LayoutVariant0TitleAnchorVariant0Variant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41221,30 +41262,30 @@ impl ToString for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41325,30 +41366,30 @@ impl ToString for LayoutVariant0TitleAnchorVariant1RowVariant0 {
     }
 }
 impl std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43371,30 +43412,30 @@ impl ToString for LegendSubtype0Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype0Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43658,31 +43699,31 @@ impl ToString for LegendSubtype0FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43879,31 +43920,31 @@ impl ToString for LegendSubtype0GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43987,31 +44028,31 @@ impl ToString for LegendSubtype0LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44110,8 +44151,8 @@ impl ToString for LegendSubtype0LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -44119,25 +44160,25 @@ impl std::str::FromStr for LegendSubtype0LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44684,8 +44725,8 @@ impl ToString for LegendSubtype0OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -44696,25 +44737,25 @@ impl std::str::FromStr for LegendSubtype0OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45211,31 +45252,31 @@ impl ToString for LegendSubtype0TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45321,31 +45362,31 @@ impl ToString for LegendSubtype0TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45444,8 +45485,8 @@ impl ToString for LegendSubtype0TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -45453,25 +45494,25 @@ impl std::str::FromStr for LegendSubtype0TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45877,32 +45918,32 @@ impl ToString for LegendSubtype0TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype0TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45978,30 +46019,30 @@ impl ToString for LegendSubtype0Type {
     }
 }
 impl std::str::FromStr for LegendSubtype0Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype0Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype0Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype0Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47164,30 +47205,30 @@ impl ToString for LegendSubtype1Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype1Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47451,31 +47492,31 @@ impl ToString for LegendSubtype1FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47672,31 +47713,31 @@ impl ToString for LegendSubtype1GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47780,31 +47821,31 @@ impl ToString for LegendSubtype1LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47903,8 +47944,8 @@ impl ToString for LegendSubtype1LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -47912,25 +47953,25 @@ impl std::str::FromStr for LegendSubtype1LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48477,8 +48518,8 @@ impl ToString for LegendSubtype1OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -48489,25 +48530,25 @@ impl std::str::FromStr for LegendSubtype1OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49004,31 +49045,31 @@ impl ToString for LegendSubtype1TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49114,31 +49155,31 @@ impl ToString for LegendSubtype1TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49237,8 +49278,8 @@ impl ToString for LegendSubtype1TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -49246,25 +49287,25 @@ impl std::str::FromStr for LegendSubtype1TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49670,32 +49711,32 @@ impl ToString for LegendSubtype1TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype1TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49771,30 +49812,30 @@ impl ToString for LegendSubtype1Type {
     }
 }
 impl std::str::FromStr for LegendSubtype1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50957,30 +50998,30 @@ impl ToString for LegendSubtype2Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype2Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51244,31 +51285,31 @@ impl ToString for LegendSubtype2FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51465,31 +51506,31 @@ impl ToString for LegendSubtype2GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51573,31 +51614,31 @@ impl ToString for LegendSubtype2LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51696,8 +51737,8 @@ impl ToString for LegendSubtype2LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -51705,25 +51746,25 @@ impl std::str::FromStr for LegendSubtype2LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52270,8 +52311,8 @@ impl ToString for LegendSubtype2OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -52282,25 +52323,25 @@ impl std::str::FromStr for LegendSubtype2OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52797,31 +52838,31 @@ impl ToString for LegendSubtype2TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52907,31 +52948,31 @@ impl ToString for LegendSubtype2TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53030,8 +53071,8 @@ impl ToString for LegendSubtype2TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -53039,25 +53080,25 @@ impl std::str::FromStr for LegendSubtype2TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53463,32 +53504,32 @@ impl ToString for LegendSubtype2TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype2TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53564,30 +53605,30 @@ impl ToString for LegendSubtype2Type {
     }
 }
 impl std::str::FromStr for LegendSubtype2Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype2Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype2Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54750,30 +54791,30 @@ impl ToString for LegendSubtype3Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype3Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55037,31 +55078,31 @@ impl ToString for LegendSubtype3FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55258,31 +55299,31 @@ impl ToString for LegendSubtype3GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55366,31 +55407,31 @@ impl ToString for LegendSubtype3LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55489,8 +55530,8 @@ impl ToString for LegendSubtype3LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -55498,25 +55539,25 @@ impl std::str::FromStr for LegendSubtype3LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56063,8 +56104,8 @@ impl ToString for LegendSubtype3OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -56075,25 +56116,25 @@ impl std::str::FromStr for LegendSubtype3OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56590,31 +56631,31 @@ impl ToString for LegendSubtype3TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56700,31 +56741,31 @@ impl ToString for LegendSubtype3TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56823,8 +56864,8 @@ impl ToString for LegendSubtype3TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -56832,25 +56873,25 @@ impl std::str::FromStr for LegendSubtype3TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57256,32 +57297,32 @@ impl ToString for LegendSubtype3TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype3TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57357,30 +57398,30 @@ impl ToString for LegendSubtype3Type {
     }
 }
 impl std::str::FromStr for LegendSubtype3Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype3Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype3Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58543,30 +58584,30 @@ impl ToString for LegendSubtype4Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype4Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58830,31 +58871,31 @@ impl ToString for LegendSubtype4FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59051,31 +59092,31 @@ impl ToString for LegendSubtype4GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59159,31 +59200,31 @@ impl ToString for LegendSubtype4LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59282,8 +59323,8 @@ impl ToString for LegendSubtype4LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -59291,25 +59332,25 @@ impl std::str::FromStr for LegendSubtype4LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59856,8 +59897,8 @@ impl ToString for LegendSubtype4OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -59868,25 +59909,25 @@ impl std::str::FromStr for LegendSubtype4OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60383,31 +60424,31 @@ impl ToString for LegendSubtype4TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60493,31 +60534,31 @@ impl ToString for LegendSubtype4TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60616,8 +60657,8 @@ impl ToString for LegendSubtype4TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -60625,25 +60666,25 @@ impl std::str::FromStr for LegendSubtype4TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61049,32 +61090,32 @@ impl ToString for LegendSubtype4TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype4TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61150,30 +61191,30 @@ impl ToString for LegendSubtype4Type {
     }
 }
 impl std::str::FromStr for LegendSubtype4Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype4Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype4Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype4Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62333,30 +62374,30 @@ impl ToString for LegendSubtype5Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype5Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62620,31 +62661,31 @@ impl ToString for LegendSubtype5FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62841,31 +62882,31 @@ impl ToString for LegendSubtype5GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62949,31 +62990,31 @@ impl ToString for LegendSubtype5LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63072,8 +63113,8 @@ impl ToString for LegendSubtype5LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -63081,25 +63122,25 @@ impl std::str::FromStr for LegendSubtype5LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63646,8 +63687,8 @@ impl ToString for LegendSubtype5OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -63658,25 +63699,25 @@ impl std::str::FromStr for LegendSubtype5OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64173,31 +64214,31 @@ impl ToString for LegendSubtype5TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64283,31 +64324,31 @@ impl ToString for LegendSubtype5TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64406,8 +64447,8 @@ impl ToString for LegendSubtype5TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -64415,25 +64456,25 @@ impl std::str::FromStr for LegendSubtype5TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64839,32 +64880,32 @@ impl ToString for LegendSubtype5TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype5TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64940,30 +64981,30 @@ impl ToString for LegendSubtype5Type {
     }
 }
 impl std::str::FromStr for LegendSubtype5Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype5Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype5Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype5Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66123,30 +66164,30 @@ impl ToString for LegendSubtype6Direction {
     }
 }
 impl std::str::FromStr for LegendSubtype6Direction {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "vertical" => Ok(Self::Vertical),
             "horizontal" => Ok(Self::Horizontal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6Direction {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6Direction {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6Direction {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66410,31 +66451,31 @@ impl ToString for LegendSubtype6FormatTypeVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6FormatTypeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "number" => Ok(Self::Number),
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6FormatTypeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66631,31 +66672,31 @@ impl ToString for LegendSubtype6GridAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6GridAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "all" => Ok(Self::All),
             "each" => Ok(Self::Each),
             "none" => Ok(Self::None),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6GridAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66739,31 +66780,31 @@ impl ToString for LegendSubtype6LabelAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6LabelAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6LabelAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66862,8 +66903,8 @@ impl ToString for LegendSubtype6LabelBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6LabelBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -66871,25 +66912,25 @@ impl std::str::FromStr for LegendSubtype6LabelBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6LabelBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67436,8 +67477,8 @@ impl ToString for LegendSubtype6OrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
@@ -67448,25 +67489,25 @@ impl std::str::FromStr for LegendSubtype6OrientVariant0 {
             "top-right" => Ok(Self::TopRight),
             "bottom-left" => Ok(Self::BottomLeft),
             "bottom-right" => Ok(Self::BottomRight),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67963,31 +68004,31 @@ impl ToString for LegendSubtype6TitleAlignVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6TitleAlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6TitleAlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68073,31 +68114,31 @@ impl ToString for LegendSubtype6TitleAnchorVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6TitleAnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6TitleAnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68196,8 +68237,8 @@ impl ToString for LegendSubtype6TitleBaselineVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6TitleBaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -68205,25 +68246,25 @@ impl std::str::FromStr for LegendSubtype6TitleBaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6TitleBaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68629,32 +68670,32 @@ impl ToString for LegendSubtype6TitleOrientVariant0 {
     }
 }
 impl std::str::FromStr for LegendSubtype6TitleOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6TitleOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68730,30 +68771,30 @@ impl ToString for LegendSubtype6Type {
     }
 }
 impl std::str::FromStr for LegendSubtype6Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "gradient" => Ok(Self::Gradient),
             "symbol" => Ok(Self::Symbol),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LegendSubtype6Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LegendSubtype6Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LegendSubtype6Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68848,29 +68889,29 @@ impl ToString for LinearGradientGradient {
     }
 }
 impl std::str::FromStr for LinearGradientGradient {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "linear" => Ok(Self::Linear),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LinearGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinearGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LinearGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69154,31 +69195,31 @@ impl ToString for LinkpathTransformOrientVariant0 {
     }
 }
 impl std::str::FromStr for LinkpathTransformOrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "horizontal" => Ok(Self::Horizontal),
             "vertical" => Ok(Self::Vertical),
             "radial" => Ok(Self::Radial),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LinkpathTransformOrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69278,33 +69319,33 @@ impl ToString for LinkpathTransformShapeVariant0 {
     }
 }
 impl std::str::FromStr for LinkpathTransformShapeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "line" => Ok(Self::Line),
             "arc" => Ok(Self::Arc),
             "curve" => Ok(Self::Curve),
             "diagonal" => Ok(Self::Diagonal),
             "orthogonal" => Ok(Self::Orthogonal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformShapeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformShapeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LinkpathTransformShapeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69558,29 +69599,29 @@ impl ToString for LinkpathTransformType {
     }
 }
 impl std::str::FromStr for LinkpathTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "linkpath" => Ok(Self::Linkpath),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LinkpathTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LinkpathTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LinkpathTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70014,29 +70055,29 @@ impl ToString for LoessTransformType {
     }
 }
 impl std::str::FromStr for LoessTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "loess" => Ok(Self::Loess),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LoessTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LoessTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LoessTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70522,29 +70563,29 @@ impl ToString for LookupTransformType {
     }
 }
 impl std::str::FromStr for LookupTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "lookup" => Ok(Self::Lookup),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LookupTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LookupTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LookupTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70940,29 +70981,29 @@ impl ToString for MarkGroupType {
     }
 }
 impl std::str::FromStr for MarkGroupType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "group" => Ok(Self::Group),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for MarkGroupType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for MarkGroupType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for MarkGroupType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71065,10 +71106,10 @@ impl From<&MarkVisualType> for MarkVisualType {
     }
 }
 impl std::convert::TryFrom<String> for MarkVisualType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         if ["group".to_string()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -71422,29 +71463,29 @@ impl ToString for NestTransformType {
     }
 }
 impl std::str::FromStr for NestTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "nest" => Ok(Self::Nest),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for NestTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NestTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NestTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71561,32 +71602,32 @@ impl From<&NumberModifiersBand> for NumberModifiersBand {
     }
 }
 impl std::str::FromStr for NumberModifiersBand {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberModifiersBand {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberModifiersBand {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberModifiersBand {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72302,32 +72343,32 @@ impl From<&NumberValueVariant0ItemSubtype0Variant0Band>
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant0Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72500,32 +72541,32 @@ impl From<&NumberValueVariant0ItemSubtype0Variant1Band>
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant1Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72698,32 +72739,32 @@ impl From<&NumberValueVariant0ItemSubtype0Variant2Band>
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant2Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72896,32 +72937,32 @@ impl From<&NumberValueVariant0ItemSubtype0Variant3Band>
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant3Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73094,32 +73135,32 @@ impl From<&NumberValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73269,32 +73310,32 @@ impl From<&NumberValueVariant0ItemSubtype1Band> for NumberValueVariant0ItemSubty
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype1Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype1Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype1Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype1Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73557,32 +73598,32 @@ impl From<&NumberValueVariant0ItemSubtype2Band> for NumberValueVariant0ItemSubty
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype2Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype2Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype2Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype2Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73845,32 +73886,32 @@ impl From<&NumberValueVariant0ItemSubtype3Band> for NumberValueVariant0ItemSubty
     }
 }
 impl std::str::FromStr for NumberValueVariant0ItemSubtype3Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant0ItemSubtype3Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant0ItemSubtype3Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant0ItemSubtype3Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74225,32 +74266,32 @@ impl From<&NumberValueVariant1Subtype0Variant0Band> for NumberValueVariant1Subty
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype0Variant0Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant0Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74419,32 +74460,32 @@ impl From<&NumberValueVariant1Subtype0Variant1Band> for NumberValueVariant1Subty
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype0Variant1Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant1Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74613,32 +74654,32 @@ impl From<&NumberValueVariant1Subtype0Variant2Band> for NumberValueVariant1Subty
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype0Variant2Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant2Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -74807,32 +74848,32 @@ impl From<&NumberValueVariant1Subtype0Variant3Band> for NumberValueVariant1Subty
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype0Variant3Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant3Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75001,32 +75042,32 @@ impl From<&NumberValueVariant1Subtype0Variant3Range> for NumberValueVariant1Subt
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75171,32 +75212,32 @@ impl From<&NumberValueVariant1Subtype1Band> for NumberValueVariant1Subtype1Band 
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype1Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype1Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype1Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype1Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75454,32 +75495,32 @@ impl From<&NumberValueVariant1Subtype2Band> for NumberValueVariant1Subtype2Band 
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype2Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype2Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype2Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype2Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75737,32 +75778,32 @@ impl From<&NumberValueVariant1Subtype3Band> for NumberValueVariant1Subtype3Band 
     }
 }
 impl std::str::FromStr for NumberValueVariant1Subtype3Band {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for NumberValueVariant1Subtype3Band {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NumberValueVariant1Subtype3Band {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NumberValueVariant1Subtype3Band {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76519,32 +76560,32 @@ impl From<&OnTriggerItemRemove> for OnTriggerItemRemove {
     }
 }
 impl std::str::FromStr for OnTriggerItemRemove {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for OnTriggerItemRemove {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OnTriggerItemRemove {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OnTriggerItemRemove {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77046,32 +77087,32 @@ impl ToString for OrientValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for OrientValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrientValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrientValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77106,32 +77147,32 @@ impl From<&OrientValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for OrientValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrientValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrientValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77415,32 +77456,32 @@ impl ToString for OrientValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for OrientValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrientValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77473,32 +77514,32 @@ impl From<&OrientValueVariant1Subtype0Variant3Range> for OrientValueVariant1Subt
     }
 }
 impl std::str::FromStr for OrientValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for OrientValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for OrientValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for OrientValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -78115,29 +78156,29 @@ impl ToString for PackTransformType {
     }
 }
 impl std::str::FromStr for PackTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pack" => Ok(Self::Pack),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PackTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PackTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PackTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -78722,29 +78763,29 @@ impl ToString for PartitionTransformType {
     }
 }
 impl std::str::FromStr for PartitionTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "partition" => Ok(Self::Partition),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PartitionTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PartitionTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PartitionTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79161,29 +79202,29 @@ impl ToString for PieTransformType {
     }
 }
 impl std::str::FromStr for PieTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pie" => Ok(Self::Pie),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PieTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PieTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PieTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79765,8 +79806,8 @@ impl ToString for PivotTransformOpVariant0 {
     }
 }
 impl std::str::FromStr for PivotTransformOpVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
@@ -79792,25 +79833,25 @@ impl std::str::FromStr for PivotTransformOpVariant0 {
             "max" => Ok(Self::Max),
             "argmin" => Ok(Self::Argmin),
             "argmax" => Ok(Self::Argmax),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PivotTransformOpVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PivotTransformOpVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PivotTransformOpVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79844,29 +79885,29 @@ impl ToString for PivotTransformType {
     }
 }
 impl std::str::FromStr for PivotTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pivot" => Ok(Self::Pivot),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for PivotTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PivotTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PivotTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -80220,29 +80261,29 @@ impl ToString for ProjectTransformType {
     }
 }
 impl std::str::FromStr for ProjectTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "project" => Ok(Self::Project),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ProjectTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ProjectTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ProjectTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81447,29 +81488,29 @@ impl ToString for QuantileTransformType {
     }
 }
 impl std::str::FromStr for QuantileTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "quantile" => Ok(Self::Quantile),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for QuantileTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for QuantileTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for QuantileTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81574,29 +81615,29 @@ impl ToString for RadialGradientGradient {
     }
 }
 impl std::str::FromStr for RadialGradientGradient {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "radial" => Ok(Self::Radial),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RadialGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RadialGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RadialGradientGradient {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82194,29 +82235,29 @@ impl ToString for RegressionTransformType {
     }
 }
 impl std::str::FromStr for RegressionTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "regression" => Ok(Self::Regression),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for RegressionTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for RegressionTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for RegressionTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82434,29 +82475,29 @@ impl ToString for ResolvefilterTransformType {
     }
 }
 impl std::str::FromStr for ResolvefilterTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "resolvefilter" => Ok(Self::Resolvefilter),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ResolvefilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ResolvefilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ResolvefilterTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82609,29 +82650,29 @@ impl ToString for SampleTransformType {
     }
 }
 impl std::str::FromStr for SampleTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "sample" => Ok(Self::Sample),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SampleTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SampleTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SampleTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85923,29 +85964,29 @@ impl ToString for ScaleDataVariant1SortVariant1Op {
     }
 }
 impl std::str::FromStr for ScaleDataVariant1SortVariant1Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleDataVariant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85987,31 +86028,31 @@ impl ToString for ScaleDataVariant1SortVariant2Op {
     }
 }
 impl std::str::FromStr for ScaleDataVariant1SortVariant2Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleDataVariant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86116,8 +86157,8 @@ impl From<&ScaleDataVariant2FieldsItemVariant1Item> for ScaleDataVariant2FieldsI
     }
 }
 impl std::str::FromStr for ScaleDataVariant2FieldsItemVariant1Item {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
@@ -86125,25 +86166,25 @@ impl std::str::FromStr for ScaleDataVariant2FieldsItemVariant1Item {
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant2(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleDataVariant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86274,29 +86315,29 @@ impl ToString for ScaleDataVariant2SortVariant1Op {
     }
 }
 impl std::str::FromStr for ScaleDataVariant2SortVariant1Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleDataVariant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86338,31 +86379,31 @@ impl ToString for ScaleDataVariant2SortVariant2Op {
     }
 }
 impl std::str::FromStr for ScaleDataVariant2SortVariant2Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleDataVariant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleDataVariant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86664,29 +86705,29 @@ impl ToString for ScaleVariant0Type {
     }
 }
 impl std::str::FromStr for ScaleVariant0Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "identity" => Ok(Self::Identity),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant0Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant0Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant0Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87114,8 +87155,8 @@ impl ToString for ScaleVariant10RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant10RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -87125,25 +87166,25 @@ impl std::str::FromStr for ScaleVariant10RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant10RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant10RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant10RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87376,29 +87417,29 @@ impl ToString for ScaleVariant10Type {
     }
 }
 impl std::str::FromStr for ScaleVariant10Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "pow" => Ok(Self::Pow),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant10Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant10Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant10Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87826,8 +87867,8 @@ impl ToString for ScaleVariant11RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant11RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -87837,25 +87878,25 @@ impl std::str::FromStr for ScaleVariant11RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant11RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant11RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant11RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88088,29 +88129,29 @@ impl ToString for ScaleVariant11Type {
     }
 }
 impl std::str::FromStr for ScaleVariant11Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "symlog" => Ok(Self::Symlog),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant11Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant11Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant11Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88699,8 +88740,8 @@ impl ToString for ScaleVariant1RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -88710,25 +88751,25 @@ impl std::str::FromStr for ScaleVariant1RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89326,29 +89367,29 @@ impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89392,31 +89433,31 @@ impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89527,8 +89568,8 @@ impl From<&ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
@@ -89536,25 +89577,25 @@ impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1I
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant2(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89687,29 +89728,29 @@ impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89753,31 +89794,31 @@ impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     }
 }
 impl std::str::FromStr for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "count" => Ok(Self::Count),
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89811,29 +89852,29 @@ impl ToString for ScaleVariant1Type {
     }
 }
 impl std::str::FromStr for ScaleVariant1Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "ordinal" => Ok(Self::Ordinal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant1Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90170,8 +90211,8 @@ impl ToString for ScaleVariant2RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant2RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -90181,25 +90222,25 @@ impl std::str::FromStr for ScaleVariant2RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant2RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant2RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant2RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90300,29 +90341,29 @@ impl ToString for ScaleVariant2Type {
     }
 }
 impl std::str::FromStr for ScaleVariant2Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "band" => Ok(Self::Band),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant2Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant2Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant2Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90659,8 +90700,8 @@ impl ToString for ScaleVariant3RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant3RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -90670,25 +90711,25 @@ impl std::str::FromStr for ScaleVariant3RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant3RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant3RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant3RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90789,29 +90830,29 @@ impl ToString for ScaleVariant3Type {
     }
 }
 impl std::str::FromStr for ScaleVariant3Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "point" => Ok(Self::Point),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant3Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant3Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant3Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91239,8 +91280,8 @@ impl ToString for ScaleVariant4RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant4RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -91250,25 +91291,25 @@ impl std::str::FromStr for ScaleVariant4RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant4RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant4RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant4RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91503,30 +91544,30 @@ impl ToString for ScaleVariant4Type {
     }
 }
 impl std::str::FromStr for ScaleVariant4Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "quantize" => Ok(Self::Quantize),
             "threshold" => Ok(Self::Threshold),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant4Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant4Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant4Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91907,8 +91948,8 @@ impl ToString for ScaleVariant5RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant5RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -91918,25 +91959,25 @@ impl std::str::FromStr for ScaleVariant5RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant5RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant5RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant5RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -92167,29 +92208,29 @@ impl ToString for ScaleVariant5Type {
     }
 }
 impl std::str::FromStr for ScaleVariant5Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "quantile" => Ok(Self::Quantile),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant5Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant5Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant5Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -92570,8 +92611,8 @@ impl ToString for ScaleVariant6RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant6RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -92581,25 +92622,25 @@ impl std::str::FromStr for ScaleVariant6RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant6RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant6RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant6RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -92830,29 +92871,29 @@ impl ToString for ScaleVariant6Type {
     }
 }
 impl std::str::FromStr for ScaleVariant6Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "bin-ordinal" => Ok(Self::BinOrdinal),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant6Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant6Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant6Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -93178,8 +93219,8 @@ impl ToString for ScaleVariant7NiceVariant1 {
     }
 }
 impl std::str::FromStr for ScaleVariant7NiceVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -93189,25 +93230,25 @@ impl std::str::FromStr for ScaleVariant7NiceVariant1 {
             "week" => Ok(Self::Week),
             "month" => Ok(Self::Month),
             "year" => Ok(Self::Year),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant7NiceVariant1 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -93318,8 +93359,8 @@ impl ToString for ScaleVariant7NiceVariant2IntervalVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -93329,25 +93370,25 @@ impl std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
             "week" => Ok(Self::Week),
             "month" => Ok(Self::Month),
             "year" => Ok(Self::Year),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -93547,8 +93588,8 @@ impl ToString for ScaleVariant7RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant7RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -93558,25 +93599,25 @@ impl std::str::FromStr for ScaleVariant7RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant7RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -93811,30 +93852,30 @@ impl ToString for ScaleVariant7Type {
     }
 }
 impl std::str::FromStr for ScaleVariant7Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "time" => Ok(Self::Time),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant7Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant7Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant7Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -94262,8 +94303,8 @@ impl ToString for ScaleVariant8RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant8RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -94273,25 +94314,25 @@ impl std::str::FromStr for ScaleVariant8RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant8RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant8RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant8RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -94530,31 +94571,31 @@ impl ToString for ScaleVariant8Type {
     }
 }
 impl std::str::FromStr for ScaleVariant8Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "linear" => Ok(Self::Linear),
             "sqrt" => Ok(Self::Sqrt),
             "sequential" => Ok(Self::Sequential),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant8Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant8Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant8Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -94982,8 +95023,8 @@ impl ToString for ScaleVariant9RangeVariant0 {
     }
 }
 impl std::str::FromStr for ScaleVariant9RangeVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "width" => Ok(Self::Width),
             "height" => Ok(Self::Height),
@@ -94993,25 +95034,25 @@ impl std::str::FromStr for ScaleVariant9RangeVariant0 {
             "ramp" => Ok(Self::Ramp),
             "diverging" => Ok(Self::Diverging),
             "heatmap" => Ok(Self::Heatmap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant9RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant9RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant9RangeVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -95242,29 +95283,29 @@ impl ToString for ScaleVariant9Type {
     }
 }
 impl std::str::FromStr for ScaleVariant9Type {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "log" => Ok(Self::Log),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for ScaleVariant9Type {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ScaleVariant9Type {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ScaleVariant9Type {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -95729,29 +95770,29 @@ impl ToString for SequenceTransformType {
     }
 }
 impl std::str::FromStr for SequenceTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "sequence" => Ok(Self::Sequence),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SequenceTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SequenceTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SequenceTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -95926,8 +95967,8 @@ impl From<&SignalName> for SignalName {
     }
 }
 impl std::convert::TryFrom<String> for SignalName {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         if [
             "parent".to_string(),
             "datum".to_string(),
@@ -95936,7 +95977,7 @@ impl std::convert::TryFrom<String> for SignalName {
         ]
         .contains(&value)
         {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -96008,29 +96049,29 @@ impl ToString for SignalVariant0Push {
     }
 }
 impl std::str::FromStr for SignalVariant0Push {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "outer" => Ok(Self::Outer),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SignalVariant0Push {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SignalVariant0Push {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SignalVariant0Push {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -96109,30 +96150,30 @@ impl ToString for SortOrderVariant0 {
     }
 }
 impl std::str::FromStr for SortOrderVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "ascending" => Ok(Self::Ascending),
             "descending" => Ok(Self::Descending),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for SortOrderVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for SortOrderVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for SortOrderVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -96589,31 +96630,31 @@ impl ToString for StackTransformOffsetVariant0 {
     }
 }
 impl std::str::FromStr for StackTransformOffsetVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "zero" => Ok(Self::Zero),
             "center" => Ok(Self::Center),
             "normalize" => Ok(Self::Normalize),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StackTransformOffsetVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StackTransformOffsetVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StackTransformOffsetVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -96647,29 +96688,29 @@ impl ToString for StackTransformType {
     }
 }
 impl std::str::FromStr for StackTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "stack" => Ok(Self::Stack),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StackTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StackTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StackTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -96865,29 +96906,29 @@ impl ToString for StratifyTransformType {
     }
 }
 impl std::str::FromStr for StratifyTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "stratify" => Ok(Self::Stratify),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StratifyTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StratifyTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StratifyTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -97682,32 +97723,32 @@ impl From<&StringValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for StringValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StringValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StringValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StringValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -97973,32 +98014,32 @@ impl From<&StringValueVariant1Subtype0Variant3Range> for StringValueVariant1Subt
     }
 }
 impl std::str::FromStr for StringValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StringValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StringValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StringValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -98597,31 +98638,31 @@ impl ToString for StrokeCapValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "butt" => Ok(Self::Butt),
             "round" => Ok(Self::Round),
             "square" => Ok(Self::Square),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -98656,32 +98697,32 @@ impl From<&StrokeCapValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for StrokeCapValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -98962,31 +99003,31 @@ impl ToString for StrokeCapValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for StrokeCapValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "butt" => Ok(Self::Butt),
             "round" => Ok(Self::Round),
             "square" => Ok(Self::Square),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99021,32 +99062,32 @@ impl From<&StrokeCapValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for StrokeCapValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeCapValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeCapValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeCapValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99645,31 +99686,31 @@ impl ToString for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
     }
 }
 impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "miter" => Ok(Self::Miter),
             "round" => Ok(Self::Round),
             "bevel" => Ok(Self::Bevel),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemSubtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99704,32 +99745,32 @@ impl From<&StrokeJoinValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100010,31 +100051,31 @@ impl ToString for StrokeJoinValueVariant1Subtype0Variant1Value {
     }
 }
 impl std::str::FromStr for StrokeJoinValueVariant1Subtype0Variant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "miter" => Ok(Self::Miter),
             "round" => Ok(Self::Round),
             "bevel" => Ok(Self::Bevel),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype0Variant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100069,32 +100110,32 @@ impl From<&StrokeJoinValueVariant1Subtype0Variant3Range>
     }
 }
 impl std::str::FromStr for StrokeJoinValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for StrokeJoinValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for StrokeJoinValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100866,32 +100907,32 @@ impl From<&TextValueVariant0ItemSubtype0Variant3Range>
     }
 }
 impl std::str::FromStr for TextValueVariant0ItemSubtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for TextValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TextValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TextValueVariant0ItemSubtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -101203,32 +101244,32 @@ impl From<&TextValueVariant1Subtype0Variant3Range> for TextValueVariant1Subtype0
     }
 }
 impl std::str::FromStr for TextValueVariant1Subtype0Variant3Range {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for TextValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TextValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TextValueVariant1Subtype0Variant3Range {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -101430,30 +101471,30 @@ impl ToString for TickBandVariant0 {
     }
 }
 impl std::str::FromStr for TickBandVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "center" => Ok(Self::Center),
             "extent" => Ok(Self::Extent),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TickBandVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickBandVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TickBandVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -101607,8 +101648,8 @@ impl ToString for TickCountVariant1 {
     }
 }
 impl std::str::FromStr for TickCountVariant1 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -101618,25 +101659,25 @@ impl std::str::FromStr for TickCountVariant1 {
             "week" => Ok(Self::Week),
             "month" => Ok(Self::Month),
             "year" => Ok(Self::Year),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TickCountVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickCountVariant1 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TickCountVariant1 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -101745,8 +101786,8 @@ impl ToString for TickCountVariant2IntervalVariant0 {
     }
 }
 impl std::str::FromStr for TickCountVariant2IntervalVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "millisecond" => Ok(Self::Millisecond),
             "second" => Ok(Self::Second),
@@ -101756,25 +101797,25 @@ impl std::str::FromStr for TickCountVariant2IntervalVariant0 {
             "week" => Ok(Self::Week),
             "month" => Ok(Self::Month),
             "year" => Ok(Self::Year),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TickCountVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TickCountVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TickCountVariant2IntervalVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -102410,30 +102451,30 @@ impl ToString for TimeunitTransformTimezoneVariant0 {
     }
 }
 impl std::str::FromStr for TimeunitTransformTimezoneVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "local" => Ok(Self::Local),
             "utc" => Ok(Self::Utc),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformTimezoneVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformTimezoneVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TimeunitTransformTimezoneVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -102467,29 +102508,29 @@ impl ToString for TimeunitTransformType {
     }
 }
 impl std::str::FromStr for TimeunitTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "timeunit" => Ok(Self::Timeunit),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TimeunitTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -102675,8 +102716,8 @@ impl ToString for TimeunitTransformUnitsVariant0ItemVariant0 {
     }
 }
 impl std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "year" => Ok(Self::Year),
             "quarter" => Ok(Self::Quarter),
@@ -102689,25 +102730,25 @@ impl std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
             "minutes" => Ok(Self::Minutes),
             "seconds" => Ok(Self::Seconds),
             "milliseconds" => Ok(Self::Milliseconds),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -103273,31 +103314,31 @@ impl ToString for TitleVariant1AlignVariant0 {
     }
 }
 impl std::str::FromStr for TitleVariant1AlignVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "center" => Ok(Self::Center),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1AlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1AlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TitleVariant1AlignVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -103383,31 +103424,31 @@ impl ToString for TitleVariant1AnchorVariant0 {
     }
 }
 impl std::str::FromStr for TitleVariant1AnchorVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1AnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1AnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TitleVariant1AnchorVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -103544,8 +103585,8 @@ impl ToString for TitleVariant1BaselineVariant0 {
     }
 }
 impl std::str::FromStr for TitleVariant1BaselineVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "top" => Ok(Self::Top),
             "middle" => Ok(Self::Middle),
@@ -103553,25 +103594,25 @@ impl std::str::FromStr for TitleVariant1BaselineVariant0 {
             "alphabetic" => Ok(Self::Alphabetic),
             "line-top" => Ok(Self::LineTop),
             "line-bottom" => Ok(Self::LineBottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1BaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1BaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TitleVariant1BaselineVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -104037,30 +104078,30 @@ impl ToString for TitleVariant1FrameVariant0 {
     }
 }
 impl std::str::FromStr for TitleVariant1FrameVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "group" => Ok(Self::Group),
             "bounds" => Ok(Self::Bounds),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1FrameVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1FrameVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TitleVariant1FrameVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -104270,33 +104311,33 @@ impl ToString for TitleVariant1OrientVariant0 {
     }
 }
 impl std::str::FromStr for TitleVariant1OrientVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "none" => Ok(Self::None),
             "left" => Ok(Self::Left),
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TitleVariant1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TitleVariant1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TitleVariant1OrientVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -105701,30 +105742,30 @@ impl ToString for TreeTransformMethodVariant0 {
     }
 }
 impl std::str::FromStr for TreeTransformMethodVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "tidy" => Ok(Self::Tidy),
             "cluster" => Ok(Self::Cluster),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TreeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TreeTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -105978,29 +106019,29 @@ impl ToString for TreeTransformType {
     }
 }
 impl std::str::FromStr for TreeTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "tree" => Ok(Self::Tree),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TreeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreeTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TreeTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -106071,29 +106112,29 @@ impl ToString for TreelinksTransformType {
     }
 }
 impl std::str::FromStr for TreelinksTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "treelinks" => Ok(Self::Treelinks),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TreelinksTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreelinksTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TreelinksTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -106614,8 +106655,8 @@ impl ToString for TreemapTransformMethodVariant0 {
     }
 }
 impl std::str::FromStr for TreemapTransformMethodVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "squarify" => Ok(Self::Squarify),
             "resquarify" => Ok(Self::Resquarify),
@@ -106623,25 +106664,25 @@ impl std::str::FromStr for TreemapTransformMethodVariant0 {
             "dice" => Ok(Self::Dice),
             "slice" => Ok(Self::Slice),
             "slicedice" => Ok(Self::Slicedice),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TreemapTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreemapTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TreemapTransformMethodVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -107111,29 +107152,29 @@ impl ToString for TreemapTransformType {
     }
 }
 impl std::str::FromStr for TreemapTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "treemap" => Ok(Self::Treemap),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TreemapTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TreemapTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TreemapTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -107482,29 +107523,29 @@ impl ToString for VoronoiTransformType {
     }
 }
 impl std::str::FromStr for VoronoiTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "voronoi" => Ok(Self::Voronoi),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for VoronoiTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for VoronoiTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for VoronoiTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -108626,8 +108667,8 @@ impl ToString for WindowTransformOpsVariant0ItemVariant0 {
     }
 }
 impl std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "row_number" => Ok(Self::RowNumber),
             "rank" => Ok(Self::Rank),
@@ -108666,25 +108707,25 @@ impl std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
             "max" => Ok(Self::Max),
             "argmin" => Ok(Self::Argmin),
             "argmax" => Ok(Self::Argmax),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WindowTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WindowTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WindowTransformOpsVariant0ItemVariant0 {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -108811,29 +108852,29 @@ impl ToString for WindowTransformType {
     }
 }
 impl std::str::FromStr for WindowTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "window" => Ok(Self::Window),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WindowTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WindowTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WindowTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -109863,29 +109904,29 @@ impl ToString for WordcloudTransformType {
     }
 }
 impl std::str::FromStr for WordcloudTransformType {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "wordcloud" => Ok(Self::Wordcloud),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for WordcloudTransformType {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for WordcloudTransformType {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for WordcloudTransformType {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "ArraySansItems"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "TestType"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80,10 +105,10 @@ impl From<&TestTypeWhereNot> for TestTypeWhereNot {
     }
 }
 impl std::convert::TryFrom<String> for TestTypeWhereNot {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         if ["start".to_string(), "middle".to_string(), "end".to_string()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -132,10 +157,10 @@ impl From<&TestTypeWhyNot> for TestTypeWhyNot {
     }
 }
 impl std::convert::TryFrom<String> for TestTypeWhyNot {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         if ["because".to_string()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "LetterBox"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69,30 +94,30 @@ impl ToString for LetterBoxLetter {
     }
 }
 impl std::str::FromStr for LetterBoxLetter {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "a" => Ok(Self::A),
             "b" => Ok(Self::B),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for LetterBoxLetter {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for LetterBoxLetter {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for LetterBoxLetter {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "IdOrName"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -40,32 +65,32 @@ impl From<&IdOrName> for IdOrName {
     }
 }
 impl std::str::FromStr for IdOrName {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Id(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Name(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for IdOrName {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdOrName {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IdOrName {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -119,32 +144,32 @@ impl From<&IdOrNameRedundant> for IdOrNameRedundant {
     }
 }
 impl std::str::FromStr for IdOrNameRedundant {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Variant0(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Variant1(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for IdOrNameRedundant {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdOrNameRedundant {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IdOrNameRedundant {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -207,32 +232,32 @@ impl From<&IdOrYolo> for IdOrYolo {
     }
 }
 impl std::str::FromStr for IdOrYolo {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::Id(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Yolo(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for IdOrYolo {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdOrYolo {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IdOrYolo {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -284,29 +309,29 @@ impl From<&IdOrYoloYolo> for IdOrYoloYolo {
     }
 }
 impl std::str::FromStr for IdOrYoloYolo {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new(".*").unwrap().find(value).is_none() {
-            return Err("doesn't match pattern \".*\"");
+            return Err("doesn't match pattern \".*\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for IdOrYoloYolo {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IdOrYoloYolo {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IdOrYoloYolo {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -317,7 +342,9 @@ impl<'de> serde::Deserialize<'de> for IdOrYoloYolo {
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID."]
@@ -353,30 +380,30 @@ impl From<&Name> for Name {
     }
 }
 impl std::str::FromStr for Name {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if value.len() > 63usize {
-            return Err("longer than 63 characters");
+            return Err("longer than 63 characters".into());
         }
-        if regress :: Regex :: new ("^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$") . unwrap () . find (value) . is_none () { return Err ("doesn't match pattern \"^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$\"") ; }
+        if regress :: Regex :: new ("^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$") . unwrap () . find (value) . is_none () { return Err ("doesn't match pattern \"^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$\"" . into ()) ; }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for Name {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Name {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for Name {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -387,7 +414,9 @@ impl<'de> serde::Deserialize<'de> for Name {
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 fn main() {}

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "DeadSimple"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "ButNotThat"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -158,29 +183,29 @@ impl ToString for JsonSuccessBaseResult {
     }
 }
 impl std::str::FromStr for JsonSuccessBaseResult {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for JsonSuccessBaseResult {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JsonSuccessBaseResult {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for JsonSuccessBaseResult {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -215,29 +240,29 @@ impl ToString for JsonSuccessResult {
     }
 }
 impl std::str::FromStr for JsonSuccessResult {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "success" => Ok(Self::Success),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for JsonSuccessResult {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for JsonSuccessResult {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for JsonSuccessResult {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -533,29 +558,29 @@ impl ToString for Unsatisfiable3B {
     }
 }
 impl std::str::FromStr for Unsatisfiable3B {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "bar" => Ok(Self::Bar),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for Unsatisfiable3B {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Unsatisfiable3B {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for Unsatisfiable3B {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -590,29 +615,29 @@ impl ToString for Unsatisfiable3C {
     }
 }
 impl std::str::FromStr for Unsatisfiable3C {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "foo" => Ok(Self::Foo),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for Unsatisfiable3C {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for Unsatisfiable3C {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for Unsatisfiable3C {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "IntOrStr"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25,32 +50,32 @@ impl From<&IntOrStr> for IntOrStr {
     }
 }
 impl std::str::FromStr for IntOrStr {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::String(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::Integer(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for IntOrStr {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IntOrStr {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IntOrStr {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "ArrayBs"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "Node"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "FloatsArentTerribleImTold"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "TestEnum"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -40,31 +65,31 @@ impl ToString for TestEnum {
     }
 }
 impl std::str::FromStr for TestEnum {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "failure" => Ok(Self::Failure),
             "skipped" => Ok(Self::Skipped),
             "success" => Ok(Self::Success),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TestEnum {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TestEnum {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TestEnum {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "TestType"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "TestBed"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "PatternString"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -30,29 +55,29 @@ impl From<&PatternString> for PatternString {
     }
 }
 impl std::str::FromStr for PatternString {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if regress::Regex::new("xx").unwrap().find(value).is_none() {
-            return Err("doesn't match pattern \"xx\"");
+            return Err("doesn't match pattern \"xx\"".into());
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str> for PatternString {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for PatternString {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for PatternString {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63,7 +88,9 @@ impl<'de> serde::Deserialize<'de> for PatternString {
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as serde::de::Error>::custom(e.to_string())
+            })
     }
 }
 #[doc = "Sub10Primes"]
@@ -102,10 +129,10 @@ impl From<&Sub10Primes> for Sub10Primes {
     }
 }
 impl std::convert::TryFrom<u32> for Sub10Primes {
-    type Error = &'static str;
-    fn try_from(value: u32) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: u32) -> Result<Self, self::error::ConversionError> {
         if ![2_u32, 3_u32, 5_u32, 7_u32].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "TestType"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73,31 +98,31 @@ impl ToString for TestTypeValue {
     }
 }
 impl std::str::FromStr for TestTypeValue {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "start" => Ok(Self::Start),
             "middle" => Ok(Self::Middle),
             "end" => Ok(Self::End),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for TestTypeValue {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for TestTypeValue {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for TestTypeValue {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1,5 +1,30 @@
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
 #[doc = "AlternativeEnum"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -37,31 +62,31 @@ impl ToString for AlternativeEnum {
     }
 }
 impl std::str::FromStr for AlternativeEnum {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Choice1" => Ok(Self::Choice1),
             "Choice2" => Ok(Self::Choice2),
             "Choice3" => Ok(Self::Choice3),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for AlternativeEnum {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for AlternativeEnum {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for AlternativeEnum {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -145,31 +170,31 @@ impl ToString for DiskAttachmentState {
     }
 }
 impl std::str::FromStr for DiskAttachmentState {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "Detached" => Ok(Self::Detached),
             "Destroyed" => Ok(Self::Destroyed),
             "Faulted" => Ok(Self::Faulted),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for DiskAttachmentState {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for DiskAttachmentState {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for DiskAttachmentState {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -238,10 +263,12 @@ impl From<&EmptyObjectProp> for EmptyObjectProp {
     }
 }
 impl std::convert::TryFrom<serde_json::Map<String, serde_json::Value>> for EmptyObjectProp {
-    type Error = &'static str;
-    fn try_from(value: serde_json::Map<String, serde_json::Value>) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Self, self::error::ConversionError> {
         if ![[].into_iter().collect()].contains(&value) {
-            Err("invalid value")
+            Err("invalid value".into())
         } else {
             Ok(Self(value))
         }
@@ -298,32 +325,32 @@ impl From<&IpNet> for IpNet {
     }
 }
 impl std::str::FromStr for IpNet {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::V4(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::V6(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for IpNet {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for IpNet {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for IpNet {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -601,31 +628,31 @@ impl ToString for NullStringEnumWithUnknownFormatInner {
     }
 }
 impl std::str::FromStr for NullStringEnumWithUnknownFormatInner {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         match value {
             "a" => Ok(Self::A),
             "b" => Ok(Self::B),
             "c" => Ok(Self::C),
-            _ => Err("invalid value"),
+            _ => Err("invalid value".into()),
         }
     }
 }
 impl std::convert::TryFrom<&str> for NullStringEnumWithUnknownFormatInner {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for NullStringEnumWithUnknownFormatInner {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for NullStringEnumWithUnknownFormatInner {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -804,32 +831,32 @@ impl From<&ReferencesVariant1Value> for ReferencesVariant1Value {
     }
 }
 impl std::str::FromStr for ReferencesVariant1Value {
-    type Err = &'static str;
-    fn from_str(value: &str) -> Result<Self, &'static str> {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
             Ok(Self::StringVersion(v))
         } else if let Ok(v) = value.parse() {
             Ok(Self::ReferenceDef(v))
         } else {
-            Err("string conversion failed for all variants")
+            Err("string conversion failed for all variants".into())
         }
     }
 }
 impl std::convert::TryFrom<&str> for ReferencesVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &str) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String> for ReferencesVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String> for ReferencesVariant1Value {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, &'static str> {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }


### PR DESCRIPTION
Fixes #459 

Introduces a new mod in the code output:

```rust
pub mod error {
    #[doc = r" Error from a TryFrom or FromStr implementation."]
    pub struct ConversionError(std::borrow::Cow<'static, str>);
    impl std::error::Error for ConversionError {}
    impl std::fmt::Display for ConversionError {
        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
            std::fmt::Display::fmt(&self.0, f)
        }
    }
    impl std::fmt::Debug for ConversionError {
        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
            std::fmt::Debug::fmt(&self.0, f)
        }
    }
    impl From<&'static str> for ConversionError {
        fn from(value: &'static str) -> Self {
            Self(value.into())
        }
    }
    impl From<String> for ConversionError {
        fn from(value: String) -> Self {
            Self(value.into())
        }
    }
}
```