### PR TITLE
Workaround for type name collisions

### DIFF
--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -374,18 +374,17 @@ impl TypeEntry {
             (format!("defaults::{}", fn_name), Some(def))
         }
     }
-    
+
     pub(crate) fn rename(&mut self, new_name: String) {
         match &mut self.details {
             TypeEntryDetails::Enum(TypeEntryEnum { name, .. })
             | TypeEntryDetails::Struct(TypeEntryStruct { name, .. })
-            | TypeEntryDetails::Newtype(TypeEntryNewtype { name, .. }) => { 
+            | TypeEntryDetails::Newtype(TypeEntryNewtype { name, .. }) => {
                 *name = new_name;
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
-    
 }
 
 pub(crate) fn validate_default_for_external_enum(

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Oxide Computer Company
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Oxide Computer Company
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -374,6 +374,18 @@ impl TypeEntry {
             (format!("defaults::{}", fn_name), Some(def))
         }
     }
+    
+    pub(crate) fn rename(&mut self, new_name: String) {
+        match &mut self.details {
+            TypeEntryDetails::Enum(TypeEntryEnum { name, .. })
+            | TypeEntryDetails::Struct(TypeEntryStruct { name, .. })
+            | TypeEntryDetails::Newtype(TypeEntryNewtype { name, .. }) => { 
+                *name = new_name;
+            },
+            _ => {},
+        }
+    }
+    
 }
 
 pub(crate) fn validate_default_for_external_enum(

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -374,17 +374,6 @@ impl TypeEntry {
             (format!("defaults::{}", fn_name), Some(def))
         }
     }
-
-    pub(crate) fn rename(&mut self, new_name: String) {
-        match &mut self.details {
-            TypeEntryDetails::Enum(TypeEntryEnum { name, .. })
-            | TypeEntryDetails::Struct(TypeEntryStruct { name, .. })
-            | TypeEntryDetails::Newtype(TypeEntryNewtype { name, .. }) => {
-                *name = new_name;
-            }
-            _ => {}
-        }
-    }
 }
 
 pub(crate) fn validate_default_for_external_enum(

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -569,7 +569,7 @@ impl TypeSpace {
                 }
 
                 Some(replace_type) => {
-                    let mut type_entry = TypeEntry::new_native(
+                    let type_entry = TypeEntry::new_native(
                         replace_type.replace_type.clone(),
                         &replace_type.impls.clone(),
                     );

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -588,13 +588,7 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
-            if let Some(mut name) = type_entry.name().cloned() {
-                while self.names.contains(&name) {
-                    name = format!("{name}Alias");
-                }
-                self.names.insert(name.clone());
-                type_entry.rename(name);
-            }
+            type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);
         }
 
@@ -690,6 +684,7 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
+            type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);
         }
 

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -588,7 +588,7 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
-            // I think we should do it this, because in this place we're iterating over all 
+            // I think we should do it this, because in this place we're iterating over all
             // created types.
             type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);
@@ -686,7 +686,7 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
-            // I think we should do it this, because in this place we're iterating over all 
+            // I think we should do it this, because in this place we're iterating over all
             // created types.
             type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -647,8 +647,8 @@ impl TypeSpace {
             }
         };
         if let Some(entry_name) = type_entry.name().cloned() {
-            type_entry.ensure_unique_name(self);
-            self.name_to_id.insert(entry_name, type_id.clone());
+            let name = type_entry.ensure_unique_name(self).unwrap_or(entry_name);
+            self.name_to_id.insert(name, type_id.clone());
         }
         self.id_to_entry.insert(type_id, type_entry);
         Ok(())
@@ -847,7 +847,7 @@ impl TypeSpace {
                 type_id.clone()
             } else {
                 let type_id = self.assign();
-                ty.ensure_unique_name(self);
+                let name = ty.ensure_unique_name(self).unwrap_or(name);
                 self.name_to_id.insert(name, type_id.clone());
                 self.id_to_entry.insert(type_id.clone(), ty);
                 type_id

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -204,7 +204,7 @@ pub struct TypeSpace {
     settings: TypeSpaceSettings,
 
     cache: SchemaCache,
-    
+
     names: HashSet<String>,
 
     // Shared functions for generating default values
@@ -595,7 +595,7 @@ impl TypeSpace {
                 self.names.insert(name.clone());
                 type_entry.rename(name);
             }
-           self.id_to_entry.insert(type_id, type_entry);
+            self.id_to_entry.insert(type_id, type_entry);
         }
 
         Ok(())

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -588,6 +588,8 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
+            // I think we should do it this, because in this place we're iterating over all 
+            // created types.
             type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);
         }
