### PR TITLE
Fix decoding encoded string pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "syn 2.0.58",
  "thiserror",
  "unicode-ident",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1264,6 +1265,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.115"
 syn = { version = "2.0.58", features = ["full"] }
 thiserror = "1.0.58"
 unicode-ident = "1.0.12"
+urlencoding = "2.1.3"
 
 
 [dev-dependencies]

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -725,7 +725,13 @@ impl TypeSpace {
 
                 Some(validation) => {
                     if let Some(pattern) = &validation.pattern {
-                        let _ = regress::Regex::new(pattern).map_err(|e| Error::InvalidSchema {
+                        let decoded_str =
+                            urlencoding::decode(pattern).map_err(|e| Error::InvalidSchema {
+                                type_name: type_name.clone().into_option(),
+                                reason: format!("invalid pattern '{}' {}", pattern, e),
+                            })?;
+
+                        regress::Regex::new(&decoded_str.to_string()).map_err(|e| Error::InvalidSchema {
                             type_name: type_name.clone().into_option(),
                             reason: format!("invalid pattern '{}' {}", pattern, e),
                         })?;
@@ -1119,6 +1125,7 @@ impl TypeSpace {
         if !ref_name.starts_with('#') {
             panic!("external references are not supported: {}", ref_name);
         }
+
         let key = ref_key(ref_name);
         let type_id = self
             .ref_to_id


### PR DESCRIPTION
## Problem
If you pass a JSON schema with a regex pattern, you will need to encode it to avoid certain characters (e.g. backslash) to escape the JSON string.

An incorrect unescaped JSON string:
```
pattern: "[0-9A-Za-z\\-]*$"  
```

vs a correct escaped JSON string:
```
pattern: "[0-9A-Za-z%5c%5c-]*$"  
```

## Solution
This PR makes sure it will decode the string value of the pattern field first before trying to validate if the regex is correct. 