### PR TITLE
Better errors for schema merging

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -27,7 +27,7 @@ impl TypeSpace {
         info!(
             "convert_schema {:?} {}",
             type_name,
-            serde_json::to_string_pretty(schema).unwrap()
+            serde_json::to_string_pretty(schema).expect("Serialize schema")
         );
         match schema {
             Schema::Object(obj) => {
@@ -494,11 +494,11 @@ impl TypeSpace {
 
                 debug!(
                     "merged schema {}",
-                    serde_json::to_string_pretty(&merged_schema).unwrap(),
+                    serde_json::to_string_pretty(&merged_schema.clone()?).unwrap(),
                 );
 
                 let (type_entry, _) =
-                    self.convert_schema_object(type_name, original_schema, &merged_schema)?;
+                    self.convert_schema_object(type_name, original_schema, &merged_schema?)?;
                 Ok((type_entry, &None))
             }
 


### PR DESCRIPTION
I've been debugging errors originating in the schema merge logic lately, and I thought I could improve the errors somewhat. This is a bit of a low-effort attempt. Not all the errors are tremendously useful, and the error messages are mostly guesswork. But they ought to be somewhat better than what came before. Let me know what you think. I'm open to feedback.

The commits are meant to be squashed.