### PR TITLE
improvements to schema merge logic

### DIFF
--- a/typify-impl/src/merge.rs
+++ b/typify-impl/src/merge.rs
@@ -266,18 +266,10 @@ fn merge_so_enum_values(
     }
 }
 
-pub(crate) fn merge_with_subschemas(
-    schema_object: SchemaObject,
-    maybe_subschemas: Option<&SubschemaValidation>,
-    defs: &BTreeMap<RefKey, Schema>,
-) -> SchemaObject {
-    try_merge_with_subschemas(schema_object, maybe_subschemas, defs).unwrap()
-}
-
 /// Merge the schema with a subschema validation object. It's important that
 /// the return value reduces the complexity of the problem so avoid infinite
 /// recursion.
-fn try_merge_with_subschemas(
+pub(crate) fn try_merge_with_subschemas(
     mut schema_object: SchemaObject,
     maybe_subschemas: Option<&SubschemaValidation>,
     defs: &BTreeMap<RefKey, Schema>,

--- a/typify/tests/schemas/merged-schemas.json
+++ b/typify/tests/schemas/merged-schemas.json
@@ -360,6 +360,63 @@
           "bar": "string"
         }
       }
+    },
+    "Unresolvable": {
+      "$comment": "subschemas all end up unresolvable",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "x": {
+              "enum": [
+                "a"
+              ]
+            }
+          },
+          "required": [
+            "x"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "x": {
+              "enum": [
+                "b"
+              ]
+            }
+          },
+          "required": [
+            "x"
+          ]
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "x": {
+          "enum": [
+            "c"
+          ]
+        }
+      },
+      "required": [
+        "x"
+      ]
+    },
+    "CommentedTypeMerged": {
+      "description": "if we don't see this, we dropped the metadata",
+      "type": "object",
+      "properties": {
+        "x": true
+      },
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "y": true
+          }
+        }
+      ]
     }
   }
 }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -79,6 +79,40 @@ impl From<&ButNotThat> for ButNotThat {
         value.clone()
     }
 }
+#[doc = "if we don't see this, we dropped the metadata"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"if we don't see this, we dropped the metadata\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"allOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"y\": true"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"x\": true"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CommentedTypeMerged {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub y: Option<serde_json::Value>,
+}
+impl From<&CommentedTypeMerged> for CommentedTypeMerged {
+    fn from(value: &CommentedTypeMerged) -> Self {
+        value.clone()
+    }
+}
 #[doc = "JsonResponseBase"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -568,6 +602,63 @@ pub struct TrimFat {
 }
 impl From<&TrimFat> for TrimFat {
     fn from(value: &TrimFat) -> Self {
+        value.clone()
+    }
+}
+#[doc = "Unresolvable"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"x\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"x\": {"]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"a\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"x\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"x\": {"]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"b\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"x\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"x\": {"]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"c\""]
+#[doc = "      ]"]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"$comment\": \"subschemas all end up unresolvable\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum Unresolvable {}
+impl From<&Unresolvable> for Unresolvable {
+    fn from(value: &Unresolvable) -> Self {
         value.clone()
     }
 }


### PR DESCRIPTION
This fixes a couple of bugs. The first (#573) is pretty simple: when we merge schemas that contain both subschemas and other stuff, we drop all metadata; we should preserve the outer schema metadata for `title` and `description` in particular.

The next is that `convert_schema_object` calls `merge_with_subschemas` and expects it not to fail... but it can fail! In particular it will fail if the result of the merged schema is unsatisfiable (i.e. there is no value that would validate against the schema). In such a situation we now handle the error and produce a "never" schema (enum with no variants).


Closes #573, #572 