@@ -684,6 +686,8 @@ impl TypeSpace {
             let type_id = TypeId(index);
             let mut type_entry = self.id_to_entry.get(&type_id).unwrap().clone();
             type_entry.finalize(self)?;
+            // I think we should do it this, because in this place we're iterating over all 
+            // created types.
             type_entry.ensure_unique_name(self);
             self.id_to_entry.insert(type_id, type_entry);
         }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -574,18 +574,6 @@ impl TypeSpace {
                         &replace_type.impls.clone(),
                     );
 
-                    // let t = &mut type_entry;
-                    // if !t.check_name( &self.names ) {
-                    //     let mut n = t.name().unwrap().clone();
-                    //     while self.names.contains(&n) {
-                    //         n = format!("{n}Alias");
-                    //     }
-                    //     t.rename(n);
-                    // }
-                    // if let Some(n) = type_entry.name(){
-                    //     dbg!(n);
-                    //     self.names.insert(n.clone());
-                    // }
                     self.id_to_entry.insert(type_id, type_entry);
                 }
             }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -514,6 +514,21 @@ impl TypeEntry {
         self.check_defaults(type_space)
     }
 
+    // Ensures that the name is unique within the provided `TypeSpace`.
+    //
+    // This function checks if the current object's name already exists in the `TypeSpace`. If it does,
+    // the function modifies the name by appending "Alias" until a unique name is found. The unique name
+    // is then inserted into the `TypeSpace` and the object's name is updated accordingly.
+    pub(crate) fn ensure_unique_name(&mut self, type_space: &mut TypeSpace) {
+        if let Some(mut name) = self.name().cloned() {
+            while type_space.names.contains(&name) {
+                name = format!("{name}Alias");
+            }
+            type_space.names.insert(name.clone());
+            self.rename(name);
+        }
+    }
+
     pub(crate) fn name(&self) -> Option<&String> {
         match &self.details {
             TypeEntryDetails::Enum(TypeEntryEnum { name, .. })

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -520,12 +520,25 @@ impl TypeEntry {
     // the function modifies the name by appending "Alias" until a unique name is found. The unique name
     // is then inserted into the `TypeSpace` and the object's name is updated accordingly.
     pub(crate) fn ensure_unique_name(&mut self, type_space: &mut TypeSpace) {
-        if let Some(mut name) = self.name().cloned() {
-            while type_space.names.contains(&name) {
-                name = format!("{name}Alias");
+        if let Some(name) = self.name() {
+            let mut postfix = 2;
+            let mut new_name = name.clone();
+            while type_space.name_to_id.contains_key(&new_name) {
+                new_name = format!("{name}{postfix}");
+                postfix += 1;
             }
-            type_space.names.insert(name.clone());
-            self.rename(name);
+            self.rename(new_name);
+        }
+    }
+
+    pub(crate) fn rename(&mut self, new_name: String) {
+        match &mut self.details {
+            TypeEntryDetails::Enum(TypeEntryEnum { name, .. })
+            | TypeEntryDetails::Struct(TypeEntryStruct { name, .. })
+            | TypeEntryDetails::Newtype(TypeEntryNewtype { name, .. }) => {
+                *name = new_name;
+            }
+            _ => {}
         }
     }
 

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -516,10 +516,13 @@ impl TypeEntry {
 
     // Ensures that the name is unique within the provided `TypeSpace`.
     //
-    // This function checks if the current object's name already exists in the `TypeSpace`. If it does,
-    // the function modifies the name by appending "Alias" until a unique name is found. The unique name
-    // is then inserted into the `TypeSpace` and the object's name is updated accordingly.
-    pub(crate) fn ensure_unique_name(&mut self, type_space: &mut TypeSpace) {
+    // This function checks if the current object's name already exists in the
+    // `TypeSpace`. If it does, the function modifies the name by appending
+    // numbers until a unique name is found (Name2, Name3 ...).
+    //
+    // The unique name is then inserted into the `TypeSpace` and the object's
+    // name is updated accordingly.
+    pub(crate) fn ensure_unique_name(&mut self, type_space: &mut TypeSpace) -> Option<String> {
         if let Some(name) = self.name() {
             let mut postfix = 2;
             let mut new_name = name.clone();
@@ -527,7 +530,10 @@ impl TypeEntry {
                 new_name = format!("{name}{postfix}");
                 postfix += 1;
             }
-            self.rename(new_name);
+            self.rename(new_name.clone());
+            Some(new_name)
+        } else {
+            None
         }
     }
 

--- a/typify/tests/schemas/property-name-collision.json
+++ b/typify/tests/schemas/property-name-collision.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "Foo": {
+            "properties": {
+                "Bar": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/FooBar"
+                        },
+                        {
+                            "$ref": "#/definitions/Baz"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "FooBar": {
+            "type": "string"
+        },
+        "Baz": {
+            "type": "string"
+        }
+    }
+}

--- a/typify/tests/schemas/property-name-collision.rs
+++ b/typify/tests/schemas/property-name-collision.rs
@@ -1,0 +1,225 @@
+#[allow(unused_imports)]
+use serde::{Deserialize, Serialize};
+#[doc = r" Error types."]
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+    impl std::error::Error for ConversionError {}
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+#[doc = "Baz"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct Baz(pub String);
+impl std::ops::Deref for Baz {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<Baz> for String {
+    fn from(value: Baz) -> Self {
+        value.0
+    }
+}
+impl From<&Baz> for Baz {
+    fn from(value: &Baz) -> Self {
+        value.clone()
+    }
+}
+impl From<String> for Baz {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for Baz {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_string()))
+    }
+}
+impl ToString for Baz {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+#[doc = "Foo"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"Bar\": {"]
+#[doc = "      \"oneOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/definitions/FooBar\""]
+#[doc = "        },"]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/definitions/Baz\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Foo {
+    #[serde(rename = "Bar", default, skip_serializing_if = "Option::is_none")]
+    pub bar: Option<FooBarAlias>,
+}
+impl From<&Foo> for Foo {
+    fn from(value: &Foo) -> Self {
+        value.clone()
+    }
+}
+#[doc = "FooBar"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct FooBar(pub String);
+impl std::ops::Deref for FooBar {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<FooBar> for String {
+    fn from(value: FooBar) -> Self {
+        value.0
+    }
+}
+impl From<&FooBar> for FooBar {
+    fn from(value: &FooBar) -> Self {
+        value.clone()
+    }
+}
+impl From<String> for FooBar {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for FooBar {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_string()))
+    }
+}
+impl ToString for FooBar {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+#[doc = "FooBarAlias"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/FooBar\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/Baz\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FooBarAlias {
+    FooBar(FooBar),
+    Baz(Baz),
+}
+impl From<&FooBarAlias> for FooBarAlias {
+    fn from(value: &FooBarAlias) -> Self {
+        value.clone()
+    }
+}
+impl std::str::FromStr for FooBarAlias {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::FooBar(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Baz(v))
+        } else {
+            Err("string conversion failed for all variants".into())
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for FooBarAlias {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<&String> for FooBarAlias {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl std::convert::TryFrom<String> for FooBarAlias {
+    type Error = self::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ToString for FooBarAlias {
+    fn to_string(&self) -> String {
+        match self {
+            Self::FooBar(x) => x.to_string(),
+            Self::Baz(x) => x.to_string(),
+        }
+    }
+}
+impl From<FooBar> for FooBarAlias {
+    fn from(value: FooBar) -> Self {
+        Self::FooBar(value)
+    }
+}
+impl From<Baz> for FooBarAlias {
+    fn from(value: Baz) -> Self {
+        Self::Baz(value)
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/property-name-collision.rs
+++ b/typify/tests/schemas/property-name-collision.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -36,7 +34,9 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Baz(pub String);
 impl std::ops::Deref for Baz {
     type Target = String;
@@ -92,7 +92,7 @@ impl ToString for Baz {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Foo {
     #[serde(rename = "Bar", default, skip_serializing_if = "Option::is_none")]
     pub bar: Option<FooBarAlias>,
@@ -112,7 +112,9 @@ impl From<&Foo> for Foo {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct FooBar(pub String);
 impl std::ops::Deref for FooBar {
     type Target = String;
@@ -163,7 +165,7 @@ impl ToString for FooBar {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FooBarAlias {
     FooBar(FooBar),

--- a/typify/tests/schemas/property-name-collision.rs
+++ b/typify/tests/schemas/property-name-collision.rs
@@ -95,7 +95,7 @@ impl ToString for Baz {
 #[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Foo {
     #[serde(rename = "Bar", default, skip_serializing_if = "Option::is_none")]
-    pub bar: Option<FooBarAlias>,
+    pub bar: Option<FooBar>,
 }
 impl From<&Foo> for Foo {
     fn from(value: &Foo) -> Self {
@@ -103,52 +103,6 @@ impl From<&Foo> for Foo {
     }
 }
 #[doc = "FooBar"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"type\": \"string\""]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(
-    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
-)]
-pub struct FooBar(pub String);
-impl std::ops::Deref for FooBar {
-    type Target = String;
-    fn deref(&self) -> &String {
-        &self.0
-    }
-}
-impl From<FooBar> for String {
-    fn from(value: FooBar) -> Self {
-        value.0
-    }
-}
-impl From<&FooBar> for FooBar {
-    fn from(value: &FooBar) -> Self {
-        value.clone()
-    }
-}
-impl From<String> for FooBar {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-impl std::str::FromStr for FooBar {
-    type Err = std::convert::Infallible;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(value.to_string()))
-    }
-}
-impl ToString for FooBar {
-    fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
-#[doc = "FooBarAlias"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -167,16 +121,16 @@ impl ToString for FooBar {
 #[doc = r" </details>"]
 #[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
-pub enum FooBarAlias {
-    FooBar(FooBar),
+pub enum FooBar {
+    FooBar(FooBar2),
     Baz(Baz),
 }
-impl From<&FooBarAlias> for FooBarAlias {
-    fn from(value: &FooBarAlias) -> Self {
+impl From<&FooBar> for FooBar {
+    fn from(value: &FooBar) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr for FooBarAlias {
+impl std::str::FromStr for FooBar {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
@@ -188,25 +142,25 @@ impl std::str::FromStr for FooBarAlias {
         }
     }
 }
-impl std::convert::TryFrom<&str> for FooBarAlias {
+impl std::convert::TryFrom<&str> for FooBar {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for FooBarAlias {
+impl std::convert::TryFrom<&String> for FooBar {
     type Error = self::error::ConversionError;
     fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String> for FooBarAlias {
+impl std::convert::TryFrom<String> for FooBar {
     type Error = self::error::ConversionError;
     fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ToString for FooBarAlias {
+impl ToString for FooBar {
     fn to_string(&self) -> String {
         match self {
             Self::FooBar(x) => x.to_string(),
@@ -214,14 +168,60 @@ impl ToString for FooBarAlias {
         }
     }
 }
-impl From<FooBar> for FooBarAlias {
-    fn from(value: FooBar) -> Self {
+impl From<FooBar2> for FooBar {
+    fn from(value: FooBar2) -> Self {
         Self::FooBar(value)
     }
 }
-impl From<Baz> for FooBarAlias {
+impl From<Baz> for FooBar {
     fn from(value: Baz) -> Self {
         Self::Baz(value)
+    }
+}
+#[doc = "FooBar2"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
+pub struct FooBar2(pub String);
+impl std::ops::Deref for FooBar2 {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<FooBar2> for String {
+    fn from(value: FooBar2) -> Self {
+        value.0
+    }
+}
+impl From<&FooBar2> for FooBar2 {
+    fn from(value: &FooBar2) -> Self {
+        value.clone()
+    }
+}
+impl From<String> for FooBar2 {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl std::str::FromStr for FooBar2 {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_string()))
+    }
+}
+impl ToString for FooBar2 {
+    fn to_string(&self) -> String {
+        self.0.to_string()
     }
 }
 fn main() {}


### PR DESCRIPTION
Problem:
If we try to generate schema from this schema:
```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "definitions": {
        "Foo": {
            "properties": {
                "Bar": {
                    "oneOf": [
                        {
                            "$ref": "#/definitions/FooBar"
                        },
                        {
                            "$ref": "#/definitions/Baz"
                        }
                    ]
                }
            },
            "type": "object"
        },
        "FooBar": {
            "type": "string"
        },
        "Baz": {
            "type": "string"
        }
    }
}
```
we get:
```rust
pub struct Baz(pub String);

pub struct Foo {
    pub bar: Option<FooBar>,
}

pub struct FooBar(pub String);

pub enum FooBar {
    FooBar(FooBar),
    Baz(Baz),
}
```
where struct `FooBar` - structure from definition:
```json
  "FooBar": {
            "type": "string"
        },
```
and enum `FooBar` - enum which come from property definition:
```json
 "Bar": {
                    "oneOf": [
                        {
                            "$ref": "#/definitions/FooBar"
                        },
                        {
                            "$ref": "#/definitions/Baz"
                        }
                    ]
                }
```
and as a result, we have a name conflict.

With my solution result will be:
```rust
pub struct Baz(pub String);

pub struct Foo {
    pub bar: Option<FooBarAlias>,
}

pub struct FooBar(pub String);

pub enum FooBarAlias {
    FooBar(FooBar),
    Baz(Baz),
}
```
I'd be happy to have a feedback :)