### PR TITLE
Fix merging num/str validations that are equal

### DIFF
--- a/typify-impl/src/merge.rs
+++ b/typify-impl/src/merge.rs
@@ -686,6 +686,7 @@ fn merge_so_number(
 ) -> Result<Option<Box<NumberValidation>>, ()> {
     match (a, b) {
         (None, other) | (other, None) => Ok(other.cloned().map(Box::new)),
+        (Some(a), Some(b)) if a == b => Ok(Some(Box::new(a.clone()))),
         (Some(_), Some(_)) => {
             unimplemented!("this is fairly fussy and I don't want to do it")
         }
@@ -698,6 +699,7 @@ fn merge_so_string(
 ) -> Result<Option<Box<StringValidation>>, ()> {
     match (a, b) {
         (None, other) | (other, None) => Ok(other.cloned().map(Box::new)),
+        (Some(a), Some(b)) if a == b => Ok(Some(Box::new(a.clone()))),
         (Some(_), Some(_)) => {
             unimplemented!("this is fairly fussy and I don't want to do it")
         }


### PR DESCRIPTION
While trying to use [progenitor](https://github.com/oxidecomputer/progenitor) with the [DHL Express API](https://developer.dhl.com/sites/default/files/2023-10/dpdhl-express-api-2.10.0_swagger.yaml), I received the following unimplemented panic: `this is fairly fussy and I don't want to do it`.

I tracked the panic down to `merge_so_number` in this repo.

The validation rules it tried to merge where the same, which is why I were able to fix the panic by adding another case that handles if both `a` and `b` are defined but simply the same.