### PR TITLE
feat(convert): use chrono::NaiveDate for dates

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -719,7 +719,7 @@ impl TypeSpace {
                 self.uses_chrono = true;
                 Ok((
                     TypeEntry::new_native(
-                        "chrono::Date<chrono::offset::Utc>",
+                        "chrono::NaiveDate",
                         &[TypeSpaceImpl::Display, TypeSpaceImpl::FromStr],
                     ),
                     metadata,


### PR DESCRIPTION
`chrono::Date` was deprecated with:

> Deprecated since 0.4.23: Use NaiveDate or DateTime<Tz> instead

Switch from `chrono::Date<chrono::offset::Utc>` to `chrono::NaiveDate`.