### PR TITLE
Add support for the `x-rust-type` extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "newline-converter",
  "rustfmt-wrapper",
  "schemars",
+ "semver",
  "serde_json",
  "tempdir",
  "typify",
@@ -895,9 +896,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1199,6 +1203,7 @@ dependencies = [
  "rustfmt-wrapper",
  "schema",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "syn",
@@ -1214,6 +1219,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_tokenstream",

--- a/README.md
+++ b/README.md
@@ -31,29 +31,30 @@ appropriate built-in type based on type attributes. For example, a JSON Schema
 might specify a maximum and/or minimum that indicates the appropriate integral
 type to use.
 
-String schemas that include a `format` are represented with the appropriate Rust
-type. For example `{ "type": "string", "format": "uuid" }` is represented as a
-`uuid::Uuid` (which requires the `uuid` crate be included as a dependency).
+String schemas that include a known `format` are represented with the
+appropriate Rust type. For example `{ "type": "string", "format": "uuid" }` is
+represented as a `uuid::Uuid` (which requires the `uuid` crate be included as a
+dependency).
 
 ### Arrays
 
 JSON Schema arrays can turn into one of three Rust types `Vec<T>`, `HashSet<T>`,
 and tuples depending on the schema properties. An array may have a fixed length
 that matches a fixed list of item types; this is well represented by a Rust
-tuples. The distinction between `Vec<T>` and `HashSet<T>` is only if the
+tuple. The distinction between `Vec<T>` and `HashSet<T>` is only if the
 schema's `uniqueItems` field is `false` or `true` respectively.
 
 ### Objects
 
-In general, objects turn in to Rust structs. If, however, the schema defines no
+In general, objects turn into Rust structs. If, however, the schema defines no
 properties, Typify emits a `HashMap<String, T>` if the `additionalProperties`
 schema specifies `T` or a `HashMap<String, serde_json::Value>` otherwise.
 
-Properties that are not in the `required` set are typically represented as an
-`Option<T>` with the `#[serde(default)]` attribute applied. Non-required
-properties with types that already have a default value (such as a `Vec<T>`)
-simply get the `#[serde(default)]` attribute (so you won't see e.g.
-`Option<Vec<T>>`).
+Properties of generated `struct` that are not in the `required` set are
+typically represented as an `Option<T>` with the `#[serde(default)]` attribute
+applied. Non-required properties with types that already have a default value
+(such as a `Vec<T>`) simply get the `#[serde(default)]` attribute (so you won't
+see e.g. `Option<Vec<T>>`).
 
 ### OneOf
 
@@ -76,6 +77,87 @@ flattened members, this is one of the weaker areas of code generation.
 
 Issues describing example schemas and desired output are welcome and helpful.
 
+## Rust -> Schema -> Rust
+
+Schemas derives from Rust types may include an extension that includes information about the original type:
+
+```json
+{
+  "type": "object",
+  "properties": { .. },
+  "x-rust-type": {
+    "crate": "crate-o-types",
+    "version": "1.0.0",
+    "path": "crate_o_types::some_mod::SomeType"
+  }
+}
+```
+
+The extension includes the name of the crate, a Cargo-style version spec, and
+the full path (that must start with ident-converted name of the crate). Each of
+the modes of using typify allow for a list of crates and versions to be
+specified. In this case, if the user specifies "crate-o-types@1.0.1" for
+example, then typify would use its `SomeType` type rather than generating one
+according to the schema.
+
+### Version requirements
+
+The `version` field within the `x-rust-type` extension follows the Cargo
+version requirements specification. If the extension specifies `0.1.0` of a
+crate and the user states that they're using `0.1.1`, then the type is used;
+conversely, if the extension specifies `0.2.2` and the user is only using
+`0.2.0` the type is not used.
+
+Crate authors may choose to adhere to greater stability than otherwise provided
+by semver. If the extension version is `>=0.1.0, <1.0.0` then the crate author
+is committing to the schema compatibility of the given type on all releases
+until `1.0.0`. It is important that crate authors populate the `version` field
+in a way that upholds type availability. For example, while `*` is a valid
+value, it is only conceivably valid if the type in question were available in
+the first ever version of a crate published and never changed incompatibly in
+any subsequent version.
+
+### Type parameters
+
+The `x-rust-type` extension may also specify type parameters:
+
+```json
+{
+  "$defs": {
+    "Sprocket": {
+      "type": "object",
+      "properties": { .. },
+      "x-rust-type": {
+        "crate": "util",
+        "version": "0.1.0",
+        "path": "util::Sprocket",
+        "parameters": [
+          {
+            "$ref": "#/$defs/Gizmo"
+          }
+        ]
+      }
+    },
+    "Gizmo": {
+      "type": "object",
+      "properties": { .. },
+      "x-rust-type": {
+        "crate": "util",
+        "version": "0.1.0",
+        "path": "util::Gizmo"
+      }
+    }
+  }
+}
+```
+
+With the `util@0.1.0` crate specified during type generation, schemas
+referencing `#/$defs/Sprocket` would use the (non-generated) type
+`util::Sprocket<util::Gizmo>`.
+
+The `parameters` field is an array of schemas. They may be inline schemas or referenced schemas.
+
+
 ## Formatting
 
 You can format generated code using crates such as
@@ -90,7 +172,7 @@ The examples below show different ways to convert a `TypeSpace` to a string
 ### `rustfmt`
 
 Best for generation of code that might be checked in alongside hand-written
-code such as in the case of an `xtask` or stand-alone code generator (list
+code such as in the case of an `xtask` or stand-alone code generator (such as
 `cargo-typify`).
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Issues describing example schemas and desired output are welcome and helpful.
 
 ## Rust -> Schema -> Rust
 
-Schemas derives from Rust types may include an extension that includes information about the original type:
+Schemas derived from Rust types may include an extension that provides
+information about the original type:
 
 ```json
 {
@@ -93,9 +94,13 @@ Schemas derives from Rust types may include an extension that includes informati
 }
 ```
 
-The extension includes the name of the crate, a Cargo-style version spec, and
-the full path (that must start with ident-converted name of the crate). Each of
-the modes of using typify allow for a list of crates and versions to be
+The extension includes the name of the crate, a Cargo-style version
+requirements spec, and the full path (that must start with ident-converted name
+of the crate).
+
+### Using types from other crates
+
+Each of the modes of using typify allow for a list of crates and versions to be
 specified. In this case, if the user specifies "crate-o-types@1.0.1" for
 example, then typify would use its `SomeType` type rather than generating one
 according to the schema.

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 color-eyre = "0.6"
 env_logger = "0.10"
 rustfmt-wrapper = "0.2.1"
+semver = "1.0.22"
 serde_json = "1.0.116"
 schemars = "0.8.17"
 

--- a/cargo-typify/src/lib.rs
+++ b/cargo-typify/src/lib.rs
@@ -140,7 +140,7 @@ pub fn convert(args: &CliArgs) -> Result<String> {
         rename,
     } in &args.crates
     {
-        settings = settings.with_crate(name, version.clone(), rename.clone());
+        settings = settings.with_crate(name, version.clone(), rename.as_ref());
     }
 
     let mut type_space = TypeSpace::new(settings);

--- a/cargo-typify/src/lib.rs
+++ b/cargo-typify/src/lib.rs
@@ -111,7 +111,7 @@ impl std::str::FromStr for CrateSpec {
             let crate_str = &s[..ii];
             let vers_str = &s[ii + 1..];
 
-            if crate_str.contains(|cc: char| !cc.is_alphanumeric() && cc != '_' && cc != '-') {
+            if !is_crate(crate_str) {
                 return None;
             }
             let version = CrateVers::parse(vers_str)?;

--- a/cargo-typify/tests/outputs/help.txt
+++ b/cargo-typify/tests/outputs/help.txt
@@ -21,6 +21,9 @@ Options:
           
           If `-` is specified, the output will be written to stdout.
 
+      --crate <CRATES>
+          Specify each crate@version that can be assumed to be in use for types found in the schema with the x-rust-type extension
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/cargo-typify/tests/outputs/help.txt
+++ b/cargo-typify/tests/outputs/help.txt
@@ -24,6 +24,11 @@ Options:
       --crate <CRATES>
           Specify each crate@version that can be assumed to be in use for types found in the schema with the x-rust-type extension
 
+      --unknown-crates <UNKNOWN_CRATES>
+          Specify the policy unknown crates found in schemas with the x-rust-type extension
+          
+          [possible values: generate, allow, deny]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/extension-schema.json
+++ b/extension-schema.json
@@ -1,0 +1,29 @@
+{
+  "description": "schema for the x-rust-type extension",
+  "type": "object",
+  "properties": {
+    "crate": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+$"
+    },
+    "version": {
+      "description": "semver requirements per a Cargo.toml dependencies entry",
+      "type": "string"
+    },
+    "path": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_]+(::[a-zA-Z0-9+]+)*$"
+    },
+    "parameters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Schema"
+      }
+    }
+  },
+  "required": [
+    "crate",
+    "path",
+    "version"
+  ]
+}

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -14,6 +14,8 @@ proc-macro2 = "1.0.81"
 quote = "1.0.36"
 regress = "0.9.1"
 schemars = "0.8.17"
+semver = "1.0.22"
+serde = "1.0.200"
 serde_json = "1.0.116"
 syn = { version = "2.0.60", features = ["full"] }
 thiserror = "1.0.59"
@@ -27,6 +29,5 @@ paste = "1.0.14"
 rustfmt-wrapper = "0.2.1"
 schema = "0.1.0"
 schemars = { version = "0.8.17", features = ["uuid1"] }
-serde = "1.0.200"
 syn = { version = "2.0.60", features = ["full", "extra-traits"] }
 uuid = "1.8.0"

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -28,6 +28,6 @@ expectorate = "1.1.0"
 paste = "1.0.14"
 rustfmt-wrapper = "0.2.1"
 schema = "0.1.0"
-schemars = { version = "0.8.17", features = ["uuid1"] }
+schemars = { version = "0.8.17", features = ["uuid1", "impl_json_schema"] }
 syn = { version = "2.0.60", features = ["full", "extra-traits"] }
 uuid = "1.8.0"

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -49,6 +49,10 @@ impl TypeSpace {
         original_schema: &'a Schema,
         schema: &'a SchemaObject,
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
+        if let Some(type_entry) = self.convert_rust_extension(schema) {
+            return Ok((type_entry, &schema.metadata));
+        }
+
         match schema {
             // If we have a schema that has an instance type array that's
             // exactly two elements and one of them is Null, we have the

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -243,10 +243,38 @@ pub struct TypeSpaceSettings {
     extra_derives: Vec<String>,
     struct_builder: bool,
 
-    crates: BTreeMap<String, semver::Version>,
+    crates: BTreeMap<String, CrateSpec>,
     patch: BTreeMap<String, TypeSpacePatch>,
     replace: BTreeMap<String, TypeSpaceReplace>,
     convert: Vec<TypeSpaceConversion>,
+}
+
+#[derive(Debug, Clone)]
+struct CrateSpec {
+    version: CrateVers,
+    rename: Option<String>,
+}
+
+/// XXX
+#[derive(Debug, Clone)]
+pub enum CrateVers {
+    /// XXX
+    Version(semver::Version),
+    /// XXX
+    Any,
+    /// XXX
+    Never,
+}
+
+impl CrateVers {
+    /// XXX
+    pub fn parse(s: &str) -> Option<Self> {
+        if s == "!" {
+            Some(Self::Never)
+        } else {
+            Some(Self::Version(semver::Version::parse(s).ok()?))
+        }
+    }
 }
 
 /// Contains a set of modifications that may be applied to an existing type.
@@ -375,12 +403,19 @@ impl TypeSpaceSettings {
     /// generate) types from the given crate and version. The version should
     /// precisely match the version of the crate that you expect as a
     /// dependency.
-    pub fn with_crate<S: ToString>(
+    pub fn with_crate<S1: ToString, S2: ToString>(
         &mut self,
-        crate_name: S,
-        version: semver::Version,
+        crate_name: S1,
+        version: CrateVers,
+        rename: Option<S2>,
     ) -> &mut Self {
-        self.crates.insert(crate_name.to_string(), version);
+        self.crates.insert(
+            crate_name.to_string(),
+            CrateSpec {
+                version,
+                rename: rename.map(|r| r.to_string()),
+            },
+        );
         self
     }
 }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -30,12 +30,12 @@ mod defaults;
 mod enums;
 mod merge;
 mod output;
+mod rust_extension;
 mod structs;
 mod type_entry;
 mod util;
 mod validate;
 mod value;
-mod x_rust;
 
 #[allow(missing_docs)]
 #[derive(Error, Debug)]

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -35,6 +35,7 @@ mod type_entry;
 mod util;
 mod validate;
 mod value;
+mod x_rust;
 
 #[allow(missing_docs)]
 #[derive(Error, Debug)]

--- a/typify-impl/src/rust_extension.rs
+++ b/typify-impl/src/rust_extension.rs
@@ -96,6 +96,9 @@ impl TypeSpace {
             .collect::<Result<Vec<_>>>()
             .ok()?;
 
-        Some(TypeEntry::new_native_params(path, &param_ids))
+        Some(TypeEntry::new_native_params(
+            format!("::{path}"),
+            &param_ids,
+        ))
     }
 }

--- a/typify-impl/src/rust_extension.rs
+++ b/typify-impl/src/rust_extension.rs
@@ -8,7 +8,8 @@ use crate::{type_entry::TypeEntry, CrateVers, Name, Result, TypeSpace};
 
 const RUST_TYPE_EXTENSION: &str = "x-rust-type";
 
-// TODO crate renames?
+/// Definition of the value of the x-rust-type extension. This structure
+/// must not change incompatibly (and probably shouldn't change at all).
 #[derive(Deserialize)]
 struct RustExtension {
     #[serde(rename = "crate")]
@@ -81,6 +82,7 @@ impl TypeSpace {
         let param_ids = parameters
             .iter()
             .map(|p_schema| {
+                // TODO could we have some reasonable type name? Do we need to?
                 let (param_id, _) = self.id_for_schema(Name::Unknown, p_schema)?;
                 Ok(param_id)
             })

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use proc_macro2::{Punct, Spacing, TokenStream, TokenTree};
 use quote::{format_ident, quote, ToTokens};
 use schemars::schema::{Metadata, Schema};
-use syn::Path;
+use syn::{punctuated::Punctuated, Path};
 
 use crate::{
     enums::output_variant,
@@ -89,6 +89,9 @@ pub(crate) enum TypeEntryNewtypeConstraints {
 pub(crate) struct TypeEntryNative {
     pub type_name: String,
     impls: Vec<TypeSpaceImpl>,
+    // TODO to support const generics, this can be TypeOrValue, but note that
+    // we may some day need to disambiguate char and &'static str
+    parameters: Vec<TypeId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -464,6 +467,17 @@ impl TypeEntry {
             details: TypeEntryDetails::Native(TypeEntryNative {
                 type_name: type_name.to_string(),
                 impls: impls.to_vec(),
+                parameters: Default::default(),
+            }),
+            extra_derives: Default::default(),
+        }
+    }
+    pub(crate) fn new_native_params<S: ToString>(type_name: S, params: &[TypeId]) -> Self {
+        TypeEntry {
+            details: TypeEntryDetails::Native(TypeEntryNative {
+                type_name: type_name.to_string(),
+                impls: Default::default(),
+                parameters: params.to_vec(),
             }),
             extra_derives: Default::default(),
         }
@@ -1644,17 +1658,43 @@ impl TypeEntry {
                 quote! { [#item_ident; #length]}
             }
 
+            TypeEntryDetails::Native(TypeEntryNative {
+                type_name,
+                impls: _,
+                parameters,
+            }) => {
+                let path =
+                    syn::parse_str::<syn::TypePath>(type_name).expect("type path wasn't valid");
+
+                let xxx = (!parameters.is_empty()).then(|| {
+                    let type_idents = parameters
+                        .iter()
+                        .map(|type_id| {
+                            type_space
+                                .id_to_entry
+                                .get(type_id)
+                                .expect("unresolved type id for tuple")
+                                .type_ident(type_space, type_mod)
+                        })
+                        .collect::<Punctuated<_, syn::Token![,]>>();
+                    type_idents
+                });
+
+                quote! {
+                    #path
+                    #type_idents
+                }
+            }
+
             TypeEntryDetails::Unit => quote! { () },
             TypeEntryDetails::String => quote! { String },
             TypeEntryDetails::Boolean => quote! { bool },
             TypeEntryDetails::JsonValue => quote! { serde_json::Value },
-            TypeEntryDetails::Native(TypeEntryNative {
-                type_name: name, ..
-            })
-            | TypeEntryDetails::Integer(name)
-            | TypeEntryDetails::Float(name) => syn::parse_str::<syn::TypePath>(name)
-                .unwrap()
-                .to_token_stream(),
+            TypeEntryDetails::Integer(name) | TypeEntryDetails::Float(name) => {
+                syn::parse_str::<syn::TypePath>(name)
+                    .unwrap()
+                    .to_token_stream()
+            }
 
             TypeEntryDetails::Reference(_) => panic!("references should be resolved by now"),
         }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -92,7 +92,14 @@ pub(crate) struct TypeEntryNative {
     // TODO to support const generics, this can be some sort of TypeOrValue,
     // but note that we may some day need to disambiguate char and &'static str
     // since schemars represents a char as a string of length 1.
-    parameters: Vec<TypeId>,
+    pub parameters: Vec<TypeId>,
+}
+impl TypeEntryNative {
+    pub(crate) fn name_match(&self, type_name: &Name) -> bool {
+        let native_name = self.type_name.rsplit("::").next().unwrap();
+        !self.parameters.is_empty()
+            || matches!(type_name, Name::Required(req) if req == native_name)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/typify-impl/src/x_rust.rs
+++ b/typify-impl/src/x_rust.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 Oxide Computer Company
+
+use schemars::schema::{Metadata, Schema, SchemaObject};
+use serde::Deserialize;
+
+use crate::{type_entry::TypeEntry, Name, Result, TypeSpace};
+
+// TODO crate renames?
+#[derive(Deserialize)]
+struct RustExtension {
+    #[serde(rename = "crate")]
+    crate_name: String,
+    version: String,
+    path: String,
+    #[serde(default)]
+    parameters: Vec<Schema>,
+}
+
+impl TypeSpace {
+    pub(crate) fn convert_rust_extension(&mut self, schema: &SchemaObject) -> Option<TypeEntry> {
+        let xxx = schema.extensions.get("x-rust")?;
+
+        // TODO warn if this fails
+        let RustExtension {
+            crate_name,
+            version,
+            path,
+            parameters,
+        } = serde_json::from_value(xxx.clone()).ok()?;
+
+        // Do the crate and version check
+        // TODO
+
+        let crate_name = crate_name.replace("-", "_");
+
+        assert!(path.starts_with("::"));
+
+        let type_name = format!("{}{}", crate_name, path);
+
+        let zzz = parameters
+            .iter()
+            .map(|p_schema| {
+                let lll = self.id_for_schema(Name::Unknown, p_schema)?;
+                Ok(lll.0)
+            })
+            .collect::<Result<Vec<_>>>()
+            .ok()?;
+
+        Some(TypeEntry::new_native_params(type_name, &zzz))
+    }
+}

--- a/typify-impl/tests/test_github.rs
+++ b/typify-impl/tests/test_github.rs
@@ -29,7 +29,7 @@ fn test_github() {
 fn test_vega() {
     env_logger::init();
     let mut settings = TypeSpaceSettings::default();
-    let raw_schema = serde_json::json! {
+    let raw_schema = serde_json::json!(
         {
             "enum": [
               null,
@@ -57,7 +57,7 @@ fn test_vega() {
               900
             ]
           }
-    };
+    );
     let schema = serde_json::from_value(raw_schema).unwrap();
     settings
         .with_conversion(schema, "MyEnum", [TypeSpaceImpl::FromStr].into_iter())

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 proc-macro2 = "1.0.81"
 quote = "1.0.36"
 schemars = "0.8.17"
+semver = { version = "1.0.22", features = ["serde"] }
 serde = "1.0.200"
 serde_json = "1.0.116"
 serde_tokenstream = "0.2.0"

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! typify macro implementation.
 

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -156,6 +156,7 @@
 
 #![deny(missing_docs)]
 
+pub use typify_impl::CrateVers;
 pub use typify_impl::Error;
 pub use typify_impl::Type;
 pub use typify_impl::TypeDetails;

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -170,5 +170,6 @@ pub use typify_impl::TypeSpacePatch;
 pub use typify_impl::TypeSpaceSettings;
 pub use typify_impl::TypeStruct;
 pub use typify_impl::TypeStructPropInfo;
+pub use typify_impl::UnknownPolicy;
 #[cfg(feature = "macro")]
 pub use typify_macro::import_types;

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! # Typify
 //!

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 use std::{error::Error, fs::File, io::BufReader};
 
@@ -32,11 +32,11 @@ fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {
     // Read the JSON contents of the file as an instance of `User`.
     let root_schema: RootSchema = serde_json::from_reader(reader)?;
 
-    let schema_raw = json! {
+    let schema_raw = json!(
         {
             "enum": [ 1, "one" ]
         }
-    };
+    );
     let schema = serde_json::from_value(schema_raw).unwrap();
 
     let mut type_space = TypeSpace::new(
@@ -57,6 +57,13 @@ fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {
                 schema,
                 "serde_json::Value",
                 [TypeSpaceImpl::Display].into_iter(),
+            )
+            // Our test use of the x-rust-type extension only refers to things
+            // in std.
+            .with_crate(
+                "std",
+                typify::CrateVers::Version("1.0.0".parse().unwrap()),
+                None,
             ),
     );
     type_space.add_root_schema(root_schema)?;

--- a/typify/tests/schemas/x-rust-type.json
+++ b/typify/tests/schemas/x-rust-type.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$comment": "this test makes weird use of types from std to avoid requiring other dependencies",
+  "$defs": {
+    "AllTheThings": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/PathBuf"
+        },
+        "option_marker": {
+          "$ref": "#/$defs/OptionMarker"
+        }
+      }
+    },
+    "PathBuf": {
+      "type": "string",
+      "x-rust-type": {
+        "crate": "std",
+        "version": "1.0.0",
+        "path": "std::path::PathBuf"
+      }
+    },
+    "OptionMarker": {
+      "$comment": "this is silly, but shows type parameters",
+      "type": "null",
+      "x-rust-type": {
+        "crate": "std",
+        "version": "1.0.0",
+        "path": "std::option::Option",
+        "parameters": [
+          {
+            "$ref": "#/$defs/Marker"
+          }
+        ]
+      }
+    },
+    "Marker": {
+      "not": true
+    }
+  }
+}

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -47,9 +47,9 @@ pub mod error {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllTheThings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub option_marker: Option<std::option::Option<Marker>>,
+    pub option_marker: Option<::std::option::Option<Marker>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<std::path::PathBuf>,
+    pub path: Option<::std::path::PathBuf>,
 }
 impl From<&AllTheThings> for AllTheThings {
     fn from(value: &AllTheThings) -> Self {

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -1,0 +1,75 @@
+#[allow(unused_imports)]
+use serde::{Deserialize, Serialize};
+#[doc = r" Error types."]
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+#[doc = "AllTheThings"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"option_marker\": {"]
+#[doc = "      \"$ref\": \"#/$defs/OptionMarker\""]
+#[doc = "    },"]
+#[doc = "    \"path\": {"]
+#[doc = "      \"$ref\": \"#/$defs/PathBuf\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AllTheThings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub option_marker: Option<std::option::Option<Marker>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<std::path::PathBuf>,
+}
+impl From<&AllTheThings> for AllTheThings {
+    fn from(value: &AllTheThings) -> Self {
+        value.clone()
+    }
+}
+#[doc = "Marker"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "false"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum Marker {}
+impl From<&Marker> for Marker {
+    fn from(value: &Marker) -> Self {
+        value.clone()
+    }
+}
+fn main() {}


### PR DESCRIPTION
This adds support for the `x-rust-type` extension. When we see this extension in types we can (depending on the configuration settings) try to use the type from the particular crate rather than generating the type. This is particularly useful for types with any of the following properties:

* Structure that's not well represented in JSON Schema such as an IP subnet that has distinct components of an IP address and netmask prefix, but that is typically represented simply as a string with a (complex) `pattern` regex.
* Mechanisms that are missed in a generated type. Consider e.g. a type representing a number of bytes that benefits from constructors and accessors aware of IEC prefixes.
* Common, atomic types along the lines of UUIDs or dates (both of which are represented with `format`s... I'm saying *like* those)