### PR TITLE
Fully qualify serde::Deserialize and serde::Serialize in outputs

### DIFF
--- a/cargo-typify/README.md
+++ b/cargo-typify/README.md
@@ -63,9 +63,7 @@ is installed. Install rustfmt with rustup component add rustfmt
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum IdOrName {
     Id(uuid::Uuid),

--- a/cargo-typify/src/lib.rs
+++ b/cargo-typify/src/lib.rs
@@ -170,8 +170,6 @@ pub fn convert(args: &CliArgs) -> Result<String> {
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
-
-use serde::{Deserialize, Serialize};
 ";
 
     let contents = format!("{intro}\n{}", type_space.to_stream());

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-use serde::{Deserialize, Serialize};
-
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -41,7 +39,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Fruit(pub serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for Fruit {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -91,7 +89,7 @@ impl From<serde_json::Map<String, serde_json::Value>> for Fruit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FruitOrVeg {
     Veg(Veggie),
@@ -136,7 +134,7 @@ impl From<Fruit> for FruitOrVeg {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]
     #[serde(rename = "veggieLike")]
@@ -182,7 +180,7 @@ impl Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fruits: Vec<String>,

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-use serde::{Deserialize, Serialize};
-
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -41,7 +39,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Fruit(pub serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for Fruit {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -91,7 +89,7 @@ impl From<serde_json::Map<String, serde_json::Value>> for Fruit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FruitOrVeg {
     Veg(Veggie),
@@ -136,7 +134,7 @@ impl From<Fruit> for FruitOrVeg {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]
     #[serde(rename = "veggieLike")]
@@ -177,7 +175,7 @@ impl From<&Veggie> for Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fruits: Vec<String>,

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-use serde::{Deserialize, Serialize};
-
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -41,7 +39,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(AnotherDerive, Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(AnotherDerive, Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Fruit(pub serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for Fruit {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -91,7 +89,7 @@ impl From<serde_json::Map<String, serde_json::Value>> for Fruit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(AnotherDerive, Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(AnotherDerive, Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FruitOrVeg {
     Veg(Veggie),
@@ -136,7 +134,7 @@ impl From<Fruit> for FruitOrVeg {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(AnotherDerive, Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(AnotherDerive, Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]
     #[serde(rename = "veggieLike")]
@@ -177,7 +175,7 @@ impl From<&Veggie> for Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(AnotherDerive, Clone, Debug, Deserialize, ExtraDerive, Serialize)]
+#[derive(AnotherDerive, Clone, Debug, ExtraDerive, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fruits: Vec<String>,

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-use serde::{Deserialize, Serialize};
-
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -41,7 +39,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Fruit(pub serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for Fruit {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -91,7 +89,7 @@ impl From<serde_json::Map<String, serde_json::Value>> for Fruit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FruitOrVeg {
     Veg(Veggie),
@@ -136,7 +134,7 @@ impl From<Fruit> for FruitOrVeg {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggie {
     #[doc = "Do I like this vegetable?"]
     #[serde(rename = "veggieLike")]
@@ -177,7 +175,7 @@ impl From<&Veggie> for Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fruits: Vec<String>,

--- a/example-build/build.rs
+++ b/example-build/build.rs
@@ -11,11 +11,8 @@ fn main() {
     let mut type_space = TypeSpace::new(TypeSpaceSettings::default().with_struct_builder(true));
     type_space.add_root_schema(schema).unwrap();
 
-    let contents = format!(
-        "{}\n{}",
-        "use serde::{Deserialize, Serialize};",
-        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap())
-    );
+    let contents =
+        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap());
 
     let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
     out_file.push("codegen.rs");

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1467,7 +1467,7 @@ mod tests {
             )*
             /// ```
             /// </details>
-            #[derive(Clone, Debug, Deserialize, Serialize)]
+            #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
             pub enum ResultX {
                 Ok(u32),
                 Err(String),
@@ -1519,7 +1519,7 @@ mod tests {
             #[doc = "true"]
             /// ```
             /// </details>
-            #[derive(A, B, C, Clone, D, Debug, Deserialize, Serialize)]
+            #[derive(A, B, C, Clone, D, Debug, serde::Deserialize, serde::Serialize)]
             pub enum ResultX {
                 Ok(u32),
                 Err(String),

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -630,7 +630,7 @@ impl TypeEntry {
     }
 
     pub(crate) fn output(&self, type_space: &TypeSpace, output: &mut OutputSpace) {
-        let derive_set = ["Serialize", "Deserialize", "Debug", "Clone"]
+        let derive_set = ["serde::Serialize", "serde::Deserialize", "Debug", "Clone"]
             .into_iter()
             .collect::<BTreeSet<_>>();
 
@@ -1344,7 +1344,7 @@ impl TypeEntry {
 
                 // We're going to impl Deserialize so we can remove it
                 // from the set of derived impls.
-                derive_set.remove("Deserialize");
+                derive_set.remove("serde::Deserialize");
 
                 // TODO: if a user were to derive schemars::JsonSchema, it
                 // wouldn't be accurate.
@@ -1428,7 +1428,7 @@ impl TypeEntry {
 
                 // We're going to impl Deserialize so we can remove it
                 // from the set of derived impls.
-                derive_set.remove("Deserialize");
+                derive_set.remove("serde::Deserialize");
 
                 // TODO: if a user were to derive schemars::JsonSchema, it
                 // wouldn't be accurate.

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -45,7 +45,16 @@ mod types {
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(
-        Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        JsonSchema,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        serde :: Deserialize,
+        serde :: Serialize,
     )]
     pub struct AllTheTraits {
         pub ok: String,
@@ -85,7 +94,7 @@ mod types {
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
-    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+    #[derive(Clone, Debug, JsonSchema, serde :: Deserialize, serde :: Serialize)]
     pub struct CompoundType {
         pub value1: String,
         pub value2: u64,
@@ -121,7 +130,7 @@ mod types {
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
-    #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+    #[derive(Clone, Debug, JsonSchema, serde :: Deserialize, serde :: Serialize)]
     pub struct Pair {
         #[serde(default = "defaults::pair_a")]
         pub a: StringEnum,
@@ -154,7 +163,17 @@ mod types {
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(
-        Clone, Copy, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        JsonSchema,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        serde :: Deserialize,
+        serde :: Serialize,
     )]
     pub enum StringEnum {
         One,

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -105,7 +105,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstance {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -159,7 +159,7 @@ impl From<&AlertInstance> for AlertInstance {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -194,7 +194,7 @@ impl From<&AlertInstanceLocation> for AlertInstanceLocation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -221,7 +221,18 @@ impl From<&AlertInstanceMessage> for AlertInstanceMessage {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AlertInstanceState {
     #[serde(rename = "open")]
     Open,
@@ -638,7 +649,7 @@ impl std::convert::TryFrom<String> for AlertInstanceState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct App {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -722,7 +733,18 @@ impl From<&App> for App {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppEventsItem {
     #[serde(rename = "check_run")]
     CheckRun,
@@ -1190,7 +1212,7 @@ impl std::convert::TryFrom<String> for AppEventsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1281,7 +1303,18 @@ impl From<&AppPermissions> for AppPermissions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsActions {
     #[serde(rename = "read")]
     Read,
@@ -1343,7 +1376,18 @@ impl std::convert::TryFrom<String> for AppPermissionsActions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsAdministration {
     #[serde(rename = "read")]
     Read,
@@ -1405,7 +1449,18 @@ impl std::convert::TryFrom<String> for AppPermissionsAdministration {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsChecks {
     #[serde(rename = "read")]
     Read,
@@ -1467,7 +1522,18 @@ impl std::convert::TryFrom<String> for AppPermissionsChecks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsContentReferences {
     #[serde(rename = "read")]
     Read,
@@ -1529,7 +1595,18 @@ impl std::convert::TryFrom<String> for AppPermissionsContentReferences {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsContents {
     #[serde(rename = "read")]
     Read,
@@ -1591,7 +1668,18 @@ impl std::convert::TryFrom<String> for AppPermissionsContents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsDeployments {
     #[serde(rename = "read")]
     Read,
@@ -1653,7 +1741,18 @@ impl std::convert::TryFrom<String> for AppPermissionsDeployments {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -1715,7 +1814,18 @@ impl std::convert::TryFrom<String> for AppPermissionsDiscussions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsEmails {
     #[serde(rename = "read")]
     Read,
@@ -1777,7 +1887,18 @@ impl std::convert::TryFrom<String> for AppPermissionsEmails {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsEnvironments {
     #[serde(rename = "read")]
     Read,
@@ -1839,7 +1960,18 @@ impl std::convert::TryFrom<String> for AppPermissionsEnvironments {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsIssues {
     #[serde(rename = "read")]
     Read,
@@ -1901,7 +2033,18 @@ impl std::convert::TryFrom<String> for AppPermissionsIssues {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsMembers {
     #[serde(rename = "read")]
     Read,
@@ -1963,7 +2106,18 @@ impl std::convert::TryFrom<String> for AppPermissionsMembers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsMetadata {
     #[serde(rename = "read")]
     Read,
@@ -2025,7 +2179,18 @@ impl std::convert::TryFrom<String> for AppPermissionsMetadata {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationAdministration {
     #[serde(rename = "read")]
     Read,
@@ -2087,7 +2252,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationAdministration 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationHooks {
     #[serde(rename = "read")]
     Read,
@@ -2149,7 +2325,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationHooks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationPackages {
     #[serde(rename = "read")]
     Read,
@@ -2211,7 +2398,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationPackages {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationPlan {
     #[serde(rename = "read")]
     Read,
@@ -2273,7 +2471,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationPlan {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationProjects {
     #[serde(rename = "read")]
     Read,
@@ -2335,7 +2544,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationProjects {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationSecrets {
     #[serde(rename = "read")]
     Read,
@@ -2397,7 +2617,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationSecrets {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationSelfHostedRunners {
     #[serde(rename = "read")]
     Read,
@@ -2461,7 +2692,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationSelfHostedRunne
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsOrganizationUserBlocking {
     #[serde(rename = "read")]
     Read,
@@ -2523,7 +2765,18 @@ impl std::convert::TryFrom<String> for AppPermissionsOrganizationUserBlocking {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsPackages {
     #[serde(rename = "read")]
     Read,
@@ -2585,7 +2838,18 @@ impl std::convert::TryFrom<String> for AppPermissionsPackages {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsPages {
     #[serde(rename = "read")]
     Read,
@@ -2647,7 +2911,18 @@ impl std::convert::TryFrom<String> for AppPermissionsPages {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsPullRequests {
     #[serde(rename = "read")]
     Read,
@@ -2709,7 +2984,18 @@ impl std::convert::TryFrom<String> for AppPermissionsPullRequests {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsRepositoryHooks {
     #[serde(rename = "read")]
     Read,
@@ -2771,7 +3057,18 @@ impl std::convert::TryFrom<String> for AppPermissionsRepositoryHooks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsRepositoryProjects {
     #[serde(rename = "read")]
     Read,
@@ -2833,7 +3130,18 @@ impl std::convert::TryFrom<String> for AppPermissionsRepositoryProjects {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsSecretScanningAlerts {
     #[serde(rename = "read")]
     Read,
@@ -2895,7 +3203,18 @@ impl std::convert::TryFrom<String> for AppPermissionsSecretScanningAlerts {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsSecrets {
     #[serde(rename = "read")]
     Read,
@@ -2957,7 +3276,18 @@ impl std::convert::TryFrom<String> for AppPermissionsSecrets {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsSecurityEvents {
     #[serde(rename = "read")]
     Read,
@@ -3019,7 +3349,18 @@ impl std::convert::TryFrom<String> for AppPermissionsSecurityEvents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsSecurityScanningAlert {
     #[serde(rename = "read")]
     Read,
@@ -3081,7 +3422,18 @@ impl std::convert::TryFrom<String> for AppPermissionsSecurityScanningAlert {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsSingleFile {
     #[serde(rename = "read")]
     Read,
@@ -3143,7 +3495,18 @@ impl std::convert::TryFrom<String> for AppPermissionsSingleFile {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsStatuses {
     #[serde(rename = "read")]
     Read,
@@ -3205,7 +3568,18 @@ impl std::convert::TryFrom<String> for AppPermissionsStatuses {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsTeamDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -3267,7 +3641,18 @@ impl std::convert::TryFrom<String> for AppPermissionsTeamDiscussions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsVulnerabilityAlerts {
     #[serde(rename = "read")]
     Read,
@@ -3329,7 +3714,18 @@ impl std::convert::TryFrom<String> for AppPermissionsVulnerabilityAlerts {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AppPermissionsWorkflows {
     #[serde(rename = "read")]
     Read,
@@ -3400,7 +3796,18 @@ impl std::convert::TryFrom<String> for AppPermissionsWorkflows {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AuthorAssociation {
     #[serde(rename = "COLLABORATOR")]
     Collaborator,
@@ -3639,7 +4046,7 @@ impl std::convert::TryFrom<String> for AuthorAssociation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRule {
     pub admin_enforced: bool,
@@ -3693,7 +4100,18 @@ impl From<&BranchProtectionRule> for BranchProtectionRule {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleAllowDeletionsEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -3762,7 +4180,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleAllowDeletionsEnforce
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleAllowForcePushesEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -3859,7 +4288,7 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleAllowForcePushesEnfor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleCreated {
     pub action: BranchProtectionRuleCreatedAction,
@@ -3889,7 +4318,18 @@ impl From<&BranchProtectionRuleCreated> for BranchProtectionRuleCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -3976,7 +4416,7 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleDeleted {
     pub action: BranchProtectionRuleDeletedAction,
@@ -4006,7 +4446,18 @@ impl From<&BranchProtectionRuleDeleted> for BranchProtectionRuleDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -4128,7 +4579,7 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEdited {
     pub action: BranchProtectionRuleEditedAction,
@@ -4159,7 +4610,18 @@ impl From<&BranchProtectionRuleEdited> for BranchProtectionRuleEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -4244,7 +4706,7 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4279,7 +4741,7 @@ impl From<&BranchProtectionRuleEditedChanges> for BranchProtectionRuleEditedChan
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorNames {
     pub from: Vec<String>,
@@ -4310,7 +4772,7 @@ impl From<&BranchProtectionRuleEditedChangesAuthorizedActorNames>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorsOnly {
     pub from: bool,
@@ -4342,7 +4804,7 @@ impl From<&BranchProtectionRuleEditedChangesAuthorizedActorsOnly>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BranchProtectionRuleEvent {
     Created(BranchProtectionRuleCreated),
@@ -4384,7 +4846,18 @@ impl From<BranchProtectionRuleEdited> for BranchProtectionRuleEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -4457,7 +4930,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleMergeQueueEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -4526,7 +5010,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleMergeQueueEnforcement
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRulePullRequestReviewsEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -4595,7 +5090,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRulePullRequestReviewsEnf
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleRequiredConversationResolutionLevel {
     #[serde(rename = "off")]
     Off,
@@ -4664,7 +5170,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredConversationR
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -4733,7 +5250,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredDeploymentsEn
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -4802,7 +5330,18 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleRequiredStatusChecksE
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BranchProtectionRuleSignatureRequirementEnforcementLevel {
     #[serde(rename = "off")]
     Off,
@@ -5139,7 +5678,7 @@ impl std::convert::TryFrom<String> for BranchProtectionRuleSignatureRequirementE
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompleted {
     pub action: CheckRunCompletedAction,
@@ -5172,7 +5711,18 @@ impl From<&CheckRunCompleted> for CheckRunCompleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCompletedAction {
     #[serde(rename = "completed")]
     Completed,
@@ -5453,7 +6003,7 @@ impl std::convert::TryFrom<String> for CheckRunCompletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRun {
     pub app: App,
@@ -5592,7 +6142,7 @@ impl From<&CheckRunCompletedCheckRun> for CheckRunCompletedCheckRun {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -5639,7 +6189,18 @@ impl From<&CheckRunCompletedCheckRunCheckSuite> for CheckRunCompletedCheckRunChe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCompletedCheckRunCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -5724,7 +6285,18 @@ impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunCheckSuiteConclu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCompletedCheckRunCheckSuiteStatus {
     #[serde(rename = "in_progress")]
     InProgress,
@@ -5799,7 +6371,18 @@ impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunCheckSuiteStatus
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCompletedCheckRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -5915,7 +6498,7 @@ impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunOutput {
     pub annotations_count: i64,
@@ -5944,7 +6527,18 @@ impl From<&CheckRunCompletedCheckRunOutput> for CheckRunCompletedCheckRunOutput 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCompletedCheckRunStatus {
     #[serde(rename = "completed")]
     Completed,
@@ -6006,7 +6600,7 @@ impl std::convert::TryFrom<String> for CheckRunCompletedCheckRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
@@ -6306,7 +6900,7 @@ impl From<&CheckRunCompletedRequestedAction> for CheckRunCompletedRequestedActio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreated {
     pub action: CheckRunCreatedAction,
@@ -6339,7 +6933,18 @@ impl From<&CheckRunCreated> for CheckRunCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -6625,7 +7230,7 @@ impl std::convert::TryFrom<String> for CheckRunCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRun {
     pub app: App,
@@ -6764,7 +7369,7 @@ impl From<&CheckRunCreatedCheckRun> for CheckRunCreatedCheckRun {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -6811,7 +7416,18 @@ impl From<&CheckRunCreatedCheckRunCheckSuite> for CheckRunCreatedCheckRunCheckSu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCreatedCheckRunCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -6896,7 +7512,18 @@ impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunCheckSuiteConclusi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCreatedCheckRunCheckSuiteStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -6969,7 +7596,18 @@ impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunCheckSuiteStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCreatedCheckRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -7085,7 +7723,7 @@ impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunOutput {
     pub annotations_count: i64,
@@ -7116,7 +7754,18 @@ impl From<&CheckRunCreatedCheckRunOutput> for CheckRunCreatedCheckRunOutput {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunCreatedCheckRunStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -7186,7 +7835,7 @@ impl std::convert::TryFrom<String> for CheckRunCreatedCheckRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
@@ -7268,7 +7917,7 @@ impl From<&CheckRunCreatedRequestedAction> for CheckRunCreatedRequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunDeployment {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -7311,7 +7960,7 @@ impl From<&CheckRunDeployment> for CheckRunDeployment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CheckRunEvent {
     Completed(CheckRunCompleted),
@@ -7416,7 +8065,7 @@ impl From<CheckRunRerequested> for CheckRunEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequest {
     pub base: CheckRunPullRequestBase,
@@ -7457,7 +8106,7 @@ impl From<&CheckRunPullRequest> for CheckRunPullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequestBase {
     #[serde(rename = "ref")]
@@ -7497,7 +8146,7 @@ impl From<&CheckRunPullRequestBase> for CheckRunPullRequestBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunPullRequestHead {
     #[serde(rename = "ref")]
@@ -7796,7 +8445,7 @@ impl From<&CheckRunPullRequestHead> for CheckRunPullRequestHead {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedAction {
     pub action: CheckRunRequestedActionAction,
@@ -7827,7 +8476,18 @@ impl From<&CheckRunRequestedAction> for CheckRunRequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRequestedActionAction {
     #[serde(rename = "requested_action")]
     RequestedAction,
@@ -8113,7 +8773,7 @@ impl std::convert::TryFrom<String> for CheckRunRequestedActionAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRun {
     pub app: App,
@@ -8252,7 +8912,7 @@ impl From<&CheckRunRequestedActionCheckRun> for CheckRunRequestedActionCheckRun 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunCheckSuite {
     pub after: Option<String>,
@@ -8301,7 +8961,18 @@ impl From<&CheckRunRequestedActionCheckRunCheckSuite>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -8386,7 +9057,18 @@ impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunCheckSuite
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRequestedActionCheckRunCheckSuiteStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -8461,7 +9143,18 @@ impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunCheckSuite
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRequestedActionCheckRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -8579,7 +9272,7 @@ impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunConclusion
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunOutput {
     pub annotations_count: i64,
@@ -8610,7 +9303,18 @@ impl From<&CheckRunRequestedActionCheckRunOutput> for CheckRunRequestedActionChe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRequestedActionCheckRunStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -8680,7 +9384,7 @@ impl std::convert::TryFrom<String> for CheckRunRequestedActionCheckRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
@@ -8969,7 +9673,7 @@ impl From<&CheckRunRequestedActionRequestedAction> for CheckRunRequestedActionRe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequested {
     pub action: CheckRunRerequestedAction,
@@ -9002,7 +9706,18 @@ impl From<&CheckRunRerequested> for CheckRunRerequested {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRerequestedAction {
     #[serde(rename = "rerequested")]
     Rerequested,
@@ -9277,7 +9992,7 @@ impl std::convert::TryFrom<String> for CheckRunRerequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRun {
     pub app: App,
@@ -9410,7 +10125,7 @@ impl From<&CheckRunRerequestedCheckRun> for CheckRunRerequestedCheckRun {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunCheckSuite {
     pub after: Option<String>,
@@ -9457,7 +10172,18 @@ impl From<&CheckRunRerequestedCheckRunCheckSuite> for CheckRunRerequestedCheckRu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -9540,7 +10266,18 @@ impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunCheckSuiteConc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRerequestedCheckRunCheckSuiteStatus {
     #[serde(rename = "completed")]
     Completed,
@@ -9607,7 +10344,18 @@ impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunCheckSuiteStat
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRerequestedCheckRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -9723,7 +10471,7 @@ impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunOutput {
     pub annotations_count: i64,
@@ -9752,7 +10500,18 @@ impl From<&CheckRunRerequestedCheckRunOutput> for CheckRunRerequestedCheckRunOut
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckRunRerequestedCheckRunStatus {
     #[serde(rename = "completed")]
     Completed,
@@ -9814,7 +10573,7 @@ impl std::convert::TryFrom<String> for CheckRunRerequestedCheckRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
@@ -9980,7 +10739,7 @@ impl From<&CheckRunRerequestedRequestedAction> for CheckRunRerequestedRequestedA
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteCompleted {
     pub action: CheckSuiteCompletedAction,
@@ -10010,7 +10769,18 @@ impl From<&CheckSuiteCompleted> for CheckSuiteCompleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteCompletedAction {
     #[serde(rename = "completed")]
     Completed,
@@ -10176,7 +10946,7 @@ impl std::convert::TryFrom<String> for CheckSuiteCompletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteCompletedCheckSuite {
     pub after: String,
@@ -10227,7 +10997,18 @@ impl From<&CheckSuiteCompletedCheckSuite> for CheckSuiteCompletedCheckSuite {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteCompletedCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -10312,7 +11093,18 @@ impl std::convert::TryFrom<String> for CheckSuiteCompletedCheckSuiteConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteCompletedCheckSuiteStatus {
     #[serde(rename = "requested")]
     Requested,
@@ -10388,7 +11180,7 @@ impl std::convert::TryFrom<String> for CheckSuiteCompletedCheckSuiteStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CheckSuiteEvent {
     Completed(CheckSuiteCompleted),
@@ -10569,7 +11361,7 @@ impl From<CheckSuiteRerequested> for CheckSuiteEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRequested {
     pub action: CheckSuiteRequestedAction,
@@ -10599,7 +11391,18 @@ impl From<&CheckSuiteRequested> for CheckSuiteRequested {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRequestedAction {
     #[serde(rename = "requested")]
     Requested,
@@ -10765,7 +11568,7 @@ impl std::convert::TryFrom<String> for CheckSuiteRequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRequestedCheckSuite {
     pub after: String,
@@ -10816,7 +11619,18 @@ impl From<&CheckSuiteRequestedCheckSuite> for CheckSuiteRequestedCheckSuite {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRequestedCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -10901,7 +11715,18 @@ impl std::convert::TryFrom<String> for CheckSuiteRequestedCheckSuiteConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRequestedCheckSuiteStatus {
     #[serde(rename = "requested")]
     Requested,
@@ -11111,7 +11936,7 @@ impl std::convert::TryFrom<String> for CheckSuiteRequestedCheckSuiteStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRerequested {
     pub action: CheckSuiteRerequestedAction,
@@ -11141,7 +11966,18 @@ impl From<&CheckSuiteRerequested> for CheckSuiteRerequested {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRerequestedAction {
     #[serde(rename = "rerequested")]
     Rerequested,
@@ -11307,7 +12143,7 @@ impl std::convert::TryFrom<String> for CheckSuiteRerequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CheckSuiteRerequestedCheckSuite {
     pub after: String,
@@ -11358,7 +12194,18 @@ impl From<&CheckSuiteRerequestedCheckSuite> for CheckSuiteRerequestedCheckSuite 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRerequestedCheckSuiteConclusion {
     #[serde(rename = "success")]
     Success,
@@ -11445,7 +12292,18 @@ impl std::convert::TryFrom<String> for CheckSuiteRerequestedCheckSuiteConclusion
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CheckSuiteRerequestedCheckSuiteStatus {
     #[serde(rename = "requested")]
     Requested,
@@ -11691,7 +12549,7 @@ impl std::convert::TryFrom<String> for CheckSuiteRerequestedCheckSuiteStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranch {
     pub action: CodeScanningAlertAppearedInBranchAction,
@@ -11726,7 +12584,18 @@ impl From<&CodeScanningAlertAppearedInBranch> for CodeScanningAlertAppearedInBra
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertAppearedInBranchAction {
     #[serde(rename = "appeared_in_branch")]
     AppearedInBranch,
@@ -11918,7 +12787,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -11962,7 +12831,18 @@ impl From<&CodeScanningAlertAppearedInBranchAlert> for CodeScanningAlertAppeared
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertAppearedInBranchAlertDismissedReason {
     #[serde(rename = "false positive")]
     FalsePositive,
@@ -12056,7 +12936,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertDis
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -12090,7 +12970,18 @@ impl From<&CodeScanningAlertAppearedInBranchAlertRule>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -12164,7 +13055,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertRul
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertAppearedInBranchAlertState {
     #[serde(rename = "open")]
     Open,
@@ -12246,7 +13148,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertAppearedInBranchAlertSta
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertAppearedInBranchAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
@@ -12473,7 +13375,7 @@ impl From<&CodeScanningAlertAppearedInBranchAlertTool>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUser {
     pub action: CodeScanningAlertClosedByUserAction,
@@ -12508,7 +13410,18 @@ impl From<&CodeScanningAlertClosedByUser> for CodeScanningAlertClosedByUser {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertClosedByUserAction {
     #[serde(rename = "closed_by_user")]
     ClosedByUser,
@@ -12722,7 +13635,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -12767,7 +13680,18 @@ impl From<&CodeScanningAlertClosedByUserAlert> for CodeScanningAlertClosedByUser
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertClosedByUserAlertDismissedReason {
     #[serde(rename = "false positive")]
     FalsePositive,
@@ -12850,7 +13774,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertDismiss
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -12905,7 +13829,7 @@ impl From<&CodeScanningAlertClosedByUserAlertInstancesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12942,7 +13866,7 @@ impl From<&CodeScanningAlertClosedByUserAlertInstancesItemLocation>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12968,7 +13892,18 @@ impl From<&CodeScanningAlertClosedByUserAlertInstancesItemMessage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertClosedByUserAlertInstancesItemState {
     #[serde(rename = "dismissed")]
     Dismissed,
@@ -13066,7 +14001,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertInstanc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -13106,7 +14041,18 @@ impl From<&CodeScanningAlertClosedByUserAlertRule> for CodeScanningAlertClosedBy
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertClosedByUserAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -13178,7 +14124,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertRuleSev
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertClosedByUserAlertState {
     #[serde(rename = "dismissed")]
     Dismissed,
@@ -13256,7 +14213,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertClosedByUserAlertState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13478,7 +14435,7 @@ impl From<&CodeScanningAlertClosedByUserAlertTool> for CodeScanningAlertClosedBy
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreated {
     pub action: CodeScanningAlertCreatedAction,
@@ -13513,7 +14470,18 @@ impl From<&CodeScanningAlertCreated> for CodeScanningAlertCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -13722,7 +14690,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -13780,7 +14748,7 @@ impl From<&CodeScanningAlertCreatedAlert> for CodeScanningAlertCreatedAlert {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItem {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -13835,7 +14803,7 @@ impl From<&CodeScanningAlertCreatedAlertInstancesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13872,7 +14840,7 @@ impl From<&CodeScanningAlertCreatedAlertInstancesItemLocation>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13899,7 +14867,18 @@ impl From<&CodeScanningAlertCreatedAlertInstancesItemMessage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertCreatedAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
@@ -14001,7 +14980,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertInstancesIte
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -14041,7 +15020,18 @@ impl From<&CodeScanningAlertCreatedAlertRule> for CodeScanningAlertCreatedAlertR
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertCreatedAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -14114,7 +15104,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertRuleSeverity
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertCreatedAlertState {
     #[serde(rename = "open")]
     Open,
@@ -14196,7 +15197,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertCreatedAlertState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14240,7 +15241,7 @@ impl From<&CodeScanningAlertCreatedAlertTool> for CodeScanningAlertCreatedAlertT
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CodeScanningAlertEvent {
     AppearedInBranch(CodeScanningAlertAppearedInBranch),
@@ -14514,7 +15515,7 @@ impl From<CodeScanningAlertReopenedByUser> for CodeScanningAlertEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixed {
     pub action: CodeScanningAlertFixedAction,
@@ -14549,7 +15550,18 @@ impl From<&CodeScanningAlertFixed> for CodeScanningAlertFixed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertFixedAction {
     #[serde(rename = "fixed")]
     Fixed,
@@ -14780,7 +15792,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertFixedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -14826,7 +15838,18 @@ impl From<&CodeScanningAlertFixedAlert> for CodeScanningAlertFixedAlert {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertFixedAlertDismissedReason {
     #[serde(rename = "false positive")]
     FalsePositive,
@@ -14909,7 +15932,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertDismissedReaso
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItem {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -14962,7 +15985,7 @@ impl From<&CodeScanningAlertFixedAlertInstancesItem> for CodeScanningAlertFixedA
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14999,7 +16022,7 @@ impl From<&CodeScanningAlertFixedAlertInstancesItemLocation>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -15025,7 +16048,18 @@ impl From<&CodeScanningAlertFixedAlertInstancesItemMessage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertFixedAlertInstancesItemState {
     #[serde(rename = "fixed")]
     Fixed,
@@ -15123,7 +16157,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertInstancesItemS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -15163,7 +16197,18 @@ impl From<&CodeScanningAlertFixedAlertRule> for CodeScanningAlertFixedAlertRule 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertFixedAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -15233,7 +16278,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertRuleSeverity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertFixedAlertState {
     #[serde(rename = "fixed")]
     Fixed,
@@ -15311,7 +16367,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertFixedAlertState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -15533,7 +16589,7 @@ impl From<&CodeScanningAlertFixedAlertTool> for CodeScanningAlertFixedAlertTool 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopened {
     pub action: CodeScanningAlertReopenedAction,
@@ -15568,7 +16624,18 @@ impl From<&CodeScanningAlertReopened> for CodeScanningAlertReopened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
@@ -15777,7 +16844,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -15834,7 +16901,7 @@ impl From<&CodeScanningAlertReopenedAlert> for CodeScanningAlertReopenedAlert {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItem {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -15889,7 +16956,7 @@ impl From<&CodeScanningAlertReopenedAlertInstancesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -15926,7 +16993,7 @@ impl From<&CodeScanningAlertReopenedAlertInstancesItemLocation>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -15952,7 +17019,18 @@ impl From<&CodeScanningAlertReopenedAlertInstancesItemMessage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
@@ -16050,7 +17128,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertInstancesIt
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -16090,7 +17168,18 @@ impl From<&CodeScanningAlertReopenedAlertRule> for CodeScanningAlertReopenedAler
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -16164,7 +17253,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertRuleSeverit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedAlertState {
     #[serde(rename = "open")]
     Open,
@@ -16250,7 +17350,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedAlertState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -16452,7 +17552,7 @@ impl From<&CodeScanningAlertReopenedAlertTool> for CodeScanningAlertReopenedAler
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUser {
     pub action: CodeScanningAlertReopenedByUserAction,
@@ -16487,7 +17587,18 @@ impl From<&CodeScanningAlertReopenedByUser> for CodeScanningAlertReopenedByUser 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedByUserAction {
     #[serde(rename = "reopened_by_user")]
     ReopenedByUser,
@@ -16676,7 +17787,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
@@ -16733,7 +17844,7 @@ impl From<&CodeScanningAlertReopenedByUserAlert> for CodeScanningAlertReopenedBy
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
     #[doc = "Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name."]
@@ -16788,7 +17899,7 @@ impl From<&CodeScanningAlertReopenedByUserAlertInstancesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -16825,7 +17936,7 @@ impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemLocation>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -16851,7 +17962,18 @@ impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemMessage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedByUserAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
@@ -16937,7 +18059,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertInsta
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
@@ -16969,7 +18091,18 @@ impl From<&CodeScanningAlertReopenedByUserAlertRule> for CodeScanningAlertReopen
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedByUserAlertRuleSeverity {
     #[serde(rename = "none")]
     None,
@@ -17041,7 +18174,18 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertRuleS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CodeScanningAlertReopenedByUserAlertState {
     #[serde(rename = "open")]
     Open,
@@ -17115,7 +18259,7 @@ impl std::convert::TryFrom<String> for CodeScanningAlertReopenedByUserAlertState
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
@@ -17206,7 +18350,7 @@ impl From<&CodeScanningAlertReopenedByUserAlertTool> for CodeScanningAlertReopen
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Commit {
     #[doc = "An array of files added in the commit."]
@@ -17353,7 +18497,7 @@ impl From<&Commit> for Commit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitCommentCreated {
     #[doc = "The action performed. Can be `created`."]
@@ -17385,7 +18529,18 @@ impl From<&CommitCommentCreated> for CommitCommentCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CommitCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -17515,7 +18670,7 @@ impl std::convert::TryFrom<String> for CommitCommentCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitCommentCreatedComment {
     pub author_association: AuthorAssociation,
@@ -17558,7 +18713,7 @@ impl From<&CommitCommentCreatedComment> for CommitCommentCreatedComment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct CommitCommentEvent(pub CommitCommentCreated);
 impl std::ops::Deref for CommitCommentEvent {
     type Target = CommitCommentCreated;
@@ -17622,7 +18777,7 @@ impl From<CommitCommentCreated> for CommitCommentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommitSimple {
     pub author: Committer,
@@ -17680,7 +18835,7 @@ impl From<&CommitSimple> for CommitSimple {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Committer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17758,7 +18913,7 @@ impl From<&Committer> for Committer {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContentReferenceCreated {
     pub action: ContentReferenceCreatedAction,
@@ -17787,7 +18942,18 @@ impl From<&ContentReferenceCreated> for ContentReferenceCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ContentReferenceCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -17859,7 +19025,7 @@ impl std::convert::TryFrom<String> for ContentReferenceCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContentReferenceCreatedContentReference {
     pub id: i64,
@@ -17885,7 +19051,7 @@ impl From<&ContentReferenceCreatedContentReference> for ContentReferenceCreatedC
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ContentReferenceEvent(pub ContentReferenceCreated);
 impl std::ops::Deref for ContentReferenceEvent {
     type Target = ContentReferenceCreated;
@@ -17972,7 +19138,7 @@ impl From<ContentReferenceCreated> for ContentReferenceEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CreateEvent {
     #[doc = "The repository's current description."]
@@ -18013,7 +19179,18 @@ impl From<&CreateEvent> for CreateEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CreateEventRefType {
     #[serde(rename = "tag")]
     Tag,
@@ -18112,7 +19289,7 @@ impl std::convert::TryFrom<String> for CreateEventRefType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -18149,7 +19326,18 @@ impl From<&DeleteEvent> for DeleteEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DeleteEventRefType {
     #[serde(rename = "tag")]
     Tag,
@@ -18274,7 +19462,7 @@ impl std::convert::TryFrom<String> for DeleteEventRefType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreated {
     pub action: DeployKeyCreatedAction,
@@ -18304,7 +19492,18 @@ impl From<&DeployKeyCreated> for DeployKeyCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DeployKeyCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -18393,7 +19592,7 @@ impl std::convert::TryFrom<String> for DeployKeyCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreatedKey {
     pub created_at: String,
@@ -18486,7 +19685,7 @@ impl From<&DeployKeyCreatedKey> for DeployKeyCreatedKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyDeleted {
     pub action: DeployKeyDeletedAction,
@@ -18516,7 +19715,18 @@ impl From<&DeployKeyDeleted> for DeployKeyDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DeployKeyDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -18605,7 +19815,7 @@ impl std::convert::TryFrom<String> for DeployKeyDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyDeletedKey {
     pub created_at: String,
@@ -18638,7 +19848,7 @@ impl From<&DeployKeyDeletedKey> for DeployKeyDeletedKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DeployKeyEvent {
     Created(DeployKeyCreated),
@@ -18789,7 +19999,7 @@ impl From<DeployKeyDeleted> for DeployKeyEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreated {
     pub action: DeploymentCreatedAction,
@@ -18821,7 +20031,18 @@ impl From<&DeploymentCreated> for DeploymentCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DeploymentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -18955,7 +20176,7 @@ impl std::convert::TryFrom<String> for DeploymentCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeployment {
     pub created_at: String,
@@ -18993,7 +20214,7 @@ impl From<&DeploymentCreatedDeployment> for DeploymentCreatedDeployment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeploymentPayload {}
 impl From<&DeploymentCreatedDeploymentPayload> for DeploymentCreatedDeploymentPayload {
@@ -19015,7 +20236,7 @@ impl From<&DeploymentCreatedDeploymentPayload> for DeploymentCreatedDeploymentPa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DeploymentEvent(pub DeploymentCreated);
 impl std::ops::Deref for DeploymentEvent {
     type Target = DeploymentCreated;
@@ -19235,7 +20456,7 @@ impl From<DeploymentCreated> for DeploymentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreated {
     pub action: DeploymentStatusCreatedAction,
@@ -19266,7 +20487,18 @@ impl From<&DeploymentStatusCreated> for DeploymentStatusCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DeploymentStatusCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -19401,7 +20633,7 @@ impl std::convert::TryFrom<String> for DeploymentStatusCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeployment {
     pub created_at: String,
@@ -19438,7 +20670,7 @@ impl From<&DeploymentStatusCreatedDeployment> for DeploymentStatusCreatedDeploym
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentPayload {}
 impl From<&DeploymentStatusCreatedDeploymentPayload> for DeploymentStatusCreatedDeploymentPayload {
@@ -19526,7 +20758,7 @@ impl From<&DeploymentStatusCreatedDeploymentPayload> for DeploymentStatusCreated
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentStatus {
     pub created_at: String,
@@ -19566,7 +20798,7 @@ impl From<&DeploymentStatusCreatedDeploymentStatus> for DeploymentStatusCreatedD
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DeploymentStatusEvent(pub DeploymentStatusCreated);
 impl std::ops::Deref for DeploymentStatusEvent {
     type Target = DeploymentStatusCreated;
@@ -19747,7 +20979,7 @@ impl From<DeploymentStatusCreated> for DeploymentStatusEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Discussion {
     pub active_lock_reason: Option<String>,
@@ -19918,7 +21150,7 @@ impl From<&Discussion> for Discussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnswered {
     pub action: DiscussionAnsweredAction,
@@ -19949,7 +21181,18 @@ impl From<&DiscussionAnswered> for DiscussionAnswered {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionAnsweredAction {
     #[serde(rename = "answered")]
     Answered,
@@ -20058,7 +21301,7 @@ impl std::convert::TryFrom<String> for DiscussionAnsweredAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredAnswer {
     pub author_association: AuthorAssociation,
@@ -20131,7 +21374,7 @@ impl From<&DiscussionAnsweredAnswer> for DiscussionAnsweredAnswer {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredDiscussion {
     pub active_lock_reason: Option<String>,
@@ -20284,7 +21527,7 @@ impl From<&DiscussionAnsweredDiscussion> for DiscussionAnsweredDiscussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredDiscussionAnswerChosenBy {
     pub avatar_url: String,
@@ -20333,7 +21576,18 @@ impl From<&DiscussionAnsweredDiscussionAnswerChosenBy>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionAnsweredDiscussionAnswerChosenByType {
     Bot,
     User,
@@ -20439,7 +21693,7 @@ impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionAnswerChosenB
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredDiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -20472,7 +21726,18 @@ impl From<&DiscussionAnsweredDiscussionCategory> for DiscussionAnsweredDiscussio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionAnsweredDiscussionState {
     #[serde(rename = "open")]
     Open,
@@ -20576,7 +21841,7 @@ impl std::convert::TryFrom<String> for DiscussionAnsweredDiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -20700,7 +21965,7 @@ impl From<&DiscussionCategory> for DiscussionCategory {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChanged {
     pub action: DiscussionCategoryChangedAction,
@@ -20731,7 +21996,18 @@ impl From<&DiscussionCategoryChanged> for DiscussionCategoryChanged {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCategoryChangedAction {
     #[serde(rename = "category_changed")]
     CategoryChanged,
@@ -20845,7 +22121,7 @@ impl std::convert::TryFrom<String> for DiscussionCategoryChangedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChanges {
     pub category: DiscussionCategoryChangedChangesCategory,
@@ -20916,7 +22192,7 @@ impl From<&DiscussionCategoryChangedChanges> for DiscussionCategoryChangedChange
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChangesCategory {
     pub from: DiscussionCategoryChangedChangesCategoryFrom,
@@ -20978,7 +22254,7 @@ impl From<&DiscussionCategoryChangedChangesCategory> for DiscussionCategoryChang
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCategoryChangedChangesCategoryFrom {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -21101,7 +22377,7 @@ impl From<&DiscussionCategoryChangedChangesCategoryFrom>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentCreated {
     pub action: DiscussionCommentCreatedAction,
@@ -21131,7 +22407,18 @@ impl From<&DiscussionCommentCreated> for DiscussionCommentCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -21241,7 +22528,7 @@ impl std::convert::TryFrom<String> for DiscussionCommentCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentCreatedComment {
     pub author_association: AuthorAssociation,
@@ -21365,7 +22652,7 @@ impl From<&DiscussionCommentCreatedComment> for DiscussionCommentCreatedComment 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentDeleted {
     pub action: DiscussionCommentDeletedAction,
@@ -21395,7 +22682,18 @@ impl From<&DiscussionCommentDeleted> for DiscussionCommentDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -21505,7 +22803,7 @@ impl std::convert::TryFrom<String> for DiscussionCommentDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentDeletedComment {
     pub author_association: AuthorAssociation,
@@ -21651,7 +22949,7 @@ impl From<&DiscussionCommentDeletedComment> for DiscussionCommentDeletedComment 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEdited {
     pub action: DiscussionCommentEditedAction,
@@ -21682,7 +22980,18 @@ impl From<&DiscussionCommentEdited> for DiscussionCommentEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -21754,7 +23063,7 @@ impl std::convert::TryFrom<String> for DiscussionCommentEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedChanges {
     pub body: DiscussionCommentEditedChangesBody,
@@ -21783,7 +23092,7 @@ impl From<&DiscussionCommentEditedChanges> for DiscussionCommentEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedChangesBody {
     pub from: String,
@@ -21859,7 +23168,7 @@ impl From<&DiscussionCommentEditedChangesBody> for DiscussionCommentEditedChange
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedComment {
     pub author_association: AuthorAssociation,
@@ -21900,7 +23209,7 @@ impl From<&DiscussionCommentEditedComment> for DiscussionCommentEditedComment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DiscussionCommentEvent {
     Created(DiscussionCommentCreated),
@@ -22008,7 +23317,7 @@ impl From<DiscussionCommentEdited> for DiscussionCommentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreated {
     pub action: DiscussionCreatedAction,
@@ -22038,7 +23347,18 @@ impl From<&DiscussionCreated> for DiscussionCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -22131,7 +23451,7 @@ impl std::convert::TryFrom<String> for DiscussionCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreatedDiscussion {
     pub active_lock_reason: Option<String>,
@@ -22211,7 +23531,7 @@ impl From<&DiscussionCreatedDiscussion> for DiscussionCreatedDiscussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreatedDiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -22243,7 +23563,18 @@ impl From<&DiscussionCreatedDiscussionCategory> for DiscussionCreatedDiscussionC
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionCreatedDiscussionState {
     #[serde(rename = "open")]
     Open,
@@ -22333,7 +23664,7 @@ impl std::convert::TryFrom<String> for DiscussionCreatedDiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionDeleted {
     pub action: DiscussionDeletedAction,
@@ -22363,7 +23694,18 @@ impl From<&DiscussionDeleted> for DiscussionDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -22479,7 +23821,7 @@ impl std::convert::TryFrom<String> for DiscussionDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEdited {
     pub action: DiscussionEditedAction,
@@ -22511,7 +23853,18 @@ impl From<&DiscussionEdited> for DiscussionEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -22592,7 +23945,7 @@ impl std::convert::TryFrom<String> for DiscussionEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -22624,7 +23977,7 @@ impl From<&DiscussionEditedChanges> for DiscussionEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChangesBody {
     pub from: String,
@@ -22653,7 +24006,7 @@ impl From<&DiscussionEditedChangesBody> for DiscussionEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChangesTitle {
     pub from: String,
@@ -22713,7 +24066,7 @@ impl From<&DiscussionEditedChangesTitle> for DiscussionEditedChangesTitle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DiscussionEvent {
     Answered(DiscussionAnswered),
@@ -22846,7 +24199,7 @@ impl From<DiscussionUnpinned> for DiscussionEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLabeled {
     pub action: DiscussionLabeledAction,
@@ -22877,7 +24230,18 @@ impl From<&DiscussionLabeled> for DiscussionLabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
@@ -22989,7 +24353,7 @@ impl std::convert::TryFrom<String> for DiscussionLabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLocked {
     pub action: DiscussionLockedAction,
@@ -23019,7 +24383,18 @@ impl From<&DiscussionLocked> for DiscussionLocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionLockedAction {
     #[serde(rename = "locked")]
     Locked,
@@ -23099,7 +24474,7 @@ impl std::convert::TryFrom<String> for DiscussionLockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLockedDiscussion {
     pub active_lock_reason: Option<String>,
@@ -23179,7 +24554,7 @@ impl From<&DiscussionLockedDiscussion> for DiscussionLockedDiscussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLockedDiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -23210,7 +24585,18 @@ impl From<&DiscussionLockedDiscussionCategory> for DiscussionLockedDiscussionCat
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionLockedDiscussionState {
     #[serde(rename = "locked")]
     Locked,
@@ -23296,7 +24682,7 @@ impl std::convert::TryFrom<String> for DiscussionLockedDiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionPinned {
     pub action: DiscussionPinnedAction,
@@ -23326,7 +24712,18 @@ impl From<&DiscussionPinned> for DiscussionPinned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionPinnedAction {
     #[serde(rename = "pinned")]
     Pinned,
@@ -23385,7 +24782,18 @@ impl std::convert::TryFrom<String> for DiscussionPinnedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionState {
     #[serde(rename = "open")]
     Open,
@@ -23496,7 +24904,7 @@ impl std::convert::TryFrom<String> for DiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionTransferred {
     pub action: DiscussionTransferredAction,
@@ -23527,7 +24935,18 @@ impl From<&DiscussionTransferred> for DiscussionTransferred {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
@@ -23594,7 +25013,7 @@ impl std::convert::TryFrom<String> for DiscussionTransferredAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionTransferredChanges {
     pub new_discussion: Discussion,
@@ -23746,7 +25165,7 @@ impl From<&DiscussionTransferredChanges> for DiscussionTransferredChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnanswered {
     pub action: DiscussionUnansweredAction,
@@ -23777,7 +25196,18 @@ impl From<&DiscussionUnanswered> for DiscussionUnanswered {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnansweredAction {
     #[serde(rename = "unanswered")]
     Unanswered,
@@ -23871,7 +25301,7 @@ impl std::convert::TryFrom<String> for DiscussionUnansweredAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnansweredDiscussion {
     pub active_lock_reason: Option<String>,
@@ -23954,7 +25384,7 @@ impl From<&DiscussionUnansweredDiscussion> for DiscussionUnansweredDiscussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnansweredDiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -23987,7 +25417,18 @@ impl From<&DiscussionUnansweredDiscussionCategory> for DiscussionUnansweredDiscu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnansweredDiscussionState {
     #[serde(rename = "open")]
     Open,
@@ -24104,7 +25545,7 @@ impl std::convert::TryFrom<String> for DiscussionUnansweredDiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnansweredOldAnswer {
     pub author_association: AuthorAssociation,
@@ -24171,7 +25612,7 @@ impl From<&DiscussionUnansweredOldAnswer> for DiscussionUnansweredOldAnswer {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlabeled {
     pub action: DiscussionUnlabeledAction,
@@ -24202,7 +25643,18 @@ impl From<&DiscussionUnlabeled> for DiscussionUnlabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
@@ -24314,7 +25766,7 @@ impl std::convert::TryFrom<String> for DiscussionUnlabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlocked {
     pub action: DiscussionUnlockedAction,
@@ -24344,7 +25796,18 @@ impl From<&DiscussionUnlocked> for DiscussionUnlocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
@@ -24424,7 +25887,7 @@ impl std::convert::TryFrom<String> for DiscussionUnlockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlockedDiscussion {
     pub active_lock_reason: Option<String>,
@@ -24504,7 +25967,7 @@ impl From<&DiscussionUnlockedDiscussion> for DiscussionUnlockedDiscussion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlockedDiscussionCategory {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -24535,7 +25998,18 @@ impl From<&DiscussionUnlockedDiscussionCategory> for DiscussionUnlockedDiscussio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnlockedDiscussionState {
     #[serde(rename = "open")]
     Open,
@@ -24621,7 +26095,7 @@ impl std::convert::TryFrom<String> for DiscussionUnlockedDiscussionState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnpinned {
     pub action: DiscussionUnpinnedAction,
@@ -24651,7 +26125,18 @@ impl From<&DiscussionUnpinned> for DiscussionUnpinned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiscussionUnpinnedAction {
     #[serde(rename = "unpinned")]
     Unpinned,
@@ -24872,7 +26357,7 @@ impl std::convert::TryFrom<String> for DiscussionUnpinnedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Everything {
     BranchProtectionRuleEvent(BranchProtectionRuleEvent),
@@ -25263,7 +26748,7 @@ impl From<WorkflowRunEvent> for Everything {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForkEvent {
     pub forkee: ForkEventForkee,
@@ -25305,7 +26790,7 @@ impl From<&ForkEvent> for ForkEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForkEventForkee {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -25444,7 +26929,7 @@ impl From<&ForkEventForkee> for ForkEventForkee {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForkEventForkeeCreatedAt {
     Variant0(i64),
@@ -25536,7 +27021,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for ForkEventForkeeCreatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForkEventForkeePermissions {
     pub admin: bool,
@@ -25573,7 +27058,7 @@ impl From<&ForkEventForkeePermissions> for ForkEventForkeePermissions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForkEventForkeePushedAt {
     Variant0(i64),
@@ -25609,7 +27094,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for ForkEventForkeePushedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct GithubAppAuthorizationEvent(pub GithubAppAuthorizationRevoked);
 impl std::ops::Deref for GithubAppAuthorizationEvent {
     type Target = GithubAppAuthorizationRevoked;
@@ -25660,7 +27145,7 @@ impl From<GithubAppAuthorizationRevoked> for GithubAppAuthorizationEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubAppAuthorizationRevoked {
     pub action: GithubAppAuthorizationRevokedAction,
@@ -25684,7 +27169,18 @@ impl From<&GithubAppAuthorizationRevoked> for GithubAppAuthorizationRevoked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GithubAppAuthorizationRevokedAction {
     #[serde(rename = "revoked")]
     Revoked,
@@ -25854,7 +27350,7 @@ impl std::convert::TryFrom<String> for GithubAppAuthorizationRevokedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubOrg {
     pub avatar_url: String,
@@ -25965,7 +27461,7 @@ impl From<&GithubOrg> for GithubOrg {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GollumEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -26031,7 +27527,7 @@ impl From<&GollumEvent> for GollumEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GollumEventPagesItem {
     #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
@@ -26066,7 +27562,18 @@ impl From<&GollumEventPagesItem> for GollumEventPagesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GollumEventPagesItemAction {
     #[serde(rename = "created")]
     Created,
@@ -26550,7 +28057,7 @@ impl std::convert::TryFrom<String> for GollumEventPagesItemAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Installation {
     pub access_tokens_url: String,
@@ -26654,7 +28161,7 @@ impl From<&Installation> for Installation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationCreated {
     pub action: InstallationCreatedAction,
@@ -26684,7 +28191,18 @@ impl From<&InstallationCreated> for InstallationCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -26746,7 +28264,7 @@ impl std::convert::TryFrom<String> for InstallationCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationCreatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -26843,7 +28361,7 @@ impl From<i64> for InstallationCreatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationCreatedRepositoriesItem {
     pub full_name: String,
@@ -26930,7 +28448,7 @@ impl From<&InstallationCreatedRepositoriesItem> for InstallationCreatedRepositor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationDeleted {
     pub action: InstallationDeletedAction,
@@ -26960,7 +28478,18 @@ impl From<&InstallationDeleted> for InstallationDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -27042,7 +28571,7 @@ impl std::convert::TryFrom<String> for InstallationDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationDeletedRepositoriesItem {
     pub full_name: String,
@@ -27085,7 +28614,7 @@ impl From<&InstallationDeletedRepositoriesItem> for InstallationDeletedRepositor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationEvent {
     Created(InstallationCreated),
@@ -27181,7 +28710,18 @@ impl From<InstallationUnsuspend> for InstallationEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationEventsItem {
     #[serde(rename = "check_run")]
     CheckRun,
@@ -27428,7 +28968,7 @@ impl std::convert::TryFrom<String> for InstallationEventsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationLite {
     #[doc = "The ID of the installation."]
@@ -27510,7 +29050,7 @@ impl From<&InstallationLite> for InstallationLite {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationNewPermissionsAccepted {
     pub action: InstallationNewPermissionsAcceptedAction,
@@ -27540,7 +29080,18 @@ impl From<&InstallationNewPermissionsAccepted> for InstallationNewPermissionsAcc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationNewPermissionsAcceptedAction {
     #[serde(rename = "new_permissions_accepted")]
     NewPermissionsAccepted,
@@ -27622,7 +29173,7 @@ impl std::convert::TryFrom<String> for InstallationNewPermissionsAcceptedAction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
     pub full_name: String,
@@ -27899,7 +29450,7 @@ impl From<&InstallationNewPermissionsAcceptedRepositoriesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -27993,7 +29544,18 @@ impl From<&InstallationPermissions> for InstallationPermissions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsActions {
     #[serde(rename = "read")]
     Read,
@@ -28055,7 +29617,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsActions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsAdministration {
     #[serde(rename = "read")]
     Read,
@@ -28117,7 +29690,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsAdministration {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsChecks {
     #[serde(rename = "read")]
     Read,
@@ -28179,7 +29763,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsChecks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsContentReferences {
     #[serde(rename = "read")]
     Read,
@@ -28241,7 +29836,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsContentReferences 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsContents {
     #[serde(rename = "read")]
     Read,
@@ -28303,7 +29909,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsContents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsDeployments {
     #[serde(rename = "read")]
     Read,
@@ -28365,7 +29982,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsDeployments {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -28427,7 +30055,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsDiscussions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsEmails {
     #[serde(rename = "read")]
     Read,
@@ -28489,7 +30128,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsEmails {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsEnvironments {
     #[serde(rename = "read")]
     Read,
@@ -28551,7 +30201,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsEnvironments {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsIssues {
     #[serde(rename = "read")]
     Read,
@@ -28613,7 +30274,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsIssues {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsMembers {
     #[serde(rename = "read")]
     Read,
@@ -28675,7 +30347,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsMembers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsMetadata {
     #[serde(rename = "read")]
     Read,
@@ -28737,7 +30420,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsMetadata {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationAdministration {
     #[serde(rename = "read")]
     Read,
@@ -28801,7 +30495,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationAdmini
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationEvents {
     #[serde(rename = "read")]
     Read,
@@ -28865,7 +30570,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationEvents
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationHooks {
     #[serde(rename = "read")]
     Read,
@@ -28927,7 +30643,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationHooks 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationPackages {
     #[serde(rename = "read")]
     Read,
@@ -28991,7 +30718,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationPackag
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationPlan {
     #[serde(rename = "read")]
     Read,
@@ -29053,7 +30791,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationPlan {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationProjects {
     #[serde(rename = "read")]
     Read,
@@ -29117,7 +30866,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationProjec
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationSecrets {
     #[serde(rename = "read")]
     Read,
@@ -29181,7 +30941,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationSecret
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationSelfHostedRunners {
     #[serde(rename = "read")]
     Read,
@@ -29245,7 +31016,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationSelfHo
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "read")]
     Read,
@@ -29309,7 +31091,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsOrganizationUserBl
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsPackages {
     #[serde(rename = "read")]
     Read,
@@ -29371,7 +31164,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsPackages {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsPages {
     #[serde(rename = "read")]
     Read,
@@ -29433,7 +31237,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsPages {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsPullRequests {
     #[serde(rename = "read")]
     Read,
@@ -29495,7 +31310,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsPullRequests {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsRepositoryHooks {
     #[serde(rename = "read")]
     Read,
@@ -29557,7 +31383,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsRepositoryHooks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsRepositoryProjects {
     #[serde(rename = "read")]
     Read,
@@ -29621,7 +31458,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsRepositoryProjects
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsSecretScanningAlerts {
     #[serde(rename = "read")]
     Read,
@@ -29685,7 +31533,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsSecretScanningAler
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsSecrets {
     #[serde(rename = "read")]
     Read,
@@ -29747,7 +31606,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsSecrets {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsSecurityEvents {
     #[serde(rename = "read")]
     Read,
@@ -29809,7 +31679,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsSecurityEvents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsSecurityScanningAlert {
     #[serde(rename = "read")]
     Read,
@@ -29873,7 +31754,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsSecurityScanningAl
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsSingleFile {
     #[serde(rename = "read")]
     Read,
@@ -29935,7 +31827,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsSingleFile {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsStatuses {
     #[serde(rename = "read")]
     Read,
@@ -29997,7 +31900,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsStatuses {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsTeamDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -30059,7 +31973,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsTeamDiscussions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsVulnerabilityAlerts {
     #[serde(rename = "read")]
     Read,
@@ -30123,7 +32048,18 @@ impl std::convert::TryFrom<String> for InstallationPermissionsVulnerabilityAlert
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationPermissionsWorkflows {
     #[serde(rename = "read")]
     Read,
@@ -30289,7 +32225,7 @@ impl std::convert::TryFrom<String> for InstallationPermissionsWorkflows {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAdded {
     pub action: InstallationRepositoriesAddedAction,
@@ -30321,7 +32257,18 @@ impl From<&InstallationRepositoriesAdded> for InstallationRepositoriesAdded {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationRepositoriesAddedAction {
     #[serde(rename = "added")]
     Added,
@@ -30403,7 +32350,7 @@ impl std::convert::TryFrom<String> for InstallationRepositoriesAddedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
     pub full_name: String,
@@ -30453,7 +32400,7 @@ impl From<&InstallationRepositoriesAddedRepositoriesAddedItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30492,7 +32439,18 @@ impl From<&InstallationRepositoriesAddedRepositoriesRemovedItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationRepositoriesAddedRepositorySelection {
     #[serde(rename = "all")]
     All,
@@ -30559,7 +32517,7 @@ impl std::convert::TryFrom<String> for InstallationRepositoriesAddedRepositorySe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationRepositoriesEvent {
     Added(InstallationRepositoriesAdded),
@@ -30705,7 +32663,7 @@ impl From<InstallationRepositoriesRemoved> for InstallationRepositoriesEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemoved {
     pub action: InstallationRepositoriesRemovedAction,
@@ -30737,7 +32695,18 @@ impl From<&InstallationRepositoriesRemoved> for InstallationRepositoriesRemoved 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationRepositoriesRemovedAction {
     #[serde(rename = "removed")]
     Removed,
@@ -30819,7 +32788,7 @@ impl std::convert::TryFrom<String> for InstallationRepositoriesRemovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemovedRepositoriesAddedItem {
     pub full_name: String,
@@ -30876,7 +32845,7 @@ impl From<&InstallationRepositoriesRemovedRepositoriesAddedItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesRemovedRepositoriesRemovedItem {
     pub full_name: String,
@@ -30910,7 +32879,18 @@ impl From<&InstallationRepositoriesRemovedRepositoriesRemovedItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationRepositoriesRemovedRepositorySelection {
     #[serde(rename = "all")]
     All,
@@ -30975,7 +32955,18 @@ impl std::convert::TryFrom<String> for InstallationRepositoriesRemovedRepository
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationRepositorySelection {
     #[serde(rename = "all")]
     All,
@@ -31114,7 +33105,7 @@ impl std::convert::TryFrom<String> for InstallationRepositorySelection {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspend {
     pub action: InstallationSuspendAction,
@@ -31144,7 +33135,18 @@ impl From<&InstallationSuspend> for InstallationSuspend {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendAction {
     #[serde(rename = "suspend")]
     Suspend,
@@ -31219,7 +33221,7 @@ impl std::convert::TryFrom<String> for InstallationSuspendAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallation {
     pub access_tokens_url: String,
@@ -31271,7 +33273,7 @@ impl From<&InstallationSuspendInstallation> for InstallationSuspendInstallation 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationSuspendInstallationCreatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -31387,7 +33389,18 @@ impl From<i64> for InstallationSuspendInstallationCreatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationEventsItem {
     #[serde(rename = "check_run")]
     CheckRun,
@@ -31867,7 +33880,7 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationEventsItem
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -31969,7 +33982,18 @@ impl From<&InstallationSuspendInstallationPermissions>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsActions {
     #[serde(rename = "read")]
     Read,
@@ -32033,7 +34057,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsAdministration {
     #[serde(rename = "read")]
     Read,
@@ -32097,7 +34132,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsChecks {
     #[serde(rename = "read")]
     Read,
@@ -32161,7 +34207,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsContentReferences {
     #[serde(rename = "read")]
     Read,
@@ -32227,7 +34284,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsContents {
     #[serde(rename = "read")]
     Read,
@@ -32291,7 +34359,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsDeployments {
     #[serde(rename = "read")]
     Read,
@@ -32355,7 +34434,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -32419,7 +34509,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsEmails {
     #[serde(rename = "read")]
     Read,
@@ -32483,7 +34584,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsEnvironments {
     #[serde(rename = "read")]
     Read,
@@ -32547,7 +34659,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsIssues {
     #[serde(rename = "read")]
     Read,
@@ -32611,7 +34734,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsMembers {
     #[serde(rename = "read")]
     Read,
@@ -32675,7 +34809,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsMetadata {
     #[serde(rename = "read")]
     Read,
@@ -32739,7 +34884,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationAdministration {
     #[serde(rename = "read")]
     Read,
@@ -32809,7 +34965,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationEvents {
     #[serde(rename = "read")]
     Read,
@@ -32877,7 +35044,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationHooks {
     #[serde(rename = "read")]
     Read,
@@ -32943,7 +35121,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationPackages {
     #[serde(rename = "read")]
     Read,
@@ -33013,7 +35202,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationPlan {
     #[serde(rename = "read")]
     Read,
@@ -33077,7 +35277,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationProjects {
     #[serde(rename = "read")]
     Read,
@@ -33147,7 +35358,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationSecrets {
     #[serde(rename = "read")]
     Read,
@@ -33215,7 +35437,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
     #[serde(rename = "read")]
     Read,
@@ -33287,7 +35520,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "read")]
     Read,
@@ -33357,7 +35601,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsPackages {
     #[serde(rename = "read")]
     Read,
@@ -33421,7 +35676,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsPages {
     #[serde(rename = "read")]
     Read,
@@ -33485,7 +35751,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsPullRequests {
     #[serde(rename = "read")]
     Read,
@@ -33549,7 +35826,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsRepositoryHooks {
     #[serde(rename = "read")]
     Read,
@@ -33613,7 +35901,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsRepositoryProjects {
     #[serde(rename = "read")]
     Read,
@@ -33681,7 +35980,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsSecretScanningAlerts {
     #[serde(rename = "read")]
     Read,
@@ -33751,7 +36061,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsSecrets {
     #[serde(rename = "read")]
     Read,
@@ -33815,7 +36136,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsSecurityEvents {
     #[serde(rename = "read")]
     Read,
@@ -33879,7 +36211,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsSecurityScanningAlert {
     #[serde(rename = "read")]
     Read,
@@ -33949,7 +36292,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsSingleFile {
     #[serde(rename = "read")]
     Read,
@@ -34013,7 +36367,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsStatuses {
     #[serde(rename = "read")]
     Read,
@@ -34077,7 +36442,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsTeamDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -34141,7 +36517,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
     #[serde(rename = "read")]
     Read,
@@ -34209,7 +36596,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationPermissionsWorkflows {
     #[serde(rename = "read")]
     Read,
@@ -34274,7 +36672,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationRepositorySelection {
     #[serde(rename = "all")]
     All,
@@ -34449,7 +36858,7 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationRepository
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallationSuspendedBy {
     pub avatar_url: String,
@@ -34498,7 +36907,18 @@ impl From<&InstallationSuspendInstallationSuspendedBy>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationSuspendedByType {
     Bot,
     User,
@@ -34563,7 +36983,18 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationSuspendedB
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationSuspendInstallationTargetType {
     User,
     Organization,
@@ -34629,7 +37060,7 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationTargetType
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationSuspendInstallationUpdatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -34726,7 +37157,7 @@ impl From<i64> for InstallationSuspendInstallationUpdatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendRepositoriesItem {
     pub full_name: String,
@@ -34757,7 +37188,18 @@ impl From<&InstallationSuspendRepositoriesItem> for InstallationSuspendRepositor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationTargetType {
     User,
     Organization,
@@ -34893,7 +37335,7 @@ impl std::convert::TryFrom<String> for InstallationTargetType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspend {
     pub action: InstallationUnsuspendAction,
@@ -34923,7 +37365,18 @@ impl From<&InstallationUnsuspend> for InstallationUnsuspend {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendAction {
     #[serde(rename = "unsuspend")]
     Unsuspend,
@@ -34997,7 +37450,7 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendInstallation {
     pub access_tokens_url: String,
@@ -35049,7 +37502,7 @@ impl From<&InstallationUnsuspendInstallation> for InstallationUnsuspendInstallat
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationUnsuspendInstallationCreatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -35167,7 +37620,18 @@ impl From<i64> for InstallationUnsuspendInstallationCreatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationEventsItem {
     #[serde(rename = "check_run")]
     CheckRun,
@@ -35647,7 +38111,7 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationEventsIt
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35751,7 +38215,18 @@ impl From<&InstallationUnsuspendInstallationPermissions>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsActions {
     #[serde(rename = "read")]
     Read,
@@ -35815,7 +38290,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsAdministration {
     #[serde(rename = "read")]
     Read,
@@ -35879,7 +38365,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsChecks {
     #[serde(rename = "read")]
     Read,
@@ -35943,7 +38440,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsContentReferences {
     #[serde(rename = "read")]
     Read,
@@ -36011,7 +38519,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsContents {
     #[serde(rename = "read")]
     Read,
@@ -36075,7 +38594,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsDeployments {
     #[serde(rename = "read")]
     Read,
@@ -36139,7 +38669,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -36203,7 +38744,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsEmails {
     #[serde(rename = "read")]
     Read,
@@ -36267,7 +38819,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsEnvironments {
     #[serde(rename = "read")]
     Read,
@@ -36331,7 +38894,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsIssues {
     #[serde(rename = "read")]
     Read,
@@ -36395,7 +38969,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsMembers {
     #[serde(rename = "read")]
     Read,
@@ -36459,7 +39044,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsMetadata {
     #[serde(rename = "read")]
     Read,
@@ -36523,7 +39119,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
     #[serde(rename = "read")]
     Read,
@@ -36595,7 +39202,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationEvents {
     #[serde(rename = "read")]
     Read,
@@ -36665,7 +39283,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationHooks {
     #[serde(rename = "read")]
     Read,
@@ -36733,7 +39362,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationPackages {
     #[serde(rename = "read")]
     Read,
@@ -36803,7 +39443,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationPlan {
     #[serde(rename = "read")]
     Read,
@@ -36871,7 +39522,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationProjects {
     #[serde(rename = "read")]
     Read,
@@ -36941,7 +39603,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
     #[serde(rename = "read")]
     Read,
@@ -37011,7 +39684,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners {
     #[serde(rename = "read")]
     Read,
@@ -37085,7 +39769,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "read")]
     Read,
@@ -37155,7 +39850,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsPackages {
     #[serde(rename = "read")]
     Read,
@@ -37219,7 +39925,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsPages {
     #[serde(rename = "read")]
     Read,
@@ -37283,7 +40000,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsPullRequests {
     #[serde(rename = "read")]
     Read,
@@ -37347,7 +40075,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     #[serde(rename = "read")]
     Read,
@@ -37413,7 +40152,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsRepositoryProjects {
     #[serde(rename = "read")]
     Read,
@@ -37483,7 +40233,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
     #[serde(rename = "read")]
     Read,
@@ -37553,7 +40314,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsSecrets {
     #[serde(rename = "read")]
     Read,
@@ -37617,7 +40389,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsSecurityEvents {
     #[serde(rename = "read")]
     Read,
@@ -37681,7 +40464,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
     #[serde(rename = "read")]
     Read,
@@ -37751,7 +40545,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsSingleFile {
     #[serde(rename = "read")]
     Read,
@@ -37815,7 +40620,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsStatuses {
     #[serde(rename = "read")]
     Read,
@@ -37879,7 +40695,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     #[serde(rename = "read")]
     Read,
@@ -37945,7 +40772,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
     #[serde(rename = "read")]
     Read,
@@ -38015,7 +40853,18 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationPermissionsWorkflows {
     #[serde(rename = "read")]
     Read,
@@ -38080,7 +40929,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationPermissi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationRepositorySelection {
     #[serde(rename = "all")]
     All,
@@ -38144,7 +41004,18 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationReposito
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum InstallationUnsuspendInstallationTargetType {
     User,
     Organization,
@@ -38210,7 +41081,7 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationTargetTy
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationUnsuspendInstallationUpdatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -38309,7 +41180,7 @@ impl From<i64> for InstallationUnsuspendInstallationUpdatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendRepositoriesItem {
     pub full_name: String,
@@ -38344,7 +41215,7 @@ impl From<&InstallationUnsuspendRepositoriesItem> for InstallationUnsuspendRepos
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum InstallationUpdatedAt {
     Variant0(chrono::DateTime<chrono::offset::Utc>),
@@ -38598,7 +41469,7 @@ impl From<i64> for InstallationUpdatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Issue {
     pub active_lock_reason: Option<IssueActiveLockReason>,
@@ -38659,7 +41530,18 @@ impl From<&Issue> for Issue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -38792,7 +41674,7 @@ impl std::convert::TryFrom<String> for IssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueComment {
     pub author_association: AuthorAssociation,
@@ -38933,7 +41815,7 @@ impl From<&IssueComment> for IssueComment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreated {
     pub action: IssueCommentCreatedAction,
@@ -38964,7 +41846,18 @@ impl From<&IssueCommentCreated> for IssueCommentCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -39090,7 +41983,7 @@ impl std::convert::TryFrom<String> for IssueCommentCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreatedIssue {
     pub active_lock_reason: Option<IssueCommentCreatedIssueActiveLockReason>,
@@ -39146,7 +42039,18 @@ impl From<&IssueCommentCreatedIssue> for IssueCommentCreatedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentCreatedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -39231,7 +42135,7 @@ impl std::convert::TryFrom<String> for IssueCommentCreatedIssueActiveLockReason 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreatedIssueAssignee {
     pub avatar_url: String,
@@ -39278,7 +42182,18 @@ impl From<&IssueCommentCreatedIssueAssignee> for IssueCommentCreatedIssueAssigne
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentCreatedIssueAssigneeType {
     Bot,
     User,
@@ -39362,7 +42277,7 @@ impl std::convert::TryFrom<String> for IssueCommentCreatedIssueAssigneeType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreatedIssuePullRequest {
     pub diff_url: String,
@@ -39389,7 +42304,18 @@ impl From<&IssueCommentCreatedIssuePullRequest> for IssueCommentCreatedIssuePull
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentCreatedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -39555,7 +42481,7 @@ impl std::convert::TryFrom<String> for IssueCommentCreatedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeleted {
     pub action: IssueCommentDeletedAction,
@@ -39586,7 +42512,18 @@ impl From<&IssueCommentDeleted> for IssueCommentDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -39712,7 +42649,7 @@ impl std::convert::TryFrom<String> for IssueCommentDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeletedIssue {
     pub active_lock_reason: Option<IssueCommentDeletedIssueActiveLockReason>,
@@ -39768,7 +42705,18 @@ impl From<&IssueCommentDeletedIssue> for IssueCommentDeletedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentDeletedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -39853,7 +42801,7 @@ impl std::convert::TryFrom<String> for IssueCommentDeletedIssueActiveLockReason 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeletedIssueAssignee {
     pub avatar_url: String,
@@ -39900,7 +42848,18 @@ impl From<&IssueCommentDeletedIssueAssignee> for IssueCommentDeletedIssueAssigne
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentDeletedIssueAssigneeType {
     Bot,
     User,
@@ -39984,7 +42943,7 @@ impl std::convert::TryFrom<String> for IssueCommentDeletedIssueAssigneeType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeletedIssuePullRequest {
     pub diff_url: String,
@@ -40011,7 +42970,18 @@ impl From<&IssueCommentDeletedIssuePullRequest> for IssueCommentDeletedIssuePull
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentDeletedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -40198,7 +43168,7 @@ impl std::convert::TryFrom<String> for IssueCommentDeletedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEdited {
     pub action: IssueCommentEditedAction,
@@ -40230,7 +43200,18 @@ impl From<&IssueCommentEdited> for IssueCommentEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -40301,7 +43282,7 @@ impl std::convert::TryFrom<String> for IssueCommentEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -40332,7 +43313,7 @@ impl From<&IssueCommentEditedChanges> for IssueCommentEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
@@ -40425,7 +43406,7 @@ impl From<&IssueCommentEditedChangesBody> for IssueCommentEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedIssue {
     pub active_lock_reason: Option<IssueCommentEditedIssueActiveLockReason>,
@@ -40481,7 +43462,18 @@ impl From<&IssueCommentEditedIssue> for IssueCommentEditedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentEditedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -40566,7 +43558,7 @@ impl std::convert::TryFrom<String> for IssueCommentEditedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedIssueAssignee {
     pub avatar_url: String,
@@ -40613,7 +43605,18 @@ impl From<&IssueCommentEditedIssueAssignee> for IssueCommentEditedIssueAssignee 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentEditedIssueAssigneeType {
     Bot,
     User,
@@ -40697,7 +43700,7 @@ impl std::convert::TryFrom<String> for IssueCommentEditedIssueAssigneeType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedIssuePullRequest {
     pub diff_url: String,
@@ -40724,7 +43727,18 @@ impl From<&IssueCommentEditedIssuePullRequest> for IssueCommentEditedIssuePullRe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueCommentEditedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -40792,7 +43806,7 @@ impl std::convert::TryFrom<String> for IssueCommentEditedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IssueCommentEvent {
     Created(IssueCommentCreated),
@@ -40848,7 +43862,7 @@ impl From<IssueCommentEdited> for IssueCommentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -40880,7 +43894,18 @@ impl From<&IssuePullRequest> for IssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssueState {
     #[serde(rename = "open")]
     Open,
@@ -40983,7 +44008,7 @@ impl std::convert::TryFrom<String> for IssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesAssigned {
     #[doc = "The action that was performed."]
@@ -41018,7 +44043,18 @@ impl From<&IssuesAssigned> for IssuesAssigned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesAssignedAction {
     #[serde(rename = "assigned")]
     Assigned,
@@ -41129,7 +44165,7 @@ impl std::convert::TryFrom<String> for IssuesAssignedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosed {
     #[doc = "The action that was performed."]
@@ -41161,7 +44197,18 @@ impl From<&IssuesClosed> for IssuesClosed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesClosedAction {
     #[serde(rename = "closed")]
     Closed,
@@ -41239,7 +44286,7 @@ impl std::convert::TryFrom<String> for IssuesClosedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosedIssue {
     pub active_lock_reason: Option<IssuesClosedIssueActiveLockReason>,
@@ -41298,7 +44345,18 @@ impl From<&IssuesClosedIssue> for IssuesClosedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesClosedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -41383,7 +44441,7 @@ impl std::convert::TryFrom<String> for IssuesClosedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -41413,7 +44471,18 @@ impl From<&IssuesClosedIssuePullRequest> for IssuesClosedIssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesClosedIssueState {
     #[serde(rename = "closed")]
     Closed,
@@ -41499,7 +44568,7 @@ impl std::convert::TryFrom<String> for IssuesClosedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDeleted {
     pub action: IssuesDeletedAction,
@@ -41529,7 +44598,18 @@ impl From<&IssuesDeleted> for IssuesDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -41635,7 +44715,7 @@ impl std::convert::TryFrom<String> for IssuesDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestoned {
     pub action: IssuesDemilestonedAction,
@@ -41666,7 +44746,18 @@ impl From<&IssuesDemilestoned> for IssuesDemilestoned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesDemilestonedAction {
     #[serde(rename = "demilestoned")]
     Demilestoned,
@@ -41736,7 +44827,7 @@ impl std::convert::TryFrom<String> for IssuesDemilestonedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestonedIssue {
     pub active_lock_reason: Option<IssuesDemilestonedIssueActiveLockReason>,
@@ -41797,7 +44888,18 @@ impl From<&IssuesDemilestonedIssue> for IssuesDemilestonedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesDemilestonedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -41882,7 +44984,7 @@ impl std::convert::TryFrom<String> for IssuesDemilestonedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -41914,7 +45016,18 @@ impl From<&IssuesDemilestonedIssuePullRequest> for IssuesDemilestonedIssuePullRe
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesDemilestonedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -42041,7 +45154,7 @@ impl std::convert::TryFrom<String> for IssuesDemilestonedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEdited {
     pub action: IssuesEditedAction,
@@ -42074,7 +45187,18 @@ impl From<&IssuesEdited> for IssuesEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -42158,7 +45282,7 @@ impl std::convert::TryFrom<String> for IssuesEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -42191,7 +45315,7 @@ impl From<&IssuesEditedChanges> for IssuesEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChangesBody {
     #[doc = "The previous version of the body."]
@@ -42222,7 +45346,7 @@ impl From<&IssuesEditedChangesBody> for IssuesEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChangesTitle {
     #[doc = "The previous version of the title."]
@@ -42292,7 +45416,7 @@ impl From<&IssuesEditedChangesTitle> for IssuesEditedChangesTitle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IssuesEvent {
     Assigned(IssuesAssigned),
@@ -42443,7 +45567,7 @@ impl From<IssuesUnpinned> for IssuesEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLabeled {
     pub action: IssuesLabeledAction,
@@ -42476,7 +45600,18 @@ impl From<&IssuesLabeled> for IssuesLabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
@@ -42595,7 +45730,7 @@ impl std::convert::TryFrom<String> for IssuesLabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLocked {
     pub action: IssuesLockedAction,
@@ -42625,7 +45760,18 @@ impl From<&IssuesLocked> for IssuesLocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesLockedAction {
     #[serde(rename = "locked")]
     Locked,
@@ -42712,7 +45858,7 @@ impl std::convert::TryFrom<String> for IssuesLockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLockedIssue {
     pub active_lock_reason: Option<IssuesLockedIssueActiveLockReason>,
@@ -42772,7 +45918,18 @@ impl From<&IssuesLockedIssue> for IssuesLockedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesLockedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -42857,7 +46014,7 @@ impl std::convert::TryFrom<String> for IssuesLockedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -42889,7 +46046,18 @@ impl From<&IssuesLockedIssuePullRequest> for IssuesLockedIssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesLockedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -42999,7 +46167,7 @@ impl std::convert::TryFrom<String> for IssuesLockedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestoned {
     pub action: IssuesMilestonedAction,
@@ -43030,7 +46198,18 @@ impl From<&IssuesMilestoned> for IssuesMilestoned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesMilestonedAction {
     #[serde(rename = "milestoned")]
     Milestoned,
@@ -43100,7 +46279,7 @@ impl std::convert::TryFrom<String> for IssuesMilestonedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssue {
     pub active_lock_reason: Option<IssuesMilestonedIssueActiveLockReason>,
@@ -43161,7 +46340,18 @@ impl From<&IssuesMilestonedIssue> for IssuesMilestonedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesMilestonedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -43331,7 +46521,7 @@ impl std::convert::TryFrom<String> for IssuesMilestonedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssueMilestone {
     pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
@@ -43370,7 +46560,18 @@ impl From<&IssuesMilestonedIssueMilestone> for IssuesMilestonedIssueMilestone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesMilestonedIssueMilestoneState {
     #[serde(rename = "open")]
     Open,
@@ -43447,7 +46648,7 @@ impl std::convert::TryFrom<String> for IssuesMilestonedIssueMilestoneState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -43479,7 +46680,18 @@ impl From<&IssuesMilestonedIssuePullRequest> for IssuesMilestonedIssuePullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesMilestonedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -43608,7 +46820,7 @@ impl std::convert::TryFrom<String> for IssuesMilestonedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpened {
     pub action: IssuesOpenedAction,
@@ -43640,7 +46852,18 @@ impl From<&IssuesOpened> for IssuesOpened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesOpenedAction {
     #[serde(rename = "opened")]
     Opened,
@@ -43707,7 +46930,7 @@ impl std::convert::TryFrom<String> for IssuesOpenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedChanges {
     pub old_issue: Issue,
@@ -43751,7 +46974,7 @@ impl From<&IssuesOpenedChanges> for IssuesOpenedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedIssue {
     pub active_lock_reason: Option<IssuesOpenedIssueActiveLockReason>,
@@ -43810,7 +47033,18 @@ impl From<&IssuesOpenedIssue> for IssuesOpenedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesOpenedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -43895,7 +47129,7 @@ impl std::convert::TryFrom<String> for IssuesOpenedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -43925,7 +47159,18 @@ impl From<&IssuesOpenedIssuePullRequest> for IssuesOpenedIssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesOpenedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -44011,7 +47256,7 @@ impl std::convert::TryFrom<String> for IssuesOpenedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesPinned {
     pub action: IssuesPinnedAction,
@@ -44041,7 +47286,18 @@ impl From<&IssuesPinned> for IssuesPinned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesPinnedAction {
     #[serde(rename = "pinned")]
     Pinned,
@@ -44146,7 +47402,7 @@ impl std::convert::TryFrom<String> for IssuesPinnedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopened {
     pub action: IssuesReopenedAction,
@@ -44176,7 +47432,18 @@ impl From<&IssuesReopened> for IssuesReopened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
@@ -44249,7 +47516,7 @@ impl std::convert::TryFrom<String> for IssuesReopenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopenedIssue {
     pub active_lock_reason: Option<IssuesReopenedIssueActiveLockReason>,
@@ -44308,7 +47575,18 @@ impl From<&IssuesReopenedIssue> for IssuesReopenedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesReopenedIssueActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -44393,7 +47671,7 @@ impl std::convert::TryFrom<String> for IssuesReopenedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -44423,7 +47701,18 @@ impl From<&IssuesReopenedIssuePullRequest> for IssuesReopenedIssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesReopenedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -44526,7 +47815,7 @@ impl std::convert::TryFrom<String> for IssuesReopenedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesTransferred {
     pub action: IssuesTransferredAction,
@@ -44557,7 +47846,18 @@ impl From<&IssuesTransferred> for IssuesTransferred {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
@@ -44624,7 +47924,7 @@ impl std::convert::TryFrom<String> for IssuesTransferredAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesTransferredChanges {
     pub new_issue: Issue,
@@ -44689,7 +47989,7 @@ impl From<&IssuesTransferredChanges> for IssuesTransferredChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnassigned {
     #[doc = "The action that was performed."]
@@ -44724,7 +48024,18 @@ impl From<&IssuesUnassigned> for IssuesUnassigned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesUnassignedAction {
     #[serde(rename = "unassigned")]
     Unassigned,
@@ -44814,7 +48125,7 @@ impl std::convert::TryFrom<String> for IssuesUnassignedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlabeled {
     pub action: IssuesUnlabeledAction,
@@ -44847,7 +48158,18 @@ impl From<&IssuesUnlabeled> for IssuesUnlabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
@@ -44956,7 +48278,7 @@ impl std::convert::TryFrom<String> for IssuesUnlabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlocked {
     pub action: IssuesUnlockedAction,
@@ -44986,7 +48308,18 @@ impl From<&IssuesUnlocked> for IssuesUnlocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
@@ -45063,7 +48396,7 @@ impl std::convert::TryFrom<String> for IssuesUnlockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlockedIssue {
     pub active_lock_reason: IssuesUnlockedIssueActiveLockReason,
@@ -45120,7 +48453,7 @@ impl From<&IssuesUnlockedIssue> for IssuesUnlockedIssue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, serde :: Serialize)]
 pub struct IssuesUnlockedIssueActiveLockReason(());
 impl std::ops::Deref for IssuesUnlockedIssueActiveLockReason {
     type Target = ();
@@ -45186,7 +48519,7 @@ impl<'de> serde::Deserialize<'de> for IssuesUnlockedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -45218,7 +48551,18 @@ impl From<&IssuesUnlockedIssuePullRequest> for IssuesUnlockedIssuePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesUnlockedIssueState {
     #[serde(rename = "open")]
     Open,
@@ -45308,7 +48652,7 @@ impl std::convert::TryFrom<String> for IssuesUnlockedIssueState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnpinned {
     pub action: IssuesUnpinnedAction,
@@ -45338,7 +48682,18 @@ impl From<&IssuesUnpinned> for IssuesUnpinned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IssuesUnpinnedAction {
     #[serde(rename = "unpinned")]
     Unpinned,
@@ -45434,7 +48789,7 @@ impl std::convert::TryFrom<String> for IssuesUnpinnedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Label {
     #[doc = "6-character hex code, without the leading #, identifying the color"]
@@ -45496,7 +48851,7 @@ impl From<&Label> for Label {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelCreated {
     pub action: LabelCreatedAction,
@@ -45527,7 +48882,18 @@ impl From<&LabelCreated> for LabelCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LabelCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -45614,7 +48980,7 @@ impl std::convert::TryFrom<String> for LabelCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelDeleted {
     pub action: LabelDeletedAction,
@@ -45645,7 +49011,18 @@ impl From<&LabelDeleted> for LabelDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LabelDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -45778,7 +49155,7 @@ impl std::convert::TryFrom<String> for LabelDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEdited {
     pub action: LabelEditedAction,
@@ -45811,7 +49188,18 @@ impl From<&LabelEdited> for LabelEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LabelEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -45908,7 +49296,7 @@ impl std::convert::TryFrom<String> for LabelEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -45943,7 +49331,7 @@ impl From<&LabelEditedChanges> for LabelEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesColor {
     #[doc = "The previous version of the color if the action was `edited`."]
@@ -45974,7 +49362,7 @@ impl From<&LabelEditedChangesColor> for LabelEditedChangesColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
@@ -46005,7 +49393,7 @@ impl From<&LabelEditedChangesDescription> for LabelEditedChangesDescription {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
@@ -46036,7 +49424,7 @@ impl From<&LabelEditedChangesName> for LabelEditedChangesName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelEvent {
     Created(LabelCreated),
@@ -46104,7 +49492,7 @@ impl From<LabelEdited> for LabelEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct License {
     pub key: String,
@@ -46140,7 +49528,7 @@ impl From<&License> for License {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Link {
     pub href: String,
@@ -46266,7 +49654,7 @@ impl From<&Link> for Link {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchase {
     pub account: MarketplacePurchaseAccount,
@@ -46318,7 +49706,7 @@ impl From<&MarketplacePurchase> for MarketplacePurchase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseAccount {
     pub id: i64,
@@ -46477,7 +49865,7 @@ impl From<&MarketplacePurchaseAccount> for MarketplacePurchaseAccount {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelled {
     pub action: MarketplacePurchaseCancelledAction,
@@ -46505,7 +49893,18 @@ impl From<&MarketplacePurchaseCancelled> for MarketplacePurchaseCancelled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarketplacePurchaseCancelledAction {
     #[serde(rename = "cancelled")]
     Cancelled,
@@ -46575,7 +49974,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchaseCancelledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledMarketplacePurchase {
     pub account: MarketplacePurchaseCancelledMarketplacePurchaseAccount,
@@ -46628,7 +50027,7 @@ impl From<&MarketplacePurchaseCancelledMarketplacePurchase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledMarketplacePurchaseAccount {
     pub id: i64,
@@ -46702,7 +50101,7 @@ impl From<&MarketplacePurchaseCancelledMarketplacePurchaseAccount>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledMarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -46821,7 +50220,7 @@ impl From<&MarketplacePurchaseCancelledMarketplacePurchasePlan>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseCancelledSender {
     pub avatar_url: String,
@@ -46993,7 +50392,7 @@ impl From<&MarketplacePurchaseCancelledSender> for MarketplacePurchaseCancelledS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChanged {
     pub action: MarketplacePurchaseChangedAction,
@@ -47021,7 +50420,18 @@ impl From<&MarketplacePurchaseChanged> for MarketplacePurchaseChanged {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarketplacePurchaseChangedAction {
     #[serde(rename = "changed")]
     Changed,
@@ -47091,7 +50501,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchaseChangedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChangedMarketplacePurchase {
     pub account: MarketplacePurchaseChangedMarketplacePurchaseAccount,
@@ -47144,7 +50554,7 @@ impl From<&MarketplacePurchaseChangedMarketplacePurchase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChangedMarketplacePurchaseAccount {
     pub id: i64,
@@ -47218,7 +50628,7 @@ impl From<&MarketplacePurchaseChangedMarketplacePurchaseAccount>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChangedMarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -47337,7 +50747,7 @@ impl From<&MarketplacePurchaseChangedMarketplacePurchasePlan>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchaseChangedSender {
     pub avatar_url: String,
@@ -47391,7 +50801,7 @@ impl From<&MarketplacePurchaseChangedSender> for MarketplacePurchaseChangedSende
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MarketplacePurchaseEvent {
     Cancelled(MarketplacePurchaseCancelled),
@@ -47574,7 +50984,7 @@ impl From<MarketplacePurchasePurchased> for MarketplacePurchaseEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChange {
     pub action: MarketplacePurchasePendingChangeAction,
@@ -47602,7 +51012,18 @@ impl From<&MarketplacePurchasePendingChange> for MarketplacePurchasePendingChang
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarketplacePurchasePendingChangeAction {
     #[serde(rename = "pending_change")]
     PendingChange,
@@ -47790,7 +51211,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelled {
     pub action: MarketplacePurchasePendingChangeCancelledAction,
@@ -47820,7 +51241,18 @@ impl From<&MarketplacePurchasePendingChangeCancelled>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarketplacePurchasePendingChangeCancelledAction {
     #[serde(rename = "pending_change_cancelled")]
     PendingChangeCancelled,
@@ -47892,7 +51324,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePendingChangeCancelled
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchase {
     pub account: MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount,
@@ -47945,7 +51377,7 @@ impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount {
     pub id: i64,
@@ -48019,7 +51451,7 @@ impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -48138,7 +51570,7 @@ impl From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub avatar_url: String,
@@ -48194,7 +51626,7 @@ impl From<&MarketplacePurchasePendingChangeCancelledSender>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeMarketplacePurchase {
     pub account: MarketplacePurchasePendingChangeMarketplacePurchaseAccount,
@@ -48247,7 +51679,7 @@ impl From<&MarketplacePurchasePendingChangeMarketplacePurchase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeMarketplacePurchaseAccount {
     pub id: i64,
@@ -48321,7 +51753,7 @@ impl From<&MarketplacePurchasePendingChangeMarketplacePurchaseAccount>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeMarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -48440,7 +51872,7 @@ impl From<&MarketplacePurchasePendingChangeMarketplacePurchasePlan>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePendingChangeSender {
     pub avatar_url: String,
@@ -48525,7 +51957,7 @@ impl From<&MarketplacePurchasePendingChangeSender> for MarketplacePurchasePendin
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -48687,7 +52119,7 @@ impl From<&MarketplacePurchasePlan> for MarketplacePurchasePlan {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchased {
     pub action: MarketplacePurchasePurchasedAction,
@@ -48715,7 +52147,18 @@ impl From<&MarketplacePurchasePurchased> for MarketplacePurchasePurchased {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarketplacePurchasePurchasedAction {
     #[serde(rename = "purchased")]
     Purchased,
@@ -48785,7 +52228,7 @@ impl std::convert::TryFrom<String> for MarketplacePurchasePurchasedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedMarketplacePurchase {
     pub account: MarketplacePurchasePurchasedMarketplacePurchaseAccount,
@@ -48838,7 +52281,7 @@ impl From<&MarketplacePurchasePurchasedMarketplacePurchase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedMarketplacePurchaseAccount {
     pub id: i64,
@@ -48912,7 +52355,7 @@ impl From<&MarketplacePurchasePurchasedMarketplacePurchaseAccount>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedMarketplacePurchasePlan {
     pub bullets: Vec<String>,
@@ -49031,7 +52474,7 @@ impl From<&MarketplacePurchasePurchasedMarketplacePurchasePlan>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarketplacePurchasePurchasedSender {
     pub avatar_url: String,
@@ -49122,7 +52565,7 @@ impl From<&MarketplacePurchasePurchasedSender> for MarketplacePurchasePurchasedS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAdded {
     pub action: MemberAddedAction,
@@ -49153,7 +52596,18 @@ impl From<&MemberAdded> for MemberAdded {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MemberAddedAction {
     #[serde(rename = "added")]
     Added,
@@ -49226,7 +52680,7 @@ impl std::convert::TryFrom<String> for MemberAddedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49260,7 +52714,7 @@ impl From<&MemberAddedChanges> for MemberAddedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChangesPermission {
     pub to: MemberAddedChangesPermissionTo,
@@ -49284,7 +52738,18 @@ impl From<&MemberAddedChangesPermission> for MemberAddedChangesPermission {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MemberAddedChangesPermissionTo {
     #[serde(rename = "write")]
     Write,
@@ -49396,7 +52861,7 @@ impl std::convert::TryFrom<String> for MemberAddedChangesPermissionTo {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEdited {
     pub action: MemberEditedAction,
@@ -49426,7 +52891,18 @@ impl From<&MemberEdited> for MemberEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MemberEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -49500,7 +52976,7 @@ impl std::convert::TryFrom<String> for MemberEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEditedChanges {
     pub old_permission: MemberEditedChangesOldPermission,
@@ -49530,7 +53006,7 @@ impl From<&MemberEditedChanges> for MemberEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberEditedChangesOldPermission {
     #[doc = "The previous permissions of the collaborator if the action was edited."]
@@ -49561,7 +53037,7 @@ impl From<&MemberEditedChangesOldPermission> for MemberEditedChangesOldPermissio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MemberEvent {
     Added(MemberAdded),
@@ -49628,7 +53104,7 @@ impl From<MemberRemoved> for MemberEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MemberRemoved {
     pub action: MemberRemovedAction,
@@ -49657,7 +53133,18 @@ impl From<&MemberRemoved> for MemberRemoved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MemberRemovedAction {
     #[serde(rename = "removed")]
     Removed,
@@ -49741,7 +53228,7 @@ impl std::convert::TryFrom<String> for MemberRemovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Membership {
     pub organization_url: String,
@@ -49808,7 +53295,7 @@ impl From<&Membership> for Membership {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MembershipAdded {
     pub action: MembershipAddedAction,
@@ -49841,7 +53328,18 @@ impl From<&MembershipAdded> for MembershipAdded {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MembershipAddedAction {
     #[serde(rename = "added")]
     Added,
@@ -49899,7 +53397,18 @@ impl std::convert::TryFrom<String> for MembershipAddedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MembershipAddedScope {
     #[serde(rename = "team")]
     Team,
@@ -49960,7 +53469,7 @@ impl std::convert::TryFrom<String> for MembershipAddedScope {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MembershipEvent {
     Added(MembershipAdded),
@@ -50058,7 +53567,7 @@ impl From<MembershipRemoved> for MembershipEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MembershipRemoved {
     pub action: MembershipRemovedAction,
@@ -50091,7 +53600,18 @@ impl From<&MembershipRemoved> for MembershipRemoved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MembershipRemovedAction {
     #[serde(rename = "removed")]
     Removed,
@@ -50150,7 +53670,18 @@ impl std::convert::TryFrom<String> for MembershipRemovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MembershipRemovedScope {
     #[serde(rename = "team")]
     Team,
@@ -50232,7 +53763,7 @@ impl std::convert::TryFrom<String> for MembershipRemovedScope {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum MembershipRemovedTeam {
     Variant0(Team),
@@ -50354,7 +53885,7 @@ impl From<Team> for MembershipRemovedTeam {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeleted {
     pub action: MetaDeletedAction,
@@ -50382,7 +53913,18 @@ impl From<&MetaDeleted> for MetaDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MetaDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -50496,7 +54038,7 @@ impl std::convert::TryFrom<String> for MetaDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeletedHook {
     pub active: bool,
@@ -50546,7 +54088,7 @@ impl From<&MetaDeletedHook> for MetaDeletedHook {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaDeletedHookConfig {
     pub content_type: MetaDeletedHookConfigContentType,
@@ -50572,7 +54114,18 @@ impl From<&MetaDeletedHookConfig> for MetaDeletedHookConfig {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MetaDeletedHookConfigContentType {
     #[serde(rename = "json")]
     Json,
@@ -50634,7 +54187,7 @@ impl std::convert::TryFrom<String> for MetaDeletedHookConfigContentType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MetaEvent(pub MetaDeleted);
 impl std::ops::Deref for MetaEvent {
     type Target = MetaDeleted;
@@ -50762,7 +54315,7 @@ impl From<MetaDeleted> for MetaEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Milestone {
     pub closed_at: Option<chrono::DateTime<chrono::offset::Utc>>,
@@ -50855,7 +54408,7 @@ impl From<&Milestone> for Milestone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneClosed {
     pub action: MilestoneClosedAction,
@@ -50885,7 +54438,18 @@ impl From<&MilestoneClosed> for MilestoneClosed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneClosedAction {
     #[serde(rename = "closed")]
     Closed,
@@ -50962,7 +54526,7 @@ impl std::convert::TryFrom<String> for MilestoneClosedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneClosedMilestone {
     pub closed_at: chrono::DateTime<chrono::offset::Utc>,
@@ -51002,7 +54566,18 @@ impl From<&MilestoneClosedMilestone> for MilestoneClosedMilestone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneClosedMilestoneState {
     #[serde(rename = "closed")]
     Closed,
@@ -51111,7 +54686,7 @@ impl std::convert::TryFrom<String> for MilestoneClosedMilestoneState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneCreated {
     pub action: MilestoneCreatedAction,
@@ -51141,7 +54716,18 @@ impl From<&MilestoneCreated> for MilestoneCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -51218,7 +54804,7 @@ impl std::convert::TryFrom<String> for MilestoneCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneCreatedMilestone {
     pub closed_at: (),
@@ -51258,7 +54844,18 @@ impl From<&MilestoneCreatedMilestone> for MilestoneCreatedMilestone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneCreatedMilestoneState {
     #[serde(rename = "open")]
     Open,
@@ -51344,7 +54941,7 @@ impl std::convert::TryFrom<String> for MilestoneCreatedMilestoneState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneDeleted {
     pub action: MilestoneDeletedAction,
@@ -51374,7 +54971,18 @@ impl From<&MilestoneDeleted> for MilestoneDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -51507,7 +55115,7 @@ impl std::convert::TryFrom<String> for MilestoneDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEdited {
     pub action: MilestoneEditedAction,
@@ -51538,7 +55146,18 @@ impl From<&MilestoneEdited> for MilestoneEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -51635,7 +55254,7 @@ impl std::convert::TryFrom<String> for MilestoneEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -51670,7 +55289,7 @@ impl From<&MilestoneEditedChanges> for MilestoneEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
@@ -51701,7 +55320,7 @@ impl From<&MilestoneEditedChangesDescription> for MilestoneEditedChangesDescript
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesDueOn {
     #[doc = "The previous version of the due date if the action was `edited`."]
@@ -51732,7 +55351,7 @@ impl From<&MilestoneEditedChangesDueOn> for MilestoneEditedChangesDueOn {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
@@ -51769,7 +55388,7 @@ impl From<&MilestoneEditedChangesTitle> for MilestoneEditedChangesTitle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MilestoneEvent {
     Closed(MilestoneClosed),
@@ -51873,7 +55492,7 @@ impl From<MilestoneOpened> for MilestoneEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneOpened {
     pub action: MilestoneOpenedAction,
@@ -51903,7 +55522,18 @@ impl From<&MilestoneOpened> for MilestoneOpened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneOpenedAction {
     #[serde(rename = "opened")]
     Opened,
@@ -51980,7 +55610,7 @@ impl std::convert::TryFrom<String> for MilestoneOpenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneOpenedMilestone {
     pub closed_at: (),
@@ -52020,7 +55650,18 @@ impl From<&MilestoneOpenedMilestone> for MilestoneOpenedMilestone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneOpenedMilestoneState {
     #[serde(rename = "open")]
     Open,
@@ -52079,7 +55720,18 @@ impl std::convert::TryFrom<String> for MilestoneOpenedMilestoneState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MilestoneState {
     #[serde(rename = "open")]
     Open,
@@ -52167,7 +55819,7 @@ impl std::convert::TryFrom<String> for MilestoneState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrgBlockBlocked {
     pub action: OrgBlockBlockedAction,
@@ -52196,7 +55848,18 @@ impl From<&OrgBlockBlocked> for OrgBlockBlocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrgBlockBlockedAction {
     #[serde(rename = "blocked")]
     Blocked,
@@ -52257,7 +55920,7 @@ impl std::convert::TryFrom<String> for OrgBlockBlockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrgBlockEvent {
     Blocked(OrgBlockBlocked),
@@ -52318,7 +55981,7 @@ impl From<OrgBlockUnblocked> for OrgBlockEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrgBlockUnblocked {
     pub action: OrgBlockUnblockedAction,
@@ -52347,7 +56010,18 @@ impl From<&OrgBlockUnblocked> for OrgBlockUnblocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrgBlockUnblockedAction {
     #[serde(rename = "unblocked")]
     Unblocked,
@@ -52471,7 +56145,7 @@ impl std::convert::TryFrom<String> for OrgBlockUnblockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Organization {
     pub avatar_url: String,
@@ -52533,7 +56207,7 @@ impl From<&Organization> for Organization {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationDeleted {
     pub action: OrganizationDeletedAction,
@@ -52561,7 +56235,18 @@ impl From<&OrganizationDeleted> for OrganizationDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrganizationDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -52631,7 +56316,7 @@ impl std::convert::TryFrom<String> for OrganizationDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrganizationEvent {
     Deleted(OrganizationDeleted),
@@ -52709,7 +56394,7 @@ impl From<OrganizationRenamed> for OrganizationEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberAdded {
     pub action: OrganizationMemberAddedAction,
@@ -52737,7 +56422,18 @@ impl From<&OrganizationMemberAdded> for OrganizationMemberAdded {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrganizationMemberAddedAction {
     #[serde(rename = "member_added")]
     MemberAdded,
@@ -52890,7 +56586,7 @@ impl std::convert::TryFrom<String> for OrganizationMemberAddedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvited {
     pub action: OrganizationMemberInvitedAction,
@@ -52919,7 +56615,18 @@ impl From<&OrganizationMemberInvited> for OrganizationMemberInvited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrganizationMemberInvitedAction {
     #[serde(rename = "member_invited")]
     MemberInvited,
@@ -53039,7 +56746,7 @@ impl std::convert::TryFrom<String> for OrganizationMemberInvitedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvitedInvitation {
     pub created_at: chrono::DateTime<chrono::offset::Utc>,
@@ -53098,7 +56805,7 @@ impl From<&OrganizationMemberInvitedInvitation> for OrganizationMemberInvitedInv
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberRemoved {
     pub action: OrganizationMemberRemovedAction,
@@ -53126,7 +56833,18 @@ impl From<&OrganizationMemberRemoved> for OrganizationMemberRemoved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrganizationMemberRemovedAction {
     #[serde(rename = "member_removed")]
     MemberRemoved,
@@ -53209,7 +56927,7 @@ impl std::convert::TryFrom<String> for OrganizationMemberRemovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OrganizationRenamed {
     pub action: OrganizationRenamedAction,
@@ -53237,7 +56955,18 @@ impl From<&OrganizationRenamed> for OrganizationRenamed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrganizationRenamedAction {
     #[serde(rename = "renamed")]
     Renamed,
@@ -53298,7 +57027,7 @@ impl std::convert::TryFrom<String> for OrganizationRenamedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackageEvent {
     Published(PackagePublished),
@@ -53647,7 +57376,7 @@ impl From<PackageUpdated> for PackageEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublished {
     pub action: PackagePublishedAction,
@@ -53675,7 +57404,18 @@ impl From<&PackagePublished> for PackagePublished {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PackagePublishedAction {
     #[serde(rename = "published")]
     Published,
@@ -54018,7 +57758,7 @@ impl std::convert::TryFrom<String> for PackagePublishedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackage {
     pub created_at: String,
@@ -54253,7 +57993,7 @@ impl From<&PackagePublishedPackage> for PackagePublishedPackage {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersion {
     pub author: User,
@@ -54345,7 +58085,7 @@ impl From<&PackagePublishedPackagePackageVersion> for PackagePublishedPackagePac
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersionPackageFilesItem {
     pub content_type: String,
@@ -54428,7 +58168,7 @@ impl From<&PackagePublishedPackagePackageVersionPackageFilesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackagePackageVersionRelease {
     pub author: User,
@@ -54487,7 +58227,7 @@ impl From<&PackagePublishedPackagePackageVersionRelease>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackageRegistry {
     pub about_url: String,
@@ -54831,7 +58571,7 @@ impl From<&PackagePublishedPackageRegistry> for PackagePublishedPackageRegistry 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdated {
     pub action: PackageUpdatedAction,
@@ -54859,7 +58599,18 @@ impl From<&PackageUpdated> for PackageUpdated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PackageUpdatedAction {
     #[serde(rename = "updated")]
     Updated,
@@ -55203,7 +58954,7 @@ impl std::convert::TryFrom<String> for PackageUpdatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackage {
     pub created_at: String,
@@ -55439,7 +59190,7 @@ impl From<&PackageUpdatedPackage> for PackageUpdatedPackage {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersion {
     pub author: User,
@@ -55531,7 +59282,7 @@ impl From<&PackageUpdatedPackagePackageVersion> for PackageUpdatedPackagePackage
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub content_type: String,
@@ -55614,7 +59365,7 @@ impl From<&PackageUpdatedPackagePackageVersionPackageFilesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackagePackageVersionRelease {
     pub author: User,
@@ -55673,7 +59424,7 @@ impl From<&PackageUpdatedPackagePackageVersionRelease>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackageRegistry {
     pub about_url: String,
@@ -55779,7 +59530,7 @@ impl From<&PackageUpdatedPackageRegistry> for PackageUpdatedPackageRegistry {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEvent {
     pub build: PageBuildEventBuild,
@@ -55857,7 +59608,7 @@ impl From<&PageBuildEvent> for PageBuildEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuild {
     pub commit: String,
@@ -55896,7 +59647,7 @@ impl From<&PageBuildEventBuild> for PageBuildEventBuild {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuildError {
     pub message: Option<String>,
@@ -56046,7 +59797,7 @@ impl From<&PageBuildEventBuildError> for PageBuildEventBuildError {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEvent {
     pub hook: PingEventHook,
@@ -56176,7 +59927,7 @@ impl From<&PingEvent> for PingEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHook {
     pub active: bool,
@@ -56238,7 +59989,7 @@ impl From<&PingEventHook> for PingEventHook {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHookConfig {
     pub content_type: PingEventHookConfigContentType,
@@ -56266,7 +60017,18 @@ impl From<&PingEventHookConfig> for PingEventHookConfig {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PingEventHookConfigContentType {
     #[serde(rename = "json")]
     Json,
@@ -56341,7 +60103,7 @@ impl std::convert::TryFrom<String> for PingEventHookConfigContentType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PingEventHookLastResponse {
     pub code: (),
@@ -56438,7 +60200,7 @@ impl From<&PingEventHookLastResponse> for PingEventHookLastResponse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Project {
     #[doc = "Body of the project"]
@@ -56541,7 +60303,7 @@ impl From<&Project> for Project {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCard {
     #[serde(default)]
@@ -56631,7 +60393,7 @@ impl From<&ProjectCard> for ProjectCard {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConverted {
     pub action: ProjectCardConvertedAction,
@@ -56662,7 +60424,18 @@ impl From<&ProjectCardConverted> for ProjectCardConverted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCardConvertedAction {
     #[serde(rename = "converted")]
     Converted,
@@ -56734,7 +60507,7 @@ impl std::convert::TryFrom<String> for ProjectCardConvertedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChanges {
     pub note: ProjectCardConvertedChangesNote,
@@ -56763,7 +60536,7 @@ impl From<&ProjectCardConvertedChanges> for ProjectCardConvertedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChangesNote {
     pub from: String,
@@ -56815,7 +60588,7 @@ impl From<&ProjectCardConvertedChangesNote> for ProjectCardConvertedChangesNote 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardCreated {
     pub action: ProjectCardCreatedAction,
@@ -56845,7 +60618,18 @@ impl From<&ProjectCardCreated> for ProjectCardCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCardCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -56931,7 +60715,7 @@ impl std::convert::TryFrom<String> for ProjectCardCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardDeleted {
     pub action: ProjectCardDeletedAction,
@@ -56961,7 +60745,18 @@ impl From<&ProjectCardDeleted> for ProjectCardDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCardDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -57069,7 +60864,7 @@ impl std::convert::TryFrom<String> for ProjectCardDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEdited {
     pub action: ProjectCardEditedAction,
@@ -57100,7 +60895,18 @@ impl From<&ProjectCardEdited> for ProjectCardEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCardEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -57172,7 +60978,7 @@ impl std::convert::TryFrom<String> for ProjectCardEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEditedChanges {
     pub note: ProjectCardEditedChangesNote,
@@ -57201,7 +61007,7 @@ impl From<&ProjectCardEditedChanges> for ProjectCardEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEditedChangesNote {
     pub from: String,
@@ -57237,7 +61043,7 @@ impl From<&ProjectCardEditedChangesNote> for ProjectCardEditedChangesNote {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectCardEvent {
     Converted(ProjectCardConverted),
@@ -57359,7 +61165,7 @@ impl From<ProjectCardMoved> for ProjectCardEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMoved {
     pub action: ProjectCardMovedAction,
@@ -57390,7 +61196,18 @@ impl From<&ProjectCardMoved> for ProjectCardMoved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCardMovedAction {
     #[serde(rename = "moved")]
     Moved,
@@ -57462,7 +61279,7 @@ impl std::convert::TryFrom<String> for ProjectCardMovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChanges {
     pub column_id: ProjectCardMovedChangesColumnId,
@@ -57491,7 +61308,7 @@ impl From<&ProjectCardMovedChanges> for ProjectCardMovedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChangesColumnId {
     pub from: i64,
@@ -57530,7 +61347,7 @@ impl From<&ProjectCardMovedChangesColumnId> for ProjectCardMovedChangesColumnId 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedProjectCard {
     pub after_id: (),
@@ -57597,7 +61414,7 @@ impl From<&ProjectCardMovedProjectCard> for ProjectCardMovedProjectCard {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectClosed {
     pub action: ProjectClosedAction,
@@ -57627,7 +61444,18 @@ impl From<&ProjectClosed> for ProjectClosed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectClosedAction {
     #[serde(rename = "closed")]
     Closed,
@@ -57727,7 +61555,7 @@ impl std::convert::TryFrom<String> for ProjectClosedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumn {
     pub cards_url: String,
@@ -57788,7 +61616,7 @@ impl From<&ProjectColumn> for ProjectColumn {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnCreated {
     pub action: ProjectColumnCreatedAction,
@@ -57818,7 +61646,18 @@ impl From<&ProjectColumnCreated> for ProjectColumnCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectColumnCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -57904,7 +61743,7 @@ impl std::convert::TryFrom<String> for ProjectColumnCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnDeleted {
     pub action: ProjectColumnDeletedAction,
@@ -57934,7 +61773,18 @@ impl From<&ProjectColumnDeleted> for ProjectColumnDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectColumnDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -58039,7 +61889,7 @@ impl std::convert::TryFrom<String> for ProjectColumnDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEdited {
     pub action: ProjectColumnEditedAction,
@@ -58070,7 +61920,18 @@ impl From<&ProjectColumnEdited> for ProjectColumnEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectColumnEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -58139,7 +62000,7 @@ impl std::convert::TryFrom<String> for ProjectColumnEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -58169,7 +62030,7 @@ impl From<&ProjectColumnEditedChanges> for ProjectColumnEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChangesName {
     pub from: String,
@@ -58202,7 +62063,7 @@ impl From<&ProjectColumnEditedChangesName> for ProjectColumnEditedChangesName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectColumnEvent {
     Created(ProjectColumnCreated),
@@ -58277,7 +62138,7 @@ impl From<ProjectColumnMoved> for ProjectColumnEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnMoved {
     pub action: ProjectColumnMovedAction,
@@ -58307,7 +62168,18 @@ impl From<&ProjectColumnMoved> for ProjectColumnMoved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectColumnMovedAction {
     #[serde(rename = "moved")]
     Moved,
@@ -58393,7 +62265,7 @@ impl std::convert::TryFrom<String> for ProjectColumnMovedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectCreated {
     pub action: ProjectCreatedAction,
@@ -58423,7 +62295,18 @@ impl From<&ProjectCreated> for ProjectCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -58509,7 +62392,7 @@ impl std::convert::TryFrom<String> for ProjectCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectDeleted {
     pub action: ProjectDeletedAction,
@@ -58539,7 +62422,18 @@ impl From<&ProjectDeleted> for ProjectDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -58659,7 +62553,7 @@ impl std::convert::TryFrom<String> for ProjectDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEdited {
     pub action: ProjectEditedAction,
@@ -58690,7 +62584,18 @@ impl From<&ProjectEdited> for ProjectEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -58774,7 +62679,7 @@ impl std::convert::TryFrom<String> for ProjectEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -58807,7 +62712,7 @@ impl From<&ProjectEditedChanges> for ProjectEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
@@ -58838,7 +62743,7 @@ impl From<&ProjectEditedChangesBody> for ProjectEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChangesName {
     #[doc = "The changes to the project if the action was `edited`."]
@@ -58875,7 +62780,7 @@ impl From<&ProjectEditedChangesName> for ProjectEditedChangesName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectEvent {
     Closed(ProjectClosed),
@@ -58956,7 +62861,7 @@ impl From<ProjectReopened> for ProjectEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectReopened {
     pub action: ProjectReopenedAction,
@@ -58986,7 +62891,18 @@ impl From<&ProjectReopened> for ProjectReopened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
@@ -59045,7 +62961,18 @@ impl std::convert::TryFrom<String> for ProjectReopenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectState {
     #[serde(rename = "open")]
     Open,
@@ -59144,7 +63071,7 @@ impl std::convert::TryFrom<String> for ProjectState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PublicEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59188,7 +63115,7 @@ impl From<&PublicEvent> for PublicEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PublicEventRepository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -59326,7 +63253,7 @@ impl From<&PublicEventRepository> for PublicEventRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PublicEventRepositoryCreatedAt {
     Variant0(i64),
@@ -59418,7 +63345,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for PublicEventRepositoryCreate
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PublicEventRepositoryPermissions {
     pub admin: bool,
@@ -59455,7 +63382,7 @@ impl From<&PublicEventRepositoryPermissions> for PublicEventRepositoryPermission
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PublicEventRepositoryPushedAt {
     Variant0(i64),
@@ -59867,7 +63794,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for PublicEventRepositoryPushed
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequest {
     pub active_lock_reason: Option<PullRequestActiveLockReason>,
@@ -59946,7 +63873,18 @@ impl From<&PullRequest> for PullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -60053,7 +63991,7 @@ impl std::convert::TryFrom<String> for PullRequestActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAssigned {
     pub action: PullRequestAssignedAction,
@@ -60086,7 +64024,18 @@ impl From<&PullRequestAssigned> for PullRequestAssigned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestAssignedAction {
     #[serde(rename = "assigned")]
     Assigned,
@@ -60176,7 +64125,7 @@ impl std::convert::TryFrom<String> for PullRequestAssignedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeDisabled {
     pub action: PullRequestAutoMergeDisabledAction,
@@ -60207,7 +64156,18 @@ impl From<&PullRequestAutoMergeDisabled> for PullRequestAutoMergeDisabled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestAutoMergeDisabledAction {
     #[serde(rename = "auto_merge_disabled")]
     AutoMergeDisabled,
@@ -60297,7 +64257,7 @@ impl std::convert::TryFrom<String> for PullRequestAutoMergeDisabledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeEnabled {
     pub action: PullRequestAutoMergeEnabledAction,
@@ -60328,7 +64288,18 @@ impl From<&PullRequestAutoMergeEnabled> for PullRequestAutoMergeEnabled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestAutoMergeEnabledAction {
     #[serde(rename = "auto_merge_enabled")]
     AutoMergeEnabled,
@@ -60407,7 +64378,7 @@ impl std::convert::TryFrom<String> for PullRequestAutoMergeEnabledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestBase {
     pub label: String,
@@ -60498,7 +64469,7 @@ impl From<&PullRequestBase> for PullRequestBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosed {
     pub action: PullRequestClosedAction,
@@ -60530,7 +64501,18 @@ impl From<&PullRequestClosed> for PullRequestClosed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestClosedAction {
     #[serde(rename = "closed")]
     Closed,
@@ -60613,7 +64595,7 @@ impl std::convert::TryFrom<String> for PullRequestClosedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosedPullRequest {
     pub active_lock_reason: Option<PullRequestClosedPullRequestActiveLockReason>,
@@ -60691,7 +64673,18 @@ impl From<&PullRequestClosedPullRequest> for PullRequestClosedPullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestClosedPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -60784,7 +64777,7 @@ impl std::convert::TryFrom<String> for PullRequestClosedPullRequestActiveLockRea
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosedPullRequestBase {
     pub label: String,
@@ -60834,7 +64827,7 @@ impl From<&PullRequestClosedPullRequestBase> for PullRequestClosedPullRequestBas
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosedPullRequestHead {
     pub label: String,
@@ -60896,7 +64889,7 @@ impl From<&PullRequestClosedPullRequestHead> for PullRequestClosedPullRequestHea
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosedPullRequestLinks {
     pub comments: Link,
@@ -60931,7 +64924,7 @@ impl From<&PullRequestClosedPullRequestLinks> for PullRequestClosedPullRequestLi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestClosedPullRequestRequestedReviewersItem {
     User(User),
@@ -60967,7 +64960,18 @@ impl From<Team> for PullRequestClosedPullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestClosedPullRequestState {
     #[serde(rename = "closed")]
     Closed,
@@ -61097,7 +65101,7 @@ impl std::convert::TryFrom<String> for PullRequestClosedPullRequestState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraft {
     pub action: PullRequestConvertedToDraftAction,
@@ -61129,7 +65133,18 @@ impl From<&PullRequestConvertedToDraft> for PullRequestConvertedToDraft {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestConvertedToDraftAction {
     #[serde(rename = "converted_to_draft")]
     ConvertedToDraft,
@@ -61222,7 +65237,7 @@ impl std::convert::TryFrom<String> for PullRequestConvertedToDraftAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraftPullRequest {
     pub active_lock_reason: Option<PullRequestConvertedToDraftPullRequestActiveLockReason>,
@@ -61300,7 +65315,18 @@ impl From<&PullRequestConvertedToDraftPullRequest> for PullRequestConvertedToDra
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestConvertedToDraftPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -61393,7 +65419,7 @@ impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestAct
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraftPullRequestBase {
     pub label: String,
@@ -61445,7 +65471,7 @@ impl From<&PullRequestConvertedToDraftPullRequestBase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraftPullRequestHead {
     pub label: String,
@@ -61509,7 +65535,7 @@ impl From<&PullRequestConvertedToDraftPullRequestHead>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraftPullRequestLinks {
     pub comments: Link,
@@ -61546,7 +65572,7 @@ impl From<&PullRequestConvertedToDraftPullRequestLinks>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
     User(User),
@@ -61584,7 +65610,18 @@ impl From<Team> for PullRequestConvertedToDraftPullRequestRequestedReviewersItem
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestConvertedToDraftPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -61715,7 +65752,7 @@ impl std::convert::TryFrom<String> for PullRequestConvertedToDraftPullRequestSta
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEdited {
     pub action: PullRequestEditedAction,
@@ -61748,7 +65785,18 @@ impl From<&PullRequestEdited> for PullRequestEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -61832,7 +65880,7 @@ impl std::convert::TryFrom<String> for PullRequestEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61865,7 +65913,7 @@ impl From<&PullRequestEditedChanges> for PullRequestEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
@@ -61896,7 +65944,7 @@ impl From<&PullRequestEditedChangesBody> for PullRequestEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
@@ -61969,7 +66017,7 @@ impl From<&PullRequestEditedChangesTitle> for PullRequestEditedChangesTitle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestEvent {
     Assigned(PullRequestAssigned),
@@ -62115,7 +66163,7 @@ impl From<PullRequestUnlocked> for PullRequestEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestHead {
     pub label: String,
@@ -62181,7 +66229,7 @@ impl From<&PullRequestHead> for PullRequestHead {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLabeled {
     pub action: PullRequestLabeledAction,
@@ -62214,7 +66262,18 @@ impl From<&PullRequestLabeled> for PullRequestLabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
@@ -62305,7 +66364,7 @@ impl std::convert::TryFrom<String> for PullRequestLabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLinks {
     pub comments: Link,
@@ -62370,7 +66429,7 @@ impl From<&PullRequestLinks> for PullRequestLinks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLocked {
     pub action: PullRequestLockedAction,
@@ -62402,7 +66461,18 @@ impl From<&PullRequestLocked> for PullRequestLocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestLockedAction {
     #[serde(rename = "locked")]
     Locked,
@@ -62532,7 +66602,7 @@ impl std::convert::TryFrom<String> for PullRequestLockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpened {
     pub action: PullRequestOpenedAction,
@@ -62564,7 +66634,18 @@ impl From<&PullRequestOpened> for PullRequestOpened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestOpenedAction {
     #[serde(rename = "opened")]
     Opened,
@@ -62657,7 +66738,7 @@ impl std::convert::TryFrom<String> for PullRequestOpenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpenedPullRequest {
     pub active_lock_reason: PullRequestOpenedPullRequestActiveLockReason,
@@ -62732,7 +66813,7 @@ impl From<&PullRequestOpenedPullRequest> for PullRequestOpenedPullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, serde :: Serialize)]
 pub struct PullRequestOpenedPullRequestActiveLockReason(());
 impl std::ops::Deref for PullRequestOpenedPullRequestActiveLockReason {
     type Target = ();
@@ -62806,7 +66887,7 @@ impl<'de> serde::Deserialize<'de> for PullRequestOpenedPullRequestActiveLockReas
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpenedPullRequestBase {
     pub label: String,
@@ -62856,7 +66937,7 @@ impl From<&PullRequestOpenedPullRequestBase> for PullRequestOpenedPullRequestBas
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpenedPullRequestHead {
     pub label: String,
@@ -62918,7 +66999,7 @@ impl From<&PullRequestOpenedPullRequestHead> for PullRequestOpenedPullRequestHea
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpenedPullRequestLinks {
     pub comments: Link,
@@ -62953,7 +67034,7 @@ impl From<&PullRequestOpenedPullRequestLinks> for PullRequestOpenedPullRequestLi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestOpenedPullRequestRequestedReviewersItem {
     User(User),
@@ -62989,7 +67070,18 @@ impl From<Team> for PullRequestOpenedPullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestOpenedPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -63123,7 +67215,7 @@ impl std::convert::TryFrom<String> for PullRequestOpenedPullRequestState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReview {
     pub action: PullRequestReadyForReviewAction,
@@ -63155,7 +67247,18 @@ impl From<&PullRequestReadyForReview> for PullRequestReadyForReview {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReadyForReviewAction {
     #[serde(rename = "ready_for_review")]
     ReadyForReview,
@@ -63252,7 +67355,7 @@ impl std::convert::TryFrom<String> for PullRequestReadyForReviewAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReviewPullRequest {
     pub active_lock_reason: Option<PullRequestReadyForReviewPullRequestActiveLockReason>,
@@ -63329,7 +67432,18 @@ impl From<&PullRequestReadyForReviewPullRequest> for PullRequestReadyForReviewPu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReadyForReviewPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -63422,7 +67536,7 @@ impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestActiv
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReviewPullRequestBase {
     pub label: String,
@@ -63472,7 +67586,7 @@ impl From<&PullRequestReadyForReviewPullRequestBase> for PullRequestReadyForRevi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReviewPullRequestHead {
     pub label: String,
@@ -63534,7 +67648,7 @@ impl From<&PullRequestReadyForReviewPullRequestHead> for PullRequestReadyForRevi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReviewPullRequestLinks {
     pub comments: Link,
@@ -63571,7 +67685,7 @@ impl From<&PullRequestReadyForReviewPullRequestLinks>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReadyForReviewPullRequestRequestedReviewersItem {
     User(User),
@@ -63607,7 +67721,18 @@ impl From<Team> for PullRequestReadyForReviewPullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReadyForReviewPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -63739,7 +67864,7 @@ impl std::convert::TryFrom<String> for PullRequestReadyForReviewPullRequestState
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopened {
     pub action: PullRequestReopenedAction,
@@ -63771,7 +67896,18 @@ impl From<&PullRequestReopened> for PullRequestReopened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
@@ -63864,7 +68000,7 @@ impl std::convert::TryFrom<String> for PullRequestReopenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopenedPullRequest {
     pub active_lock_reason: Option<PullRequestReopenedPullRequestActiveLockReason>,
@@ -63942,7 +68078,18 @@ impl From<&PullRequestReopenedPullRequest> for PullRequestReopenedPullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReopenedPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -64035,7 +68182,7 @@ impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestActiveLockR
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopenedPullRequestBase {
     pub label: String,
@@ -64085,7 +68232,7 @@ impl From<&PullRequestReopenedPullRequestBase> for PullRequestReopenedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopenedPullRequestHead {
     pub label: String,
@@ -64147,7 +68294,7 @@ impl From<&PullRequestReopenedPullRequestHead> for PullRequestReopenedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopenedPullRequestLinks {
     pub comments: Link,
@@ -64182,7 +68329,7 @@ impl From<&PullRequestReopenedPullRequestLinks> for PullRequestReopenedPullReque
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReopenedPullRequestRequestedReviewersItem {
     User(User),
@@ -64218,7 +68365,18 @@ impl From<Team> for PullRequestReopenedPullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReopenedPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -64279,7 +68437,7 @@ impl std::convert::TryFrom<String> for PullRequestReopenedPullRequestState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestRequestedReviewersItem {
     User(User),
@@ -64484,7 +68642,7 @@ impl From<Team> for PullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewComment {
     pub author_association: AuthorAssociation,
@@ -64886,7 +69044,7 @@ impl From<&PullRequestReviewComment> for PullRequestReviewComment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreated {
     pub action: PullRequestReviewCommentCreatedAction,
@@ -64917,7 +69075,18 @@ impl From<&PullRequestReviewCommentCreated> for PullRequestReviewCommentCreated 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -65271,7 +69440,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
@@ -65337,7 +69506,18 @@ impl From<&PullRequestReviewCommentCreatedPullRequest>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -65430,7 +69610,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestBase {
     pub label: String,
@@ -65482,7 +69662,7 @@ impl From<&PullRequestReviewCommentCreatedPullRequestBase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestHead {
     pub label: String,
@@ -65546,7 +69726,7 @@ impl From<&PullRequestReviewCommentCreatedPullRequestHead>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequestLinks {
     pub comments: Link,
@@ -65583,7 +69763,7 @@ impl From<&PullRequestReviewCommentCreatedPullRequestLinks>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
     User(User),
@@ -65620,7 +69800,18 @@ impl From<Team> for PullRequestReviewCommentCreatedPullRequestRequestedReviewers
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentCreatedPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -66016,7 +70207,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentCreatedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeleted {
     pub action: PullRequestReviewCommentDeletedAction,
@@ -66047,7 +70238,18 @@ impl From<&PullRequestReviewCommentDeleted> for PullRequestReviewCommentDeleted 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -66401,7 +70603,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
@@ -66467,7 +70669,18 @@ impl From<&PullRequestReviewCommentDeletedPullRequest>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -66560,7 +70773,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestBase {
     pub label: String,
@@ -66612,7 +70825,7 @@ impl From<&PullRequestReviewCommentDeletedPullRequestBase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestHead {
     pub label: String,
@@ -66676,7 +70889,7 @@ impl From<&PullRequestReviewCommentDeletedPullRequestHead>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequestLinks {
     pub comments: Link,
@@ -66713,7 +70926,7 @@ impl From<&PullRequestReviewCommentDeletedPullRequestLinks>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
     User(User),
@@ -66750,7 +70963,18 @@ impl From<Team> for PullRequestReviewCommentDeletedPullRequestRequestedReviewers
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentDeletedPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -67167,7 +71391,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentDeletedPullReques
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEdited {
     pub action: PullRequestReviewCommentEditedAction,
@@ -67199,7 +71423,18 @@ impl From<&PullRequestReviewCommentEdited> for PullRequestReviewCommentEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -67270,7 +71505,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -67301,7 +71536,7 @@ impl From<&PullRequestReviewCommentEditedChanges> for PullRequestReviewCommentEd
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
@@ -67624,7 +71859,7 @@ impl From<&PullRequestReviewCommentEditedChangesBody>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequest {
     pub active_lock_reason: Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
@@ -67690,7 +71925,18 @@ impl From<&PullRequestReviewCommentEditedPullRequest>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentEditedPullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -67783,7 +72029,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedPullRequest
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestBase {
     pub label: String,
@@ -67835,7 +72081,7 @@ impl From<&PullRequestReviewCommentEditedPullRequestBase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestHead {
     pub label: String,
@@ -67899,7 +72145,7 @@ impl From<&PullRequestReviewCommentEditedPullRequestHead>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequestLinks {
     pub comments: Link,
@@ -67936,7 +72182,7 @@ impl From<&PullRequestReviewCommentEditedPullRequestLinks>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
     User(User),
@@ -67973,7 +72219,18 @@ impl From<Team> for PullRequestReviewCommentEditedPullRequestRequestedReviewersI
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentEditedPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -68043,7 +72300,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentEditedPullRequest
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReviewCommentEvent {
     Created(PullRequestReviewCommentCreated),
@@ -68097,7 +72354,7 @@ impl From<PullRequestReviewCommentEdited> for PullRequestReviewCommentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentLinks {
     pub html: Link,
@@ -68125,7 +72382,18 @@ impl From<&PullRequestReviewCommentLinks> for PullRequestReviewCommentLinks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentSide {
     #[serde(rename = "LEFT")]
     Left,
@@ -68189,7 +72457,18 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentSide {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewCommentStartSide {
     #[serde(rename = "LEFT")]
     Left,
@@ -68358,7 +72637,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewCommentStartSide {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissed {
     pub action: PullRequestReviewDismissedAction,
@@ -68389,7 +72668,18 @@ impl From<&PullRequestReviewDismissed> for PullRequestReviewDismissed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewDismissedAction {
     #[serde(rename = "dismissed")]
     Dismissed,
@@ -68518,7 +72808,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewDismissedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissedReview {
     pub author_association: AuthorAssociation,
@@ -68565,7 +72855,7 @@ impl From<&PullRequestReviewDismissedReview> for PullRequestReviewDismissedRevie
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissedReviewLinks {
     pub html: Link,
@@ -68589,7 +72879,18 @@ impl From<&PullRequestReviewDismissedReviewLinks> for PullRequestReviewDismissed
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewDismissedReviewState {
     #[serde(rename = "dismissed")]
     Dismissed,
@@ -68771,7 +73072,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewDismissedReviewState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEdited {
     pub action: PullRequestReviewEditedAction,
@@ -68803,7 +73104,18 @@ impl From<&PullRequestReviewEdited> for PullRequestReviewEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -68873,7 +73185,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -68904,7 +73216,7 @@ impl From<&PullRequestReviewEditedChanges> for PullRequestReviewEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
@@ -68997,7 +73309,7 @@ impl From<&PullRequestReviewEditedChangesBody> for PullRequestReviewEditedChange
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedReview {
     pub author_association: AuthorAssociation,
@@ -69044,7 +73356,7 @@ impl From<&PullRequestReviewEditedReview> for PullRequestReviewEditedReview {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedReviewLinks {
     pub html: Link,
@@ -69075,7 +73387,7 @@ impl From<&PullRequestReviewEditedReviewLinks> for PullRequestReviewEditedReview
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PullRequestReviewEvent {
     Dismissed(PullRequestReviewDismissed),
@@ -69199,7 +73511,7 @@ impl From<PullRequestReviewSubmitted> for PullRequestReviewEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PullRequestReviewRequestRemoved {
     Variant0 {
@@ -69247,7 +73559,18 @@ impl From<&PullRequestReviewRequestRemoved> for PullRequestReviewRequestRemoved 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewRequestRemovedVariant0Action {
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
@@ -69306,7 +73629,18 @@ impl std::convert::TryFrom<String> for PullRequestReviewRequestRemovedVariant0Ac
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewRequestRemovedVariant1Action {
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
@@ -69449,7 +73783,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewRequestRemovedVariant1Ac
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PullRequestReviewRequested {
     Variant0 {
@@ -69497,7 +73831,18 @@ impl From<&PullRequestReviewRequested> for PullRequestReviewRequested {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewRequestedVariant0Action {
     #[serde(rename = "review_requested")]
     ReviewRequested,
@@ -69554,7 +73899,18 @@ impl std::convert::TryFrom<String> for PullRequestReviewRequestedVariant0Action 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewRequestedVariant1Action {
     #[serde(rename = "review_requested")]
     ReviewRequested,
@@ -69716,7 +74072,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewRequestedVariant1Action 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmitted {
     pub action: PullRequestReviewSubmittedAction,
@@ -69747,7 +74103,18 @@ impl From<&PullRequestReviewSubmitted> for PullRequestReviewSubmitted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestReviewSubmittedAction {
     #[serde(rename = "submitted")]
     Submitted,
@@ -69873,7 +74240,7 @@ impl std::convert::TryFrom<String> for PullRequestReviewSubmittedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmittedReview {
     pub author_association: AuthorAssociation,
@@ -69920,7 +74287,7 @@ impl From<&PullRequestReviewSubmittedReview> for PullRequestReviewSubmittedRevie
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmittedReviewLinks {
     pub html: Link,
@@ -69946,7 +74313,18 @@ impl From<&PullRequestReviewSubmittedReviewLinks> for PullRequestReviewSubmitted
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -70049,7 +74427,7 @@ impl std::convert::TryFrom<String> for PullRequestState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestSynchronize {
     pub action: PullRequestSynchronizeAction,
@@ -70083,7 +74461,18 @@ impl From<&PullRequestSynchronize> for PullRequestSynchronize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestSynchronizeAction {
     #[serde(rename = "synchronize")]
     Synchronize,
@@ -70178,7 +74567,7 @@ impl std::convert::TryFrom<String> for PullRequestSynchronizeAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnassigned {
     pub action: PullRequestUnassignedAction,
@@ -70211,7 +74600,18 @@ impl From<&PullRequestUnassigned> for PullRequestUnassigned {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestUnassignedAction {
     #[serde(rename = "unassigned")]
     Unassigned,
@@ -70306,7 +74706,7 @@ impl std::convert::TryFrom<String> for PullRequestUnassignedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlabeled {
     pub action: PullRequestUnlabeledAction,
@@ -70339,7 +74739,18 @@ impl From<&PullRequestUnlabeled> for PullRequestUnlabeled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
@@ -70430,7 +74841,7 @@ impl std::convert::TryFrom<String> for PullRequestUnlabeledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlocked {
     pub action: PullRequestUnlockedAction,
@@ -70462,7 +74873,18 @@ impl From<&PullRequestUnlocked> for PullRequestUnlocked {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PullRequestUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
@@ -70598,7 +75020,7 @@ impl std::convert::TryFrom<String> for PullRequestUnlockedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PushEvent {
     #[doc = "The SHA of the most recent commit on `ref` after the push."]
@@ -70746,7 +75168,7 @@ impl From<&PushEvent> for PushEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Release {
     pub assets: Vec<ReleaseAsset>,
@@ -70858,7 +75280,7 @@ impl From<&Release> for Release {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseAsset {
     pub browser_download_url: String,
@@ -70897,7 +75319,18 @@ impl From<&ReleaseAsset> for ReleaseAsset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseAssetState {
     #[serde(rename = "uploaded")]
     Uploaded,
@@ -70983,7 +75416,7 @@ impl std::convert::TryFrom<String> for ReleaseAssetState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseCreated {
     pub action: ReleaseCreatedAction,
@@ -71013,7 +75446,18 @@ impl From<&ReleaseCreated> for ReleaseCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -71099,7 +75543,7 @@ impl std::convert::TryFrom<String> for ReleaseCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseDeleted {
     pub action: ReleaseDeletedAction,
@@ -71129,7 +75573,18 @@ impl From<&ReleaseDeleted> for ReleaseDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -71248,7 +75703,7 @@ impl std::convert::TryFrom<String> for ReleaseDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEdited {
     pub action: ReleaseEditedAction,
@@ -71279,7 +75734,18 @@ impl From<&ReleaseEdited> for ReleaseEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -71362,7 +75828,7 @@ impl std::convert::TryFrom<String> for ReleaseEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -71395,7 +75861,7 @@ impl From<&ReleaseEditedChanges> for ReleaseEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
@@ -71426,7 +75892,7 @@ impl From<&ReleaseEditedChangesBody> for ReleaseEditedChangesBody {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
@@ -71469,7 +75935,7 @@ impl From<&ReleaseEditedChangesName> for ReleaseEditedChangesName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ReleaseEvent {
     Created(ReleaseCreated),
@@ -71582,7 +76048,7 @@ impl From<ReleaseUnpublished> for ReleaseEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePrereleased {
     pub action: ReleasePrereleasedAction,
@@ -71612,7 +76078,18 @@ impl From<&ReleasePrereleased> for ReleasePrereleased {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleasePrereleasedAction {
     #[serde(rename = "prereleased")]
     Prereleased,
@@ -71686,7 +76163,7 @@ impl std::convert::TryFrom<String> for ReleasePrereleasedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePrereleasedRelease {
     pub assets: Vec<ReleaseAsset>,
@@ -71775,7 +76252,7 @@ impl From<&ReleasePrereleasedRelease> for ReleasePrereleasedRelease {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePublished {
     pub action: ReleasePublishedAction,
@@ -71805,7 +76282,18 @@ impl From<&ReleasePublished> for ReleasePublished {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleasePublishedAction {
     #[serde(rename = "published")]
     Published,
@@ -71876,7 +76364,7 @@ impl std::convert::TryFrom<String> for ReleasePublishedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleasePublishedRelease {
     pub assets: Vec<ReleaseAsset>,
@@ -71949,7 +76437,7 @@ impl From<&ReleasePublishedRelease> for ReleasePublishedRelease {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseReleased {
     pub action: ReleaseReleasedAction,
@@ -71979,7 +76467,18 @@ impl From<&ReleaseReleased> for ReleaseReleased {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseReleasedAction {
     #[serde(rename = "released")]
     Released,
@@ -72081,7 +76580,7 @@ impl std::convert::TryFrom<String> for ReleaseReleasedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseUnpublished {
     pub action: ReleaseUnpublishedAction,
@@ -72111,7 +76610,18 @@ impl From<&ReleaseUnpublished> for ReleaseUnpublished {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ReleaseUnpublishedAction {
     #[serde(rename = "unpublished")]
     Unpublished,
@@ -72181,7 +76691,7 @@ impl std::convert::TryFrom<String> for ReleaseUnpublishedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseUnpublishedRelease {
     pub assets: Vec<ReleaseAsset>,
@@ -72242,7 +76752,7 @@ impl From<&ReleaseUnpublishedRelease> for ReleaseUnpublishedRelease {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepoRef {
     pub id: i64,
@@ -72726,7 +77236,7 @@ impl From<&RepoRef> for RepoRef {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Repository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -72906,7 +77416,7 @@ impl From<&Repository> for Repository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchived {
     pub action: RepositoryArchivedAction,
@@ -72935,7 +77445,18 @@ impl From<&RepositoryArchived> for RepositoryArchived {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryArchivedAction {
     #[serde(rename = "archived")]
     Archived,
@@ -73010,7 +77531,7 @@ impl std::convert::TryFrom<String> for RepositoryArchivedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchivedRepository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -73148,7 +77669,7 @@ impl From<&RepositoryArchivedRepository> for RepositoryArchivedRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryArchivedRepositoryCreatedAt {
     Variant0(i64),
@@ -73240,7 +77761,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryArchivedRepositor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchivedRepositoryPermissions {
     pub admin: bool,
@@ -73277,7 +77798,7 @@ impl From<&RepositoryArchivedRepositoryPermissions> for RepositoryArchivedReposi
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryArchivedRepositoryPushedAt {
     Variant0(i64),
@@ -73337,7 +77858,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryArchivedRepositor
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryCreated {
     pub action: RepositoryCreatedAction,
@@ -73366,7 +77887,18 @@ impl From<&RepositoryCreated> for RepositoryCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -73428,7 +77960,7 @@ impl std::convert::TryFrom<String> for RepositoryCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryCreatedAt {
     Variant0(i64),
@@ -73525,7 +78057,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryCreatedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDeleted {
     pub action: RepositoryDeletedAction,
@@ -73554,7 +78086,18 @@ impl From<&RepositoryDeleted> for RepositoryDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -73612,7 +78155,7 @@ impl std::convert::TryFrom<String> for RepositoryDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct RepositoryDispatchEvent(pub RepositoryDispatchOnDemandTest);
 impl std::ops::Deref for RepositoryDispatchEvent {
     type Target = RepositoryDispatchOnDemandTest;
@@ -73683,7 +78226,7 @@ impl From<RepositoryDispatchOnDemandTest> for RepositoryDispatchEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDispatchOnDemandTest {
     pub action: RepositoryDispatchOnDemandTestAction,
@@ -73713,7 +78256,18 @@ impl From<&RepositoryDispatchOnDemandTest> for RepositoryDispatchOnDemandTest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryDispatchOnDemandTestAction {
     #[serde(rename = "on-demand-test")]
     OnDemandTest,
@@ -73844,7 +78398,7 @@ impl std::convert::TryFrom<String> for RepositoryDispatchOnDemandTestAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEdited {
     pub action: RepositoryEditedAction,
@@ -73874,7 +78428,18 @@ impl From<&RepositoryEdited> for RepositoryEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -73973,7 +78538,7 @@ impl std::convert::TryFrom<String> for RepositoryEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74007,7 +78572,7 @@ impl From<&RepositoryEditedChanges> for RepositoryEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDefaultBranch {
     pub from: String,
@@ -74039,7 +78604,7 @@ impl From<&RepositoryEditedChangesDefaultBranch> for RepositoryEditedChangesDefa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDescription {
     pub from: Option<String>,
@@ -74071,7 +78636,7 @@ impl From<&RepositoryEditedChangesDescription> for RepositoryEditedChangesDescri
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesHomepage {
     pub from: Option<String>,
@@ -74119,7 +78684,7 @@ impl From<&RepositoryEditedChangesHomepage> for RepositoryEditedChangesHomepage 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryEvent {
     Archived(RepositoryArchived),
@@ -74222,7 +78787,7 @@ impl From<RepositoryUnarchived> for RepositoryEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryImportEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74253,7 +78818,18 @@ impl From<&RepositoryImportEvent> for RepositoryImportEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryImportEventStatus {
     #[serde(rename = "success")]
     Success,
@@ -74550,7 +79126,7 @@ impl std::convert::TryFrom<String> for RepositoryImportEventStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryLite {
     pub archive_url: String,
@@ -74641,7 +79217,7 @@ impl From<&RepositoryLite> for RepositoryLite {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPermissions {
     pub admin: bool,
@@ -74715,7 +79291,7 @@ impl From<&RepositoryPermissions> for RepositoryPermissions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatized {
     pub action: RepositoryPrivatizedAction,
@@ -74744,7 +79320,18 @@ impl From<&RepositoryPrivatized> for RepositoryPrivatized {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryPrivatizedAction {
     #[serde(rename = "privatized")]
     Privatized,
@@ -74818,7 +79405,7 @@ impl std::convert::TryFrom<String> for RepositoryPrivatizedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatizedRepository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -74956,7 +79543,7 @@ impl From<&RepositoryPrivatizedRepository> for RepositoryPrivatizedRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryPrivatizedRepositoryCreatedAt {
     Variant0(i64),
@@ -75048,7 +79635,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPrivatizedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatizedRepositoryPermissions {
     pub admin: bool,
@@ -75087,7 +79674,7 @@ impl From<&RepositoryPrivatizedRepositoryPermissions>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryPrivatizedRepositoryPushedAt {
     Variant0(i64),
@@ -75167,7 +79754,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPrivatizedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicized {
     pub action: RepositoryPublicizedAction,
@@ -75196,7 +79783,18 @@ impl From<&RepositoryPublicized> for RepositoryPublicized {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryPublicizedAction {
     #[serde(rename = "publicized")]
     Publicized,
@@ -75270,7 +79868,7 @@ impl std::convert::TryFrom<String> for RepositoryPublicizedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicizedRepository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -75408,7 +80006,7 @@ impl From<&RepositoryPublicizedRepository> for RepositoryPublicizedRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryPublicizedRepositoryCreatedAt {
     Variant0(i64),
@@ -75500,7 +80098,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPublicizedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicizedRepositoryPermissions {
     pub admin: bool,
@@ -75539,7 +80137,7 @@ impl From<&RepositoryPublicizedRepositoryPermissions>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryPublicizedRepositoryPushedAt {
     Variant0(i64),
@@ -75582,7 +80180,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPublicizedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryPushedAt {
     Variant0(i64),
@@ -75673,7 +80271,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryPushedAt {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamed {
     pub action: RepositoryRenamedAction,
@@ -75703,7 +80301,18 @@ impl From<&RepositoryRenamed> for RepositoryRenamed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryRenamedAction {
     #[serde(rename = "renamed")]
     Renamed,
@@ -75784,7 +80393,7 @@ impl std::convert::TryFrom<String> for RepositoryRenamedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChanges {
     pub repository: RepositoryRenamedChangesRepository,
@@ -75822,7 +80431,7 @@ impl From<&RepositoryRenamedChanges> for RepositoryRenamedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChangesRepository {
     pub name: RepositoryRenamedChangesRepositoryName,
@@ -75851,7 +80460,7 @@ impl From<&RepositoryRenamedChangesRepository> for RepositoryRenamedChangesRepos
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChangesRepositoryName {
     pub from: String,
@@ -75927,7 +80536,7 @@ impl From<&RepositoryRenamedChangesRepositoryName> for RepositoryRenamedChangesR
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferred {
     pub action: RepositoryTransferredAction,
@@ -75957,7 +80566,18 @@ impl From<&RepositoryTransferred> for RepositoryTransferred {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
@@ -76035,7 +80655,7 @@ impl std::convert::TryFrom<String> for RepositoryTransferredAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChanges {
     pub owner: RepositoryTransferredChangesOwner,
@@ -76070,7 +80690,7 @@ impl From<&RepositoryTransferredChanges> for RepositoryTransferredChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwner {
     pub from: RepositoryTransferredChangesOwnerFrom,
@@ -76096,7 +80716,7 @@ impl From<&RepositoryTransferredChangesOwner> for RepositoryTransferredChangesOw
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwnerFrom {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -76166,7 +80786,7 @@ impl From<&RepositoryTransferredChangesOwnerFrom> for RepositoryTransferredChang
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchived {
     pub action: RepositoryUnarchivedAction,
@@ -76195,7 +80815,18 @@ impl From<&RepositoryUnarchived> for RepositoryUnarchived {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryUnarchivedAction {
     #[serde(rename = "unarchived")]
     Unarchived,
@@ -76270,7 +80901,7 @@ impl std::convert::TryFrom<String> for RepositoryUnarchivedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchivedRepository {
     #[doc = "Whether to allow auto-merge for pull requests."]
@@ -76408,7 +81039,7 @@ impl From<&RepositoryUnarchivedRepository> for RepositoryUnarchivedRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryUnarchivedRepositoryCreatedAt {
     Variant0(i64),
@@ -76500,7 +81131,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryUnarchivedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchivedRepositoryPermissions {
     pub admin: bool,
@@ -76539,7 +81170,7 @@ impl From<&RepositoryUnarchivedRepositoryPermissions>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryUnarchivedRepositoryPushedAt {
     Variant0(i64),
@@ -76649,7 +81280,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for RepositoryUnarchivedReposit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertCreate {
     pub action: RepositoryVulnerabilityAlertCreateAction,
@@ -76677,7 +81308,18 @@ impl From<&RepositoryVulnerabilityAlertCreate> for RepositoryVulnerabilityAlertC
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryVulnerabilityAlertCreateAction {
     #[serde(rename = "create")]
     Create,
@@ -76780,7 +81422,7 @@ impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertCreateAction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertCreateAlert {
     pub affected_package_name: String,
@@ -76898,7 +81540,7 @@ impl From<&RepositoryVulnerabilityAlertCreateAlert> for RepositoryVulnerabilityA
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertDismiss {
     pub action: RepositoryVulnerabilityAlertDismissAction,
@@ -76926,7 +81568,18 @@ impl From<&RepositoryVulnerabilityAlertDismiss> for RepositoryVulnerabilityAlert
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryVulnerabilityAlertDismissAction {
     #[serde(rename = "dismiss")]
     Dismiss,
@@ -77034,7 +81687,7 @@ impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertDismissAction
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertDismissAlert {
     pub affected_package_name: String,
@@ -77078,7 +81731,7 @@ impl From<&RepositoryVulnerabilityAlertDismissAlert> for RepositoryVulnerability
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RepositoryVulnerabilityAlertEvent {
     Create(RepositoryVulnerabilityAlertCreate),
@@ -77193,7 +81846,7 @@ impl From<RepositoryVulnerabilityAlertResolve> for RepositoryVulnerabilityAlertE
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertResolve {
     pub action: RepositoryVulnerabilityAlertResolveAction,
@@ -77221,7 +81874,18 @@ impl From<&RepositoryVulnerabilityAlertResolve> for RepositoryVulnerabilityAlert
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RepositoryVulnerabilityAlertResolveAction {
     #[serde(rename = "resolve")]
     Resolve,
@@ -77326,7 +81990,7 @@ impl std::convert::TryFrom<String> for RepositoryVulnerabilityAlertResolveAction
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryVulnerabilityAlertResolveAlert {
     pub affected_package_name: String,
@@ -77417,7 +82081,7 @@ impl From<&RepositoryVulnerabilityAlertResolveAlert> for RepositoryVulnerability
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertCreated {
     pub action: SecretScanningAlertCreatedAction,
@@ -77446,7 +82110,18 @@ impl From<&SecretScanningAlertCreated> for SecretScanningAlertCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecretScanningAlertCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -77526,7 +82201,7 @@ impl std::convert::TryFrom<String> for SecretScanningAlertCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertCreatedAlert {
     pub number: i64,
@@ -77560,7 +82235,7 @@ impl From<&SecretScanningAlertCreatedAlert> for SecretScanningAlertCreatedAlert 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SecretScanningAlertEvent {
     Created(SecretScanningAlertCreated),
@@ -77655,7 +82330,7 @@ impl From<SecretScanningAlertResolved> for SecretScanningAlertEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertReopened {
     pub action: SecretScanningAlertReopenedAction,
@@ -77685,7 +82360,18 @@ impl From<&SecretScanningAlertReopened> for SecretScanningAlertReopened {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecretScanningAlertReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
@@ -77765,7 +82451,7 @@ impl std::convert::TryFrom<String> for SecretScanningAlertReopenedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertReopenedAlert {
     pub number: i64,
@@ -77853,7 +82539,7 @@ impl From<&SecretScanningAlertReopenedAlert> for SecretScanningAlertReopenedAler
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertResolved {
     pub action: SecretScanningAlertResolvedAction,
@@ -77883,7 +82569,18 @@ impl From<&SecretScanningAlertResolved> for SecretScanningAlertResolved {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecretScanningAlertResolvedAction {
     #[serde(rename = "resolved")]
     Resolved,
@@ -77969,7 +82666,7 @@ impl std::convert::TryFrom<String> for SecretScanningAlertResolvedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretScanningAlertResolvedAlert {
     pub number: i64,
@@ -77999,7 +82696,18 @@ impl From<&SecretScanningAlertResolvedAlert> for SecretScanningAlertResolvedAler
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecretScanningAlertResolvedAlertResolution {
     #[serde(rename = "false_positive")]
     FalsePositive,
@@ -78080,7 +82788,7 @@ impl std::convert::TryFrom<String> for SecretScanningAlertResolvedAlertResolutio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SecurityAdvisoryEvent {
     Performed(SecurityAdvisoryPerformed),
@@ -78308,7 +83016,7 @@ impl From<SecurityAdvisoryWithdrawn> for SecurityAdvisoryEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformed {
     pub action: SecurityAdvisoryPerformedAction,
@@ -78332,7 +83040,18 @@ impl From<&SecurityAdvisoryPerformed> for SecurityAdvisoryPerformed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecurityAdvisoryPerformedAction {
     #[serde(rename = "performed")]
     Performed,
@@ -78553,7 +83272,7 @@ impl std::convert::TryFrom<String> for SecurityAdvisoryPerformedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisory {
     pub cvss: SecurityAdvisoryPerformedSecurityAdvisoryCvss,
@@ -78602,7 +83321,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisory>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCvss {
     pub score: f64,
@@ -78638,7 +83357,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryCvss>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
@@ -78674,7 +83393,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryCwesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
@@ -78708,7 +83427,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem {
     pub url: String,
@@ -78776,7 +83495,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -78811,7 +83530,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
@@ -78848,7 +83567,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
@@ -79056,7 +83775,7 @@ impl From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublished {
     pub action: SecurityAdvisoryPublishedAction,
@@ -79080,7 +83799,18 @@ impl From<&SecurityAdvisoryPublished> for SecurityAdvisoryPublished {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecurityAdvisoryPublishedAction {
     #[serde(rename = "published")]
     Published,
@@ -79301,7 +84031,7 @@ impl std::convert::TryFrom<String> for SecurityAdvisoryPublishedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisory {
     pub cvss: SecurityAdvisoryPublishedSecurityAdvisoryCvss,
@@ -79350,7 +84080,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisory>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCvss {
     pub score: f64,
@@ -79386,7 +84116,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryCvss>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
@@ -79422,7 +84152,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryCwesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
@@ -79456,7 +84186,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem {
     pub url: String,
@@ -79524,7 +84254,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -79559,7 +84289,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
@@ -79596,7 +84326,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
@@ -79804,7 +84534,7 @@ impl From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdated {
     pub action: SecurityAdvisoryUpdatedAction,
@@ -79828,7 +84558,18 @@ impl From<&SecurityAdvisoryUpdated> for SecurityAdvisoryUpdated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecurityAdvisoryUpdatedAction {
     #[serde(rename = "updated")]
     Updated,
@@ -80049,7 +84790,7 @@ impl std::convert::TryFrom<String> for SecurityAdvisoryUpdatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
     pub cvss: SecurityAdvisoryUpdatedSecurityAdvisoryCvss,
@@ -80096,7 +84837,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisory> for SecurityAdvisoryUpdatedS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCvss {
     pub score: f64,
@@ -80132,7 +84873,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryCvss>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem {
     pub cwe_id: String,
@@ -80168,7 +84909,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
@@ -80202,7 +84943,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem {
     pub url: String,
@@ -80270,7 +85011,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -80305,7 +85046,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
@@ -80342,7 +85083,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatche
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
@@ -80547,7 +85288,7 @@ impl From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawn {
     pub action: SecurityAdvisoryWithdrawnAction,
@@ -80571,7 +85312,18 @@ impl From<&SecurityAdvisoryWithdrawn> for SecurityAdvisoryWithdrawn {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SecurityAdvisoryWithdrawnAction {
     #[serde(rename = "withdrawn")]
     Withdrawn,
@@ -80789,7 +85541,7 @@ impl std::convert::TryFrom<String> for SecurityAdvisoryWithdrawnAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
     pub cvss: SecurityAdvisoryWithdrawnSecurityAdvisoryCvss,
@@ -80838,7 +85590,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisory>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCvss {
     pub score: f64,
@@ -80874,7 +85626,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCvss>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem {
     pub cwe_id: String,
@@ -80910,7 +85662,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem {
     #[serde(rename = "type")]
@@ -80944,7 +85696,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem {
     pub url: String,
@@ -81012,7 +85764,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
     pub first_patched_version:
@@ -81047,7 +85799,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: String,
@@ -81084,7 +85836,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatc
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: String,
@@ -81411,7 +86163,7 @@ impl From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequest {
     pub active_lock_reason: Option<SimplePullRequestActiveLockReason>,
@@ -81473,7 +86225,18 @@ impl From<&SimplePullRequest> for SimplePullRequest {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SimplePullRequestActiveLockReason {
     #[serde(rename = "resolved")]
     Resolved,
@@ -81564,7 +86327,7 @@ impl std::convert::TryFrom<String> for SimplePullRequestActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestBase {
     pub label: String,
@@ -81614,7 +86377,7 @@ impl From<&SimplePullRequestBase> for SimplePullRequestBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestHead {
     pub label: String,
@@ -81676,7 +86439,7 @@ impl From<&SimplePullRequestHead> for SimplePullRequestHead {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequestLinks {
     pub comments: Link,
@@ -81711,7 +86474,7 @@ impl From<&SimplePullRequestLinks> for SimplePullRequestLinks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SimplePullRequestRequestedReviewersItem {
     User(User),
@@ -81746,7 +86509,18 @@ impl From<Team> for SimplePullRequestRequestedReviewersItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SimplePullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -81855,7 +86629,7 @@ impl std::convert::TryFrom<String> for SimplePullRequestState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCancelled {
     pub action: SponsorshipCancelledAction,
@@ -81880,7 +86654,18 @@ impl From<&SponsorshipCancelled> for SponsorshipCancelled {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipCancelledAction {
     #[serde(rename = "cancelled")]
     Cancelled,
@@ -81963,7 +86748,7 @@ impl std::convert::TryFrom<String> for SponsorshipCancelledAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCancelledSponsorship {
     pub created_at: String,
@@ -82039,7 +86824,7 @@ impl From<&SponsorshipCancelledSponsorship> for SponsorshipCancelledSponsorship 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCreated {
     pub action: SponsorshipCreatedAction,
@@ -82064,7 +86849,18 @@ impl From<&SponsorshipCreated> for SponsorshipCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -82147,7 +86943,7 @@ impl std::convert::TryFrom<String> for SponsorshipCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipCreatedSponsorship {
     pub created_at: String,
@@ -82243,7 +87039,7 @@ impl From<&SponsorshipCreatedSponsorship> for SponsorshipCreatedSponsorship {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEdited {
     pub action: SponsorshipEditedAction,
@@ -82269,7 +87065,18 @@ impl From<&SponsorshipEdited> for SponsorshipEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -82339,7 +87146,7 @@ impl std::convert::TryFrom<String> for SponsorshipEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -82370,7 +87177,7 @@ impl From<&SponsorshipEditedChanges> for SponsorshipEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChangesPrivacyLevel {
     #[doc = "The `edited` event types include the details about the change when someone edits a sponsorship to change the privacy."]
@@ -82420,7 +87227,7 @@ impl From<&SponsorshipEditedChangesPrivacyLevel> for SponsorshipEditedChangesPri
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedSponsorship {
     pub created_at: String,
@@ -82464,7 +87271,7 @@ impl From<&SponsorshipEditedSponsorship> for SponsorshipEditedSponsorship {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SponsorshipEvent {
     Cancelled(SponsorshipCancelled),
@@ -82574,7 +87381,7 @@ impl From<SponsorshipTierChanged> for SponsorshipEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingCancellation {
     pub action: SponsorshipPendingCancellationAction,
@@ -82602,7 +87409,18 @@ impl From<&SponsorshipPendingCancellation> for SponsorshipPendingCancellation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipPendingCancellationAction {
     #[serde(rename = "pending_cancellation")]
     PendingCancellation,
@@ -82685,7 +87503,7 @@ impl std::convert::TryFrom<String> for SponsorshipPendingCancellationAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingCancellationSponsorship {
     pub created_at: String,
@@ -82789,7 +87607,7 @@ impl From<&SponsorshipPendingCancellationSponsorship>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChange {
     pub action: SponsorshipPendingTierChangeAction,
@@ -82818,7 +87636,18 @@ impl From<&SponsorshipPendingTierChange> for SponsorshipPendingTierChange {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipPendingTierChangeAction {
     #[serde(rename = "pending_tier_change")]
     PendingTierChange,
@@ -82890,7 +87719,7 @@ impl std::convert::TryFrom<String> for SponsorshipPendingTierChangeAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeChanges {
     pub tier: SponsorshipPendingTierChangeChangesTier,
@@ -82919,7 +87748,7 @@ impl From<&SponsorshipPendingTierChangeChanges> for SponsorshipPendingTierChange
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeChangesTier {
     pub from: SponsorshipTier,
@@ -82968,7 +87797,7 @@ impl From<&SponsorshipPendingTierChangeChangesTier> for SponsorshipPendingTierCh
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeSponsorship {
     pub created_at: String,
@@ -83033,7 +87862,7 @@ impl From<&SponsorshipPendingTierChangeSponsorship> for SponsorshipPendingTierCh
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTier {
     pub created_at: String,
@@ -83133,7 +87962,7 @@ impl From<&SponsorshipTier> for SponsorshipTier {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChanged {
     pub action: SponsorshipTierChangedAction,
@@ -83159,7 +87988,18 @@ impl From<&SponsorshipTierChanged> for SponsorshipTierChanged {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SponsorshipTierChangedAction {
     #[serde(rename = "tier_changed")]
     TierChanged,
@@ -83231,7 +88071,7 @@ impl std::convert::TryFrom<String> for SponsorshipTierChangedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChanges {
     pub tier: SponsorshipTierChangedChangesTier,
@@ -83260,7 +88100,7 @@ impl From<&SponsorshipTierChangedChanges> for SponsorshipTierChangedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChangesTier {
     pub from: SponsorshipTier,
@@ -83309,7 +88149,7 @@ impl From<&SponsorshipTierChangedChangesTier> for SponsorshipTierChangedChangesT
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedSponsorship {
     pub created_at: String,
@@ -83367,7 +88207,7 @@ impl From<&SponsorshipTierChangedSponsorship> for SponsorshipTierChangedSponsors
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StarCreated {
     pub action: StarCreatedAction,
@@ -83398,7 +88238,18 @@ impl From<&StarCreated> for StarCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StarCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -83485,7 +88336,7 @@ impl std::convert::TryFrom<String> for StarCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StarDeleted {
     pub action: StarDeletedAction,
@@ -83516,7 +88367,18 @@ impl From<&StarDeleted> for StarDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StarDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -83577,7 +88439,7 @@ impl std::convert::TryFrom<String> for StarDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StarEvent {
     Created(StarCreated),
@@ -83934,7 +88796,7 @@ impl From<StarDeleted> for StarEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -84009,7 +88871,7 @@ impl From<&StatusEvent> for StatusEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventBranchesItem {
     pub commit: StatusEventBranchesItemCommit,
@@ -84045,7 +88907,7 @@ impl From<&StatusEventBranchesItem> for StatusEventBranchesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventBranchesItemCommit {
     pub sha: String,
@@ -84268,7 +89130,7 @@ impl From<&StatusEventBranchesItemCommit> for StatusEventBranchesItemCommit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommit {
     pub author: Option<User>,
@@ -84418,7 +89280,7 @@ impl From<&StatusEventCommit> for StatusEventCommit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommit {
     pub author: StatusEventCommitCommitAuthor,
@@ -84460,7 +89322,7 @@ impl From<&StatusEventCommitCommit> for StatusEventCommitCommit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitAuthor {
     pub date: chrono::DateTime<chrono::offset::Utc>,
@@ -84502,7 +89364,7 @@ impl From<&StatusEventCommitCommitAuthor> for StatusEventCommitCommitAuthor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitCommitter {
     pub date: chrono::DateTime<chrono::offset::Utc>,
@@ -84542,7 +89404,7 @@ impl From<&StatusEventCommitCommitCommitter> for StatusEventCommitCommitCommitte
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitTree {
     pub sha: String,
@@ -84605,7 +89467,7 @@ impl From<&StatusEventCommitCommitTree> for StatusEventCommitCommitTree {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitVerification {
     pub payload: Option<String>,
@@ -84643,7 +89505,18 @@ impl From<&StatusEventCommitCommitVerification> for StatusEventCommitCommitVerif
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StatusEventCommitCommitVerificationReason {
     #[serde(rename = "expired_key")]
     ExpiredKey,
@@ -84766,7 +89639,7 @@ impl std::convert::TryFrom<String> for StatusEventCommitCommitVerificationReason
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitParentsItem {
     pub html_url: String,
@@ -84795,7 +89668,18 @@ impl From<&StatusEventCommitParentsItem> for StatusEventCommitParentsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StatusEventState {
     #[serde(rename = "pending")]
     Pending,
@@ -85002,7 +89886,7 @@ impl std::convert::TryFrom<String> for StatusEventState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Team {
     #[doc = "Description of the team"]
@@ -85065,7 +89949,7 @@ impl From<&Team> for Team {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamAddEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -85122,7 +90006,7 @@ impl From<&TeamAddEvent> for TeamAddEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamAddedToRepository {
     pub action: TeamAddedToRepositoryAction,
@@ -85152,7 +90036,18 @@ impl From<&TeamAddedToRepository> for TeamAddedToRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamAddedToRepositoryAction {
     #[serde(rename = "added_to_repository")]
     AddedToRepository,
@@ -85238,7 +90133,7 @@ impl std::convert::TryFrom<String> for TeamAddedToRepositoryAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamCreated {
     pub action: TeamCreatedAction,
@@ -85268,7 +90163,18 @@ impl From<&TeamCreated> for TeamCreated {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamCreatedAction {
     #[serde(rename = "created")]
     Created,
@@ -85354,7 +90260,7 @@ impl std::convert::TryFrom<String> for TeamCreatedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamDeleted {
     pub action: TeamDeletedAction,
@@ -85384,7 +90290,18 @@ impl From<&TeamDeleted> for TeamDeleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
@@ -85553,7 +90470,7 @@ impl std::convert::TryFrom<String> for TeamDeletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEdited {
     pub action: TeamEditedAction,
@@ -85584,7 +90501,18 @@ impl From<&TeamEdited> for TeamEdited {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamEditedAction {
     #[serde(rename = "edited")]
     Edited,
@@ -85717,7 +90645,7 @@ impl std::convert::TryFrom<String> for TeamEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChanges {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -85754,7 +90682,7 @@ impl From<&TeamEditedChanges> for TeamEditedChanges {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
@@ -85785,7 +90713,7 @@ impl From<&TeamEditedChangesDescription> for TeamEditedChangesDescription {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
@@ -85816,7 +90744,7 @@ impl From<&TeamEditedChangesName> for TeamEditedChangesName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesPrivacy {
     #[doc = "The previous version of the team's privacy if the action was `edited`."]
@@ -85870,7 +90798,7 @@ impl From<&TeamEditedChangesPrivacy> for TeamEditedChangesPrivacy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepository {
     pub permissions: TeamEditedChangesRepositoryPermissions,
@@ -85914,7 +90842,7 @@ impl From<&TeamEditedChangesRepository> for TeamEditedChangesRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissions {
     pub from: TeamEditedChangesRepositoryPermissionsFrom,
@@ -85949,7 +90877,7 @@ impl From<&TeamEditedChangesRepositoryPermissions> for TeamEditedChangesReposito
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
@@ -85995,7 +90923,7 @@ impl From<&TeamEditedChangesRepositoryPermissionsFrom>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TeamEvent {
     AddedToRepository(TeamAddedToRepository),
@@ -86110,7 +91038,7 @@ impl From<TeamRemovedFromRepository> for TeamEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamParent {
     #[doc = "Description of the team"]
@@ -86150,7 +91078,18 @@ impl From<&TeamParent> for TeamParent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamParentPrivacy {
     #[serde(rename = "open")]
     Open,
@@ -86217,7 +91156,18 @@ impl std::convert::TryFrom<String> for TeamParentPrivacy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamPrivacy {
     #[serde(rename = "open")]
     Open,
@@ -86311,7 +91261,7 @@ impl std::convert::TryFrom<String> for TeamPrivacy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TeamRemovedFromRepository {
     pub action: TeamRemovedFromRepositoryAction,
@@ -86341,7 +91291,18 @@ impl From<&TeamRemovedFromRepository> for TeamRemovedFromRepository {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TeamRemovedFromRepositoryAction {
     #[serde(rename = "removed_from_repository")]
     RemovedFromRepository,
@@ -86500,7 +91461,7 @@ impl std::convert::TryFrom<String> for TeamRemovedFromRepositoryAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct User {
     pub avatar_url: String,
@@ -86547,7 +91508,18 @@ impl From<&User> for User {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum UserType {
     Bot,
     User,
@@ -86610,7 +91582,7 @@ impl std::convert::TryFrom<String> for UserType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct WatchEvent(pub WatchStarted);
 impl std::ops::Deref for WatchEvent {
     type Target = WatchStarted;
@@ -86671,7 +91643,7 @@ impl From<WatchStarted> for WatchEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WatchStarted {
     pub action: WatchStartedAction,
@@ -86700,7 +91672,18 @@ impl From<&WatchStarted> for WatchStarted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WatchStartedAction {
     #[serde(rename = "started")]
     Started,
@@ -86821,7 +91804,7 @@ impl std::convert::TryFrom<String> for WatchStartedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WebhookEvents {
     Variant0(Vec<WebhookEventsVariant0Item>),
@@ -86901,7 +91884,18 @@ impl From<[String; 1usize]> for WebhookEvents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WebhookEventsVariant0Item {
     #[serde(rename = "check_run")]
     CheckRun,
@@ -87189,7 +92183,7 @@ impl std::convert::TryFrom<String> for WebhookEventsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Workflow {
     pub badge_url: String,
@@ -87259,7 +92253,7 @@ impl From<&Workflow> for Workflow {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowDispatchEvent {
     pub inputs: Option<serde_json::Map<String, serde_json::Value>>,
@@ -87382,7 +92376,7 @@ impl From<&WorkflowDispatchEvent> for WorkflowDispatchEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJob {
     pub check_run_url: String,
@@ -87468,7 +92462,7 @@ impl From<&WorkflowJob> for WorkflowJob {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobCompleted {
     pub action: WorkflowJobCompletedAction,
@@ -87498,7 +92492,18 @@ impl From<&WorkflowJobCompleted> for WorkflowJobCompleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobCompletedAction {
     #[serde(rename = "completed")]
     Completed,
@@ -87572,7 +92577,7 @@ impl std::convert::TryFrom<String> for WorkflowJobCompletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobCompletedWorkflowJob {
     pub check_run_url: String,
@@ -87610,7 +92615,18 @@ impl From<&WorkflowJobCompletedWorkflowJob> for WorkflowJobCompletedWorkflowJob 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobCompletedWorkflowJobConclusion {
     #[serde(rename = "success")]
     Success,
@@ -87675,7 +92691,18 @@ impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobConclusion
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobCompletedWorkflowJobStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -87741,7 +92768,18 @@ impl std::convert::TryFrom<String> for WorkflowJobCompletedWorkflowJobStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobConclusion {
     #[serde(rename = "success")]
     Success,
@@ -87809,7 +92847,7 @@ impl std::convert::TryFrom<String> for WorkflowJobConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WorkflowJobEvent {
     Completed(WorkflowJobCompleted),
@@ -87957,7 +92995,7 @@ impl From<WorkflowJobStarted> for WorkflowJobEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueued {
     pub action: WorkflowJobQueuedAction,
@@ -87987,7 +93025,18 @@ impl From<&WorkflowJobQueued> for WorkflowJobQueued {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobQueuedAction {
     #[serde(rename = "queued")]
     Queued,
@@ -88120,7 +93169,7 @@ impl std::convert::TryFrom<String> for WorkflowJobQueuedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueuedWorkflowJob {
     pub check_run_url: String,
@@ -88157,7 +93206,18 @@ impl From<&WorkflowJobQueuedWorkflowJob> for WorkflowJobQueuedWorkflowJob {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobQueuedWorkflowJobStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -88272,7 +93332,7 @@ impl std::convert::TryFrom<String> for WorkflowJobQueuedWorkflowJobStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobStarted {
     pub action: WorkflowJobStartedAction,
@@ -88302,7 +93362,18 @@ impl From<&WorkflowJobStarted> for WorkflowJobStarted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobStartedAction {
     #[serde(rename = "started")]
     Started,
@@ -88385,7 +93456,7 @@ impl std::convert::TryFrom<String> for WorkflowJobStartedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobStartedWorkflowJob {
     pub check_run_url: String,
@@ -88422,7 +93493,7 @@ impl From<&WorkflowJobStartedWorkflowJob> for WorkflowJobStartedWorkflowJob {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, serde :: Serialize)]
 pub struct WorkflowJobStartedWorkflowJobConclusion(());
 impl std::ops::Deref for WorkflowJobStartedWorkflowJobConclusion {
     type Target = ();
@@ -88474,7 +93545,18 @@ impl<'de> serde::Deserialize<'de> for WorkflowJobStartedWorkflowJobConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobStartedWorkflowJobStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -88541,7 +93623,18 @@ impl std::convert::TryFrom<String> for WorkflowJobStartedWorkflowJobStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowJobStatus {
     #[serde(rename = "queued")]
     Queued,
@@ -88811,7 +93904,7 @@ impl std::convert::TryFrom<String> for WorkflowJobStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRun {
     pub artifacts_url: String,
@@ -88918,7 +94011,7 @@ impl From<&WorkflowRun> for WorkflowRun {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompleted {
     pub action: WorkflowRunCompletedAction,
@@ -88949,7 +94042,18 @@ impl From<&WorkflowRunCompleted> for WorkflowRunCompleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunCompletedAction {
     #[serde(rename = "completed")]
     Completed,
@@ -89028,7 +94132,7 @@ impl std::convert::TryFrom<String> for WorkflowRunCompletedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompletedWorkflowRun {
     pub artifacts_url: String,
@@ -89083,7 +94187,18 @@ impl From<&WorkflowRunCompletedWorkflowRun> for WorkflowRunCompletedWorkflowRun 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunCompletedWorkflowRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -89223,7 +94338,7 @@ impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunConclusion
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompletedWorkflowRunPullRequestsItem {
     pub base: WorkflowRunCompletedWorkflowRunPullRequestsItemBase,
@@ -89266,7 +94381,7 @@ impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItem>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemBase {
     #[serde(rename = "ref")]
@@ -89308,7 +94423,7 @@ impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItemBase>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemHead {
     #[serde(rename = "ref")]
@@ -89339,7 +94454,18 @@ impl From<&WorkflowRunCompletedWorkflowRunPullRequestsItemHead>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunCompletedWorkflowRunStatus {
     #[serde(rename = "requested")]
     Requested,
@@ -89414,7 +94540,18 @@ impl std::convert::TryFrom<String> for WorkflowRunCompletedWorkflowRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunConclusion {
     #[serde(rename = "success")]
     Success,
@@ -89499,7 +94636,7 @@ impl std::convert::TryFrom<String> for WorkflowRunConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WorkflowRunEvent {
     Completed(WorkflowRunCompleted),
@@ -89590,7 +94727,7 @@ impl From<WorkflowRunRequested> for WorkflowRunEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItem {
     pub base: WorkflowRunPullRequestsItemBase,
@@ -89631,7 +94768,7 @@ impl From<&WorkflowRunPullRequestsItem> for WorkflowRunPullRequestsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItemBase {
     #[serde(rename = "ref")]
@@ -89671,7 +94808,7 @@ impl From<&WorkflowRunPullRequestsItemBase> for WorkflowRunPullRequestsItemBase 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunPullRequestsItemHead {
     #[serde(rename = "ref")]
@@ -89730,7 +94867,7 @@ impl From<&WorkflowRunPullRequestsItemHead> for WorkflowRunPullRequestsItemHead 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunRequested {
     pub action: WorkflowRunRequestedAction,
@@ -89761,7 +94898,18 @@ impl From<&WorkflowRunRequested> for WorkflowRunRequested {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunRequestedAction {
     #[serde(rename = "requested")]
     Requested,
@@ -89821,7 +94969,18 @@ impl std::convert::TryFrom<String> for WorkflowRunRequestedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowRunStatus {
     #[serde(rename = "requested")]
     Requested,
@@ -89897,7 +95056,7 @@ impl std::convert::TryFrom<String> for WorkflowRunStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WorkflowStep {
     InProgress(WorkflowStepInProgress),
@@ -89967,7 +95126,7 @@ impl From<WorkflowStepCompleted> for WorkflowStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowStepCompleted {
     pub completed_at: String,
@@ -89997,7 +95156,18 @@ impl From<&WorkflowStepCompleted> for WorkflowStepCompleted {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowStepCompletedConclusion {
     #[serde(rename = "failure")]
     Failure,
@@ -90062,7 +95232,18 @@ impl std::convert::TryFrom<String> for WorkflowStepCompletedConclusion {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowStepCompletedStatus {
     #[serde(rename = "completed")]
     Completed,
@@ -90150,7 +95331,7 @@ impl std::convert::TryFrom<String> for WorkflowStepCompletedStatus {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowStepInProgress {
     pub completed_at: (),
@@ -90178,7 +95359,18 @@ impl From<&WorkflowStepInProgress> for WorkflowStepInProgress {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WorkflowStepInProgressStatus {
     #[serde(rename = "in_progress")]
     InProgress,

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -199,7 +199,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregateTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -256,7 +256,7 @@ impl From<&AggregateTransform> for AggregateTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformAs {
     Variant0(Vec<AggregateTransformAsVariant0Item>),
@@ -297,7 +297,7 @@ impl From<SignalRef> for AggregateTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformAsVariant0Item {
     Variant0(String),
@@ -331,7 +331,7 @@ impl From<SignalRef> for AggregateTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformCross {
     Variant0(bool),
@@ -370,7 +370,7 @@ impl From<SignalRef> for AggregateTransformCross {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformDrop {
     Variant0(bool),
@@ -429,7 +429,7 @@ impl From<SignalRef> for AggregateTransformDrop {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformFields {
     Variant0(Vec<AggregateTransformFieldsVariant0Item>),
@@ -473,7 +473,7 @@ impl From<SignalRef> for AggregateTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformFieldsVariant0Item {
     Variant0(ScaleField),
@@ -531,7 +531,7 @@ impl From<Expr> for AggregateTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupby {
     Variant0(Vec<AggregateTransformGroupbyVariant0Item>),
@@ -572,7 +572,7 @@ impl From<SignalRef> for AggregateTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -619,7 +619,7 @@ impl From<Expr> for AggregateTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformKey {
     ScaleField(ScaleField),
@@ -698,7 +698,7 @@ impl From<Expr> for AggregateTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformOps {
     Variant0(Vec<AggregateTransformOpsVariant0Item>),
@@ -761,7 +761,7 @@ impl From<SignalRef> for AggregateTransformOps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AggregateTransformOpsVariant0Item {
     Variant0(AggregateTransformOpsVariant0ItemVariant0),
@@ -817,7 +817,18 @@ impl From<SignalRef> for AggregateTransformOpsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "values")]
     Values,
@@ -967,7 +978,18 @@ impl std::convert::TryFrom<String> for AggregateTransformOpsVariant0ItemVariant0
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AggregateTransformType {
     #[serde(rename = "aggregate")]
     Aggregate,
@@ -1196,7 +1218,7 @@ impl std::convert::TryFrom<String> for AggregateTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValue {
     Variant0(Vec<AlignValueVariant0Item>),
@@ -1313,7 +1335,7 @@ impl From<AlignValueVariant1> for AlignValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant0Item {
     Variant0(AlignValueVariant0ItemVariant0),
@@ -1444,7 +1466,7 @@ impl From<AlignValueVariant0ItemVariant2> for AlignValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemVariant0 {
     Variant0 {
@@ -1495,7 +1517,18 @@ impl From<&AlignValueVariant0ItemVariant0> for AlignValueVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AlignValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "left")]
     Left,
@@ -1566,7 +1599,7 @@ impl std::convert::TryFrom<String> for AlignValueVariant0ItemVariant0Variant1Val
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -1726,7 +1759,18 @@ impl From<bool> for AlignValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant0ItemVariant1 {}
 impl From<&AlignValueVariant0ItemVariant1> for AlignValueVariant0ItemVariant1 {
@@ -1833,7 +1877,18 @@ impl From<&AlignValueVariant0ItemVariant1> for AlignValueVariant0ItemVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant0ItemVariant2 {}
 impl From<&AlignValueVariant0ItemVariant2> for AlignValueVariant0ItemVariant2 {
@@ -1930,7 +1985,7 @@ impl From<&AlignValueVariant0ItemVariant2> for AlignValueVariant0ItemVariant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant1 {
     Variant0(AlignValueVariant1Variant0),
@@ -2054,7 +2109,7 @@ impl From<AlignValueVariant1Variant2> for AlignValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant1Variant0 {
     Variant0 {
@@ -2097,7 +2152,18 @@ impl From<&AlignValueVariant1Variant0> for AlignValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AlignValueVariant1Variant0Variant1Value {
     #[serde(rename = "left")]
     Left,
@@ -2166,7 +2232,7 @@ impl std::convert::TryFrom<String> for AlignValueVariant1Variant0Variant1Value {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AlignValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -2321,7 +2387,18 @@ impl From<bool> for AlignValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant1Variant1 {}
 impl From<&AlignValueVariant1Variant1> for AlignValueVariant1Variant1 {
@@ -2425,7 +2502,18 @@ impl From<&AlignValueVariant1Variant1> for AlignValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant1Variant2 {}
 impl From<&AlignValueVariant1Variant2> for AlignValueVariant1Variant2 {
@@ -2618,7 +2706,7 @@ impl From<&AlignValueVariant1Variant2> for AlignValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValue {
     Variant0(Vec<AnchorValueVariant0Item>),
@@ -2735,7 +2823,7 @@ impl From<AnchorValueVariant1> for AnchorValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0Item {
     Variant0(AnchorValueVariant0ItemVariant0),
@@ -2866,7 +2954,7 @@ impl From<AnchorValueVariant0ItemVariant2> for AnchorValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemVariant0 {
     Variant0 {
@@ -2917,7 +3005,18 @@ impl From<&AnchorValueVariant0ItemVariant0> for AnchorValueVariant0ItemVariant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AnchorValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "start")]
     Start,
@@ -2988,7 +3087,7 @@ impl std::convert::TryFrom<String> for AnchorValueVariant0ItemVariant0Variant1Va
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -3148,7 +3247,18 @@ impl From<bool> for AnchorValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant0ItemVariant1 {}
 impl From<&AnchorValueVariant0ItemVariant1> for AnchorValueVariant0ItemVariant1 {
@@ -3255,7 +3365,18 @@ impl From<&AnchorValueVariant0ItemVariant1> for AnchorValueVariant0ItemVariant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant0ItemVariant2 {}
 impl From<&AnchorValueVariant0ItemVariant2> for AnchorValueVariant0ItemVariant2 {
@@ -3352,7 +3473,7 @@ impl From<&AnchorValueVariant0ItemVariant2> for AnchorValueVariant0ItemVariant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1 {
     Variant0(AnchorValueVariant1Variant0),
@@ -3476,7 +3597,7 @@ impl From<AnchorValueVariant1Variant2> for AnchorValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1Variant0 {
     Variant0 {
@@ -3519,7 +3640,18 @@ impl From<&AnchorValueVariant1Variant0> for AnchorValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AnchorValueVariant1Variant0Variant1Value {
     #[serde(rename = "start")]
     Start,
@@ -3588,7 +3720,7 @@ impl std::convert::TryFrom<String> for AnchorValueVariant1Variant0Variant1Value 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -3743,7 +3875,18 @@ impl From<bool> for AnchorValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant1Variant1 {}
 impl From<&AnchorValueVariant1Variant1> for AnchorValueVariant1Variant1 {
@@ -3847,7 +3990,18 @@ impl From<&AnchorValueVariant1Variant1> for AnchorValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant1Variant2 {}
 impl From<&AnchorValueVariant1Variant2> for AnchorValueVariant1Variant2 {
@@ -4028,7 +4182,7 @@ impl From<&AnchorValueVariant1Variant2> for AnchorValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValue {
     Variant0(Vec<AnyValueVariant0Item>),
@@ -4139,7 +4293,7 @@ impl From<AnyValueVariant1> for AnyValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant0Item {
     Variant0(AnyValueVariant0ItemVariant0),
@@ -4264,7 +4418,7 @@ impl From<AnyValueVariant0ItemVariant2> for AnyValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemVariant0 {
     Variant0 {
@@ -4318,7 +4472,7 @@ impl From<&AnyValueVariant0ItemVariant0> for AnyValueVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -4472,7 +4626,18 @@ impl From<bool> for AnyValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant0ItemVariant1 {}
 impl From<&AnyValueVariant0ItemVariant1> for AnyValueVariant0ItemVariant1 {
@@ -4573,7 +4738,18 @@ impl From<&AnyValueVariant0ItemVariant1> for AnyValueVariant0ItemVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant0ItemVariant2 {}
 impl From<&AnyValueVariant0ItemVariant2> for AnyValueVariant0ItemVariant2 {
@@ -4664,7 +4840,7 @@ impl From<&AnyValueVariant0ItemVariant2> for AnyValueVariant0ItemVariant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant1 {
     Variant0(AnyValueVariant1Variant0),
@@ -4782,7 +4958,7 @@ impl From<AnyValueVariant1Variant2> for AnyValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Variant0 {
     Variant0 {
@@ -4828,7 +5004,7 @@ impl From<&AnyValueVariant1Variant0> for AnyValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -4977,7 +5153,18 @@ impl From<bool> for AnyValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant1Variant1 {}
 impl From<&AnyValueVariant1Variant1> for AnyValueVariant1Variant1 {
@@ -5075,7 +5262,18 @@ impl From<&AnyValueVariant1Variant1> for AnyValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant1Variant2 {}
 impl From<&AnyValueVariant1Variant2> for AnyValueVariant1Variant2 {
@@ -5100,7 +5298,7 @@ impl From<&AnyValueVariant1Variant2> for AnyValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayOrSignal {
     Variant0(Vec<serde_json::Value>),
@@ -5298,7 +5496,7 @@ impl From<SignalRef> for ArrayOrSignal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValue {
     Variant0(Vec<ArrayValueVariant0Item>),
@@ -5411,7 +5609,7 @@ impl From<ArrayValueVariant1> for ArrayValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0Item {
     Variant0(ArrayValueVariant0ItemVariant0),
@@ -5538,7 +5736,7 @@ impl From<ArrayValueVariant0ItemVariant2> for ArrayValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemVariant0 {
     Variant0 {
@@ -5592,7 +5790,7 @@ impl From<&ArrayValueVariant0ItemVariant0> for ArrayValueVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -5748,7 +5946,18 @@ impl From<bool> for ArrayValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant0ItemVariant1 {}
 impl From<&ArrayValueVariant0ItemVariant1> for ArrayValueVariant0ItemVariant1 {
@@ -5851,7 +6060,18 @@ impl From<&ArrayValueVariant0ItemVariant1> for ArrayValueVariant0ItemVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant0ItemVariant2 {}
 impl From<&ArrayValueVariant0ItemVariant2> for ArrayValueVariant0ItemVariant2 {
@@ -5944,7 +6164,7 @@ impl From<&ArrayValueVariant0ItemVariant2> for ArrayValueVariant0ItemVariant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1 {
     Variant0(ArrayValueVariant1Variant0),
@@ -6064,7 +6284,7 @@ impl From<ArrayValueVariant1Variant2> for ArrayValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Variant0 {
     Variant0 {
@@ -6110,7 +6330,7 @@ impl From<&ArrayValueVariant1Variant0> for ArrayValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -6261,7 +6481,18 @@ impl From<bool> for ArrayValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant1Variant1 {}
 impl From<&ArrayValueVariant1Variant1> for ArrayValueVariant1Variant1 {
@@ -6361,7 +6592,18 @@ impl From<&ArrayValueVariant1Variant1> for ArrayValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant1Variant2 {}
 impl From<&ArrayValueVariant1Variant2> for ArrayValueVariant1Variant2 {
@@ -6421,7 +6663,7 @@ impl From<&ArrayValueVariant1Variant2> for ArrayValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Autosize {
     Variant0(AutosizeVariant0),
@@ -6467,7 +6709,18 @@ impl From<SignalRef> for Autosize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AutosizeVariant0 {
     #[serde(rename = "pad")]
     Pad,
@@ -6540,7 +6793,18 @@ impl std::convert::TryFrom<String> for AutosizeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AutosizeVariant1Contains {
     #[serde(rename = "content")]
     Content,
@@ -6605,7 +6869,18 @@ impl std::convert::TryFrom<String> for AutosizeVariant1Contains {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AutosizeVariant1Type {
     #[serde(rename = "pad")]
     Pad,
@@ -7515,7 +7790,7 @@ impl Default for AutosizeVariant1Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Axis {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7865,7 +8140,7 @@ impl From<&Axis> for Axis {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisBandPosition {
     Variant0(f64),
@@ -7903,7 +8178,7 @@ impl From<NumberValue> for AxisBandPosition {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainCap {
     Variant0(String),
@@ -7939,7 +8214,7 @@ impl From<StringValue> for AxisDomainCap {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainColor {
     Variant0,
@@ -7976,7 +8251,7 @@ impl From<ColorValue> for AxisDomainColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainDash {
     Variant0(Vec<f64>),
@@ -8014,7 +8289,7 @@ impl From<ArrayValue> for AxisDomainDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainDashOffset {
     Variant0(f64),
@@ -8052,7 +8327,7 @@ impl From<NumberValue> for AxisDomainDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainOpacity {
     Variant0(f64),
@@ -8090,7 +8365,7 @@ impl From<NumberValue> for AxisDomainOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisDomainWidth {
     Variant0(f64),
@@ -8142,7 +8417,7 @@ impl From<NumberValue> for AxisDomainWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AxisEncode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8216,7 +8491,7 @@ impl From<&AxisEncode> for AxisEncode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum AxisFormat {
     Variant0(String),
@@ -8275,7 +8550,7 @@ impl From<SignalRef> for AxisFormat {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisFormatType {
     Variant0(AxisFormatTypeVariant0),
@@ -8310,7 +8585,18 @@ impl From<SignalRef> for AxisFormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisFormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -8379,7 +8665,7 @@ impl std::convert::TryFrom<String> for AxisFormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridCap {
     Variant0(String),
@@ -8415,7 +8701,7 @@ impl From<StringValue> for AxisGridCap {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridColor {
     Variant0,
@@ -8452,7 +8738,7 @@ impl From<ColorValue> for AxisGridColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridDash {
     Variant0(Vec<f64>),
@@ -8490,7 +8776,7 @@ impl From<ArrayValue> for AxisGridDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridDashOffset {
     Variant0(f64),
@@ -8528,7 +8814,7 @@ impl From<NumberValue> for AxisGridDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridOpacity {
     Variant0(f64),
@@ -8566,7 +8852,7 @@ impl From<NumberValue> for AxisGridOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisGridWidth {
     Variant0(f64),
@@ -8608,7 +8894,7 @@ impl From<NumberValue> for AxisGridWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelAlign {
     Variant0(AxisLabelAlignVariant0),
@@ -8643,7 +8929,18 @@ impl From<AlignValue> for AxisLabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisLabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -8712,7 +9009,7 @@ impl std::convert::TryFrom<String> for AxisLabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelAngle {
     Variant0(f64),
@@ -8757,7 +9054,7 @@ impl From<NumberValue> for AxisLabelAngle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelBaseline {
     Variant0(AxisLabelBaselineVariant0),
@@ -8795,7 +9092,18 @@ impl From<BaselineValue> for AxisLabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisLabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -8879,7 +9187,7 @@ impl std::convert::TryFrom<String> for AxisLabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelBound {
     Variant0(bool),
@@ -8926,7 +9234,7 @@ impl From<SignalRef> for AxisLabelBound {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelColor {
     Variant0,
@@ -8963,7 +9271,7 @@ impl From<ColorValue> for AxisLabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFlush {
     Variant0(bool),
@@ -9007,7 +9315,7 @@ impl From<SignalRef> for AxisLabelFlush {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFont {
     Variant0(String),
@@ -9040,7 +9348,7 @@ impl From<StringValue> for AxisLabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFontSize {
     Variant0(f64),
@@ -9078,7 +9386,7 @@ impl From<NumberValue> for AxisLabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFontStyle {
     Variant0(String),
@@ -9135,7 +9443,7 @@ impl From<StringValue> for AxisLabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelFontWeight {
     Variant0(MyEnum),
@@ -9173,7 +9481,7 @@ impl From<FontWeightValue> for AxisLabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelLimit {
     Variant0(f64),
@@ -9211,7 +9519,7 @@ impl From<NumberValue> for AxisLabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelLineHeight {
     Variant0(f64),
@@ -9249,7 +9557,7 @@ impl From<NumberValue> for AxisLabelLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelOffset {
     Variant0(f64),
@@ -9287,7 +9595,7 @@ impl From<NumberValue> for AxisLabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelOpacity {
     Variant0(f64),
@@ -9325,7 +9633,7 @@ impl From<NumberValue> for AxisLabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisLabelPadding {
     Variant0(f64),
@@ -9363,7 +9671,7 @@ impl From<NumberValue> for AxisLabelPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisMaxExtent {
     Variant0(f64),
@@ -9401,7 +9709,7 @@ impl From<NumberValue> for AxisMaxExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisMinExtent {
     Variant0(f64),
@@ -9439,7 +9747,7 @@ impl From<NumberValue> for AxisMinExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisOffset {
     Variant0(f64),
@@ -9482,7 +9790,7 @@ impl From<NumberValue> for AxisOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisOrient {
     Variant0(AxisOrientVariant0),
@@ -9518,7 +9826,18 @@ impl From<SignalRef> for AxisOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisOrientVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -9591,7 +9910,7 @@ impl std::convert::TryFrom<String> for AxisOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisPosition {
     Variant0(f64),
@@ -9629,7 +9948,7 @@ impl From<NumberValue> for AxisPosition {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickCap {
     Variant0(String),
@@ -9665,7 +9984,7 @@ impl From<StringValue> for AxisTickCap {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickColor {
     Variant0,
@@ -9702,7 +10021,7 @@ impl From<ColorValue> for AxisTickColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickDash {
     Variant0(Vec<f64>),
@@ -9740,7 +10059,7 @@ impl From<ArrayValue> for AxisTickDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickDashOffset {
     Variant0(f64),
@@ -9778,7 +10097,7 @@ impl From<NumberValue> for AxisTickDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickOffset {
     Variant0(f64),
@@ -9816,7 +10135,7 @@ impl From<NumberValue> for AxisTickOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickOpacity {
     Variant0(f64),
@@ -9854,7 +10173,7 @@ impl From<NumberValue> for AxisTickOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickRound {
     Variant0(bool),
@@ -9892,7 +10211,7 @@ impl From<BooleanValue> for AxisTickRound {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickSize {
     Variant0(f64),
@@ -9930,7 +10249,7 @@ impl From<NumberValue> for AxisTickSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTickWidth {
     Variant0(f64),
@@ -9972,7 +10291,7 @@ impl From<NumberValue> for AxisTickWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleAlign {
     Variant0(AxisTitleAlignVariant0),
@@ -10007,7 +10326,18 @@ impl From<AlignValue> for AxisTitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisTitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -10081,7 +10411,7 @@ impl std::convert::TryFrom<String> for AxisTitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleAnchor {
     Variant0(Option<AxisTitleAnchorVariant0>),
@@ -10117,7 +10447,18 @@ impl From<AnchorValue> for AxisTitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisTitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -10186,7 +10527,7 @@ impl std::convert::TryFrom<String> for AxisTitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleAngle {
     Variant0(f64),
@@ -10231,7 +10572,7 @@ impl From<NumberValue> for AxisTitleAngle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleBaseline {
     Variant0(AxisTitleBaselineVariant0),
@@ -10269,7 +10610,18 @@ impl From<BaselineValue> for AxisTitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AxisTitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -10353,7 +10705,7 @@ impl std::convert::TryFrom<String> for AxisTitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleColor {
     Variant0,
@@ -10387,7 +10739,7 @@ impl From<ColorValue> for AxisTitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFont {
     Variant0(String),
@@ -10420,7 +10772,7 @@ impl From<StringValue> for AxisTitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFontSize {
     Variant0(f64),
@@ -10458,7 +10810,7 @@ impl From<NumberValue> for AxisTitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFontStyle {
     Variant0(String),
@@ -10515,7 +10867,7 @@ impl From<StringValue> for AxisTitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleFontWeight {
     Variant0(MyEnum),
@@ -10553,7 +10905,7 @@ impl From<FontWeightValue> for AxisTitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleLimit {
     Variant0(f64),
@@ -10591,7 +10943,7 @@ impl From<NumberValue> for AxisTitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleLineHeight {
     Variant0(f64),
@@ -10629,7 +10981,7 @@ impl From<NumberValue> for AxisTitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleOpacity {
     Variant0(f64),
@@ -10667,7 +11019,7 @@ impl From<NumberValue> for AxisTitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitlePadding {
     Variant0(f64),
@@ -10705,7 +11057,7 @@ impl From<NumberValue> for AxisTitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleX {
     Variant0(f64),
@@ -10743,7 +11095,7 @@ impl From<NumberValue> for AxisTitleX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTitleY {
     Variant0(f64),
@@ -10781,7 +11133,7 @@ impl From<NumberValue> for AxisTitleY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum AxisTranslate {
     Variant0(f64),
@@ -10812,7 +11164,7 @@ impl From<NumberValue> for AxisTranslate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Background(pub StringOrSignal);
 impl std::ops::Deref for Background {
     type Target = StringOrSignal;
@@ -11011,7 +11363,7 @@ impl From<StringOrSignal> for Background {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum BaseColorValue {
     Variant0(BaseColorValueVariant0),
@@ -11136,7 +11488,7 @@ impl From<BaseColorValueVariant0> for BaseColorValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0 {
     Variant0(BaseColorValueVariant0Variant0),
@@ -11263,7 +11615,7 @@ impl From<BaseColorValueVariant0Variant2> for BaseColorValueVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Variant0 {
     Variant0 {
@@ -11309,7 +11661,7 @@ impl From<&BaseColorValueVariant0Variant0> for BaseColorValueVariant0Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Variant0Variant3Range {
     Variant0(f64),
@@ -11469,7 +11821,18 @@ impl From<bool> for BaseColorValueVariant0Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaseColorValueVariant0Variant1 {}
 impl From<&BaseColorValueVariant0Variant1> for BaseColorValueVariant0Variant1 {
@@ -11576,7 +11939,18 @@ impl From<&BaseColorValueVariant0Variant1> for BaseColorValueVariant0Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaseColorValueVariant0Variant2 {}
 impl From<&BaseColorValueVariant0Variant2> for BaseColorValueVariant0Variant2 {
@@ -11607,7 +11981,7 @@ impl From<&BaseColorValueVariant0Variant2> for BaseColorValueVariant0Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant4Color {
     Rgb(ColorRgb),
@@ -11827,7 +12201,7 @@ impl From<ColorHcl> for BaseColorValueVariant4Color {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValue {
     Variant0(Vec<BaselineValueVariant0Item>),
@@ -11945,7 +12319,7 @@ impl From<BaselineValueVariant1> for BaselineValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0Item {
     Variant0(BaselineValueVariant0ItemVariant0),
@@ -12077,7 +12451,7 @@ impl From<BaselineValueVariant0ItemVariant2> for BaselineValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemVariant0 {
     Variant0 {
@@ -12129,7 +12503,18 @@ impl From<&BaselineValueVariant0ItemVariant0> for BaselineValueVariant0ItemVaria
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BaselineValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "top")]
     Top,
@@ -12204,7 +12589,7 @@ impl std::convert::TryFrom<String> for BaselineValueVariant0ItemVariant0Variant1
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -12365,7 +12750,18 @@ impl From<bool> for BaselineValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant0ItemVariant1 {}
 impl From<&BaselineValueVariant0ItemVariant1> for BaselineValueVariant0ItemVariant1 {
@@ -12473,7 +12869,18 @@ impl From<&BaselineValueVariant0ItemVariant1> for BaselineValueVariant0ItemVaria
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant0ItemVariant2 {}
 impl From<&BaselineValueVariant0ItemVariant2> for BaselineValueVariant0ItemVariant2 {
@@ -12571,7 +12978,7 @@ impl From<&BaselineValueVariant0ItemVariant2> for BaselineValueVariant0ItemVaria
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1 {
     Variant0(BaselineValueVariant1Variant0),
@@ -12696,7 +13103,7 @@ impl From<BaselineValueVariant1Variant2> for BaselineValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1Variant0 {
     Variant0 {
@@ -12740,7 +13147,18 @@ impl From<&BaselineValueVariant1Variant0> for BaselineValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BaselineValueVariant1Variant0Variant1Value {
     #[serde(rename = "top")]
     Top,
@@ -12815,7 +13233,7 @@ impl std::convert::TryFrom<String> for BaselineValueVariant1Variant0Variant1Valu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -12973,7 +13391,18 @@ impl From<bool> for BaselineValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant1Variant1 {}
 impl From<&BaselineValueVariant1Variant1> for BaselineValueVariant1Variant1 {
@@ -13078,7 +13507,18 @@ impl From<&BaselineValueVariant1Variant1> for BaselineValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant1Variant2 {}
 impl From<&BaselineValueVariant1Variant2> for BaselineValueVariant1Variant2 {
@@ -13311,7 +13751,7 @@ impl From<&BaselineValueVariant1Variant2> for BaselineValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BinTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -13367,7 +13807,7 @@ impl From<&BinTransform> for BinTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAnchor {
     Variant0(f64),
@@ -13421,7 +13861,7 @@ impl From<SignalRef> for BinTransformAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAs {
     Variant0([BinTransformAsVariant0Item; 2usize]),
@@ -13467,7 +13907,7 @@ impl From<SignalRef> for BinTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformAsVariant0Item {
     Variant0(String),
@@ -13501,7 +13941,7 @@ impl From<SignalRef> for BinTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformBase {
     Variant0(f64),
@@ -13558,7 +13998,7 @@ impl From<SignalRef> for BinTransformBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformDivide {
     Variant0(Vec<BinTransformDivideVariant0Item>),
@@ -13604,7 +14044,7 @@ impl From<SignalRef> for BinTransformDivide {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformDivideVariant0Item {
     Variant0(f64),
@@ -13654,7 +14094,7 @@ impl From<SignalRef> for BinTransformDivideVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformExtent {
     Variant0([BinTransformExtentVariant0Item; 2usize]),
@@ -13692,7 +14132,7 @@ impl From<SignalRef> for BinTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformExtentVariant0Item {
     Variant0(f64),
@@ -13733,7 +14173,7 @@ impl From<SignalRef> for BinTransformExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformField {
     ScaleField(ScaleField),
@@ -13778,7 +14218,7 @@ impl From<Expr> for BinTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformInterval {
     Variant0(bool),
@@ -13822,7 +14262,7 @@ impl From<SignalRef> for BinTransformInterval {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformMaxbins {
     Variant0(f64),
@@ -13865,7 +14305,7 @@ impl From<SignalRef> for BinTransformMaxbins {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformMinstep {
     Variant0(f64),
@@ -13903,7 +14343,7 @@ impl From<SignalRef> for BinTransformMinstep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformName {
     Variant0(String),
@@ -13937,7 +14377,7 @@ impl From<SignalRef> for BinTransformName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformNice {
     Variant0(bool),
@@ -13980,7 +14420,7 @@ impl From<SignalRef> for BinTransformNice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformSpan {
     Variant0(f64),
@@ -14018,7 +14458,7 @@ impl From<SignalRef> for BinTransformSpan {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformStep {
     Variant0(f64),
@@ -14066,7 +14506,7 @@ impl From<SignalRef> for BinTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformSteps {
     Variant0(Vec<BinTransformStepsVariant0Item>),
@@ -14104,7 +14544,7 @@ impl From<SignalRef> for BinTransformSteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BinTransformStepsVariant0Item {
     Variant0(f64),
@@ -14137,7 +14577,18 @@ impl From<SignalRef> for BinTransformStepsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BinTransformType {
     #[serde(rename = "bin")]
     Bin,
@@ -14327,7 +14778,7 @@ impl std::convert::TryFrom<String> for BinTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Bind {
     Variant0 {
@@ -14400,7 +14851,18 @@ impl From<&Bind> for Bind {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BindVariant0Input {
     #[serde(rename = "checkbox")]
     Checkbox,
@@ -14457,7 +14919,18 @@ impl std::convert::TryFrom<String> for BindVariant0Input {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BindVariant1Input {
     #[serde(rename = "radio")]
     Radio,
@@ -14517,7 +14990,18 @@ impl std::convert::TryFrom<String> for BindVariant1Input {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BindVariant2Input {
     #[serde(rename = "range")]
     Range,
@@ -14578,7 +15062,7 @@ impl std::convert::TryFrom<String> for BindVariant2Input {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct BindVariant3Input(String);
 impl std::ops::Deref for BindVariant3Input {
     type Target = String;
@@ -14833,7 +15317,7 @@ impl<'de> serde::Deserialize<'de> for BindVariant3Input {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValue {
     Variant0(Vec<BlendValueVariant0Item>),
@@ -14963,7 +15447,7 @@ impl From<BlendValueVariant1> for BlendValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant0Item {
     Variant0(BlendValueVariant0ItemVariant0),
@@ -15107,7 +15591,7 @@ impl From<BlendValueVariant0ItemVariant2> for BlendValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemVariant0 {
     Variant0 {
@@ -15171,7 +15655,18 @@ impl From<&BlendValueVariant0ItemVariant0> for BlendValueVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BlendValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "multiply")]
     Multiply,
@@ -15290,7 +15785,7 @@ impl std::convert::TryFrom<String> for BlendValueVariant0ItemVariant0Variant1Val
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -15463,7 +15958,18 @@ impl From<bool> for BlendValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant0ItemVariant1 {}
 impl From<&BlendValueVariant0ItemVariant1> for BlendValueVariant0ItemVariant1 {
@@ -15583,7 +16089,18 @@ impl From<&BlendValueVariant0ItemVariant1> for BlendValueVariant0ItemVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant0ItemVariant2 {}
 impl From<&BlendValueVariant0ItemVariant2> for BlendValueVariant0ItemVariant2 {
@@ -15693,7 +16210,7 @@ impl From<&BlendValueVariant0ItemVariant2> for BlendValueVariant0ItemVariant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant1 {
     Variant0(BlendValueVariant1Variant0),
@@ -15830,7 +16347,7 @@ impl From<BlendValueVariant1Variant2> for BlendValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant1Variant0 {
     Variant0 {
@@ -15886,7 +16403,18 @@ impl From<&BlendValueVariant1Variant0> for BlendValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum BlendValueVariant1Variant0Variant1Value {
     #[serde(rename = "multiply")]
     Multiply,
@@ -16003,7 +16531,7 @@ impl std::convert::TryFrom<String> for BlendValueVariant1Variant0Variant1Value {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BlendValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -16171,7 +16699,18 @@ impl From<bool> for BlendValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant1Variant1 {}
 impl From<&BlendValueVariant1Variant1> for BlendValueVariant1Variant1 {
@@ -16288,7 +16827,18 @@ impl From<&BlendValueVariant1Variant1> for BlendValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant1Variant2 {}
 impl From<&BlendValueVariant1Variant2> for BlendValueVariant1Variant2 {
@@ -16313,7 +16863,7 @@ impl From<&BlendValueVariant1Variant2> for BlendValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanOrSignal {
     Variant0(bool),
@@ -16511,7 +17061,7 @@ impl From<SignalRef> for BooleanOrSignal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValue {
     Variant0(Vec<BooleanValueVariant0Item>),
@@ -16624,7 +17174,7 @@ impl From<BooleanValueVariant1> for BooleanValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0Item {
     Variant0(BooleanValueVariant0ItemVariant0),
@@ -16751,7 +17301,7 @@ impl From<BooleanValueVariant0ItemVariant2> for BooleanValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemVariant0 {
     Variant0 {
@@ -16805,7 +17355,7 @@ impl From<&BooleanValueVariant0ItemVariant0> for BooleanValueVariant0ItemVariant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -16961,7 +17511,18 @@ impl From<bool> for BooleanValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant0ItemVariant1 {}
 impl From<&BooleanValueVariant0ItemVariant1> for BooleanValueVariant0ItemVariant1 {
@@ -17064,7 +17625,18 @@ impl From<&BooleanValueVariant0ItemVariant1> for BooleanValueVariant0ItemVariant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant0ItemVariant2 {}
 impl From<&BooleanValueVariant0ItemVariant2> for BooleanValueVariant0ItemVariant2 {
@@ -17157,7 +17729,7 @@ impl From<&BooleanValueVariant0ItemVariant2> for BooleanValueVariant0ItemVariant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1 {
     Variant0(BooleanValueVariant1Variant0),
@@ -17277,7 +17849,7 @@ impl From<BooleanValueVariant1Variant2> for BooleanValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Variant0 {
     Variant0 {
@@ -17323,7 +17895,7 @@ impl From<&BooleanValueVariant1Variant0> for BooleanValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -17476,7 +18048,18 @@ impl From<bool> for BooleanValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant1Variant1 {}
 impl From<&BooleanValueVariant1Variant1> for BooleanValueVariant1Variant1 {
@@ -17576,7 +18159,18 @@ impl From<&BooleanValueVariant1Variant1> for BooleanValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant1Variant2 {}
 impl From<&BooleanValueVariant1Variant2> for BooleanValueVariant1Variant2 {
@@ -17611,7 +18205,7 @@ impl From<&BooleanValueVariant1Variant2> for BooleanValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CollectTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17638,7 +18232,18 @@ impl From<&CollectTransform> for CollectTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CollectTransformType {
     #[serde(rename = "collect")]
     Collect,
@@ -17708,7 +18313,7 @@ impl std::convert::TryFrom<String> for CollectTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ColorHcl {
     pub c: NumberValue,
     pub h: NumberValue,
@@ -17745,7 +18350,7 @@ impl From<&ColorHcl> for ColorHcl {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ColorHsl {
     pub h: NumberValue,
     pub l: NumberValue,
@@ -17782,7 +18387,7 @@ impl From<&ColorHsl> for ColorHsl {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ColorLab {
     pub a: NumberValue,
     pub b: NumberValue,
@@ -17819,7 +18424,7 @@ impl From<&ColorLab> for ColorLab {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ColorRgb {
     pub b: NumberValue,
     pub g: NumberValue,
@@ -17885,7 +18490,7 @@ impl From<&ColorRgb> for ColorRgb {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Compare {
     Variant0 {
@@ -17923,7 +18528,7 @@ impl From<&Compare> for Compare {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CompareVariant0Field {
     ScaleField(ScaleField),
@@ -17961,7 +18566,7 @@ impl From<Expr> for CompareVariant0Field {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CompareVariant1FieldItem {
     ScaleField(ScaleField),
@@ -18159,7 +18764,7 @@ impl From<Expr> for CompareVariant1FieldItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContourTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -18210,7 +18815,7 @@ impl From<&ContourTransform> for ContourTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformBandwidth {
     Variant0(f64),
@@ -18248,7 +18853,7 @@ impl From<SignalRef> for ContourTransformBandwidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformCellSize {
     Variant0(f64),
@@ -18286,7 +18891,7 @@ impl From<SignalRef> for ContourTransformCellSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformCount {
     Variant0(f64),
@@ -18324,7 +18929,7 @@ impl From<SignalRef> for ContourTransformCount {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformNice {
     Variant0(bool),
@@ -18374,7 +18979,7 @@ impl From<SignalRef> for ContourTransformNice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformSize {
     Variant0([ContourTransformSizeVariant0Item; 2usize]),
@@ -18412,7 +19017,7 @@ impl From<SignalRef> for ContourTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformSizeVariant0Item {
     Variant0(f64),
@@ -18451,7 +19056,7 @@ impl From<SignalRef> for ContourTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformSmooth {
     Variant0(bool),
@@ -18504,7 +19109,7 @@ impl From<SignalRef> for ContourTransformSmooth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformThresholds {
     Variant0(Vec<ContourTransformThresholdsVariant0Item>),
@@ -18542,7 +19147,7 @@ impl From<SignalRef> for ContourTransformThresholds {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformThresholdsVariant0Item {
     Variant0(f64),
@@ -18575,7 +19180,18 @@ impl From<SignalRef> for ContourTransformThresholdsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ContourTransformType {
     #[serde(rename = "contour")]
     Contour,
@@ -18646,7 +19262,7 @@ impl std::convert::TryFrom<String> for ContourTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformValues {
     Variant0(Vec<ContourTransformValuesVariant0Item>),
@@ -18684,7 +19300,7 @@ impl From<SignalRef> for ContourTransformValues {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformValuesVariant0Item {
     Variant0(f64),
@@ -18725,7 +19341,7 @@ impl From<SignalRef> for ContourTransformValuesVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformWeight {
     ScaleField(ScaleField),
@@ -18772,7 +19388,7 @@ impl From<Expr> for ContourTransformWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformX {
     ScaleField(ScaleField),
@@ -18819,7 +19435,7 @@ impl From<Expr> for ContourTransformX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ContourTransformY {
     ScaleField(ScaleField),
@@ -18946,7 +19562,7 @@ impl From<Expr> for ContourTransformY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CountpatternTransform {
     #[serde(rename = "as", default = "defaults::countpattern_transform_as")]
@@ -19001,7 +19617,7 @@ impl From<&CountpatternTransform> for CountpatternTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformAs {
     Variant0([CountpatternTransformAsVariant0Item; 2usize]),
@@ -19047,7 +19663,7 @@ impl From<SignalRef> for CountpatternTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformAsVariant0Item {
     Variant0(String),
@@ -19085,7 +19701,7 @@ impl From<SignalRef> for CountpatternTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformCase {
     Variant0(CountpatternTransformCaseVariant0),
@@ -19125,7 +19741,18 @@ impl From<SignalRef> for CountpatternTransformCase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CountpatternTransformCaseVariant0 {
     #[serde(rename = "upper")]
     Upper,
@@ -19197,7 +19824,7 @@ impl std::convert::TryFrom<String> for CountpatternTransformCaseVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformField {
     ScaleField(ScaleField),
@@ -19242,7 +19869,7 @@ impl From<Expr> for CountpatternTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformPattern {
     Variant0(String),
@@ -19280,7 +19907,7 @@ impl From<SignalRef> for CountpatternTransformPattern {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CountpatternTransformStopwords {
     Variant0(String),
@@ -19308,7 +19935,18 @@ impl From<SignalRef> for CountpatternTransformStopwords {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CountpatternTransformType {
     #[serde(rename = "countpattern")]
     Countpattern,
@@ -19405,7 +20043,7 @@ impl std::convert::TryFrom<String> for CountpatternTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CrossTransform {
     #[serde(rename = "as", default = "defaults::cross_transform_as")]
@@ -19455,7 +20093,7 @@ impl From<&CrossTransform> for CrossTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CrossTransformAs {
     Variant0([CrossTransformAsVariant0Item; 2usize]),
@@ -19501,7 +20139,7 @@ impl From<SignalRef> for CrossTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CrossTransformAsVariant0Item {
     Variant0(String),
@@ -19529,7 +20167,18 @@ impl From<SignalRef> for CrossTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CrossTransformType {
     #[serde(rename = "cross")]
     Cross,
@@ -19633,7 +20282,7 @@ impl std::convert::TryFrom<String> for CrossTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CrossfilterTransform {
     pub fields: CrossfilterTransformFields,
@@ -19678,7 +20327,7 @@ impl From<&CrossfilterTransform> for CrossfilterTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFields {
     Variant0(Vec<CrossfilterTransformFieldsVariant0Item>),
@@ -19719,7 +20368,7 @@ impl From<SignalRef> for CrossfilterTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -19764,7 +20413,7 @@ impl From<Expr> for CrossfilterTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum CrossfilterTransformQuery {
     Variant0(Vec<serde_json::Value>),
@@ -19797,7 +20446,18 @@ impl From<SignalRef> for CrossfilterTransformQuery {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CrossfilterTransformType {
     #[serde(rename = "crossfilter")]
     Crossfilter,
@@ -20486,7 +21146,7 @@ impl std::convert::TryFrom<String> for CrossfilterTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Data {
     Variant0 {
@@ -20555,7 +21215,7 @@ impl From<&Data> for Data {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant1Source {
     Variant0(String),
@@ -20836,7 +21496,7 @@ impl From<Vec<String>> for DataVariant1Source {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2Format {
     Variant0 {
@@ -20909,7 +21569,7 @@ impl From<SignalRef> for DataVariant2Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DataVariant2FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parse: Option<DataVariant2FormatVariant0Subtype0Parse>,
@@ -20959,7 +21619,7 @@ impl From<&DataVariant2FormatVariant0Subtype0> for DataVariant2FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype0Parse {
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant0),
@@ -21009,7 +21669,18 @@ impl From<SignalRef> for DataVariant2FormatVariant0Subtype0Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -21078,7 +21749,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0),
@@ -21158,7 +21829,18 @@ impl From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -21231,7 +21913,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = String;
@@ -21353,7 +22035,7 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype0ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -21408,7 +22090,7 @@ impl From<&DataVariant2FormatVariant0Subtype1> for DataVariant2FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype1Parse {
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant0),
@@ -21458,7 +22140,18 @@ impl From<SignalRef> for DataVariant2FormatVariant0Subtype1Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -21527,7 +22220,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0),
@@ -21607,7 +22300,18 @@ impl From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -21680,7 +22384,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = String;
@@ -21759,7 +22463,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype1ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype1Type {
     #[serde(rename = "json")]
     Json,
@@ -21862,7 +22577,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -21915,7 +22630,7 @@ impl From<&DataVariant2FormatVariant0Subtype2> for DataVariant2FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype2Parse {
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant0),
@@ -21965,7 +22680,18 @@ impl From<SignalRef> for DataVariant2FormatVariant0Subtype2Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -22034,7 +22760,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0),
@@ -22114,7 +22840,18 @@ impl From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -22187,7 +22924,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = String;
@@ -22267,7 +23004,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype2ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype2Type {
     #[serde(rename = "csv")]
     Csv,
@@ -22377,7 +23125,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype3 {
     pub delimiter: String,
@@ -22431,7 +23179,7 @@ impl From<&DataVariant2FormatVariant0Subtype3> for DataVariant2FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype3Parse {
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant0),
@@ -22481,7 +23229,18 @@ impl From<SignalRef> for DataVariant2FormatVariant0Subtype3Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -22550,7 +23309,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0),
@@ -22630,7 +23389,18 @@ impl From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -22703,7 +23473,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = String;
@@ -22782,7 +23552,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant2FormatVariant0Subtype3ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype3Type {
     #[serde(rename = "dsv")]
     Dsv,
@@ -22886,7 +23667,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant2FormatVariant0Subtype4 {
     Variant0 {
@@ -22923,7 +23704,18 @@ impl From<&DataVariant2FormatVariant0Subtype4> for DataVariant2FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype4Variant0Type {
     #[serde(rename = "topojson")]
     Topojson,
@@ -22983,7 +23775,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "interior")]
     Interior,
@@ -23045,7 +23848,18 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant2FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
     Topojson,
@@ -23356,7 +24170,7 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3Format {
     Variant0 {
@@ -23429,7 +24243,7 @@ impl From<SignalRef> for DataVariant3Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DataVariant3FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parse: Option<DataVariant3FormatVariant0Subtype0Parse>,
@@ -23479,7 +24293,7 @@ impl From<&DataVariant3FormatVariant0Subtype0> for DataVariant3FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype0Parse {
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant0),
@@ -23529,7 +24343,18 @@ impl From<SignalRef> for DataVariant3FormatVariant0Subtype0Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -23598,7 +24423,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0),
@@ -23678,7 +24503,18 @@ impl From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -23751,7 +24587,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = String;
@@ -23873,7 +24709,7 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype0ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -23928,7 +24764,7 @@ impl From<&DataVariant3FormatVariant0Subtype1> for DataVariant3FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype1Parse {
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant0),
@@ -23978,7 +24814,18 @@ impl From<SignalRef> for DataVariant3FormatVariant0Subtype1Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -24047,7 +24894,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0),
@@ -24127,7 +24974,18 @@ impl From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -24200,7 +25058,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = String;
@@ -24279,7 +25137,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype1ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype1Type {
     #[serde(rename = "json")]
     Json,
@@ -24382,7 +25251,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -24435,7 +25304,7 @@ impl From<&DataVariant3FormatVariant0Subtype2> for DataVariant3FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype2Parse {
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant0),
@@ -24485,7 +25354,18 @@ impl From<SignalRef> for DataVariant3FormatVariant0Subtype2Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -24554,7 +25434,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0),
@@ -24634,7 +25514,18 @@ impl From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -24707,7 +25598,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = String;
@@ -24787,7 +25678,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype2ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype2Type {
     #[serde(rename = "csv")]
     Csv,
@@ -24897,7 +25799,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype3 {
     pub delimiter: String,
@@ -24951,7 +25853,7 @@ impl From<&DataVariant3FormatVariant0Subtype3> for DataVariant3FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype3Parse {
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant0),
@@ -25001,7 +25903,18 @@ impl From<SignalRef> for DataVariant3FormatVariant0Subtype3Parse {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
@@ -25070,7 +25983,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0),
@@ -25150,7 +26063,18 @@ impl From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "boolean")]
     Boolean,
@@ -25223,7 +26147,7 @@ impl std::convert::TryFrom<String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1(String);
 impl std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = String;
@@ -25302,7 +26226,18 @@ impl<'de> serde::Deserialize<'de> for DataVariant3FormatVariant0Subtype3ParseVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype3Type {
     #[serde(rename = "dsv")]
     Dsv,
@@ -25406,7 +26341,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum DataVariant3FormatVariant0Subtype4 {
     Variant0 {
@@ -25443,7 +26378,18 @@ impl From<&DataVariant3FormatVariant0Subtype4> for DataVariant3FormatVariant0Sub
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype4Variant0Type {
     #[serde(rename = "topojson")]
     Topojson,
@@ -25503,7 +26449,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "interior")]
     Interior,
@@ -25565,7 +26522,18 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DataVariant3FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
     Topojson,
@@ -25626,7 +26594,7 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype4Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DataVariant3Values {
     Variant0(serde_json::Value),
@@ -25955,7 +26923,7 @@ impl From<SignalRef> for DataVariant3Values {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DensityTransform {
     #[serde(rename = "as", default = "defaults::density_transform_as")]
@@ -26013,7 +26981,7 @@ impl From<&DensityTransform> for DensityTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformAs {
     Variant0(Vec<DensityTransformAsVariant0Item>),
@@ -26059,7 +27027,7 @@ impl From<SignalRef> for DensityTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformAsVariant0Item {
     Variant0(String),
@@ -26277,7 +27245,7 @@ impl From<SignalRef> for DensityTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(tag = "function", deny_unknown_fields)]
 pub enum DensityTransformDistribution {
     #[serde(rename = "normal")]
@@ -26339,7 +27307,7 @@ impl From<&DensityTransformDistribution> for DensityTransformDistribution {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionBandwidth {
     Variant0(f64),
@@ -26378,7 +27346,7 @@ impl From<SignalRef> for DensityTransformDistributionBandwidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionDistributions {
     Variant0(Vec<serde_json::Value>),
@@ -26421,7 +27389,7 @@ impl From<SignalRef> for DensityTransformDistributionDistributions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionField {
     ScaleField(ScaleField),
@@ -26466,7 +27434,7 @@ impl From<Expr> for DensityTransformDistributionField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMax {
     Variant0(f64),
@@ -26509,7 +27477,7 @@ impl From<SignalRef> for DensityTransformDistributionMax {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMean {
     Variant0(f64),
@@ -26547,7 +27515,7 @@ impl From<SignalRef> for DensityTransformDistributionMean {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMin {
     Variant0(f64),
@@ -26586,7 +27554,7 @@ impl From<SignalRef> for DensityTransformDistributionMin {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionStdev {
     Variant0(f64),
@@ -26639,7 +27607,7 @@ impl From<SignalRef> for DensityTransformDistributionStdev {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionWeights {
     Variant0(Vec<DensityTransformDistributionWeightsVariant0Item>),
@@ -26679,7 +27647,7 @@ impl From<SignalRef> for DensityTransformDistributionWeights {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionWeightsVariant0Item {
     Variant0(f64),
@@ -26731,7 +27699,7 @@ impl From<SignalRef> for DensityTransformDistributionWeightsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformExtent {
     Variant0([DensityTransformExtentVariant0Item; 2usize]),
@@ -26769,7 +27737,7 @@ impl From<SignalRef> for DensityTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformExtentVariant0Item {
     Variant0(f64),
@@ -26808,7 +27776,7 @@ impl From<SignalRef> for DensityTransformExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformMaxsteps {
     Variant0(f64),
@@ -26852,7 +27820,7 @@ impl From<SignalRef> for DensityTransformMaxsteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformMethod {
     Variant0(String),
@@ -26891,7 +27859,7 @@ impl From<SignalRef> for DensityTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformMinsteps {
     Variant0(f64),
@@ -26934,7 +27902,7 @@ impl From<SignalRef> for DensityTransformMinsteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DensityTransformSteps {
     Variant0(f64),
@@ -26967,7 +27935,18 @@ impl From<SignalRef> for DensityTransformSteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DensityTransformType {
     #[serde(rename = "density")]
     Density,
@@ -27194,7 +28173,7 @@ impl std::convert::TryFrom<String> for DensityTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValue {
     Variant0(Vec<DirectionValueVariant0Item>),
@@ -27310,7 +28289,7 @@ impl From<DirectionValueVariant1> for DirectionValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0Item {
     Variant0(DirectionValueVariant0ItemVariant0),
@@ -27440,7 +28419,7 @@ impl From<DirectionValueVariant0ItemVariant2> for DirectionValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemVariant0 {
     Variant0 {
@@ -27490,7 +28469,18 @@ impl From<&DirectionValueVariant0ItemVariant0> for DirectionValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DirectionValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "horizontal")]
     Horizontal,
@@ -27557,7 +28547,7 @@ impl std::convert::TryFrom<String> for DirectionValueVariant0ItemVariant0Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -27716,7 +28706,18 @@ impl From<bool> for DirectionValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant0ItemVariant1 {}
 impl From<&DirectionValueVariant0ItemVariant1> for DirectionValueVariant0ItemVariant1 {
@@ -27822,7 +28823,18 @@ impl From<&DirectionValueVariant0ItemVariant1> for DirectionValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant0ItemVariant2 {}
 impl From<&DirectionValueVariant0ItemVariant2> for DirectionValueVariant0ItemVariant2 {
@@ -27918,7 +28930,7 @@ impl From<&DirectionValueVariant0ItemVariant2> for DirectionValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1 {
     Variant0(DirectionValueVariant1Variant0),
@@ -28041,7 +29053,7 @@ impl From<DirectionValueVariant1Variant2> for DirectionValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1Variant0 {
     Variant0 {
@@ -28083,7 +29095,18 @@ impl From<&DirectionValueVariant1Variant0> for DirectionValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DirectionValueVariant1Variant0Variant1Value {
     #[serde(rename = "horizontal")]
     Horizontal,
@@ -28150,7 +29173,7 @@ impl std::convert::TryFrom<String> for DirectionValueVariant1Variant0Variant1Val
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -28306,7 +29329,18 @@ impl From<bool> for DirectionValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant1Variant1 {}
 impl From<&DirectionValueVariant1Variant1> for DirectionValueVariant1Variant1 {
@@ -28409,7 +29443,18 @@ impl From<&DirectionValueVariant1Variant1> for DirectionValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant1Variant2 {}
 impl From<&DirectionValueVariant1Variant2> for DirectionValueVariant1Variant2 {
@@ -28509,7 +29554,7 @@ impl From<&DirectionValueVariant1Variant2> for DirectionValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DotbinTransform {
     #[serde(rename = "as", default = "defaults::dotbin_transform_as")]
@@ -28549,7 +29594,7 @@ impl From<&DotbinTransform> for DotbinTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformAs {
     Variant0(String),
@@ -28590,7 +29635,7 @@ impl From<SignalRef> for DotbinTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformField {
     ScaleField(ScaleField),
@@ -28647,7 +29692,7 @@ impl From<Expr> for DotbinTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupby {
     Variant0(Vec<DotbinTransformGroupbyVariant0Item>),
@@ -28688,7 +29733,7 @@ impl From<SignalRef> for DotbinTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -28732,7 +29777,7 @@ impl From<Expr> for DotbinTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformSmooth {
     Variant0(bool),
@@ -28770,7 +29815,7 @@ impl From<SignalRef> for DotbinTransformSmooth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum DotbinTransformStep {
     Variant0(f64),
@@ -28803,7 +29848,18 @@ impl From<SignalRef> for DotbinTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DotbinTransformType {
     #[serde(rename = "dotbin")]
     Dotbin,
@@ -28857,7 +29913,9 @@ impl std::convert::TryFrom<String> for DotbinTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Element(pub String);
 impl std::ops::Deref for Element {
     type Target = String;
@@ -28907,7 +29965,7 @@ impl ToString for Element {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Encode {}
 impl From<&Encode> for Encode {
@@ -29135,7 +30193,7 @@ impl From<&Encode> for Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub align: Option<AlignValue>,
@@ -29409,7 +30467,7 @@ impl From<&EncodeEntry> for EncodeEntry {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Everything {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autosize: Option<Autosize>,
@@ -29474,7 +30532,7 @@ impl From<&Everything> for Everything {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum EverythingMarksItem {
     Group(MarkGroup),
@@ -29516,7 +30574,7 @@ impl From<MarkVisual> for EverythingMarksItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Expr {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
     pub as_: Option<String>,
@@ -29537,7 +30595,9 @@ impl From<&Expr> for Expr {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct ExprString(pub String);
 impl std::ops::Deref for ExprString {
     type Target = String;
@@ -29609,7 +30669,7 @@ impl ToString for ExprString {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExtentTransform {
     pub field: ExtentTransformField,
@@ -29643,7 +30703,7 @@ impl From<&ExtentTransform> for ExtentTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ExtentTransformField {
     ScaleField(ScaleField),
@@ -29682,7 +30742,18 @@ impl From<Expr> for ExtentTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ExtentTransformType {
     #[serde(rename = "extent")]
     Extent,
@@ -29826,7 +30897,7 @@ impl std::convert::TryFrom<String> for ExtentTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Facet {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -29926,7 +30997,7 @@ impl From<&Facet> for Facet {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum FacetFacet {
     Variant0 {
@@ -29981,7 +31052,7 @@ impl From<&FacetFacet> for FacetFacet {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FacetFacetVariant1Aggregate {
     #[serde(rename = "as", default, skip_serializing_if = "Vec::is_empty")]
@@ -30018,7 +31089,7 @@ impl From<&FacetFacetVariant1Aggregate> for FacetFacetVariant1Aggregate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FacetFacetVariant1Groupby {
     Variant0(String),
@@ -30093,7 +31164,7 @@ impl From<Vec<String>> for FacetFacetVariant1Groupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Field {
     Variant0(String),
@@ -30150,7 +31221,7 @@ impl From<SignalRef> for Field {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FilterTransform {
     pub expr: ExprString,
@@ -30176,7 +31247,18 @@ impl From<&FilterTransform> for FilterTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum FilterTransformType {
     #[serde(rename = "filter")]
     Filter,
@@ -30298,7 +31380,7 @@ impl std::convert::TryFrom<String> for FilterTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FlattenTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -30343,7 +31425,7 @@ impl From<&FlattenTransform> for FlattenTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformAs {
     Variant0(Vec<FlattenTransformAsVariant0Item>),
@@ -30381,7 +31463,7 @@ impl From<SignalRef> for FlattenTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformAsVariant0Item {
     Variant0(String),
@@ -30427,7 +31509,7 @@ impl From<SignalRef> for FlattenTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformFields {
     Variant0(Vec<FlattenTransformFieldsVariant0Item>),
@@ -30468,7 +31550,7 @@ impl From<SignalRef> for FlattenTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -30512,7 +31594,7 @@ impl From<Expr> for FlattenTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FlattenTransformIndex {
     Variant0(String),
@@ -30540,7 +31622,18 @@ impl From<SignalRef> for FlattenTransformIndex {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum FlattenTransformType {
     #[serde(rename = "flatten")]
     Flatten,
@@ -30658,7 +31751,7 @@ impl std::convert::TryFrom<String> for FlattenTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FoldTransform {
     #[serde(rename = "as", default = "defaults::fold_transform_as")]
@@ -30707,7 +31800,7 @@ impl From<&FoldTransform> for FoldTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformAs {
     Variant0([FoldTransformAsVariant0Item; 2usize]),
@@ -30753,7 +31846,7 @@ impl From<SignalRef> for FoldTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformAsVariant0Item {
     Variant0(String),
@@ -30799,7 +31892,7 @@ impl From<SignalRef> for FoldTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformFields {
     Variant0(Vec<FoldTransformFieldsVariant0Item>),
@@ -30840,7 +31933,7 @@ impl From<SignalRef> for FoldTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FoldTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -30879,7 +31972,18 @@ impl From<Expr> for FoldTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum FoldTransformType {
     #[serde(rename = "fold")]
     Fold,
@@ -31148,7 +32252,7 @@ impl std::convert::TryFrom<String> for FoldTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValue {
     Variant0(Vec<FontWeightValueVariant0Item>),
@@ -31285,7 +32389,7 @@ impl From<FontWeightValueVariant1> for FontWeightValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0Item {
     Variant0(FontWeightValueVariant0ItemVariant0),
@@ -31436,7 +32540,7 @@ impl From<FontWeightValueVariant0ItemVariant2> for FontWeightValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemVariant0 {
     Variant0 {
@@ -31490,7 +32594,7 @@ impl From<&FontWeightValueVariant0ItemVariant0> for FontWeightValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -31670,7 +32774,18 @@ impl From<bool> for FontWeightValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant0ItemVariant1 {}
 impl From<&FontWeightValueVariant0ItemVariant1> for FontWeightValueVariant0ItemVariant1 {
@@ -31797,7 +32912,18 @@ impl From<&FontWeightValueVariant0ItemVariant1> for FontWeightValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant0ItemVariant2 {}
 impl From<&FontWeightValueVariant0ItemVariant2> for FontWeightValueVariant0ItemVariant2 {
@@ -31914,7 +33040,7 @@ impl From<&FontWeightValueVariant0ItemVariant2> for FontWeightValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1 {
     Variant0(FontWeightValueVariant1Variant0),
@@ -32058,7 +33184,7 @@ impl From<FontWeightValueVariant1Variant2> for FontWeightValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Variant0 {
     Variant0 {
@@ -32104,7 +33230,7 @@ impl From<&FontWeightValueVariant1Variant0> for FontWeightValueVariant1Variant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -32281,7 +33407,18 @@ impl From<bool> for FontWeightValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant1Variant1 {}
 impl From<&FontWeightValueVariant1Variant1> for FontWeightValueVariant1Variant1 {
@@ -32405,7 +33542,18 @@ impl From<&FontWeightValueVariant1Variant1> for FontWeightValueVariant1Variant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant1Variant2 {}
 impl From<&FontWeightValueVariant1Variant2> for FontWeightValueVariant1Variant2 {
@@ -32837,7 +33985,7 @@ impl From<&FontWeightValueVariant1Variant2> for FontWeightValueVariant1Variant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ForceTransform {
     #[serde(default = "defaults::force_transform_alpha")]
@@ -32893,7 +34041,7 @@ impl From<&ForceTransform> for ForceTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAlpha {
     Variant0(f64),
@@ -32937,7 +34085,7 @@ impl From<SignalRef> for ForceTransformAlpha {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaMin {
     Variant0(f64),
@@ -32980,7 +34128,7 @@ impl From<SignalRef> for ForceTransformAlphaMin {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaTarget {
     Variant0(f64),
@@ -33034,7 +34182,7 @@ impl From<SignalRef> for ForceTransformAlphaTarget {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAs {
     Variant0(Vec<ForceTransformAsVariant0Item>),
@@ -33082,7 +34230,7 @@ impl From<SignalRef> for ForceTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformAsVariant0Item {
     Variant0(String),
@@ -33402,7 +34550,7 @@ impl From<SignalRef> for ForceTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(tag = "force", deny_unknown_fields)]
 pub enum ForceTransformForcesItem {
     #[serde(rename = "center")]
@@ -33496,7 +34644,7 @@ impl From<&ForceTransformForcesItem> for ForceTransformForcesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistance {
     Variant0(f64),
@@ -33551,7 +34699,7 @@ impl From<ParamField> for ForceTransformForcesItemDistance {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistanceMax {
     Variant0(f64),
@@ -33590,7 +34738,7 @@ impl From<SignalRef> for ForceTransformForcesItemDistanceMax {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistanceMin {
     Variant0(f64),
@@ -33636,7 +34784,7 @@ impl From<SignalRef> for ForceTransformForcesItemDistanceMin {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemId {
     ScaleField(ScaleField),
@@ -33681,7 +34829,7 @@ impl From<Expr> for ForceTransformForcesItemId {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemIterations {
     Variant0(f64),
@@ -33730,7 +34878,7 @@ impl From<SignalRef> for ForceTransformForcesItemIterations {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemRadius {
     Variant0(f64),
@@ -33781,7 +34929,7 @@ impl From<ParamField> for ForceTransformForcesItemRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemStrength {
     Variant0(f64),
@@ -33825,7 +34973,7 @@ impl From<SignalRef> for ForceTransformForcesItemStrength {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemTheta {
     Variant0(f64),
@@ -33868,7 +35016,7 @@ impl From<SignalRef> for ForceTransformForcesItemTheta {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemX {
     Variant0(f64),
@@ -33906,7 +35054,7 @@ impl From<SignalRef> for ForceTransformForcesItemX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemY {
     Variant0(f64),
@@ -33945,7 +35093,7 @@ impl From<SignalRef> for ForceTransformForcesItemY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformIterations {
     Variant0(f64),
@@ -33988,7 +35136,7 @@ impl From<SignalRef> for ForceTransformIterations {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformRestart {
     Variant0(bool),
@@ -34026,7 +35174,7 @@ impl From<SignalRef> for ForceTransformRestart {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformStatic {
     Variant0(bool),
@@ -34059,7 +35207,18 @@ impl From<SignalRef> for ForceTransformStatic {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ForceTransformType {
     #[serde(rename = "force")]
     Force,
@@ -34121,7 +35280,7 @@ impl std::convert::TryFrom<String> for ForceTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ForceTransformVelocityDecay {
     Variant0(f64),
@@ -34196,7 +35355,7 @@ impl From<SignalRef> for ForceTransformVelocityDecay {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FormulaTransform {
     #[serde(rename = "as")]
@@ -34231,7 +35390,7 @@ impl From<&FormulaTransform> for FormulaTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FormulaTransformAs {
     Variant0(String),
@@ -34264,7 +35423,7 @@ impl From<SignalRef> for FormulaTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum FormulaTransformInitonly {
     Variant0(bool),
@@ -34297,7 +35456,18 @@ impl From<SignalRef> for FormulaTransformInitonly {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum FormulaTransformType {
     #[serde(rename = "formula")]
     Formula,
@@ -34357,7 +35527,7 @@ impl std::convert::TryFrom<String> for FormulaTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct From {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -34430,7 +35600,7 @@ impl From<&From> for From {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeojsonTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -34479,7 +35649,7 @@ impl From<&GeojsonTransform> for GeojsonTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeojsonTransformFields {
     Variant0([GeojsonTransformFieldsVariant0Item; 2usize]),
@@ -34520,7 +35690,7 @@ impl From<SignalRef> for GeojsonTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeojsonTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -34567,7 +35737,7 @@ impl From<Expr> for GeojsonTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeojsonTransformGeojson {
     ScaleField(ScaleField),
@@ -34606,7 +35776,18 @@ impl From<Expr> for GeojsonTransformGeojson {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GeojsonTransformType {
     #[serde(rename = "geojson")]
     Geojson,
@@ -34717,7 +35898,7 @@ impl std::convert::TryFrom<String> for GeojsonTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeopathTransform {
     #[serde(rename = "as", default = "defaults::geopath_transform_as")]
@@ -34760,7 +35941,7 @@ impl From<&GeopathTransform> for GeopathTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopathTransformAs {
     Variant0(String),
@@ -34801,7 +35982,7 @@ impl From<SignalRef> for GeopathTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopathTransformField {
     ScaleField(ScaleField),
@@ -34851,7 +36032,7 @@ impl From<Expr> for GeopathTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopathTransformPointRadius {
     Variant0(f64),
@@ -34896,7 +36077,18 @@ impl From<ParamField> for GeopathTransformPointRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GeopathTransformType {
     #[serde(rename = "geopath")]
     Geopath,
@@ -35020,7 +36212,7 @@ impl std::convert::TryFrom<String> for GeopathTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeopointTransform {
     #[serde(rename = "as", default = "defaults::geopoint_transform_as")]
@@ -35070,7 +36262,7 @@ impl From<&GeopointTransform> for GeopointTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformAs {
     Variant0([GeopointTransformAsVariant0Item; 2usize]),
@@ -35116,7 +36308,7 @@ impl From<SignalRef> for GeopointTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformAsVariant0Item {
     Variant0(String),
@@ -35164,7 +36356,7 @@ impl From<SignalRef> for GeopointTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformFields {
     Variant0([GeopointTransformFieldsVariant0Item; 2usize]),
@@ -35205,7 +36397,7 @@ impl From<SignalRef> for GeopointTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeopointTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -35244,7 +36436,18 @@ impl From<Expr> for GeopointTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GeopointTransformType {
     #[serde(rename = "geopoint")]
     Geopoint,
@@ -35356,7 +36559,7 @@ impl std::convert::TryFrom<String> for GeopointTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeoshapeTransform {
     #[serde(rename = "as", default = "defaults::geoshape_transform_as")]
@@ -35399,7 +36602,7 @@ impl From<&GeoshapeTransform> for GeoshapeTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeoshapeTransformAs {
     Variant0(String),
@@ -35441,7 +36644,7 @@ impl From<SignalRef> for GeoshapeTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeoshapeTransformField {
     ScaleField(ScaleField),
@@ -35498,7 +36701,7 @@ impl From<Expr> for GeoshapeTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GeoshapeTransformPointRadius {
     Variant0(f64),
@@ -35543,7 +36746,18 @@ impl From<ParamField> for GeoshapeTransformPointRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GeoshapeTransformType {
     #[serde(rename = "geoshape")]
     Geoshape,
@@ -35613,7 +36827,7 @@ impl std::convert::TryFrom<String> for GeoshapeTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct GradientStops(pub Vec<GradientStopsItem>);
 impl std::ops::Deref for GradientStops {
     type Target = Vec<GradientStopsItem>;
@@ -35659,7 +36873,7 @@ impl From<Vec<GradientStopsItem>> for GradientStops {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GradientStopsItem {
     pub color: String,
@@ -35818,7 +37032,7 @@ impl From<&GradientStopsItem> for GradientStopsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GraticuleTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35879,7 +37093,7 @@ impl From<&GraticuleTransform> for GraticuleTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtent {
     Variant0([serde_json::Value; 2usize]),
@@ -35920,7 +37134,7 @@ impl From<SignalRef> for GraticuleTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMajor {
     Variant0([serde_json::Value; 2usize]),
@@ -35961,7 +37175,7 @@ impl From<SignalRef> for GraticuleTransformExtentMajor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMinor {
     Variant0([serde_json::Value; 2usize]),
@@ -36000,7 +37214,7 @@ impl From<SignalRef> for GraticuleTransformExtentMinor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformPrecision {
     Variant0(f64),
@@ -36055,7 +37269,7 @@ impl From<SignalRef> for GraticuleTransformPrecision {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStep {
     Variant0([GraticuleTransformStepVariant0Item; 2usize]),
@@ -36109,7 +37323,7 @@ impl From<SignalRef> for GraticuleTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajor {
     Variant0([GraticuleTransformStepMajorVariant0Item; 2usize]),
@@ -36155,7 +37369,7 @@ impl From<SignalRef> for GraticuleTransformStepMajor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajorVariant0Item {
     Variant0(f64),
@@ -36209,7 +37423,7 @@ impl From<SignalRef> for GraticuleTransformStepMajorVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinor {
     Variant0([GraticuleTransformStepMinorVariant0Item; 2usize]),
@@ -36255,7 +37469,7 @@ impl From<SignalRef> for GraticuleTransformStepMinor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinorVariant0Item {
     Variant0(f64),
@@ -36293,7 +37507,7 @@ impl From<SignalRef> for GraticuleTransformStepMinorVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepVariant0Item {
     Variant0(f64),
@@ -36326,7 +37540,18 @@ impl From<SignalRef> for GraticuleTransformStepVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum GraticuleTransformType {
     #[serde(rename = "graticule")]
     Graticule,
@@ -36398,7 +37623,7 @@ impl std::convert::TryFrom<String> for GraticuleTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GuideEncode {
     #[serde(default)]
@@ -36507,7 +37732,7 @@ impl From<&GuideEncode> for GuideEncode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HeatmapTransform {
     #[serde(rename = "as", default = "defaults::heatmap_transform_as")]
@@ -36548,7 +37773,7 @@ impl From<&HeatmapTransform> for HeatmapTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformAs {
     Variant0(String),
@@ -36592,7 +37817,7 @@ impl From<SignalRef> for HeatmapTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformColor {
     Variant0(String),
@@ -36640,7 +37865,7 @@ impl From<ParamField> for HeatmapTransformColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformField {
     ScaleField(ScaleField),
@@ -36690,7 +37915,7 @@ impl From<Expr> for HeatmapTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformOpacity {
     Variant0(f64),
@@ -36744,7 +37969,7 @@ impl From<ParamField> for HeatmapTransformOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HeatmapTransformResolve {
     Variant0(HeatmapTransformResolveVariant0),
@@ -36783,7 +38008,18 @@ impl From<SignalRef> for HeatmapTransformResolve {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum HeatmapTransformResolveVariant0 {
     #[serde(rename = "shared")]
     Shared,
@@ -36843,7 +38079,18 @@ impl std::convert::TryFrom<String> for HeatmapTransformResolveVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum HeatmapTransformType {
     #[serde(rename = "heatmap")]
     Heatmap,
@@ -36922,7 +38169,7 @@ impl std::convert::TryFrom<String> for HeatmapTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IdentifierTransform {
     #[serde(rename = "as")]
@@ -36954,7 +38201,7 @@ impl From<&IdentifierTransform> for IdentifierTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IdentifierTransformAs {
     Variant0(String),
@@ -36982,7 +38229,18 @@ impl From<SignalRef> for IdentifierTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IdentifierTransformType {
     #[serde(rename = "identifier")]
     Identifier,
@@ -37130,7 +38388,7 @@ impl std::convert::TryFrom<String> for IdentifierTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImputeTransform {
     pub field: ImputeTransformField,
@@ -37173,7 +38431,7 @@ impl From<&ImputeTransform> for ImputeTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformField {
     ScaleField(ScaleField),
@@ -37230,7 +38488,7 @@ impl From<Expr> for ImputeTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupby {
     Variant0(Vec<ImputeTransformGroupbyVariant0Item>),
@@ -37271,7 +38529,7 @@ impl From<SignalRef> for ImputeTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -37318,7 +38576,7 @@ impl From<Expr> for ImputeTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformKey {
     ScaleField(ScaleField),
@@ -37363,7 +38621,7 @@ impl From<Expr> for ImputeTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformKeyvals {
     Variant0(Vec<serde_json::Value>),
@@ -37408,7 +38666,7 @@ impl From<SignalRef> for ImputeTransformKeyvals {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ImputeTransformMethod {
     Variant0(ImputeTransformMethodVariant0),
@@ -37450,7 +38708,18 @@ impl From<SignalRef> for ImputeTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ImputeTransformMethodVariant0 {
     #[serde(rename = "value")]
     Value,
@@ -37522,7 +38791,18 @@ impl std::convert::TryFrom<String> for ImputeTransformMethodVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ImputeTransformType {
     #[serde(rename = "impute")]
     Impute,
@@ -37735,7 +39015,7 @@ impl std::convert::TryFrom<String> for ImputeTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IsocontourTransform {
     #[serde(rename = "as", default = "defaults::isocontour_transform_as")]
@@ -37789,7 +39069,7 @@ impl From<&IsocontourTransform> for IsocontourTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformAs {
     Variant0(String),
@@ -37831,7 +39111,7 @@ impl From<SignalRef> for IsocontourTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformField {
     ScaleField(ScaleField),
@@ -37875,7 +39155,7 @@ impl From<Expr> for IsocontourTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformLevels {
     Variant0(f64),
@@ -37913,7 +39193,7 @@ impl From<SignalRef> for IsocontourTransformLevels {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformNice {
     Variant0(bool),
@@ -37955,7 +39235,7 @@ impl From<SignalRef> for IsocontourTransformNice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformResolve {
     Variant0(IsocontourTransformResolveVariant0),
@@ -37994,7 +39274,18 @@ impl From<SignalRef> for IsocontourTransformResolve {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IsocontourTransformResolveVariant0 {
     #[serde(rename = "shared")]
     Shared,
@@ -38065,7 +39356,7 @@ impl std::convert::TryFrom<String> for IsocontourTransformResolveVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformScale {
     Variant0(f64),
@@ -38116,7 +39407,7 @@ impl From<ParamField> for IsocontourTransformScale {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformSmooth {
     Variant0(bool),
@@ -38169,7 +39460,7 @@ impl From<SignalRef> for IsocontourTransformSmooth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholds {
     Variant0(Vec<IsocontourTransformThresholdsVariant0Item>),
@@ -38207,7 +39498,7 @@ impl From<SignalRef> for IsocontourTransformThresholds {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholdsVariant0Item {
     Variant0(f64),
@@ -38263,7 +39554,7 @@ impl From<SignalRef> for IsocontourTransformThresholdsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslate {
     Variant0(Vec<IsocontourTransformTranslateVariant0Item>),
@@ -38307,7 +39598,7 @@ impl From<SignalRef> for IsocontourTransformTranslate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslateVariant0Item {
     Variant0(f64),
@@ -38352,7 +39643,18 @@ impl From<ParamField> for IsocontourTransformTranslateVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum IsocontourTransformType {
     #[serde(rename = "isocontour")]
     Isocontour,
@@ -38414,7 +39716,7 @@ impl std::convert::TryFrom<String> for IsocontourTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IsocontourTransformZero {
     Variant0(bool),
@@ -38594,7 +39896,7 @@ impl From<SignalRef> for IsocontourTransformZero {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JoinaggregateTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -38647,7 +39949,7 @@ impl From<&JoinaggregateTransform> for JoinaggregateTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAs {
     Variant0(Vec<JoinaggregateTransformAsVariant0Item>),
@@ -38688,7 +39990,7 @@ impl From<SignalRef> for JoinaggregateTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAsVariant0Item {
     Variant0(String),
@@ -38738,7 +40040,7 @@ impl From<SignalRef> for JoinaggregateTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFields {
     Variant0(Vec<JoinaggregateTransformFieldsVariant0Item>),
@@ -38782,7 +40084,7 @@ impl From<SignalRef> for JoinaggregateTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFieldsVariant0Item {
     Variant0(ScaleField),
@@ -38840,7 +40142,7 @@ impl From<Expr> for JoinaggregateTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupby {
     Variant0(Vec<JoinaggregateTransformGroupbyVariant0Item>),
@@ -38881,7 +40183,7 @@ impl From<SignalRef> for JoinaggregateTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -38930,7 +40232,7 @@ impl From<Expr> for JoinaggregateTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformKey {
     ScaleField(ScaleField),
@@ -39009,7 +40311,7 @@ impl From<Expr> for JoinaggregateTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOps {
     Variant0(Vec<JoinaggregateTransformOpsVariant0Item>),
@@ -39072,7 +40374,7 @@ impl From<SignalRef> for JoinaggregateTransformOps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOpsVariant0Item {
     Variant0(JoinaggregateTransformOpsVariant0ItemVariant0),
@@ -39128,7 +40430,18 @@ impl From<SignalRef> for JoinaggregateTransformOpsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum JoinaggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "values")]
     Values,
@@ -39278,7 +40591,18 @@ impl std::convert::TryFrom<String> for JoinaggregateTransformOpsVariant0ItemVari
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum JoinaggregateTransformType {
     #[serde(rename = "joinaggregate")]
     Joinaggregate,
@@ -39486,7 +40810,7 @@ impl std::convert::TryFrom<String> for JoinaggregateTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Kde2dTransform {
     #[serde(rename = "as", default = "defaults::kde2d_transform_as")]
@@ -39532,7 +40856,7 @@ impl From<&Kde2dTransform> for Kde2dTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformAs {
     Variant0(String),
@@ -39582,7 +40906,7 @@ impl From<SignalRef> for Kde2dTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidth {
     Variant0([Kde2dTransformBandwidthVariant0Item; 2usize]),
@@ -39620,7 +40944,7 @@ impl From<SignalRef> for Kde2dTransformBandwidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidthVariant0Item {
     Variant0(f64),
@@ -39658,7 +40982,7 @@ impl From<SignalRef> for Kde2dTransformBandwidthVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformCellSize {
     Variant0(f64),
@@ -39696,7 +41020,7 @@ impl From<SignalRef> for Kde2dTransformCellSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformCounts {
     Variant0(bool),
@@ -39747,7 +41071,7 @@ impl From<SignalRef> for Kde2dTransformCounts {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupby {
     Variant0(Vec<Kde2dTransformGroupbyVariant0Item>),
@@ -39788,7 +41112,7 @@ impl From<SignalRef> for Kde2dTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -39844,7 +41168,7 @@ impl From<Expr> for Kde2dTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformSize {
     Variant0([Kde2dTransformSizeVariant0Item; 2usize]),
@@ -39882,7 +41206,7 @@ impl From<SignalRef> for Kde2dTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformSizeVariant0Item {
     Variant0(f64),
@@ -39915,7 +41239,18 @@ impl From<SignalRef> for Kde2dTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum Kde2dTransformType {
     #[serde(rename = "kde2d")]
     Kde2d,
@@ -39979,7 +41314,7 @@ impl std::convert::TryFrom<String> for Kde2dTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformWeight {
     ScaleField(ScaleField),
@@ -40026,7 +41361,7 @@ impl From<Expr> for Kde2dTransformWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformX {
     ScaleField(ScaleField),
@@ -40073,7 +41408,7 @@ impl From<Expr> for Kde2dTransformX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Kde2dTransformY {
     ScaleField(ScaleField),
@@ -40283,7 +41618,7 @@ impl From<Expr> for Kde2dTransformY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct KdeTransform {
     #[serde(rename = "as", default = "defaults::kde_transform_as")]
@@ -40348,7 +41683,7 @@ impl From<&KdeTransform> for KdeTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformAs {
     Variant0(Vec<KdeTransformAsVariant0Item>),
@@ -40394,7 +41729,7 @@ impl From<SignalRef> for KdeTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformAsVariant0Item {
     Variant0(String),
@@ -40427,7 +41762,7 @@ impl From<SignalRef> for KdeTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformBandwidth {
     Variant0(f64),
@@ -40465,7 +41800,7 @@ impl From<SignalRef> for KdeTransformBandwidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformCounts {
     Variant0(bool),
@@ -40503,7 +41838,7 @@ impl From<SignalRef> for KdeTransformCounts {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformCumulative {
     Variant0(bool),
@@ -40553,7 +41888,7 @@ impl From<SignalRef> for KdeTransformCumulative {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformExtent {
     Variant0([KdeTransformExtentVariant0Item; 2usize]),
@@ -40591,7 +41926,7 @@ impl From<SignalRef> for KdeTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformExtentVariant0Item {
     Variant0(f64),
@@ -40632,7 +41967,7 @@ impl From<SignalRef> for KdeTransformExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformField {
     ScaleField(ScaleField),
@@ -40689,7 +42024,7 @@ impl From<Expr> for KdeTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformGroupby {
     Variant0(Vec<KdeTransformGroupbyVariant0Item>),
@@ -40730,7 +42065,7 @@ impl From<SignalRef> for KdeTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -40775,7 +42110,7 @@ impl From<Expr> for KdeTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformMaxsteps {
     Variant0(f64),
@@ -40819,7 +42154,7 @@ impl From<SignalRef> for KdeTransformMaxsteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformMinsteps {
     Variant0(f64),
@@ -40866,7 +42201,7 @@ impl From<SignalRef> for KdeTransformMinsteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformResolve {
     Variant0(KdeTransformResolveVariant0),
@@ -40905,7 +42240,18 @@ impl From<SignalRef> for KdeTransformResolve {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum KdeTransformResolveVariant0 {
     #[serde(rename = "shared")]
     Shared,
@@ -40970,7 +42316,7 @@ impl std::convert::TryFrom<String> for KdeTransformResolveVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum KdeTransformSteps {
     Variant0(f64),
@@ -41003,7 +42349,18 @@ impl From<SignalRef> for KdeTransformSteps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum KdeTransformType {
     #[serde(rename = "kde")]
     Kde,
@@ -41070,7 +42427,7 @@ impl std::convert::TryFrom<String> for KdeTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelOverlap {
     Variant0(bool),
@@ -41110,7 +42467,18 @@ impl From<SignalRef> for LabelOverlap {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LabelOverlapVariant1 {
     #[serde(rename = "parity")]
     Parity,
@@ -41359,7 +42727,7 @@ impl std::convert::TryFrom<String> for LabelOverlapVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LabelTransform {
     #[serde(default = "defaults::label_transform_anchor")]
@@ -41440,7 +42808,7 @@ impl From<&LabelTransform> for LabelTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAnchor {
     Variant0(Vec<LabelTransformAnchorVariant0Item>),
@@ -41492,7 +42860,7 @@ impl From<SignalRef> for LabelTransformAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAnchorVariant0Item {
     Variant0(String),
@@ -41544,7 +42912,7 @@ impl From<SignalRef> for LabelTransformAnchorVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAs {
     Variant0([LabelTransformAsVariant0Item; 5usize]),
@@ -41593,7 +42961,7 @@ impl From<SignalRef> for LabelTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAsVariant0Item {
     Variant0(String),
@@ -41627,7 +42995,7 @@ impl From<SignalRef> for LabelTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidBaseMark {
     Variant0(bool),
@@ -41673,7 +43041,7 @@ impl From<SignalRef> for LabelTransformAvoidBaseMark {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidMarks {
     Variant0(Vec<String>),
@@ -41712,7 +43080,7 @@ impl From<SignalRef> for LabelTransformAvoidMarks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformLineAnchor {
     Variant0(String),
@@ -41750,7 +43118,7 @@ impl From<SignalRef> for LabelTransformLineAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformMarkIndex {
     Variant0(f64),
@@ -41789,7 +43157,7 @@ impl From<SignalRef> for LabelTransformMarkIndex {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformMethod {
     Variant0(String),
@@ -41840,7 +43208,7 @@ impl From<SignalRef> for LabelTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformOffset {
     Variant0(Vec<LabelTransformOffsetVariant0Item>),
@@ -41883,7 +43251,7 @@ impl From<SignalRef> for LabelTransformOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformOffsetVariant0Item {
     Variant0(f64),
@@ -41924,7 +43292,7 @@ impl From<SignalRef> for LabelTransformOffsetVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformPadding {
     Variant0(f64),
@@ -41975,7 +43343,7 @@ impl From<SignalRef> for LabelTransformPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformSize {
     Variant0([LabelTransformSizeVariant0Item; 2usize]),
@@ -42013,7 +43381,7 @@ impl From<SignalRef> for LabelTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LabelTransformSizeVariant0Item {
     Variant0(f64),
@@ -42046,7 +43414,18 @@ impl From<SignalRef> for LabelTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LabelTransformType {
     #[serde(rename = "label")]
     Label,
@@ -42371,7 +43750,7 @@ impl std::convert::TryFrom<String> for LabelTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Layout {
     Variant0 {
@@ -42479,7 +43858,7 @@ impl From<SignalRef> for Layout {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Align {
     Variant0(LayoutVariant0AlignVariant0),
@@ -42521,7 +43900,7 @@ impl From<LayoutVariant0AlignVariant0> for LayoutVariant0Align {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant0 {
     Variant0(LayoutVariant0AlignVariant0Variant0),
@@ -42556,7 +43935,18 @@ impl From<SignalRef> for LayoutVariant0AlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0AlignVariant0Variant0 {
     #[serde(rename = "all")]
     All,
@@ -42629,7 +44019,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant0Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant1Column {
     Variant0(LayoutVariant0AlignVariant1ColumnVariant0),
@@ -42664,7 +44054,18 @@ impl From<SignalRef> for LayoutVariant0AlignVariant1Column {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0AlignVariant1ColumnVariant0 {
     #[serde(rename = "all")]
     All,
@@ -42739,7 +44140,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant1ColumnVariant0
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0AlignVariant1Row {
     Variant0(LayoutVariant0AlignVariant1RowVariant0),
@@ -42774,7 +44175,18 @@ impl From<SignalRef> for LayoutVariant0AlignVariant1Row {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0AlignVariant1RowVariant0 {
     #[serde(rename = "all")]
     All,
@@ -42846,7 +44258,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0AlignVariant1RowVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0Bounds {
     Variant0(LayoutVariant0BoundsVariant0),
@@ -42880,7 +44292,18 @@ impl From<SignalRef> for LayoutVariant0Bounds {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0BoundsVariant0 {
     #[serde(rename = "full")]
     Full,
@@ -42957,7 +44380,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0BoundsVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Center {
     Variant0(bool),
@@ -43013,7 +44436,7 @@ impl From<SignalRef> for LayoutVariant0Center {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0FooterBand {
     Variant0(NumberOrSignal),
@@ -43064,7 +44487,7 @@ impl From<NumberOrSignal> for LayoutVariant0FooterBand {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0HeaderBand {
     Variant0(NumberOrSignal),
@@ -43127,7 +44550,7 @@ impl From<NumberOrSignal> for LayoutVariant0HeaderBand {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Offset {
     Variant0(f64),
@@ -43203,7 +44626,7 @@ impl From<SignalRef> for LayoutVariant0Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0Padding {
     Variant0(f64),
@@ -43286,7 +44709,7 @@ impl From<SignalRef> for LayoutVariant0Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0TitleAnchor {
     Variant0(LayoutVariant0TitleAnchorVariant0),
@@ -43327,7 +44750,7 @@ impl From<LayoutVariant0TitleAnchorVariant0> for LayoutVariant0TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant0 {
     Variant0(LayoutVariant0TitleAnchorVariant0Variant0),
@@ -43361,7 +44784,18 @@ impl From<SignalRef> for LayoutVariant0TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0TitleAnchorVariant0Variant0 {
     #[serde(rename = "start")]
     Start,
@@ -43431,7 +44865,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant0Variant0
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Column {
     Variant0(LayoutVariant0TitleAnchorVariant1ColumnVariant0),
@@ -43467,7 +44901,18 @@ impl From<SignalRef> for LayoutVariant0TitleAnchorVariant1Column {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -43537,7 +44982,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant1ColumnVa
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LayoutVariant0TitleAnchorVariant1Row {
     Variant0(LayoutVariant0TitleAnchorVariant1RowVariant0),
@@ -43571,7 +45016,18 @@ impl From<SignalRef> for LayoutVariant0TitleAnchorVariant1Row {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LayoutVariant0TitleAnchorVariant1RowVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -43650,7 +45106,7 @@ impl std::convert::TryFrom<String> for LayoutVariant0TitleAnchorVariant1RowVaria
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LayoutVariant0TitleBand {
     Variant0(NumberOrSignal),
@@ -44459,7 +45915,7 @@ impl From<NumberOrSignal> for LayoutVariant0TitleBand {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Legend {
     Variant0 {
@@ -46678,7 +48134,7 @@ impl From<&Legend> for Legend {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0CornerRadius {
     Variant0(f64),
@@ -46712,7 +48168,18 @@ impl From<NumberValue> for LegendVariant0CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -46791,7 +48258,7 @@ impl std::convert::TryFrom<String> for LegendVariant0Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant0Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -46832,7 +48299,7 @@ impl From<&LegendVariant0Encode> for LegendVariant0Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0FillColor {
     Variant0,
@@ -46902,7 +48369,7 @@ impl From<ColorValue> for LegendVariant0FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant0Format {
     Variant0(String),
@@ -46961,7 +48428,7 @@ impl From<SignalRef> for LegendVariant0Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0FormatType {
     Variant0(LegendVariant0FormatTypeVariant0),
@@ -46996,7 +48463,18 @@ impl From<SignalRef> for LegendVariant0FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -47065,7 +48543,7 @@ impl std::convert::TryFrom<String> for LegendVariant0FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0GradientOpacity {
     Variant0(f64),
@@ -47106,7 +48584,7 @@ impl From<NumberValue> for LegendVariant0GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0GradientStrokeColor {
     Variant0,
@@ -47140,7 +48618,7 @@ impl From<ColorValue> for LegendVariant0GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0GradientStrokeWidth {
     Variant0(f64),
@@ -47182,7 +48660,7 @@ impl From<NumberValue> for LegendVariant0GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0GridAlign {
     Variant0(LegendVariant0GridAlignVariant0),
@@ -47217,7 +48695,18 @@ impl From<SignalRef> for LegendVariant0GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -47290,7 +48779,7 @@ impl std::convert::TryFrom<String> for LegendVariant0GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelAlign {
     Variant0(LegendVariant0LabelAlignVariant0),
@@ -47325,7 +48814,18 @@ impl From<AlignValue> for LegendVariant0LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -47401,7 +48901,7 @@ impl std::convert::TryFrom<String> for LegendVariant0LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelBaseline {
     Variant0(LegendVariant0LabelBaselineVariant0),
@@ -47439,7 +48939,18 @@ impl From<BaselineValue> for LegendVariant0LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -47523,7 +49034,7 @@ impl std::convert::TryFrom<String> for LegendVariant0LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelColor {
     Variant0,
@@ -47557,7 +49068,7 @@ impl From<ColorValue> for LegendVariant0LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelFont {
     Variant0(String),
@@ -47590,7 +49101,7 @@ impl From<StringValue> for LegendVariant0LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelFontSize {
     Variant0(f64),
@@ -47628,7 +49139,7 @@ impl From<NumberValue> for LegendVariant0LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelFontStyle {
     Variant0(String),
@@ -47685,7 +49196,7 @@ impl From<StringValue> for LegendVariant0LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelFontWeight {
     Variant0(MyEnum),
@@ -47723,7 +49234,7 @@ impl From<FontWeightValue> for LegendVariant0LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelLimit {
     Variant0(f64),
@@ -47761,7 +49272,7 @@ impl From<NumberValue> for LegendVariant0LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelOffset {
     Variant0(f64),
@@ -47799,7 +49310,7 @@ impl From<NumberValue> for LegendVariant0LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelOpacity {
     Variant0(f64),
@@ -47837,7 +49348,7 @@ impl From<NumberValue> for LegendVariant0LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LegendX {
     Variant0(f64),
@@ -47875,7 +49386,7 @@ impl From<NumberValue> for LegendVariant0LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0LegendY {
     Variant0(f64),
@@ -47913,7 +49424,7 @@ impl From<NumberValue> for LegendVariant0LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0Offset {
     Variant0(f64),
@@ -47962,7 +49473,7 @@ impl From<NumberValue> for LegendVariant0Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0Orient {
     Variant0(LegendVariant0OrientVariant0),
@@ -48004,7 +49515,18 @@ impl From<SignalRef> for LegendVariant0Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -48097,7 +49619,7 @@ impl std::convert::TryFrom<String> for LegendVariant0OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0Padding {
     Variant0(f64),
@@ -48138,7 +49660,7 @@ impl From<NumberValue> for LegendVariant0Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0StrokeColor {
     Variant0,
@@ -48175,7 +49697,7 @@ impl From<ColorValue> for LegendVariant0StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolDash {
     Variant0(Vec<f64>),
@@ -48213,7 +49735,7 @@ impl From<ArrayValue> for LegendVariant0SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolDashOffset {
     Variant0(f64),
@@ -48254,7 +49776,7 @@ impl From<NumberValue> for LegendVariant0SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolFillColor {
     Variant0,
@@ -48288,7 +49810,7 @@ impl From<ColorValue> for LegendVariant0SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolOffset {
     Variant0(f64),
@@ -48326,7 +49848,7 @@ impl From<NumberValue> for LegendVariant0SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolOpacity {
     Variant0(f64),
@@ -48364,7 +49886,7 @@ impl From<NumberValue> for LegendVariant0SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolSize {
     Variant0(f64),
@@ -48405,7 +49927,7 @@ impl From<NumberValue> for LegendVariant0SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolStrokeColor {
     Variant0,
@@ -48439,7 +49961,7 @@ impl From<ColorValue> for LegendVariant0SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolStrokeWidth {
     Variant0(f64),
@@ -48477,7 +49999,7 @@ impl From<NumberValue> for LegendVariant0SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolType {
     Variant0(String),
@@ -48514,7 +50036,7 @@ impl From<StringValue> for LegendVariant0SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleAlign {
     Variant0(LegendVariant0TitleAlignVariant0),
@@ -48549,7 +50071,18 @@ impl From<AlignValue> for LegendVariant0TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -48623,7 +50156,7 @@ impl std::convert::TryFrom<String> for LegendVariant0TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleAnchor {
     Variant0(Option<LegendVariant0TitleAnchorVariant0>),
@@ -48659,7 +50192,18 @@ impl From<AnchorValue> for LegendVariant0TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -48735,7 +50279,7 @@ impl std::convert::TryFrom<String> for LegendVariant0TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleBaseline {
     Variant0(LegendVariant0TitleBaselineVariant0),
@@ -48773,7 +50317,18 @@ impl From<BaselineValue> for LegendVariant0TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -48857,7 +50412,7 @@ impl std::convert::TryFrom<String> for LegendVariant0TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleColor {
     Variant0,
@@ -48891,7 +50446,7 @@ impl From<ColorValue> for LegendVariant0TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleFont {
     Variant0(String),
@@ -48924,7 +50479,7 @@ impl From<StringValue> for LegendVariant0TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleFontSize {
     Variant0(f64),
@@ -48962,7 +50517,7 @@ impl From<NumberValue> for LegendVariant0TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleFontStyle {
     Variant0(String),
@@ -49019,7 +50574,7 @@ impl From<StringValue> for LegendVariant0TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleFontWeight {
     Variant0(MyEnum),
@@ -49057,7 +50612,7 @@ impl From<FontWeightValue> for LegendVariant0TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleLimit {
     Variant0(f64),
@@ -49095,7 +50650,7 @@ impl From<NumberValue> for LegendVariant0TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleLineHeight {
     Variant0(f64),
@@ -49133,7 +50688,7 @@ impl From<NumberValue> for LegendVariant0TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleOpacity {
     Variant0(f64),
@@ -49176,7 +50731,7 @@ impl From<NumberValue> for LegendVariant0TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleOrient {
     Variant0(LegendVariant0TitleOrientVariant0),
@@ -49212,7 +50767,18 @@ impl From<OrientValue> for LegendVariant0TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -49285,7 +50851,7 @@ impl std::convert::TryFrom<String> for LegendVariant0TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant0TitlePadding {
     Variant0(f64),
@@ -49319,7 +50885,18 @@ impl From<NumberValue> for LegendVariant0TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant0Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -49384,7 +50961,7 @@ impl std::convert::TryFrom<String> for LegendVariant0Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1CornerRadius {
     Variant0(f64),
@@ -49418,7 +50995,18 @@ impl From<NumberValue> for LegendVariant1CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -49497,7 +51085,7 @@ impl std::convert::TryFrom<String> for LegendVariant1Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant1Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49538,7 +51126,7 @@ impl From<&LegendVariant1Encode> for LegendVariant1Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1FillColor {
     Variant0,
@@ -49608,7 +51196,7 @@ impl From<ColorValue> for LegendVariant1FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant1Format {
     Variant0(String),
@@ -49667,7 +51255,7 @@ impl From<SignalRef> for LegendVariant1Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1FormatType {
     Variant0(LegendVariant1FormatTypeVariant0),
@@ -49702,7 +51290,18 @@ impl From<SignalRef> for LegendVariant1FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -49771,7 +51370,7 @@ impl std::convert::TryFrom<String> for LegendVariant1FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1GradientOpacity {
     Variant0(f64),
@@ -49812,7 +51411,7 @@ impl From<NumberValue> for LegendVariant1GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1GradientStrokeColor {
     Variant0,
@@ -49846,7 +51445,7 @@ impl From<ColorValue> for LegendVariant1GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1GradientStrokeWidth {
     Variant0(f64),
@@ -49888,7 +51487,7 @@ impl From<NumberValue> for LegendVariant1GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1GridAlign {
     Variant0(LegendVariant1GridAlignVariant0),
@@ -49923,7 +51522,18 @@ impl From<SignalRef> for LegendVariant1GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -49996,7 +51606,7 @@ impl std::convert::TryFrom<String> for LegendVariant1GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelAlign {
     Variant0(LegendVariant1LabelAlignVariant0),
@@ -50031,7 +51641,18 @@ impl From<AlignValue> for LegendVariant1LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -50107,7 +51728,7 @@ impl std::convert::TryFrom<String> for LegendVariant1LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelBaseline {
     Variant0(LegendVariant1LabelBaselineVariant0),
@@ -50145,7 +51766,18 @@ impl From<BaselineValue> for LegendVariant1LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -50229,7 +51861,7 @@ impl std::convert::TryFrom<String> for LegendVariant1LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelColor {
     Variant0,
@@ -50263,7 +51895,7 @@ impl From<ColorValue> for LegendVariant1LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelFont {
     Variant0(String),
@@ -50296,7 +51928,7 @@ impl From<StringValue> for LegendVariant1LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelFontSize {
     Variant0(f64),
@@ -50334,7 +51966,7 @@ impl From<NumberValue> for LegendVariant1LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelFontStyle {
     Variant0(String),
@@ -50391,7 +52023,7 @@ impl From<StringValue> for LegendVariant1LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelFontWeight {
     Variant0(MyEnum),
@@ -50429,7 +52061,7 @@ impl From<FontWeightValue> for LegendVariant1LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelLimit {
     Variant0(f64),
@@ -50467,7 +52099,7 @@ impl From<NumberValue> for LegendVariant1LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelOffset {
     Variant0(f64),
@@ -50505,7 +52137,7 @@ impl From<NumberValue> for LegendVariant1LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelOpacity {
     Variant0(f64),
@@ -50543,7 +52175,7 @@ impl From<NumberValue> for LegendVariant1LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LegendX {
     Variant0(f64),
@@ -50581,7 +52213,7 @@ impl From<NumberValue> for LegendVariant1LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1LegendY {
     Variant0(f64),
@@ -50619,7 +52251,7 @@ impl From<NumberValue> for LegendVariant1LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1Offset {
     Variant0(f64),
@@ -50668,7 +52300,7 @@ impl From<NumberValue> for LegendVariant1Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1Orient {
     Variant0(LegendVariant1OrientVariant0),
@@ -50710,7 +52342,18 @@ impl From<SignalRef> for LegendVariant1Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -50803,7 +52446,7 @@ impl std::convert::TryFrom<String> for LegendVariant1OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1Padding {
     Variant0(f64),
@@ -50844,7 +52487,7 @@ impl From<NumberValue> for LegendVariant1Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1StrokeColor {
     Variant0,
@@ -50881,7 +52524,7 @@ impl From<ColorValue> for LegendVariant1StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolDash {
     Variant0(Vec<f64>),
@@ -50919,7 +52562,7 @@ impl From<ArrayValue> for LegendVariant1SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolDashOffset {
     Variant0(f64),
@@ -50960,7 +52603,7 @@ impl From<NumberValue> for LegendVariant1SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolFillColor {
     Variant0,
@@ -50994,7 +52637,7 @@ impl From<ColorValue> for LegendVariant1SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolOffset {
     Variant0(f64),
@@ -51032,7 +52675,7 @@ impl From<NumberValue> for LegendVariant1SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolOpacity {
     Variant0(f64),
@@ -51070,7 +52713,7 @@ impl From<NumberValue> for LegendVariant1SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolSize {
     Variant0(f64),
@@ -51111,7 +52754,7 @@ impl From<NumberValue> for LegendVariant1SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolStrokeColor {
     Variant0,
@@ -51145,7 +52788,7 @@ impl From<ColorValue> for LegendVariant1SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolStrokeWidth {
     Variant0(f64),
@@ -51183,7 +52826,7 @@ impl From<NumberValue> for LegendVariant1SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolType {
     Variant0(String),
@@ -51220,7 +52863,7 @@ impl From<StringValue> for LegendVariant1SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleAlign {
     Variant0(LegendVariant1TitleAlignVariant0),
@@ -51255,7 +52898,18 @@ impl From<AlignValue> for LegendVariant1TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -51329,7 +52983,7 @@ impl std::convert::TryFrom<String> for LegendVariant1TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleAnchor {
     Variant0(Option<LegendVariant1TitleAnchorVariant0>),
@@ -51365,7 +53019,18 @@ impl From<AnchorValue> for LegendVariant1TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -51441,7 +53106,7 @@ impl std::convert::TryFrom<String> for LegendVariant1TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleBaseline {
     Variant0(LegendVariant1TitleBaselineVariant0),
@@ -51479,7 +53144,18 @@ impl From<BaselineValue> for LegendVariant1TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -51563,7 +53239,7 @@ impl std::convert::TryFrom<String> for LegendVariant1TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleColor {
     Variant0,
@@ -51597,7 +53273,7 @@ impl From<ColorValue> for LegendVariant1TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleFont {
     Variant0(String),
@@ -51630,7 +53306,7 @@ impl From<StringValue> for LegendVariant1TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleFontSize {
     Variant0(f64),
@@ -51668,7 +53344,7 @@ impl From<NumberValue> for LegendVariant1TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleFontStyle {
     Variant0(String),
@@ -51725,7 +53401,7 @@ impl From<StringValue> for LegendVariant1TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleFontWeight {
     Variant0(MyEnum),
@@ -51763,7 +53439,7 @@ impl From<FontWeightValue> for LegendVariant1TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleLimit {
     Variant0(f64),
@@ -51801,7 +53477,7 @@ impl From<NumberValue> for LegendVariant1TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleLineHeight {
     Variant0(f64),
@@ -51839,7 +53515,7 @@ impl From<NumberValue> for LegendVariant1TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleOpacity {
     Variant0(f64),
@@ -51882,7 +53558,7 @@ impl From<NumberValue> for LegendVariant1TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleOrient {
     Variant0(LegendVariant1TitleOrientVariant0),
@@ -51918,7 +53594,18 @@ impl From<OrientValue> for LegendVariant1TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -51991,7 +53678,7 @@ impl std::convert::TryFrom<String> for LegendVariant1TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant1TitlePadding {
     Variant0(f64),
@@ -52025,7 +53712,18 @@ impl From<NumberValue> for LegendVariant1TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant1Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -52090,7 +53788,7 @@ impl std::convert::TryFrom<String> for LegendVariant1Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2CornerRadius {
     Variant0(f64),
@@ -52124,7 +53822,18 @@ impl From<NumberValue> for LegendVariant2CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -52203,7 +53912,7 @@ impl std::convert::TryFrom<String> for LegendVariant2Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant2Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -52244,7 +53953,7 @@ impl From<&LegendVariant2Encode> for LegendVariant2Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2FillColor {
     Variant0,
@@ -52314,7 +54023,7 @@ impl From<ColorValue> for LegendVariant2FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant2Format {
     Variant0(String),
@@ -52373,7 +54082,7 @@ impl From<SignalRef> for LegendVariant2Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2FormatType {
     Variant0(LegendVariant2FormatTypeVariant0),
@@ -52408,7 +54117,18 @@ impl From<SignalRef> for LegendVariant2FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -52477,7 +54197,7 @@ impl std::convert::TryFrom<String> for LegendVariant2FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2GradientOpacity {
     Variant0(f64),
@@ -52518,7 +54238,7 @@ impl From<NumberValue> for LegendVariant2GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2GradientStrokeColor {
     Variant0,
@@ -52552,7 +54272,7 @@ impl From<ColorValue> for LegendVariant2GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2GradientStrokeWidth {
     Variant0(f64),
@@ -52594,7 +54314,7 @@ impl From<NumberValue> for LegendVariant2GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2GridAlign {
     Variant0(LegendVariant2GridAlignVariant0),
@@ -52629,7 +54349,18 @@ impl From<SignalRef> for LegendVariant2GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -52702,7 +54433,7 @@ impl std::convert::TryFrom<String> for LegendVariant2GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelAlign {
     Variant0(LegendVariant2LabelAlignVariant0),
@@ -52737,7 +54468,18 @@ impl From<AlignValue> for LegendVariant2LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -52813,7 +54555,7 @@ impl std::convert::TryFrom<String> for LegendVariant2LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelBaseline {
     Variant0(LegendVariant2LabelBaselineVariant0),
@@ -52851,7 +54593,18 @@ impl From<BaselineValue> for LegendVariant2LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -52935,7 +54688,7 @@ impl std::convert::TryFrom<String> for LegendVariant2LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelColor {
     Variant0,
@@ -52969,7 +54722,7 @@ impl From<ColorValue> for LegendVariant2LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelFont {
     Variant0(String),
@@ -53002,7 +54755,7 @@ impl From<StringValue> for LegendVariant2LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelFontSize {
     Variant0(f64),
@@ -53040,7 +54793,7 @@ impl From<NumberValue> for LegendVariant2LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelFontStyle {
     Variant0(String),
@@ -53097,7 +54850,7 @@ impl From<StringValue> for LegendVariant2LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelFontWeight {
     Variant0(MyEnum),
@@ -53135,7 +54888,7 @@ impl From<FontWeightValue> for LegendVariant2LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelLimit {
     Variant0(f64),
@@ -53173,7 +54926,7 @@ impl From<NumberValue> for LegendVariant2LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelOffset {
     Variant0(f64),
@@ -53211,7 +54964,7 @@ impl From<NumberValue> for LegendVariant2LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelOpacity {
     Variant0(f64),
@@ -53249,7 +55002,7 @@ impl From<NumberValue> for LegendVariant2LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LegendX {
     Variant0(f64),
@@ -53287,7 +55040,7 @@ impl From<NumberValue> for LegendVariant2LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2LegendY {
     Variant0(f64),
@@ -53325,7 +55078,7 @@ impl From<NumberValue> for LegendVariant2LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2Offset {
     Variant0(f64),
@@ -53374,7 +55127,7 @@ impl From<NumberValue> for LegendVariant2Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2Orient {
     Variant0(LegendVariant2OrientVariant0),
@@ -53416,7 +55169,18 @@ impl From<SignalRef> for LegendVariant2Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -53509,7 +55273,7 @@ impl std::convert::TryFrom<String> for LegendVariant2OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2Padding {
     Variant0(f64),
@@ -53550,7 +55314,7 @@ impl From<NumberValue> for LegendVariant2Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2StrokeColor {
     Variant0,
@@ -53587,7 +55351,7 @@ impl From<ColorValue> for LegendVariant2StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolDash {
     Variant0(Vec<f64>),
@@ -53625,7 +55389,7 @@ impl From<ArrayValue> for LegendVariant2SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolDashOffset {
     Variant0(f64),
@@ -53666,7 +55430,7 @@ impl From<NumberValue> for LegendVariant2SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolFillColor {
     Variant0,
@@ -53700,7 +55464,7 @@ impl From<ColorValue> for LegendVariant2SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolOffset {
     Variant0(f64),
@@ -53738,7 +55502,7 @@ impl From<NumberValue> for LegendVariant2SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolOpacity {
     Variant0(f64),
@@ -53776,7 +55540,7 @@ impl From<NumberValue> for LegendVariant2SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolSize {
     Variant0(f64),
@@ -53817,7 +55581,7 @@ impl From<NumberValue> for LegendVariant2SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolStrokeColor {
     Variant0,
@@ -53851,7 +55615,7 @@ impl From<ColorValue> for LegendVariant2SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolStrokeWidth {
     Variant0(f64),
@@ -53889,7 +55653,7 @@ impl From<NumberValue> for LegendVariant2SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolType {
     Variant0(String),
@@ -53926,7 +55690,7 @@ impl From<StringValue> for LegendVariant2SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleAlign {
     Variant0(LegendVariant2TitleAlignVariant0),
@@ -53961,7 +55725,18 @@ impl From<AlignValue> for LegendVariant2TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -54035,7 +55810,7 @@ impl std::convert::TryFrom<String> for LegendVariant2TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleAnchor {
     Variant0(Option<LegendVariant2TitleAnchorVariant0>),
@@ -54071,7 +55846,18 @@ impl From<AnchorValue> for LegendVariant2TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -54147,7 +55933,7 @@ impl std::convert::TryFrom<String> for LegendVariant2TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleBaseline {
     Variant0(LegendVariant2TitleBaselineVariant0),
@@ -54185,7 +55971,18 @@ impl From<BaselineValue> for LegendVariant2TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -54269,7 +56066,7 @@ impl std::convert::TryFrom<String> for LegendVariant2TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleColor {
     Variant0,
@@ -54303,7 +56100,7 @@ impl From<ColorValue> for LegendVariant2TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleFont {
     Variant0(String),
@@ -54336,7 +56133,7 @@ impl From<StringValue> for LegendVariant2TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleFontSize {
     Variant0(f64),
@@ -54374,7 +56171,7 @@ impl From<NumberValue> for LegendVariant2TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleFontStyle {
     Variant0(String),
@@ -54431,7 +56228,7 @@ impl From<StringValue> for LegendVariant2TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleFontWeight {
     Variant0(MyEnum),
@@ -54469,7 +56266,7 @@ impl From<FontWeightValue> for LegendVariant2TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleLimit {
     Variant0(f64),
@@ -54507,7 +56304,7 @@ impl From<NumberValue> for LegendVariant2TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleLineHeight {
     Variant0(f64),
@@ -54545,7 +56342,7 @@ impl From<NumberValue> for LegendVariant2TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleOpacity {
     Variant0(f64),
@@ -54588,7 +56385,7 @@ impl From<NumberValue> for LegendVariant2TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleOrient {
     Variant0(LegendVariant2TitleOrientVariant0),
@@ -54624,7 +56421,18 @@ impl From<OrientValue> for LegendVariant2TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -54697,7 +56505,7 @@ impl std::convert::TryFrom<String> for LegendVariant2TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant2TitlePadding {
     Variant0(f64),
@@ -54731,7 +56539,18 @@ impl From<NumberValue> for LegendVariant2TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant2Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -54796,7 +56615,7 @@ impl std::convert::TryFrom<String> for LegendVariant2Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3CornerRadius {
     Variant0(f64),
@@ -54830,7 +56649,18 @@ impl From<NumberValue> for LegendVariant3CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -54909,7 +56739,7 @@ impl std::convert::TryFrom<String> for LegendVariant3Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant3Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -54950,7 +56780,7 @@ impl From<&LegendVariant3Encode> for LegendVariant3Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3FillColor {
     Variant0,
@@ -55020,7 +56850,7 @@ impl From<ColorValue> for LegendVariant3FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant3Format {
     Variant0(String),
@@ -55079,7 +56909,7 @@ impl From<SignalRef> for LegendVariant3Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3FormatType {
     Variant0(LegendVariant3FormatTypeVariant0),
@@ -55114,7 +56944,18 @@ impl From<SignalRef> for LegendVariant3FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -55183,7 +57024,7 @@ impl std::convert::TryFrom<String> for LegendVariant3FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3GradientOpacity {
     Variant0(f64),
@@ -55224,7 +57065,7 @@ impl From<NumberValue> for LegendVariant3GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3GradientStrokeColor {
     Variant0,
@@ -55258,7 +57099,7 @@ impl From<ColorValue> for LegendVariant3GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3GradientStrokeWidth {
     Variant0(f64),
@@ -55300,7 +57141,7 @@ impl From<NumberValue> for LegendVariant3GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3GridAlign {
     Variant0(LegendVariant3GridAlignVariant0),
@@ -55335,7 +57176,18 @@ impl From<SignalRef> for LegendVariant3GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -55408,7 +57260,7 @@ impl std::convert::TryFrom<String> for LegendVariant3GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelAlign {
     Variant0(LegendVariant3LabelAlignVariant0),
@@ -55443,7 +57295,18 @@ impl From<AlignValue> for LegendVariant3LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -55519,7 +57382,7 @@ impl std::convert::TryFrom<String> for LegendVariant3LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelBaseline {
     Variant0(LegendVariant3LabelBaselineVariant0),
@@ -55557,7 +57420,18 @@ impl From<BaselineValue> for LegendVariant3LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -55641,7 +57515,7 @@ impl std::convert::TryFrom<String> for LegendVariant3LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelColor {
     Variant0,
@@ -55675,7 +57549,7 @@ impl From<ColorValue> for LegendVariant3LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelFont {
     Variant0(String),
@@ -55708,7 +57582,7 @@ impl From<StringValue> for LegendVariant3LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelFontSize {
     Variant0(f64),
@@ -55746,7 +57620,7 @@ impl From<NumberValue> for LegendVariant3LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelFontStyle {
     Variant0(String),
@@ -55803,7 +57677,7 @@ impl From<StringValue> for LegendVariant3LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelFontWeight {
     Variant0(MyEnum),
@@ -55841,7 +57715,7 @@ impl From<FontWeightValue> for LegendVariant3LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelLimit {
     Variant0(f64),
@@ -55879,7 +57753,7 @@ impl From<NumberValue> for LegendVariant3LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelOffset {
     Variant0(f64),
@@ -55917,7 +57791,7 @@ impl From<NumberValue> for LegendVariant3LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelOpacity {
     Variant0(f64),
@@ -55955,7 +57829,7 @@ impl From<NumberValue> for LegendVariant3LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LegendX {
     Variant0(f64),
@@ -55993,7 +57867,7 @@ impl From<NumberValue> for LegendVariant3LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3LegendY {
     Variant0(f64),
@@ -56031,7 +57905,7 @@ impl From<NumberValue> for LegendVariant3LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3Offset {
     Variant0(f64),
@@ -56080,7 +57954,7 @@ impl From<NumberValue> for LegendVariant3Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3Orient {
     Variant0(LegendVariant3OrientVariant0),
@@ -56122,7 +57996,18 @@ impl From<SignalRef> for LegendVariant3Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -56215,7 +58100,7 @@ impl std::convert::TryFrom<String> for LegendVariant3OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3Padding {
     Variant0(f64),
@@ -56256,7 +58141,7 @@ impl From<NumberValue> for LegendVariant3Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3StrokeColor {
     Variant0,
@@ -56293,7 +58178,7 @@ impl From<ColorValue> for LegendVariant3StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolDash {
     Variant0(Vec<f64>),
@@ -56331,7 +58216,7 @@ impl From<ArrayValue> for LegendVariant3SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolDashOffset {
     Variant0(f64),
@@ -56372,7 +58257,7 @@ impl From<NumberValue> for LegendVariant3SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolFillColor {
     Variant0,
@@ -56406,7 +58291,7 @@ impl From<ColorValue> for LegendVariant3SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolOffset {
     Variant0(f64),
@@ -56444,7 +58329,7 @@ impl From<NumberValue> for LegendVariant3SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolOpacity {
     Variant0(f64),
@@ -56482,7 +58367,7 @@ impl From<NumberValue> for LegendVariant3SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolSize {
     Variant0(f64),
@@ -56523,7 +58408,7 @@ impl From<NumberValue> for LegendVariant3SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolStrokeColor {
     Variant0,
@@ -56557,7 +58442,7 @@ impl From<ColorValue> for LegendVariant3SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolStrokeWidth {
     Variant0(f64),
@@ -56595,7 +58480,7 @@ impl From<NumberValue> for LegendVariant3SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolType {
     Variant0(String),
@@ -56632,7 +58517,7 @@ impl From<StringValue> for LegendVariant3SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleAlign {
     Variant0(LegendVariant3TitleAlignVariant0),
@@ -56667,7 +58552,18 @@ impl From<AlignValue> for LegendVariant3TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -56741,7 +58637,7 @@ impl std::convert::TryFrom<String> for LegendVariant3TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleAnchor {
     Variant0(Option<LegendVariant3TitleAnchorVariant0>),
@@ -56777,7 +58673,18 @@ impl From<AnchorValue> for LegendVariant3TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -56853,7 +58760,7 @@ impl std::convert::TryFrom<String> for LegendVariant3TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleBaseline {
     Variant0(LegendVariant3TitleBaselineVariant0),
@@ -56891,7 +58798,18 @@ impl From<BaselineValue> for LegendVariant3TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -56975,7 +58893,7 @@ impl std::convert::TryFrom<String> for LegendVariant3TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleColor {
     Variant0,
@@ -57009,7 +58927,7 @@ impl From<ColorValue> for LegendVariant3TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleFont {
     Variant0(String),
@@ -57042,7 +58960,7 @@ impl From<StringValue> for LegendVariant3TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleFontSize {
     Variant0(f64),
@@ -57080,7 +58998,7 @@ impl From<NumberValue> for LegendVariant3TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleFontStyle {
     Variant0(String),
@@ -57137,7 +59055,7 @@ impl From<StringValue> for LegendVariant3TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleFontWeight {
     Variant0(MyEnum),
@@ -57175,7 +59093,7 @@ impl From<FontWeightValue> for LegendVariant3TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleLimit {
     Variant0(f64),
@@ -57213,7 +59131,7 @@ impl From<NumberValue> for LegendVariant3TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleLineHeight {
     Variant0(f64),
@@ -57251,7 +59169,7 @@ impl From<NumberValue> for LegendVariant3TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleOpacity {
     Variant0(f64),
@@ -57294,7 +59212,7 @@ impl From<NumberValue> for LegendVariant3TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleOrient {
     Variant0(LegendVariant3TitleOrientVariant0),
@@ -57330,7 +59248,18 @@ impl From<OrientValue> for LegendVariant3TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -57403,7 +59332,7 @@ impl std::convert::TryFrom<String> for LegendVariant3TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant3TitlePadding {
     Variant0(f64),
@@ -57437,7 +59366,18 @@ impl From<NumberValue> for LegendVariant3TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant3Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -57502,7 +59442,7 @@ impl std::convert::TryFrom<String> for LegendVariant3Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4CornerRadius {
     Variant0(f64),
@@ -57536,7 +59476,18 @@ impl From<NumberValue> for LegendVariant4CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -57615,7 +59566,7 @@ impl std::convert::TryFrom<String> for LegendVariant4Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant4Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -57656,7 +59607,7 @@ impl From<&LegendVariant4Encode> for LegendVariant4Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4FillColor {
     Variant0,
@@ -57726,7 +59677,7 @@ impl From<ColorValue> for LegendVariant4FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant4Format {
     Variant0(String),
@@ -57785,7 +59736,7 @@ impl From<SignalRef> for LegendVariant4Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4FormatType {
     Variant0(LegendVariant4FormatTypeVariant0),
@@ -57820,7 +59771,18 @@ impl From<SignalRef> for LegendVariant4FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -57889,7 +59851,7 @@ impl std::convert::TryFrom<String> for LegendVariant4FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4GradientOpacity {
     Variant0(f64),
@@ -57930,7 +59892,7 @@ impl From<NumberValue> for LegendVariant4GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4GradientStrokeColor {
     Variant0,
@@ -57964,7 +59926,7 @@ impl From<ColorValue> for LegendVariant4GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4GradientStrokeWidth {
     Variant0(f64),
@@ -58006,7 +59968,7 @@ impl From<NumberValue> for LegendVariant4GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4GridAlign {
     Variant0(LegendVariant4GridAlignVariant0),
@@ -58041,7 +60003,18 @@ impl From<SignalRef> for LegendVariant4GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -58114,7 +60087,7 @@ impl std::convert::TryFrom<String> for LegendVariant4GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelAlign {
     Variant0(LegendVariant4LabelAlignVariant0),
@@ -58149,7 +60122,18 @@ impl From<AlignValue> for LegendVariant4LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -58225,7 +60209,7 @@ impl std::convert::TryFrom<String> for LegendVariant4LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelBaseline {
     Variant0(LegendVariant4LabelBaselineVariant0),
@@ -58263,7 +60247,18 @@ impl From<BaselineValue> for LegendVariant4LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -58347,7 +60342,7 @@ impl std::convert::TryFrom<String> for LegendVariant4LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelColor {
     Variant0,
@@ -58381,7 +60376,7 @@ impl From<ColorValue> for LegendVariant4LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelFont {
     Variant0(String),
@@ -58414,7 +60409,7 @@ impl From<StringValue> for LegendVariant4LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelFontSize {
     Variant0(f64),
@@ -58452,7 +60447,7 @@ impl From<NumberValue> for LegendVariant4LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelFontStyle {
     Variant0(String),
@@ -58509,7 +60504,7 @@ impl From<StringValue> for LegendVariant4LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelFontWeight {
     Variant0(MyEnum),
@@ -58547,7 +60542,7 @@ impl From<FontWeightValue> for LegendVariant4LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelLimit {
     Variant0(f64),
@@ -58585,7 +60580,7 @@ impl From<NumberValue> for LegendVariant4LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelOffset {
     Variant0(f64),
@@ -58623,7 +60618,7 @@ impl From<NumberValue> for LegendVariant4LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelOpacity {
     Variant0(f64),
@@ -58661,7 +60656,7 @@ impl From<NumberValue> for LegendVariant4LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LegendX {
     Variant0(f64),
@@ -58699,7 +60694,7 @@ impl From<NumberValue> for LegendVariant4LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4LegendY {
     Variant0(f64),
@@ -58737,7 +60732,7 @@ impl From<NumberValue> for LegendVariant4LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4Offset {
     Variant0(f64),
@@ -58786,7 +60781,7 @@ impl From<NumberValue> for LegendVariant4Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4Orient {
     Variant0(LegendVariant4OrientVariant0),
@@ -58828,7 +60823,18 @@ impl From<SignalRef> for LegendVariant4Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -58921,7 +60927,7 @@ impl std::convert::TryFrom<String> for LegendVariant4OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4Padding {
     Variant0(f64),
@@ -58962,7 +60968,7 @@ impl From<NumberValue> for LegendVariant4Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4StrokeColor {
     Variant0,
@@ -58999,7 +61005,7 @@ impl From<ColorValue> for LegendVariant4StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolDash {
     Variant0(Vec<f64>),
@@ -59037,7 +61043,7 @@ impl From<ArrayValue> for LegendVariant4SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolDashOffset {
     Variant0(f64),
@@ -59078,7 +61084,7 @@ impl From<NumberValue> for LegendVariant4SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolFillColor {
     Variant0,
@@ -59112,7 +61118,7 @@ impl From<ColorValue> for LegendVariant4SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolOffset {
     Variant0(f64),
@@ -59150,7 +61156,7 @@ impl From<NumberValue> for LegendVariant4SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolOpacity {
     Variant0(f64),
@@ -59188,7 +61194,7 @@ impl From<NumberValue> for LegendVariant4SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolSize {
     Variant0(f64),
@@ -59229,7 +61235,7 @@ impl From<NumberValue> for LegendVariant4SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolStrokeColor {
     Variant0,
@@ -59263,7 +61269,7 @@ impl From<ColorValue> for LegendVariant4SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolStrokeWidth {
     Variant0(f64),
@@ -59301,7 +61307,7 @@ impl From<NumberValue> for LegendVariant4SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolType {
     Variant0(String),
@@ -59338,7 +61344,7 @@ impl From<StringValue> for LegendVariant4SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleAlign {
     Variant0(LegendVariant4TitleAlignVariant0),
@@ -59373,7 +61379,18 @@ impl From<AlignValue> for LegendVariant4TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -59447,7 +61464,7 @@ impl std::convert::TryFrom<String> for LegendVariant4TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleAnchor {
     Variant0(Option<LegendVariant4TitleAnchorVariant0>),
@@ -59483,7 +61500,18 @@ impl From<AnchorValue> for LegendVariant4TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -59559,7 +61587,7 @@ impl std::convert::TryFrom<String> for LegendVariant4TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleBaseline {
     Variant0(LegendVariant4TitleBaselineVariant0),
@@ -59597,7 +61625,18 @@ impl From<BaselineValue> for LegendVariant4TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -59681,7 +61720,7 @@ impl std::convert::TryFrom<String> for LegendVariant4TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleColor {
     Variant0,
@@ -59715,7 +61754,7 @@ impl From<ColorValue> for LegendVariant4TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleFont {
     Variant0(String),
@@ -59748,7 +61787,7 @@ impl From<StringValue> for LegendVariant4TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleFontSize {
     Variant0(f64),
@@ -59786,7 +61825,7 @@ impl From<NumberValue> for LegendVariant4TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleFontStyle {
     Variant0(String),
@@ -59843,7 +61882,7 @@ impl From<StringValue> for LegendVariant4TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleFontWeight {
     Variant0(MyEnum),
@@ -59881,7 +61920,7 @@ impl From<FontWeightValue> for LegendVariant4TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleLimit {
     Variant0(f64),
@@ -59919,7 +61958,7 @@ impl From<NumberValue> for LegendVariant4TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleLineHeight {
     Variant0(f64),
@@ -59957,7 +61996,7 @@ impl From<NumberValue> for LegendVariant4TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleOpacity {
     Variant0(f64),
@@ -60000,7 +62039,7 @@ impl From<NumberValue> for LegendVariant4TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleOrient {
     Variant0(LegendVariant4TitleOrientVariant0),
@@ -60036,7 +62075,18 @@ impl From<OrientValue> for LegendVariant4TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -60109,7 +62159,7 @@ impl std::convert::TryFrom<String> for LegendVariant4TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant4TitlePadding {
     Variant0(f64),
@@ -60143,7 +62193,18 @@ impl From<NumberValue> for LegendVariant4TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant4Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -60208,7 +62269,7 @@ impl std::convert::TryFrom<String> for LegendVariant4Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5CornerRadius {
     Variant0(f64),
@@ -60242,7 +62303,18 @@ impl From<NumberValue> for LegendVariant5CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -60321,7 +62393,7 @@ impl std::convert::TryFrom<String> for LegendVariant5Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant5Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -60362,7 +62434,7 @@ impl From<&LegendVariant5Encode> for LegendVariant5Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5FillColor {
     Variant0,
@@ -60432,7 +62504,7 @@ impl From<ColorValue> for LegendVariant5FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant5Format {
     Variant0(String),
@@ -60491,7 +62563,7 @@ impl From<SignalRef> for LegendVariant5Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5FormatType {
     Variant0(LegendVariant5FormatTypeVariant0),
@@ -60526,7 +62598,18 @@ impl From<SignalRef> for LegendVariant5FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -60595,7 +62678,7 @@ impl std::convert::TryFrom<String> for LegendVariant5FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5GradientOpacity {
     Variant0(f64),
@@ -60636,7 +62719,7 @@ impl From<NumberValue> for LegendVariant5GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5GradientStrokeColor {
     Variant0,
@@ -60670,7 +62753,7 @@ impl From<ColorValue> for LegendVariant5GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5GradientStrokeWidth {
     Variant0(f64),
@@ -60712,7 +62795,7 @@ impl From<NumberValue> for LegendVariant5GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5GridAlign {
     Variant0(LegendVariant5GridAlignVariant0),
@@ -60747,7 +62830,18 @@ impl From<SignalRef> for LegendVariant5GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -60820,7 +62914,7 @@ impl std::convert::TryFrom<String> for LegendVariant5GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelAlign {
     Variant0(LegendVariant5LabelAlignVariant0),
@@ -60855,7 +62949,18 @@ impl From<AlignValue> for LegendVariant5LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -60931,7 +63036,7 @@ impl std::convert::TryFrom<String> for LegendVariant5LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelBaseline {
     Variant0(LegendVariant5LabelBaselineVariant0),
@@ -60969,7 +63074,18 @@ impl From<BaselineValue> for LegendVariant5LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -61053,7 +63169,7 @@ impl std::convert::TryFrom<String> for LegendVariant5LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelColor {
     Variant0,
@@ -61087,7 +63203,7 @@ impl From<ColorValue> for LegendVariant5LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelFont {
     Variant0(String),
@@ -61120,7 +63236,7 @@ impl From<StringValue> for LegendVariant5LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelFontSize {
     Variant0(f64),
@@ -61158,7 +63274,7 @@ impl From<NumberValue> for LegendVariant5LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelFontStyle {
     Variant0(String),
@@ -61215,7 +63331,7 @@ impl From<StringValue> for LegendVariant5LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelFontWeight {
     Variant0(MyEnum),
@@ -61253,7 +63369,7 @@ impl From<FontWeightValue> for LegendVariant5LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelLimit {
     Variant0(f64),
@@ -61291,7 +63407,7 @@ impl From<NumberValue> for LegendVariant5LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelOffset {
     Variant0(f64),
@@ -61329,7 +63445,7 @@ impl From<NumberValue> for LegendVariant5LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelOpacity {
     Variant0(f64),
@@ -61367,7 +63483,7 @@ impl From<NumberValue> for LegendVariant5LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LegendX {
     Variant0(f64),
@@ -61405,7 +63521,7 @@ impl From<NumberValue> for LegendVariant5LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5LegendY {
     Variant0(f64),
@@ -61443,7 +63559,7 @@ impl From<NumberValue> for LegendVariant5LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5Offset {
     Variant0(f64),
@@ -61492,7 +63608,7 @@ impl From<NumberValue> for LegendVariant5Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5Orient {
     Variant0(LegendVariant5OrientVariant0),
@@ -61534,7 +63650,18 @@ impl From<SignalRef> for LegendVariant5Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -61627,7 +63754,7 @@ impl std::convert::TryFrom<String> for LegendVariant5OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5Padding {
     Variant0(f64),
@@ -61668,7 +63795,7 @@ impl From<NumberValue> for LegendVariant5Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5StrokeColor {
     Variant0,
@@ -61705,7 +63832,7 @@ impl From<ColorValue> for LegendVariant5StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolDash {
     Variant0(Vec<f64>),
@@ -61743,7 +63870,7 @@ impl From<ArrayValue> for LegendVariant5SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolDashOffset {
     Variant0(f64),
@@ -61784,7 +63911,7 @@ impl From<NumberValue> for LegendVariant5SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolFillColor {
     Variant0,
@@ -61818,7 +63945,7 @@ impl From<ColorValue> for LegendVariant5SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolOffset {
     Variant0(f64),
@@ -61856,7 +63983,7 @@ impl From<NumberValue> for LegendVariant5SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolOpacity {
     Variant0(f64),
@@ -61894,7 +64021,7 @@ impl From<NumberValue> for LegendVariant5SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolSize {
     Variant0(f64),
@@ -61935,7 +64062,7 @@ impl From<NumberValue> for LegendVariant5SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolStrokeColor {
     Variant0,
@@ -61969,7 +64096,7 @@ impl From<ColorValue> for LegendVariant5SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolStrokeWidth {
     Variant0(f64),
@@ -62007,7 +64134,7 @@ impl From<NumberValue> for LegendVariant5SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolType {
     Variant0(String),
@@ -62044,7 +64171,7 @@ impl From<StringValue> for LegendVariant5SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleAlign {
     Variant0(LegendVariant5TitleAlignVariant0),
@@ -62079,7 +64206,18 @@ impl From<AlignValue> for LegendVariant5TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -62153,7 +64291,7 @@ impl std::convert::TryFrom<String> for LegendVariant5TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleAnchor {
     Variant0(Option<LegendVariant5TitleAnchorVariant0>),
@@ -62189,7 +64327,18 @@ impl From<AnchorValue> for LegendVariant5TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -62265,7 +64414,7 @@ impl std::convert::TryFrom<String> for LegendVariant5TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleBaseline {
     Variant0(LegendVariant5TitleBaselineVariant0),
@@ -62303,7 +64452,18 @@ impl From<BaselineValue> for LegendVariant5TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -62387,7 +64547,7 @@ impl std::convert::TryFrom<String> for LegendVariant5TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleColor {
     Variant0,
@@ -62421,7 +64581,7 @@ impl From<ColorValue> for LegendVariant5TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleFont {
     Variant0(String),
@@ -62454,7 +64614,7 @@ impl From<StringValue> for LegendVariant5TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleFontSize {
     Variant0(f64),
@@ -62492,7 +64652,7 @@ impl From<NumberValue> for LegendVariant5TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleFontStyle {
     Variant0(String),
@@ -62549,7 +64709,7 @@ impl From<StringValue> for LegendVariant5TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleFontWeight {
     Variant0(MyEnum),
@@ -62587,7 +64747,7 @@ impl From<FontWeightValue> for LegendVariant5TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleLimit {
     Variant0(f64),
@@ -62625,7 +64785,7 @@ impl From<NumberValue> for LegendVariant5TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleLineHeight {
     Variant0(f64),
@@ -62663,7 +64823,7 @@ impl From<NumberValue> for LegendVariant5TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleOpacity {
     Variant0(f64),
@@ -62706,7 +64866,7 @@ impl From<NumberValue> for LegendVariant5TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleOrient {
     Variant0(LegendVariant5TitleOrientVariant0),
@@ -62742,7 +64902,18 @@ impl From<OrientValue> for LegendVariant5TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -62815,7 +64986,7 @@ impl std::convert::TryFrom<String> for LegendVariant5TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant5TitlePadding {
     Variant0(f64),
@@ -62849,7 +65020,18 @@ impl From<NumberValue> for LegendVariant5TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant5Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -62914,7 +65096,7 @@ impl std::convert::TryFrom<String> for LegendVariant5Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6CornerRadius {
     Variant0(f64),
@@ -62948,7 +65130,18 @@ impl From<NumberValue> for LegendVariant6CornerRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6Direction {
     #[serde(rename = "vertical")]
     Vertical,
@@ -63027,7 +65220,7 @@ impl std::convert::TryFrom<String> for LegendVariant6Direction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant6Encode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63068,7 +65261,7 @@ impl From<&LegendVariant6Encode> for LegendVariant6Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6FillColor {
     Variant0,
@@ -63138,7 +65331,7 @@ impl From<ColorValue> for LegendVariant6FillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant6Format {
     Variant0(String),
@@ -63197,7 +65390,7 @@ impl From<SignalRef> for LegendVariant6Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6FormatType {
     Variant0(LegendVariant6FormatTypeVariant0),
@@ -63232,7 +65425,18 @@ impl From<SignalRef> for LegendVariant6FormatType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6FormatTypeVariant0 {
     #[serde(rename = "number")]
     Number,
@@ -63301,7 +65505,7 @@ impl std::convert::TryFrom<String> for LegendVariant6FormatTypeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6GradientOpacity {
     Variant0(f64),
@@ -63342,7 +65546,7 @@ impl From<NumberValue> for LegendVariant6GradientOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6GradientStrokeColor {
     Variant0,
@@ -63376,7 +65580,7 @@ impl From<ColorValue> for LegendVariant6GradientStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6GradientStrokeWidth {
     Variant0(f64),
@@ -63418,7 +65622,7 @@ impl From<NumberValue> for LegendVariant6GradientStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6GridAlign {
     Variant0(LegendVariant6GridAlignVariant0),
@@ -63453,7 +65657,18 @@ impl From<SignalRef> for LegendVariant6GridAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6GridAlignVariant0 {
     #[serde(rename = "all")]
     All,
@@ -63526,7 +65741,7 @@ impl std::convert::TryFrom<String> for LegendVariant6GridAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelAlign {
     Variant0(LegendVariant6LabelAlignVariant0),
@@ -63561,7 +65776,18 @@ impl From<AlignValue> for LegendVariant6LabelAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6LabelAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -63637,7 +65863,7 @@ impl std::convert::TryFrom<String> for LegendVariant6LabelAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelBaseline {
     Variant0(LegendVariant6LabelBaselineVariant0),
@@ -63675,7 +65901,18 @@ impl From<BaselineValue> for LegendVariant6LabelBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6LabelBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -63759,7 +65996,7 @@ impl std::convert::TryFrom<String> for LegendVariant6LabelBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelColor {
     Variant0,
@@ -63793,7 +66030,7 @@ impl From<ColorValue> for LegendVariant6LabelColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelFont {
     Variant0(String),
@@ -63826,7 +66063,7 @@ impl From<StringValue> for LegendVariant6LabelFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelFontSize {
     Variant0(f64),
@@ -63864,7 +66101,7 @@ impl From<NumberValue> for LegendVariant6LabelFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelFontStyle {
     Variant0(String),
@@ -63921,7 +66158,7 @@ impl From<StringValue> for LegendVariant6LabelFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelFontWeight {
     Variant0(MyEnum),
@@ -63959,7 +66196,7 @@ impl From<FontWeightValue> for LegendVariant6LabelFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelLimit {
     Variant0(f64),
@@ -63997,7 +66234,7 @@ impl From<NumberValue> for LegendVariant6LabelLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelOffset {
     Variant0(f64),
@@ -64035,7 +66272,7 @@ impl From<NumberValue> for LegendVariant6LabelOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelOpacity {
     Variant0(f64),
@@ -64073,7 +66310,7 @@ impl From<NumberValue> for LegendVariant6LabelOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LegendX {
     Variant0(f64),
@@ -64111,7 +66348,7 @@ impl From<NumberValue> for LegendVariant6LegendX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6LegendY {
     Variant0(f64),
@@ -64149,7 +66386,7 @@ impl From<NumberValue> for LegendVariant6LegendY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6Offset {
     Variant0(f64),
@@ -64198,7 +66435,7 @@ impl From<NumberValue> for LegendVariant6Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6Orient {
     Variant0(LegendVariant6OrientVariant0),
@@ -64240,7 +66477,18 @@ impl From<SignalRef> for LegendVariant6Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -64333,7 +66581,7 @@ impl std::convert::TryFrom<String> for LegendVariant6OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6Padding {
     Variant0(f64),
@@ -64374,7 +66622,7 @@ impl From<NumberValue> for LegendVariant6Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6StrokeColor {
     Variant0,
@@ -64411,7 +66659,7 @@ impl From<ColorValue> for LegendVariant6StrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolDash {
     Variant0(Vec<f64>),
@@ -64449,7 +66697,7 @@ impl From<ArrayValue> for LegendVariant6SymbolDash {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolDashOffset {
     Variant0(f64),
@@ -64490,7 +66738,7 @@ impl From<NumberValue> for LegendVariant6SymbolDashOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolFillColor {
     Variant0,
@@ -64524,7 +66772,7 @@ impl From<ColorValue> for LegendVariant6SymbolFillColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolOffset {
     Variant0(f64),
@@ -64562,7 +66810,7 @@ impl From<NumberValue> for LegendVariant6SymbolOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolOpacity {
     Variant0(f64),
@@ -64600,7 +66848,7 @@ impl From<NumberValue> for LegendVariant6SymbolOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolSize {
     Variant0(f64),
@@ -64641,7 +66889,7 @@ impl From<NumberValue> for LegendVariant6SymbolSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolStrokeColor {
     Variant0,
@@ -64675,7 +66923,7 @@ impl From<ColorValue> for LegendVariant6SymbolStrokeColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolStrokeWidth {
     Variant0(f64),
@@ -64713,7 +66961,7 @@ impl From<NumberValue> for LegendVariant6SymbolStrokeWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolType {
     Variant0(String),
@@ -64750,7 +66998,7 @@ impl From<StringValue> for LegendVariant6SymbolType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleAlign {
     Variant0(LegendVariant6TitleAlignVariant0),
@@ -64785,7 +67033,18 @@ impl From<AlignValue> for LegendVariant6TitleAlign {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6TitleAlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -64859,7 +67118,7 @@ impl std::convert::TryFrom<String> for LegendVariant6TitleAlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleAnchor {
     Variant0(Option<LegendVariant6TitleAnchorVariant0>),
@@ -64895,7 +67154,18 @@ impl From<AnchorValue> for LegendVariant6TitleAnchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6TitleAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -64971,7 +67241,7 @@ impl std::convert::TryFrom<String> for LegendVariant6TitleAnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleBaseline {
     Variant0(LegendVariant6TitleBaselineVariant0),
@@ -65009,7 +67279,18 @@ impl From<BaselineValue> for LegendVariant6TitleBaseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6TitleBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -65093,7 +67374,7 @@ impl std::convert::TryFrom<String> for LegendVariant6TitleBaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleColor {
     Variant0,
@@ -65127,7 +67408,7 @@ impl From<ColorValue> for LegendVariant6TitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleFont {
     Variant0(String),
@@ -65160,7 +67441,7 @@ impl From<StringValue> for LegendVariant6TitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleFontSize {
     Variant0(f64),
@@ -65198,7 +67479,7 @@ impl From<NumberValue> for LegendVariant6TitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleFontStyle {
     Variant0(String),
@@ -65255,7 +67536,7 @@ impl From<StringValue> for LegendVariant6TitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleFontWeight {
     Variant0(MyEnum),
@@ -65293,7 +67574,7 @@ impl From<FontWeightValue> for LegendVariant6TitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleLimit {
     Variant0(f64),
@@ -65331,7 +67612,7 @@ impl From<NumberValue> for LegendVariant6TitleLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleLineHeight {
     Variant0(f64),
@@ -65369,7 +67650,7 @@ impl From<NumberValue> for LegendVariant6TitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleOpacity {
     Variant0(f64),
@@ -65412,7 +67693,7 @@ impl From<NumberValue> for LegendVariant6TitleOpacity {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleOrient {
     Variant0(LegendVariant6TitleOrientVariant0),
@@ -65448,7 +67729,18 @@ impl From<OrientValue> for LegendVariant6TitleOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6TitleOrientVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -65521,7 +67813,7 @@ impl std::convert::TryFrom<String> for LegendVariant6TitleOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LegendVariant6TitlePadding {
     Variant0(f64),
@@ -65555,7 +67847,18 @@ impl From<NumberValue> for LegendVariant6TitlePadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LegendVariant6Type {
     #[serde(rename = "gradient")]
     Gradient,
@@ -65643,7 +67946,7 @@ impl std::convert::TryFrom<String> for LegendVariant6Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LinearGradient {
     pub gradient: LinearGradientGradient,
@@ -65676,7 +67979,18 @@ impl From<&LinearGradient> for LinearGradient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LinearGradientGradient {
     #[serde(rename = "linear")]
     Linear,
@@ -65846,7 +68160,7 @@ impl std::convert::TryFrom<String> for LinearGradientGradient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LinkpathTransform {
     #[serde(rename = "as", default = "defaults::linkpath_transform_as")]
@@ -65893,7 +68207,7 @@ impl From<&LinkpathTransform> for LinkpathTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformAs {
     Variant0(String),
@@ -65936,7 +68250,7 @@ impl From<SignalRef> for LinkpathTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformOrient {
     Variant0(LinkpathTransformOrientVariant0),
@@ -65976,7 +68290,18 @@ impl From<SignalRef> for LinkpathTransformOrient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LinkpathTransformOrientVariant0 {
     #[serde(rename = "horizontal")]
     Horizontal,
@@ -66052,7 +68377,7 @@ impl std::convert::TryFrom<String> for LinkpathTransformOrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformShape {
     Variant0(LinkpathTransformShapeVariant0),
@@ -66094,7 +68419,18 @@ impl From<SignalRef> for LinkpathTransformShape {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LinkpathTransformShapeVariant0 {
     #[serde(rename = "line")]
     Line,
@@ -66175,7 +68511,7 @@ impl std::convert::TryFrom<String> for LinkpathTransformShapeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformSourceX {
     ScaleField(ScaleField),
@@ -66230,7 +68566,7 @@ impl From<Expr> for LinkpathTransformSourceX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformSourceY {
     ScaleField(ScaleField),
@@ -66285,7 +68621,7 @@ impl From<Expr> for LinkpathTransformSourceY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformTargetX {
     ScaleField(ScaleField),
@@ -66340,7 +68676,7 @@ impl From<Expr> for LinkpathTransformTargetX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LinkpathTransformTargetY {
     ScaleField(ScaleField),
@@ -66386,7 +68722,18 @@ impl From<Expr> for LinkpathTransformTargetY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LinkpathTransformType {
     #[serde(rename = "linkpath")]
     Linkpath,
@@ -66458,7 +68805,7 @@ impl std::convert::TryFrom<String> for LinkpathTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Listener {
     Variant0(SignalRef),
@@ -66586,7 +68933,7 @@ impl From<Stream> for Listener {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LoessTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -66634,7 +68981,7 @@ impl From<&LoessTransform> for LoessTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformAs {
     Variant0(Vec<LoessTransformAsVariant0Item>),
@@ -66672,7 +69019,7 @@ impl From<SignalRef> for LoessTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformAsVariant0Item {
     Variant0(String),
@@ -66706,7 +69053,7 @@ impl From<SignalRef> for LoessTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformBandwidth {
     Variant0(f64),
@@ -66762,7 +69109,7 @@ impl From<SignalRef> for LoessTransformBandwidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformGroupby {
     Variant0(Vec<LoessTransformGroupbyVariant0Item>),
@@ -66803,7 +69150,7 @@ impl From<SignalRef> for LoessTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -66842,7 +69189,18 @@ impl From<Expr> for LoessTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LoessTransformType {
     #[serde(rename = "loess")]
     Loess,
@@ -66906,7 +69264,7 @@ impl std::convert::TryFrom<String> for LoessTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformX {
     ScaleField(ScaleField),
@@ -66953,7 +69311,7 @@ impl From<Expr> for LoessTransformX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LoessTransformY {
     ScaleField(ScaleField),
@@ -67090,7 +69448,7 @@ impl From<Expr> for LoessTransformY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LookupTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -67139,7 +69497,7 @@ impl From<&LookupTransform> for LookupTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformAs {
     Variant0(Vec<LookupTransformAsVariant0Item>),
@@ -67177,7 +69535,7 @@ impl From<SignalRef> for LookupTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformAsVariant0Item {
     Variant0(String),
@@ -67223,7 +69581,7 @@ impl From<SignalRef> for LookupTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformFields {
     Variant0(Vec<LookupTransformFieldsVariant0Item>),
@@ -67264,7 +69622,7 @@ impl From<SignalRef> for LookupTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -67311,7 +69669,7 @@ impl From<Expr> for LookupTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformKey {
     ScaleField(ScaleField),
@@ -67350,7 +69708,18 @@ impl From<Expr> for LookupTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LookupTransformType {
     #[serde(rename = "lookup")]
     Lookup,
@@ -67424,7 +69793,7 @@ impl std::convert::TryFrom<String> for LookupTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformValues {
     Variant0(Vec<LookupTransformValuesVariant0Item>),
@@ -67465,7 +69834,7 @@ impl From<SignalRef> for LookupTransformValues {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum LookupTransformValuesVariant0Item {
     ScaleField(ScaleField),
@@ -67549,7 +69918,7 @@ impl From<Expr> for LookupTransformValuesVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Mark {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aria: Option<bool>,
@@ -67623,7 +69992,7 @@ impl From<&Mark> for Mark {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MarkGroup {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aria: Option<bool>,
@@ -67696,7 +70065,7 @@ impl From<&MarkGroup> for MarkGroup {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MarkGroupFrom {
     From(From),
@@ -67734,7 +70103,7 @@ impl From<Facet> for MarkGroupFrom {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum MarkGroupMarksItem {
     Group(MarkGroup),
@@ -67768,7 +70137,18 @@ impl From<MarkVisual> for MarkGroupMarksItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum MarkGroupType {
     #[serde(rename = "group")]
     Group,
@@ -67841,7 +70221,7 @@ impl std::convert::TryFrom<String> for MarkGroupType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MarkVisual {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aria: Option<bool>,
@@ -67915,7 +70295,7 @@ impl From<&MarkVisual> for MarkVisual {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Markclip {
     Variant0(BooleanOrSignal),
@@ -67942,7 +70322,9 @@ impl From<BooleanOrSignal> for Markclip {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Marktype(pub String);
 impl std::ops::Deref for Marktype {
     type Target = String;
@@ -68033,7 +70415,7 @@ impl ToString for Marktype {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NestTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -68067,7 +70449,7 @@ impl From<&NestTransform> for NestTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NestTransformGenerate {
     Variant0(bool),
@@ -68118,7 +70500,7 @@ impl From<SignalRef> for NestTransformGenerate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NestTransformKeys {
     Variant0(Vec<NestTransformKeysVariant0Item>),
@@ -68159,7 +70541,7 @@ impl From<SignalRef> for NestTransformKeys {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NestTransformKeysVariant0Item {
     ScaleField(ScaleField),
@@ -68198,7 +70580,18 @@ impl From<Expr> for NestTransformKeysVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum NestTransformType {
     #[serde(rename = "nest")]
     Nest,
@@ -68304,7 +70697,7 @@ impl std::convert::TryFrom<String> for NestTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct NumberModifiers {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub band: Option<NumberModifiersBand>,
@@ -68343,7 +70736,7 @@ impl From<&NumberModifiers> for NumberModifiers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersBand {
     Variant0(f64),
@@ -68419,7 +70812,7 @@ impl From<bool> for NumberModifiersBand {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersExponent {
     Variant0(f64),
@@ -68457,7 +70850,7 @@ impl From<NumberValue> for NumberModifiersExponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersMult {
     Variant0(f64),
@@ -68495,7 +70888,7 @@ impl From<NumberValue> for NumberModifiersMult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberModifiersOffset {
     Variant0(f64),
@@ -68533,7 +70926,7 @@ impl From<NumberValue> for NumberModifiersOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberOrSignal {
     Variant0(f64),
@@ -68731,7 +71124,7 @@ impl From<SignalRef> for NumberOrSignal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValue {
     Variant0(Vec<NumberValueVariant0Item>),
@@ -68844,7 +71237,7 @@ impl From<NumberValueVariant1> for NumberValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0Item {
     Variant0(NumberValueVariant0ItemVariant0),
@@ -69026,7 +71419,7 @@ impl From<NumberValueVariant0ItemVariant2> for NumberValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0 {
     Variant0 {
@@ -69128,7 +71521,7 @@ impl From<&NumberValueVariant0ItemVariant0> for NumberValueVariant0ItemVariant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant0Band {
     Variant0(f64),
@@ -69206,7 +71599,7 @@ impl From<bool> for NumberValueVariant0ItemVariant0Variant0Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant0Exponent {
     Variant0(f64),
@@ -69246,7 +71639,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant0Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant0Mult {
     Variant0(f64),
@@ -69286,7 +71679,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant0Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant0Offset {
     Variant0(f64),
@@ -69326,7 +71719,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant0Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant1Band {
     Variant0(f64),
@@ -69404,7 +71797,7 @@ impl From<bool> for NumberValueVariant0ItemVariant0Variant1Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant1Exponent {
     Variant0(f64),
@@ -69444,7 +71837,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant1Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant1Mult {
     Variant0(f64),
@@ -69484,7 +71877,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant1Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant1Offset {
     Variant0(f64),
@@ -69524,7 +71917,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant1Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant2Band {
     Variant0(f64),
@@ -69602,7 +71995,7 @@ impl From<bool> for NumberValueVariant0ItemVariant0Variant2Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant2Exponent {
     Variant0(f64),
@@ -69642,7 +72035,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant2Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant2Mult {
     Variant0(f64),
@@ -69682,7 +72075,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant2Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant2Offset {
     Variant0(f64),
@@ -69722,7 +72115,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant2Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Band {
     Variant0(f64),
@@ -69800,7 +72193,7 @@ impl From<bool> for NumberValueVariant0ItemVariant0Variant3Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Exponent {
     Variant0(f64),
@@ -69840,7 +72233,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant3Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Mult {
     Variant0(f64),
@@ -69880,7 +72273,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant3Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Offset {
     Variant0(f64),
@@ -69920,7 +72313,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant0Variant3Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -70123,7 +72516,18 @@ impl From<bool> for NumberValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant0ItemVariant1 {}
 impl From<&NumberValueVariant0ItemVariant1> for NumberValueVariant0ItemVariant1 {
@@ -70273,7 +72677,18 @@ impl From<&NumberValueVariant0ItemVariant1> for NumberValueVariant0ItemVariant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant0ItemVariant2 {}
 impl From<&NumberValueVariant0ItemVariant2> for NumberValueVariant0ItemVariant2 {
@@ -70298,7 +72713,7 @@ impl From<&NumberValueVariant0ItemVariant2> for NumberValueVariant0ItemVariant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant3Exponent {
     Variant0(f64),
@@ -70336,7 +72751,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant3Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant3Mult {
     Variant0(f64),
@@ -70374,7 +72789,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant3Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant3Offset {
     Variant0(f64),
@@ -70480,7 +72895,7 @@ impl From<NumberValue> for NumberValueVariant0ItemVariant3Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1 {
     Variant0(NumberValueVariant1Variant0),
@@ -70657,7 +73072,7 @@ impl From<NumberValueVariant1Variant2> for NumberValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0 {
     Variant0 {
@@ -70751,7 +73166,7 @@ impl From<&NumberValueVariant1Variant0> for NumberValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant0Band {
     Variant0(f64),
@@ -70827,7 +73242,7 @@ impl From<bool> for NumberValueVariant1Variant0Variant0Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant0Exponent {
     Variant0(f64),
@@ -70867,7 +73282,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant0Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant0Mult {
     Variant0(f64),
@@ -70905,7 +73320,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant0Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant0Offset {
     Variant0(f64),
@@ -70945,7 +73360,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant0Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant1Band {
     Variant0(f64),
@@ -71021,7 +73436,7 @@ impl From<bool> for NumberValueVariant1Variant0Variant1Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant1Exponent {
     Variant0(f64),
@@ -71061,7 +73476,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant1Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant1Mult {
     Variant0(f64),
@@ -71099,7 +73514,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant1Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant1Offset {
     Variant0(f64),
@@ -71139,7 +73554,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant1Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant2Band {
     Variant0(f64),
@@ -71215,7 +73630,7 @@ impl From<bool> for NumberValueVariant1Variant0Variant2Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant2Exponent {
     Variant0(f64),
@@ -71255,7 +73670,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant2Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant2Mult {
     Variant0(f64),
@@ -71293,7 +73708,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant2Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant2Offset {
     Variant0(f64),
@@ -71333,7 +73748,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant2Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Band {
     Variant0(f64),
@@ -71409,7 +73824,7 @@ impl From<bool> for NumberValueVariant1Variant0Variant3Band {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Exponent {
     Variant0(f64),
@@ -71449,7 +73864,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant3Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Mult {
     Variant0(f64),
@@ -71487,7 +73902,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant3Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Offset {
     Variant0(f64),
@@ -71527,7 +73942,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant0Variant3Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -71725,7 +74140,18 @@ impl From<bool> for NumberValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant1Variant1 {}
 impl From<&NumberValueVariant1Variant1> for NumberValueVariant1Variant1 {
@@ -71872,7 +74298,18 @@ impl From<&NumberValueVariant1Variant1> for NumberValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant1Variant2 {}
 impl From<&NumberValueVariant1Variant2> for NumberValueVariant1Variant2 {
@@ -71897,7 +74334,7 @@ impl From<&NumberValueVariant1Variant2> for NumberValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant3Exponent {
     Variant0(f64),
@@ -71935,7 +74372,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant3Exponent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant3Mult {
     Variant0(f64),
@@ -71973,7 +74410,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant3Mult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant3Offset {
     Variant0(f64),
@@ -72081,7 +74518,7 @@ impl From<Box<NumberValue>> for NumberValueVariant1Variant3Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct OnEvents(pub Vec<OnEventsItem>);
 impl std::ops::Deref for OnEvents {
     type Target = Vec<OnEventsItem>;
@@ -72188,7 +74625,7 @@ impl From<Vec<OnEventsItem>> for OnEvents {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OnEventsItem {
     Variant0 {
@@ -72233,7 +74670,7 @@ impl From<&OnEventsItem> for OnEventsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant0Events {
     Variant0(Selector),
@@ -72284,7 +74721,7 @@ impl From<Vec<Listener>> for OnEventsItemVariant0Events {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant1Events {
     Variant0(Selector),
@@ -72340,7 +74777,7 @@ impl From<Vec<Listener>> for OnEventsItemVariant1Events {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant1Update {
     Variant0(ExprString),
@@ -72396,7 +74833,7 @@ impl From<SignalRef> for OnEventsItemVariant1Update {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct OnMarkTrigger(pub Vec<OnMarkTriggerItem>);
 impl std::ops::Deref for OnMarkTrigger {
     type Target = Vec<OnMarkTriggerItem>;
@@ -72444,7 +74881,7 @@ impl From<Vec<OnMarkTriggerItem>> for OnMarkTrigger {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OnMarkTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -72502,7 +74939,7 @@ impl From<&OnMarkTriggerItem> for OnMarkTriggerItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct OnTrigger(pub Vec<OnTriggerItem>);
 impl std::ops::Deref for OnTrigger {
     type Target = Vec<OnTriggerItem>;
@@ -72566,7 +75003,7 @@ impl From<Vec<OnTriggerItem>> for OnTrigger {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OnTriggerItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -72603,7 +75040,7 @@ impl From<&OnTriggerItem> for OnTriggerItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OnTriggerItemRemove {
     Variant0(bool),
@@ -72849,7 +75286,7 @@ impl From<ExprString> for OnTriggerItemRemove {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValue {
     Variant0(Vec<OrientValueVariant0Item>),
@@ -72967,7 +75404,7 @@ impl From<OrientValueVariant1> for OrientValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant0Item {
     Variant0(OrientValueVariant0ItemVariant0),
@@ -73099,7 +75536,7 @@ impl From<OrientValueVariant0ItemVariant2> for OrientValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemVariant0 {
     Variant0 {
@@ -73151,7 +75588,18 @@ impl From<&OrientValueVariant0ItemVariant0> for OrientValueVariant0ItemVariant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrientValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "left")]
     Left,
@@ -73226,7 +75674,7 @@ impl std::convert::TryFrom<String> for OrientValueVariant0ItemVariant0Variant1Va
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -73387,7 +75835,18 @@ impl From<bool> for OrientValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant0ItemVariant1 {}
 impl From<&OrientValueVariant0ItemVariant1> for OrientValueVariant0ItemVariant1 {
@@ -73495,7 +75954,18 @@ impl From<&OrientValueVariant0ItemVariant1> for OrientValueVariant0ItemVariant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant0ItemVariant2 {}
 impl From<&OrientValueVariant0ItemVariant2> for OrientValueVariant0ItemVariant2 {
@@ -73593,7 +76063,7 @@ impl From<&OrientValueVariant0ItemVariant2> for OrientValueVariant0ItemVariant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant1 {
     Variant0(OrientValueVariant1Variant0),
@@ -73718,7 +76188,7 @@ impl From<OrientValueVariant1Variant2> for OrientValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant1Variant0 {
     Variant0 {
@@ -73762,7 +76232,18 @@ impl From<&OrientValueVariant1Variant0> for OrientValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum OrientValueVariant1Variant0Variant1Value {
     #[serde(rename = "left")]
     Left,
@@ -73835,7 +76316,7 @@ impl std::convert::TryFrom<String> for OrientValueVariant1Variant0Variant1Value 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OrientValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -73991,7 +76472,18 @@ impl From<bool> for OrientValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant1Variant1 {}
 impl From<&OrientValueVariant1Variant1> for OrientValueVariant1Variant1 {
@@ -74096,7 +76588,18 @@ impl From<&OrientValueVariant1Variant1> for OrientValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant1Variant2 {}
 impl From<&OrientValueVariant1Variant2> for OrientValueVariant1Variant2 {
@@ -74218,7 +76721,7 @@ impl From<&OrientValueVariant1Variant2> for OrientValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackTransform {
     #[serde(rename = "as", default = "defaults::pack_transform_as")]
@@ -74279,7 +76782,7 @@ impl From<&PackTransform> for PackTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformAs {
     Variant0([PackTransformAsVariant0Item; 5usize]),
@@ -74328,7 +76831,7 @@ impl From<SignalRef> for PackTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformAsVariant0Item {
     Variant0(String),
@@ -74364,7 +76867,7 @@ impl From<SignalRef> for PackTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformField {
     ScaleField(ScaleField),
@@ -74408,7 +76911,7 @@ impl From<Expr> for PackTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformPadding {
     Variant0(f64),
@@ -74449,7 +76952,7 @@ impl From<SignalRef> for PackTransformPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformRadius {
     ScaleField(ScaleField),
@@ -74505,7 +77008,7 @@ impl From<Expr> for PackTransformRadius {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformSize {
     Variant0([PackTransformSizeVariant0Item; 2usize]),
@@ -74543,7 +77046,7 @@ impl From<SignalRef> for PackTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PackTransformSizeVariant0Item {
     Variant0(f64),
@@ -74576,7 +77079,18 @@ impl From<SignalRef> for PackTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PackTransformType {
     #[serde(rename = "pack")]
     Pack,
@@ -74655,7 +77169,7 @@ impl std::convert::TryFrom<String> for PackTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Padding {
     Variant0(f64),
@@ -74708,7 +77222,7 @@ impl From<SignalRef> for Padding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ParamField {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -74832,7 +77346,7 @@ impl From<&ParamField> for ParamField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PartitionTransform {
     #[serde(rename = "as", default = "defaults::partition_transform_as")]
@@ -74894,7 +77408,7 @@ impl From<&PartitionTransform> for PartitionTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformAs {
     Variant0([PartitionTransformAsVariant0Item; 6usize]),
@@ -74944,7 +77458,7 @@ impl From<SignalRef> for PartitionTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformAsVariant0Item {
     Variant0(String),
@@ -74980,7 +77494,7 @@ impl From<SignalRef> for PartitionTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformField {
     ScaleField(ScaleField),
@@ -75024,7 +77538,7 @@ impl From<Expr> for PartitionTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformPadding {
     Variant0(f64),
@@ -75062,7 +77576,7 @@ impl From<SignalRef> for PartitionTransformPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformRound {
     Variant0(bool),
@@ -75112,7 +77626,7 @@ impl From<SignalRef> for PartitionTransformRound {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformSize {
     Variant0([PartitionTransformSizeVariant0Item; 2usize]),
@@ -75150,7 +77664,7 @@ impl From<SignalRef> for PartitionTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PartitionTransformSizeVariant0Item {
     Variant0(f64),
@@ -75183,7 +77697,18 @@ impl From<SignalRef> for PartitionTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PartitionTransformType {
     #[serde(rename = "partition")]
     Partition,
@@ -75321,7 +77846,7 @@ impl std::convert::TryFrom<String> for PartitionTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PieTransform {
     #[serde(rename = "as", default = "defaults::pie_transform_as")]
@@ -75381,7 +77906,7 @@ impl From<&PieTransform> for PieTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformAs {
     Variant0([PieTransformAsVariant0Item; 2usize]),
@@ -75427,7 +77952,7 @@ impl From<SignalRef> for PieTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformAsVariant0Item {
     Variant0(String),
@@ -75461,7 +77986,7 @@ impl From<SignalRef> for PieTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformEndAngle {
     Variant0(f64),
@@ -75507,7 +78032,7 @@ impl From<SignalRef> for PieTransformEndAngle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformField {
     ScaleField(ScaleField),
@@ -75551,7 +78076,7 @@ impl From<Expr> for PieTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformSort {
     Variant0(bool),
@@ -75589,7 +78114,7 @@ impl From<SignalRef> for PieTransformSort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PieTransformStartAngle {
     Variant0(f64),
@@ -75622,7 +78147,18 @@ impl From<SignalRef> for PieTransformStartAngle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PieTransformType {
     #[serde(rename = "pie")]
     Pie,
@@ -75800,7 +78336,7 @@ impl std::convert::TryFrom<String> for PieTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PivotTransform {
     pub field: PivotTransformField,
@@ -75843,7 +78379,7 @@ impl From<&PivotTransform> for PivotTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformField {
     ScaleField(ScaleField),
@@ -75900,7 +78436,7 @@ impl From<Expr> for PivotTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformGroupby {
     Variant0(Vec<PivotTransformGroupbyVariant0Item>),
@@ -75941,7 +78477,7 @@ impl From<SignalRef> for PivotTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -75988,7 +78524,7 @@ impl From<Expr> for PivotTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformKey {
     ScaleField(ScaleField),
@@ -76032,7 +78568,7 @@ impl From<Expr> for PivotTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformLimit {
     Variant0(f64),
@@ -76096,7 +78632,7 @@ impl From<SignalRef> for PivotTransformLimit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformOp {
     Variant0(PivotTransformOpVariant0),
@@ -76157,7 +78693,18 @@ impl From<SignalRef> for PivotTransformOp {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PivotTransformOpVariant0 {
     #[serde(rename = "values")]
     Values,
@@ -76305,7 +78852,18 @@ impl std::convert::TryFrom<String> for PivotTransformOpVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum PivotTransformType {
     #[serde(rename = "pivot")]
     Pivot,
@@ -76369,7 +78927,7 @@ impl std::convert::TryFrom<String> for PivotTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum PivotTransformValue {
     ScaleField(ScaleField),
@@ -76466,7 +79024,7 @@ impl From<Expr> for PivotTransformValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -76513,7 +79071,7 @@ impl From<&ProjectTransform> for ProjectTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformAs {
     Variant0(Vec<ProjectTransformAsVariant0Item>),
@@ -76554,7 +79112,7 @@ impl From<SignalRef> for ProjectTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformAsVariant0Item {
     Variant0(String),
@@ -76601,7 +79159,7 @@ impl From<SignalRef> for ProjectTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformFields {
     Variant0(Vec<ProjectTransformFieldsVariant0Item>),
@@ -76642,7 +79200,7 @@ impl From<SignalRef> for ProjectTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectTransformFieldsVariant0Item {
     ScaleField(ScaleField),
@@ -76681,7 +79239,18 @@ impl From<Expr> for ProjectTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ProjectTransformType {
     #[serde(rename = "project")]
     Project,
@@ -76898,7 +79467,7 @@ impl std::convert::TryFrom<String> for ProjectTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Projection {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub center: Option<ProjectionCenter>,
@@ -76963,7 +79532,7 @@ impl From<&Projection> for Projection {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionCenter {
     Variant0([NumberOrSignal; 2usize]),
@@ -77018,7 +79587,7 @@ impl From<SignalRef> for ProjectionCenter {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionClipExtent {
     Variant0([ProjectionClipExtentVariant0Item; 2usize]),
@@ -77061,7 +79630,7 @@ impl From<SignalRef> for ProjectionClipExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionClipExtentVariant0Item {
     Variant0([NumberOrSignal; 2usize]),
@@ -77116,7 +79685,7 @@ impl From<SignalRef> for ProjectionClipExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionExtent {
     Variant0([ProjectionExtentVariant0Item; 2usize]),
@@ -77159,7 +79728,7 @@ impl From<SignalRef> for ProjectionExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionExtentVariant0Item {
     Variant0([NumberOrSignal; 2usize]),
@@ -77197,7 +79766,7 @@ impl From<SignalRef> for ProjectionExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionFit {
     Variant0(serde_json::Map<String, serde_json::Value>),
@@ -77240,7 +79809,7 @@ impl From<Vec<serde_json::Value>> for ProjectionFit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionParallels {
     Variant0([NumberOrSignal; 2usize]),
@@ -77283,7 +79852,7 @@ impl From<SignalRef> for ProjectionParallels {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionRotate {
     Variant0(Vec<NumberOrSignal>),
@@ -77326,7 +79895,7 @@ impl From<SignalRef> for ProjectionRotate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionSize {
     Variant0([NumberOrSignal; 2usize]),
@@ -77369,7 +79938,7 @@ impl From<SignalRef> for ProjectionSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ProjectionTranslate {
     Variant0([NumberOrSignal; 2usize]),
@@ -77506,7 +80075,7 @@ impl From<SignalRef> for ProjectionTranslate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct QuantileTransform {
     #[serde(rename = "as", default = "defaults::quantile_transform_as")]
@@ -77559,7 +80128,7 @@ impl From<&QuantileTransform> for QuantileTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformAs {
     Variant0(Vec<QuantileTransformAsVariant0Item>),
@@ -77605,7 +80174,7 @@ impl From<SignalRef> for QuantileTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformAsVariant0Item {
     Variant0(String),
@@ -77641,7 +80210,7 @@ impl From<SignalRef> for QuantileTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformField {
     ScaleField(ScaleField),
@@ -77698,7 +80267,7 @@ impl From<Expr> for QuantileTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupby {
     Variant0(Vec<QuantileTransformGroupbyVariant0Item>),
@@ -77739,7 +80308,7 @@ impl From<SignalRef> for QuantileTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -77793,7 +80362,7 @@ impl From<Expr> for QuantileTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformProbs {
     Variant0(Vec<QuantileTransformProbsVariant0Item>),
@@ -77831,7 +80400,7 @@ impl From<SignalRef> for QuantileTransformProbs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformProbsVariant0Item {
     Variant0(f64),
@@ -77870,7 +80439,7 @@ impl From<SignalRef> for QuantileTransformProbsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum QuantileTransformStep {
     Variant0(f64),
@@ -77908,7 +80477,18 @@ impl From<SignalRef> for QuantileTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum QuantileTransformType {
     #[serde(rename = "quantile")]
     Quantile,
@@ -77998,7 +80578,7 @@ impl std::convert::TryFrom<String> for QuantileTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RadialGradient {
     pub gradient: RadialGradientGradient,
@@ -78035,7 +80615,18 @@ impl From<&RadialGradient> for RadialGradient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RadialGradientGradient {
     #[serde(rename = "radial")]
     Radial,
@@ -78228,7 +80819,7 @@ impl std::convert::TryFrom<String> for RadialGradientGradient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RegressionTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -78282,7 +80873,7 @@ impl From<&RegressionTransform> for RegressionTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformAs {
     Variant0(Vec<RegressionTransformAsVariant0Item>),
@@ -78320,7 +80911,7 @@ impl From<SignalRef> for RegressionTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformAsVariant0Item {
     Variant0(String),
@@ -78365,7 +80956,7 @@ impl From<SignalRef> for RegressionTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformExtent {
     Variant0([RegressionTransformExtentVariant0Item; 2usize]),
@@ -78403,7 +80994,7 @@ impl From<SignalRef> for RegressionTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformExtentVariant0Item {
     Variant0(f64),
@@ -78454,7 +81045,7 @@ impl From<SignalRef> for RegressionTransformExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupby {
     Variant0(Vec<RegressionTransformGroupbyVariant0Item>),
@@ -78495,7 +81086,7 @@ impl From<SignalRef> for RegressionTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -78540,7 +81131,7 @@ impl From<Expr> for RegressionTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformMethod {
     Variant0(String),
@@ -78579,7 +81170,7 @@ impl From<SignalRef> for RegressionTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformOrder {
     Variant0(f64),
@@ -78622,7 +81213,7 @@ impl From<SignalRef> for RegressionTransformOrder {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformParams {
     Variant0(bool),
@@ -78655,7 +81246,18 @@ impl From<SignalRef> for RegressionTransformParams {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum RegressionTransformType {
     #[serde(rename = "regression")]
     Regression,
@@ -78719,7 +81321,7 @@ impl std::convert::TryFrom<String> for RegressionTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformX {
     ScaleField(ScaleField),
@@ -78766,7 +81368,7 @@ impl From<Expr> for RegressionTransformX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum RegressionTransformY {
     ScaleField(ScaleField),
@@ -78830,7 +81432,7 @@ impl From<Expr> for RegressionTransformY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResolvefilterTransform {
     pub filter: serde_json::Value,
@@ -78862,7 +81464,7 @@ impl From<&ResolvefilterTransform> for ResolvefilterTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ResolvefilterTransformIgnore {
     Variant0(f64),
@@ -78895,7 +81497,18 @@ impl From<SignalRef> for ResolvefilterTransformIgnore {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ResolvefilterTransformType {
     #[serde(rename = "resolvefilter")]
     Resolvefilter,
@@ -78954,7 +81567,7 @@ impl std::convert::TryFrom<String> for ResolvefilterTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Rule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub test: Option<String>,
@@ -78999,7 +81612,7 @@ impl From<&Rule> for Rule {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SampleTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -79032,7 +81645,7 @@ impl From<&SampleTransform> for SampleTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SampleTransformSize {
     Variant0(f64),
@@ -79070,7 +81683,18 @@ impl From<SignalRef> for SampleTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SampleTransformType {
     #[serde(rename = "sample")]
     Sample,
@@ -81570,7 +84194,7 @@ impl std::convert::TryFrom<String> for SampleTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Scale {
     Variant0 {
@@ -81979,7 +84603,7 @@ impl From<&Scale> for Scale {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleBins {
     Variant0(Vec<NumberOrSignal>),
@@ -82216,7 +84840,7 @@ impl From<SignalRef> for ScaleBins {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleData {
     Variant0 {
@@ -82271,7 +84895,7 @@ impl From<&ScaleData> for ScaleData {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant0Sort {
     Variant0(bool),
@@ -82345,7 +84969,7 @@ impl From<bool> for ScaleDataVariant0Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant1Sort {
     Variant0(bool),
@@ -82384,7 +85008,18 @@ impl From<bool> for ScaleDataVariant1Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleDataVariant1SortVariant1Op {
     #[serde(rename = "count")]
     Count,
@@ -82442,7 +85077,18 @@ impl std::convert::TryFrom<String> for ScaleDataVariant1SortVariant1Op {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleDataVariant1SortVariant2Op {
     #[serde(rename = "count")]
     Count,
@@ -82540,7 +85186,7 @@ impl std::convert::TryFrom<String> for ScaleDataVariant1SortVariant2Op {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2FieldsItem {
     Variant0 { data: String, field: StringOrSignal },
@@ -82582,7 +85228,7 @@ impl From<SignalRef> for ScaleDataVariant2FieldsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleDataVariant2FieldsItemVariant1Item {
     Variant0(String),
@@ -82696,7 +85342,7 @@ impl From<bool> for ScaleDataVariant2FieldsItemVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2Sort {
     Variant0(bool),
@@ -82735,7 +85381,18 @@ impl From<bool> for ScaleDataVariant2Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleDataVariant2SortVariant1Op {
     #[serde(rename = "count")]
     Count,
@@ -82793,7 +85450,18 @@ impl std::convert::TryFrom<String> for ScaleDataVariant2SortVariant1Op {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleDataVariant2SortVariant2Op {
     #[serde(rename = "count")]
     Count,
@@ -82855,7 +85523,7 @@ impl std::convert::TryFrom<String> for ScaleDataVariant2SortVariant2Op {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ScaleField(pub StringOrSignal);
 impl std::ops::Deref for ScaleField {
     type Target = StringOrSignal;
@@ -82910,7 +85578,7 @@ impl From<StringOrSignal> for ScaleField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleInterpolate {
     Variant0(String),
@@ -82977,7 +85645,7 @@ impl From<SignalRef> for ScaleInterpolate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant0Domain {
     Variant0(Vec<ScaleVariant0DomainVariant0Item>),
@@ -83024,7 +85692,7 @@ impl From<SignalRef> for ScaleVariant0Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant0DomainRaw {
     Variant0,
@@ -83078,7 +85746,7 @@ impl From<SignalRef> for ScaleVariant0DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant0DomainVariant0Item {
     Variant0,
@@ -83125,7 +85793,18 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant0DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant0Type {
     #[serde(rename = "identity")]
     Identity,
@@ -83214,7 +85893,7 @@ impl std::convert::TryFrom<String> for ScaleVariant0Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10Domain {
     Variant0(Vec<ScaleVariant10DomainVariant0Item>),
@@ -83261,7 +85940,7 @@ impl From<SignalRef> for ScaleVariant10Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10DomainRaw {
     Variant0,
@@ -83315,7 +85994,7 @@ impl From<SignalRef> for ScaleVariant10DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10DomainVariant0Item {
     Variant0,
@@ -83370,7 +86049,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant10DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10Nice {
     Variant0(bool),
@@ -83501,7 +86180,7 @@ impl From<SignalRef> for ScaleVariant10Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant10Range {
     Variant0(ScaleVariant10RangeVariant0),
@@ -83554,7 +86233,18 @@ impl From<SignalRef> for ScaleVariant10Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant10RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -83658,7 +86348,7 @@ impl std::convert::TryFrom<String> for ScaleVariant10RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant1Item {
     Variant0,
@@ -83715,7 +86405,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant10RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -83766,7 +86456,7 @@ impl From<SignalRef> for ScaleVariant10RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Scheme {
     Variant0(String),
@@ -83807,7 +86497,7 @@ impl From<SignalRef> for ScaleVariant10RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -83837,7 +86527,18 @@ impl From<SignalRef> for ScaleVariant10RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant10Type {
     #[serde(rename = "pow")]
     Pow,
@@ -83926,7 +86627,7 @@ impl std::convert::TryFrom<String> for ScaleVariant10Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11Domain {
     Variant0(Vec<ScaleVariant11DomainVariant0Item>),
@@ -83973,7 +86674,7 @@ impl From<SignalRef> for ScaleVariant11Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11DomainRaw {
     Variant0,
@@ -84027,7 +86728,7 @@ impl From<SignalRef> for ScaleVariant11DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11DomainVariant0Item {
     Variant0,
@@ -84082,7 +86783,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant11DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11Nice {
     Variant0(bool),
@@ -84213,7 +86914,7 @@ impl From<SignalRef> for ScaleVariant11Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant11Range {
     Variant0(ScaleVariant11RangeVariant0),
@@ -84266,7 +86967,18 @@ impl From<SignalRef> for ScaleVariant11Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant11RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -84370,7 +87082,7 @@ impl std::convert::TryFrom<String> for ScaleVariant11RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant1Item {
     Variant0,
@@ -84427,7 +87139,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant11RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -84478,7 +87190,7 @@ impl From<SignalRef> for ScaleVariant11RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Scheme {
     Variant0(String),
@@ -84519,7 +87231,7 @@ impl From<SignalRef> for ScaleVariant11RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -84549,7 +87261,18 @@ impl From<SignalRef> for ScaleVariant11RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant11Type {
     #[serde(rename = "symlog")]
     Symlog,
@@ -84638,7 +87361,7 @@ impl std::convert::TryFrom<String> for ScaleVariant11Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1Domain {
     Variant0(Vec<ScaleVariant1DomainVariant0Item>),
@@ -84685,7 +87408,7 @@ impl From<SignalRef> for ScaleVariant1Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1DomainRaw {
     Variant0,
@@ -84739,7 +87462,7 @@ impl From<SignalRef> for ScaleVariant1DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1DomainVariant0Item {
     Variant0,
@@ -85080,7 +87803,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant1DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1Range {
     Variant0(ScaleVariant1RangeVariant0),
@@ -85139,7 +87862,18 @@ impl From<SignalRef> for ScaleVariant1Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -85243,7 +87977,7 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant1Item {
     Variant0,
@@ -85300,7 +88034,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant1RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -85351,7 +88085,7 @@ impl From<SignalRef> for ScaleVariant1RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Scheme {
     Variant0(String),
@@ -85390,7 +88124,7 @@ impl From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -85617,7 +88351,7 @@ impl From<SignalRef> for ScaleVariant1RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3 {
     Variant0 {
@@ -85672,7 +88406,7 @@ impl From<&ScaleVariant1RangeVariant3> for ScaleVariant1RangeVariant3 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant0Sort {
     Variant0(bool),
@@ -85746,7 +88480,7 @@ impl From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant1Sort {
     Variant0(bool),
@@ -85785,7 +88519,18 @@ impl From<bool> for ScaleVariant1RangeVariant3Variant1Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     #[serde(rename = "count")]
     Count,
@@ -85845,7 +88590,18 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant1SortVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     #[serde(rename = "count")]
     Count,
@@ -85945,7 +88701,7 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant1SortVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItem {
     Variant0 { data: String, field: StringOrSignal },
@@ -85991,7 +88747,7 @@ impl From<SignalRef> for ScaleVariant1RangeVariant3Variant2FieldsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
     Variant0(String),
@@ -86107,7 +88863,7 @@ impl From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2Sort {
     Variant0(bool),
@@ -86146,7 +88902,18 @@ impl From<bool> for ScaleVariant1RangeVariant3Variant2Sort {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     #[serde(rename = "count")]
     Count,
@@ -86206,7 +88973,18 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2SortVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     #[serde(rename = "count")]
     Count,
@@ -86272,7 +89050,18 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2SortVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant1Type {
     #[serde(rename = "ordinal")]
     Ordinal,
@@ -86361,7 +89150,7 @@ impl std::convert::TryFrom<String> for ScaleVariant1Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2Domain {
     Variant0(Vec<ScaleVariant2DomainVariant0Item>),
@@ -86408,7 +89197,7 @@ impl From<SignalRef> for ScaleVariant2Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2DomainRaw {
     Variant0,
@@ -86462,7 +89251,7 @@ impl From<SignalRef> for ScaleVariant2DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2DomainVariant0Item {
     Variant0,
@@ -86563,7 +89352,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant2DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant2Range {
     Variant0(ScaleVariant2RangeVariant0),
@@ -86610,7 +89399,18 @@ impl From<SignalRef> for ScaleVariant2Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant2RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -86714,7 +89514,7 @@ impl std::convert::TryFrom<String> for ScaleVariant2RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant2RangeVariant1Item {
     Variant0,
@@ -86761,7 +89561,18 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant2RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant2Type {
     #[serde(rename = "band")]
     Band,
@@ -86850,7 +89661,7 @@ impl std::convert::TryFrom<String> for ScaleVariant2Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3Domain {
     Variant0(Vec<ScaleVariant3DomainVariant0Item>),
@@ -86897,7 +89708,7 @@ impl From<SignalRef> for ScaleVariant3Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3DomainRaw {
     Variant0,
@@ -86951,7 +89762,7 @@ impl From<SignalRef> for ScaleVariant3DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3DomainVariant0Item {
     Variant0,
@@ -87052,7 +89863,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant3DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant3Range {
     Variant0(ScaleVariant3RangeVariant0),
@@ -87099,7 +89910,18 @@ impl From<SignalRef> for ScaleVariant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant3RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -87203,7 +90025,7 @@ impl std::convert::TryFrom<String> for ScaleVariant3RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant3RangeVariant1Item {
     Variant0,
@@ -87250,7 +90072,18 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant3RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant3Type {
     #[serde(rename = "point")]
     Point,
@@ -87339,7 +90172,7 @@ impl std::convert::TryFrom<String> for ScaleVariant3Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4Domain {
     Variant0(Vec<ScaleVariant4DomainVariant0Item>),
@@ -87386,7 +90219,7 @@ impl From<SignalRef> for ScaleVariant4Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4DomainRaw {
     Variant0,
@@ -87440,7 +90273,7 @@ impl From<SignalRef> for ScaleVariant4DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4DomainVariant0Item {
     Variant0,
@@ -87495,7 +90328,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant4DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4Nice {
     Variant0(bool),
@@ -87626,7 +90459,7 @@ impl From<SignalRef> for ScaleVariant4Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant4Range {
     Variant0(ScaleVariant4RangeVariant0),
@@ -87679,7 +90512,18 @@ impl From<SignalRef> for ScaleVariant4Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant4RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -87783,7 +90627,7 @@ impl std::convert::TryFrom<String> for ScaleVariant4RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant1Item {
     Variant0,
@@ -87840,7 +90684,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant4RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -87891,7 +90735,7 @@ impl From<SignalRef> for ScaleVariant4RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Scheme {
     Variant0(String),
@@ -87930,7 +90774,7 @@ impl From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -87961,7 +90805,18 @@ impl From<SignalRef> for ScaleVariant4RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant4Type {
     #[serde(rename = "quantize")]
     Quantize,
@@ -88054,7 +90909,7 @@ impl std::convert::TryFrom<String> for ScaleVariant4Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5Domain {
     Variant0(Vec<ScaleVariant5DomainVariant0Item>),
@@ -88101,7 +90956,7 @@ impl From<SignalRef> for ScaleVariant5Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5DomainRaw {
     Variant0,
@@ -88155,7 +91010,7 @@ impl From<SignalRef> for ScaleVariant5DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5DomainVariant0Item {
     Variant0,
@@ -88294,7 +91149,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant5DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant5Range {
     Variant0(ScaleVariant5RangeVariant0),
@@ -88347,7 +91202,18 @@ impl From<SignalRef> for ScaleVariant5Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant5RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -88451,7 +91317,7 @@ impl std::convert::TryFrom<String> for ScaleVariant5RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant1Item {
     Variant0,
@@ -88508,7 +91374,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant5RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -88559,7 +91425,7 @@ impl From<SignalRef> for ScaleVariant5RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Scheme {
     Variant0(String),
@@ -88598,7 +91464,7 @@ impl From<SignalRef> for ScaleVariant5RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -88628,7 +91494,18 @@ impl From<SignalRef> for ScaleVariant5RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant5Type {
     #[serde(rename = "quantile")]
     Quantile,
@@ -88717,7 +91594,7 @@ impl std::convert::TryFrom<String> for ScaleVariant5Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6Domain {
     Variant0(Vec<ScaleVariant6DomainVariant0Item>),
@@ -88764,7 +91641,7 @@ impl From<SignalRef> for ScaleVariant6Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6DomainRaw {
     Variant0,
@@ -88818,7 +91695,7 @@ impl From<SignalRef> for ScaleVariant6DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6DomainVariant0Item {
     Variant0,
@@ -88957,7 +91834,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant6DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant6Range {
     Variant0(ScaleVariant6RangeVariant0),
@@ -89010,7 +91887,18 @@ impl From<SignalRef> for ScaleVariant6Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant6RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -89114,7 +92002,7 @@ impl std::convert::TryFrom<String> for ScaleVariant6RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant1Item {
     Variant0,
@@ -89171,7 +92059,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant6RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -89222,7 +92110,7 @@ impl From<SignalRef> for ScaleVariant6RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Scheme {
     Variant0(String),
@@ -89261,7 +92149,7 @@ impl From<SignalRef> for ScaleVariant6RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -89291,7 +92179,18 @@ impl From<SignalRef> for ScaleVariant6RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant6Type {
     #[serde(rename = "bin-ordinal")]
     BinOrdinal,
@@ -89380,7 +92279,7 @@ impl std::convert::TryFrom<String> for ScaleVariant6Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7Domain {
     Variant0(Vec<ScaleVariant7DomainVariant0Item>),
@@ -89427,7 +92326,7 @@ impl From<SignalRef> for ScaleVariant7Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7DomainRaw {
     Variant0,
@@ -89481,7 +92380,7 @@ impl From<SignalRef> for ScaleVariant7DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7DomainVariant0Item {
     Variant0,
@@ -89573,7 +92472,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant7DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant7Nice {
     Variant0(bool),
@@ -89618,7 +92517,18 @@ impl From<ScaleVariant7NiceVariant1> for ScaleVariant7Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant7NiceVariant1 {
     #[serde(rename = "millisecond")]
     Millisecond,
@@ -89716,7 +92626,7 @@ impl std::convert::TryFrom<String> for ScaleVariant7NiceVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7NiceVariant2Interval {
     Variant0(ScaleVariant7NiceVariant2IntervalVariant0),
@@ -89756,7 +92666,18 @@ impl From<SignalRef> for ScaleVariant7NiceVariant2Interval {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant7NiceVariant2IntervalVariant0 {
     #[serde(rename = "millisecond")]
     Millisecond,
@@ -89934,7 +92855,7 @@ impl std::convert::TryFrom<String> for ScaleVariant7NiceVariant2IntervalVariant0
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant7Range {
     Variant0(ScaleVariant7RangeVariant0),
@@ -89987,7 +92908,18 @@ impl From<SignalRef> for ScaleVariant7Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant7RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -90091,7 +93023,7 @@ impl std::convert::TryFrom<String> for ScaleVariant7RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant1Item {
     Variant0,
@@ -90148,7 +93080,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant7RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -90199,7 +93131,7 @@ impl From<SignalRef> for ScaleVariant7RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Scheme {
     Variant0(String),
@@ -90238,7 +93170,7 @@ impl From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -90269,7 +93201,18 @@ impl From<SignalRef> for ScaleVariant7RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant7Type {
     #[serde(rename = "time")]
     Time,
@@ -90362,7 +93305,7 @@ impl std::convert::TryFrom<String> for ScaleVariant7Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8Domain {
     Variant0(Vec<ScaleVariant8DomainVariant0Item>),
@@ -90409,7 +93352,7 @@ impl From<SignalRef> for ScaleVariant8Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8DomainRaw {
     Variant0,
@@ -90463,7 +93406,7 @@ impl From<SignalRef> for ScaleVariant8DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8DomainVariant0Item {
     Variant0,
@@ -90518,7 +93461,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant8DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8Nice {
     Variant0(bool),
@@ -90649,7 +93592,7 @@ impl From<SignalRef> for ScaleVariant8Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant8Range {
     Variant0(ScaleVariant8RangeVariant0),
@@ -90702,7 +93645,18 @@ impl From<SignalRef> for ScaleVariant8Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant8RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -90806,7 +93760,7 @@ impl std::convert::TryFrom<String> for ScaleVariant8RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant1Item {
     Variant0,
@@ -90863,7 +93817,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant8RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -90914,7 +93868,7 @@ impl From<SignalRef> for ScaleVariant8RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Scheme {
     Variant0(String),
@@ -90953,7 +93907,7 @@ impl From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -90985,7 +93939,18 @@ impl From<SignalRef> for ScaleVariant8RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant8Type {
     #[serde(rename = "linear")]
     Linear,
@@ -91082,7 +94047,7 @@ impl std::convert::TryFrom<String> for ScaleVariant8Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9Domain {
     Variant0(Vec<ScaleVariant9DomainVariant0Item>),
@@ -91129,7 +94094,7 @@ impl From<SignalRef> for ScaleVariant9Domain {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9DomainRaw {
     Variant0,
@@ -91183,7 +94148,7 @@ impl From<SignalRef> for ScaleVariant9DomainRaw {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9DomainVariant0Item {
     Variant0,
@@ -91238,7 +94203,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant9DomainVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9Nice {
     Variant0(bool),
@@ -91369,7 +94334,7 @@ impl From<SignalRef> for ScaleVariant9Nice {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant9Range {
     Variant0(ScaleVariant9RangeVariant0),
@@ -91422,7 +94387,18 @@ impl From<SignalRef> for ScaleVariant9Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant9RangeVariant0 {
     #[serde(rename = "width")]
     Width,
@@ -91526,7 +94502,7 @@ impl std::convert::TryFrom<String> for ScaleVariant9RangeVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant1Item {
     Variant0,
@@ -91583,7 +94559,7 @@ impl From<Vec<NumberOrSignal>> for ScaleVariant9RangeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Extent {
     Variant0([NumberOrSignal; 2usize]),
@@ -91634,7 +94610,7 @@ impl From<SignalRef> for ScaleVariant9RangeVariant2Extent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Scheme {
     Variant0(String),
@@ -91673,7 +94649,7 @@ impl From<SignalRef> for ScaleVariant9RangeVariant2Scheme {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2SchemeVariant1Item {
     Variant0(String),
@@ -91703,7 +94679,18 @@ impl From<SignalRef> for ScaleVariant9RangeVariant2SchemeVariant1Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum ScaleVariant9Type {
     #[serde(rename = "log")]
     Log,
@@ -91820,7 +94807,7 @@ impl std::convert::TryFrom<String> for ScaleVariant9Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Scope {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub axes: Vec<Axis>,
@@ -91867,7 +94854,7 @@ impl From<&Scope> for Scope {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ScopeMarksItem {
     Group(MarkGroup),
@@ -91898,7 +94885,9 @@ impl From<MarkVisual> for ScopeMarksItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Selector(pub String);
 impl std::ops::Deref for Selector {
     type Target = String;
@@ -92000,7 +94989,7 @@ impl ToString for Selector {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SequenceTransform {
     #[serde(rename = "as", default = "defaults::sequence_transform_as")]
@@ -92037,7 +95026,7 @@ impl From<&SequenceTransform> for SequenceTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformAs {
     Variant0(String),
@@ -92075,7 +95064,7 @@ impl From<SignalRef> for SequenceTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformStart {
     Variant0(f64),
@@ -92114,7 +95103,7 @@ impl From<SignalRef> for SequenceTransformStart {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformStep {
     Variant0(f64),
@@ -92157,7 +95146,7 @@ impl From<SignalRef> for SequenceTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SequenceTransformStop {
     Variant0(f64),
@@ -92190,7 +95179,18 @@ impl From<SignalRef> for SequenceTransformStop {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SequenceTransformType {
     #[serde(rename = "sequence")]
     Sequence,
@@ -92324,7 +95324,7 @@ impl std::convert::TryFrom<String> for SequenceTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Signal {
     Variant0 {
@@ -92386,7 +95386,7 @@ impl From<&Signal> for Signal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct SignalName(String);
 impl std::ops::Deref for SignalName {
     type Target = String;
@@ -92448,7 +95448,7 @@ impl<'de> serde::Deserialize<'de> for SignalName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct SignalRef {
     pub signal: String,
 }
@@ -92469,7 +95469,18 @@ impl From<&SignalRef> for SignalRef {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SignalVariant0Push {
     #[serde(rename = "outer")]
     Outer,
@@ -92533,7 +95544,7 @@ impl std::convert::TryFrom<String> for SignalVariant0Push {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum SortOrder {
     Variant0(SortOrderVariant0),
@@ -92567,7 +95578,18 @@ impl From<SignalRef> for SortOrder {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum SortOrderVariant0 {
     #[serde(rename = "ascending")]
     Ascending,
@@ -92719,7 +95741,7 @@ impl std::convert::TryFrom<String> for SortOrderVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StackTransform {
     #[serde(rename = "as", default = "defaults::stack_transform_as")]
@@ -92775,7 +95797,7 @@ impl From<&StackTransform> for StackTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformAs {
     Variant0([StackTransformAsVariant0Item; 2usize]),
@@ -92821,7 +95843,7 @@ impl From<SignalRef> for StackTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformAsVariant0Item {
     Variant0(String),
@@ -92857,7 +95879,7 @@ impl From<SignalRef> for StackTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformField {
     ScaleField(ScaleField),
@@ -92914,7 +95936,7 @@ impl From<Expr> for StackTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformGroupby {
     Variant0(Vec<StackTransformGroupbyVariant0Item>),
@@ -92955,7 +95977,7 @@ impl From<SignalRef> for StackTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -93004,7 +96026,7 @@ impl From<Expr> for StackTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StackTransformOffset {
     Variant0(StackTransformOffsetVariant0),
@@ -93044,7 +96066,18 @@ impl From<SignalRef> for StackTransformOffset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StackTransformOffsetVariant0 {
     #[serde(rename = "zero")]
     Zero,
@@ -93108,7 +96141,18 @@ impl std::convert::TryFrom<String> for StackTransformOffsetVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StackTransformType {
     #[serde(rename = "stack")]
     Stack,
@@ -93204,7 +96248,7 @@ impl std::convert::TryFrom<String> for StackTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StratifyTransform {
     pub key: StratifyTransformKey,
@@ -93240,7 +96284,7 @@ impl From<&StratifyTransform> for StratifyTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StratifyTransformKey {
     ScaleField(ScaleField),
@@ -93287,7 +96331,7 @@ impl From<Expr> for StratifyTransformKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StratifyTransformParentKey {
     ScaleField(ScaleField),
@@ -93326,7 +96370,18 @@ impl From<Expr> for StratifyTransformParentKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StratifyTransformType {
     #[serde(rename = "stratify")]
     Stratify,
@@ -93467,7 +96522,7 @@ impl std::convert::TryFrom<String> for StratifyTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Stream {
     Variant0 {
@@ -93551,7 +96606,7 @@ impl From<&Stream> for Stream {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StreamVariant0Filter {
     Variant0(ExprString),
@@ -93593,7 +96648,7 @@ impl From<Vec<ExprString>> for StreamVariant0Filter {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StreamVariant1Filter {
     Variant0(ExprString),
@@ -93635,7 +96690,7 @@ impl From<Vec<ExprString>> for StreamVariant1Filter {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StreamVariant2Filter {
     Variant0(ExprString),
@@ -93671,7 +96726,7 @@ impl From<Vec<ExprString>> for StreamVariant2Filter {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct StringModifiers {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<Field>,
@@ -93698,7 +96753,7 @@ impl From<&StringModifiers> for StringModifiers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringOrSignal {
     Variant0(String),
@@ -93891,7 +96946,7 @@ impl From<SignalRef> for StringOrSignal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValue {
     Variant0(Vec<StringValueVariant0Item>),
@@ -94004,7 +97059,7 @@ impl From<StringValueVariant1> for StringValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant0Item {
     Variant0(StringValueVariant0ItemVariant0),
@@ -94131,7 +97186,7 @@ impl From<StringValueVariant0ItemVariant2> for StringValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemVariant0 {
     Variant0 {
@@ -94185,7 +97240,7 @@ impl From<&StringValueVariant0ItemVariant0> for StringValueVariant0ItemVariant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -94341,7 +97396,18 @@ impl From<bool> for StringValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant0ItemVariant1 {}
 impl From<&StringValueVariant0ItemVariant1> for StringValueVariant0ItemVariant1 {
@@ -94444,7 +97510,18 @@ impl From<&StringValueVariant0ItemVariant1> for StringValueVariant0ItemVariant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant0ItemVariant2 {}
 impl From<&StringValueVariant0ItemVariant2> for StringValueVariant0ItemVariant2 {
@@ -94537,7 +97614,7 @@ impl From<&StringValueVariant0ItemVariant2> for StringValueVariant0ItemVariant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant1 {
     Variant0(StringValueVariant1Variant0),
@@ -94657,7 +97734,7 @@ impl From<StringValueVariant1Variant2> for StringValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant1Variant0 {
     Variant0 {
@@ -94703,7 +97780,7 @@ impl From<&StringValueVariant1Variant0> for StringValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StringValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -94854,7 +97931,18 @@ impl From<bool> for StringValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant1Variant1 {}
 impl From<&StringValueVariant1Variant1> for StringValueVariant1Variant1 {
@@ -94954,7 +98042,18 @@ impl From<&StringValueVariant1Variant1> for StringValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant1Variant2 {}
 impl From<&StringValueVariant1Variant2> for StringValueVariant1Variant2 {
@@ -95147,7 +98246,7 @@ impl From<&StringValueVariant1Variant2> for StringValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValue {
     Variant0(Vec<StrokeCapValueVariant0Item>),
@@ -95264,7 +98363,7 @@ impl From<StrokeCapValueVariant1> for StrokeCapValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0Item {
     Variant0(StrokeCapValueVariant0ItemVariant0),
@@ -95395,7 +98494,7 @@ impl From<StrokeCapValueVariant0ItemVariant2> for StrokeCapValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemVariant0 {
     Variant0 {
@@ -95446,7 +98545,18 @@ impl From<&StrokeCapValueVariant0ItemVariant0> for StrokeCapValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StrokeCapValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "butt")]
     Butt,
@@ -95517,7 +98627,7 @@ impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemVariant0Variant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -95677,7 +98787,18 @@ impl From<bool> for StrokeCapValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant0ItemVariant1 {}
 impl From<&StrokeCapValueVariant0ItemVariant1> for StrokeCapValueVariant0ItemVariant1 {
@@ -95784,7 +98905,18 @@ impl From<&StrokeCapValueVariant0ItemVariant1> for StrokeCapValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant0ItemVariant2 {}
 impl From<&StrokeCapValueVariant0ItemVariant2> for StrokeCapValueVariant0ItemVariant2 {
@@ -95881,7 +99013,7 @@ impl From<&StrokeCapValueVariant0ItemVariant2> for StrokeCapValueVariant0ItemVar
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1 {
     Variant0(StrokeCapValueVariant1Variant0),
@@ -96005,7 +99137,7 @@ impl From<StrokeCapValueVariant1Variant2> for StrokeCapValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Variant0 {
     Variant0 {
@@ -96048,7 +99180,18 @@ impl From<&StrokeCapValueVariant1Variant0> for StrokeCapValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StrokeCapValueVariant1Variant0Variant1Value {
     #[serde(rename = "butt")]
     Butt,
@@ -96119,7 +99262,7 @@ impl std::convert::TryFrom<String> for StrokeCapValueVariant1Variant0Variant1Val
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -96276,7 +99419,18 @@ impl From<bool> for StrokeCapValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant1Variant1 {}
 impl From<&StrokeCapValueVariant1Variant1> for StrokeCapValueVariant1Variant1 {
@@ -96380,7 +99534,18 @@ impl From<&StrokeCapValueVariant1Variant1> for StrokeCapValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant1Variant2 {}
 impl From<&StrokeCapValueVariant1Variant2> for StrokeCapValueVariant1Variant2 {
@@ -96573,7 +99738,7 @@ impl From<&StrokeCapValueVariant1Variant2> for StrokeCapValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValue {
     Variant0(Vec<StrokeJoinValueVariant0Item>),
@@ -96690,7 +99855,7 @@ impl From<StrokeJoinValueVariant1> for StrokeJoinValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0Item {
     Variant0(StrokeJoinValueVariant0ItemVariant0),
@@ -96821,7 +99986,7 @@ impl From<StrokeJoinValueVariant0ItemVariant2> for StrokeJoinValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemVariant0 {
     Variant0 {
@@ -96872,7 +100037,18 @@ impl From<&StrokeJoinValueVariant0ItemVariant0> for StrokeJoinValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StrokeJoinValueVariant0ItemVariant0Variant1Value {
     #[serde(rename = "miter")]
     Miter,
@@ -96943,7 +100119,7 @@ impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemVariant0Varian
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -97103,7 +100279,18 @@ impl From<bool> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant0ItemVariant1 {}
 impl From<&StrokeJoinValueVariant0ItemVariant1> for StrokeJoinValueVariant0ItemVariant1 {
@@ -97210,7 +100397,18 @@ impl From<&StrokeJoinValueVariant0ItemVariant1> for StrokeJoinValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant0ItemVariant2 {}
 impl From<&StrokeJoinValueVariant0ItemVariant2> for StrokeJoinValueVariant0ItemVariant2 {
@@ -97307,7 +100505,7 @@ impl From<&StrokeJoinValueVariant0ItemVariant2> for StrokeJoinValueVariant0ItemV
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1 {
     Variant0(StrokeJoinValueVariant1Variant0),
@@ -97431,7 +100629,7 @@ impl From<StrokeJoinValueVariant1Variant2> for StrokeJoinValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Variant0 {
     Variant0 {
@@ -97474,7 +100672,18 @@ impl From<&StrokeJoinValueVariant1Variant0> for StrokeJoinValueVariant1Variant0 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum StrokeJoinValueVariant1Variant0Variant1Value {
     #[serde(rename = "miter")]
     Miter,
@@ -97545,7 +100754,7 @@ impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Variant0Variant1Va
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -97702,7 +100911,18 @@ impl From<bool> for StrokeJoinValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant1Variant1 {}
 impl From<&StrokeJoinValueVariant1Variant1> for StrokeJoinValueVariant1Variant1 {
@@ -97806,7 +101026,18 @@ impl From<&StrokeJoinValueVariant1Variant1> for StrokeJoinValueVariant1Variant1 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant1Variant2 {}
 impl From<&StrokeJoinValueVariant1Variant2> for StrokeJoinValueVariant1Variant2 {
@@ -97834,7 +101065,7 @@ impl From<&StrokeJoinValueVariant1Variant2> for StrokeJoinValueVariant1Variant2 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Style {
     Variant0(String),
@@ -97877,7 +101108,7 @@ impl From<Vec<String>> for Style {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextOrSignal {
     Variant0(TextOrSignalVariant0),
@@ -97918,7 +101149,7 @@ impl From<SignalRef> for TextOrSignal {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextOrSignalVariant0 {
     Variant0(String),
@@ -98131,7 +101362,7 @@ impl From<Vec<String>> for TextOrSignalVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValue {
     Variant0(Vec<TextValueVariant0Item>),
@@ -98254,7 +101485,7 @@ impl From<TextValueVariant1> for TextValue {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant0Item {
     Variant0(TextValueVariant0ItemVariant0),
@@ -98391,7 +101622,7 @@ impl From<TextValueVariant0ItemVariant2> for TextValueVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0 {
     Variant0 {
@@ -98448,7 +101679,7 @@ impl From<&TextValueVariant0ItemVariant0> for TextValueVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0Variant1Value {
     Variant0(String),
@@ -98483,7 +101714,7 @@ impl From<Vec<String>> for TextValueVariant0ItemVariant0Variant1Value {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0Variant3Range {
     Variant0(f64),
@@ -98649,7 +101880,18 @@ impl From<bool> for TextValueVariant0ItemVariant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant0ItemVariant1 {}
 impl From<&TextValueVariant0ItemVariant1> for TextValueVariant0ItemVariant1 {
@@ -98762,7 +102004,18 @@ impl From<&TextValueVariant0ItemVariant1> for TextValueVariant0ItemVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant0ItemVariant2 {}
 impl From<&TextValueVariant0ItemVariant2> for TextValueVariant0ItemVariant2 {
@@ -98865,7 +102118,7 @@ impl From<&TextValueVariant0ItemVariant2> for TextValueVariant0ItemVariant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant1 {
     Variant0(TextValueVariant1Variant0),
@@ -98995,7 +102248,7 @@ impl From<TextValueVariant1Variant2> for TextValueVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0 {
     Variant0 {
@@ -99044,7 +102297,7 @@ impl From<&TextValueVariant1Variant0> for TextValueVariant1Variant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0Variant1Value {
     Variant0(String),
@@ -99077,7 +102330,7 @@ impl From<Vec<String>> for TextValueVariant1Variant0Variant1Value {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0Variant3Range {
     Variant0(f64),
@@ -99238,7 +102491,18 @@ impl From<bool> for TextValueVariant1Variant0Variant3Range {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant1Variant1 {}
 impl From<&TextValueVariant1Variant1> for TextValueVariant1Variant1 {
@@ -99348,7 +102612,18 @@ impl From<&TextValueVariant1Variant1> for TextValueVariant1Variant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant1Variant2 {}
 impl From<&TextValueVariant1Variant2> for TextValueVariant1Variant2 {
@@ -99376,7 +102651,7 @@ impl From<&TextValueVariant1Variant2> for TextValueVariant1Variant2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TickBand {
     Variant0(TickBandVariant0),
@@ -99410,7 +102685,18 @@ impl From<SignalRef> for TickBand {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TickBandVariant0 {
     #[serde(rename = "center")]
     Center,
@@ -99518,7 +102804,7 @@ impl std::convert::TryFrom<String> for TickBandVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum TickCount {
     Variant0(f64),
@@ -99569,7 +102855,18 @@ impl From<SignalRef> for TickCount {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TickCountVariant1 {
     #[serde(rename = "millisecond")]
     Millisecond,
@@ -99667,7 +102964,7 @@ impl std::convert::TryFrom<String> for TickCountVariant1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TickCountVariant2Interval {
     Variant0(TickCountVariant2IntervalVariant0),
@@ -99707,7 +103004,18 @@ impl From<SignalRef> for TickCountVariant2Interval {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TickCountVariant2IntervalVariant0 {
     #[serde(rename = "millisecond")]
     Millisecond,
@@ -99942,7 +103250,7 @@ impl std::convert::TryFrom<String> for TickCountVariant2IntervalVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TimeunitTransform {
     #[serde(rename = "as", default = "defaults::timeunit_transform_as")]
@@ -100003,7 +103311,7 @@ impl From<&TimeunitTransform> for TimeunitTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformAs {
     Variant0([TimeunitTransformAsVariant0Item; 2usize]),
@@ -100049,7 +103357,7 @@ impl From<SignalRef> for TimeunitTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformAsVariant0Item {
     Variant0(String),
@@ -100092,7 +103400,7 @@ impl From<SignalRef> for TimeunitTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtent {
     Variant0(Vec<TimeunitTransformExtentVariant0Item>),
@@ -100130,7 +103438,7 @@ impl From<SignalRef> for TimeunitTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtentVariant0Item {
     Variant0(f64),
@@ -100171,7 +103479,7 @@ impl From<SignalRef> for TimeunitTransformExtentVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformField {
     ScaleField(ScaleField),
@@ -100216,7 +103524,7 @@ impl From<Expr> for TimeunitTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformInterval {
     Variant0(bool),
@@ -100260,7 +103568,7 @@ impl From<SignalRef> for TimeunitTransformInterval {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformMaxbins {
     Variant0(f64),
@@ -100304,7 +103612,7 @@ impl From<SignalRef> for TimeunitTransformMaxbins {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformStep {
     Variant0(f64),
@@ -100351,7 +103659,7 @@ impl From<SignalRef> for TimeunitTransformStep {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformTimezone {
     Variant0(TimeunitTransformTimezoneVariant0),
@@ -100390,7 +103698,18 @@ impl From<SignalRef> for TimeunitTransformTimezone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TimeunitTransformTimezoneVariant0 {
     #[serde(rename = "local")]
     Local,
@@ -100450,7 +103769,18 @@ impl std::convert::TryFrom<String> for TimeunitTransformTimezoneVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TimeunitTransformType {
     #[serde(rename = "timeunit")]
     Timeunit,
@@ -100533,7 +103863,7 @@ impl std::convert::TryFrom<String> for TimeunitTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnits {
     Variant0(Vec<TimeunitTransformUnitsVariant0Item>),
@@ -100583,7 +103913,7 @@ impl From<SignalRef> for TimeunitTransformUnits {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnitsVariant0Item {
     Variant0(TimeunitTransformUnitsVariant0ItemVariant0),
@@ -100626,7 +103956,18 @@ impl From<SignalRef> for TimeunitTransformUnitsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TimeunitTransformUnitsVariant0ItemVariant0 {
     #[serde(rename = "year")]
     Year,
@@ -101084,7 +104425,7 @@ impl std::convert::TryFrom<String> for TimeunitTransformUnitsVariant0ItemVariant
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Title {
     Variant0(String),
@@ -101215,7 +104556,7 @@ impl From<&Title> for Title {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Align {
     Variant0(TitleVariant1AlignVariant0),
@@ -101250,7 +104591,18 @@ impl From<AlignValue> for TitleVariant1Align {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TitleVariant1AlignVariant0 {
     #[serde(rename = "left")]
     Left,
@@ -101324,7 +104676,7 @@ impl std::convert::TryFrom<String> for TitleVariant1AlignVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Anchor {
     Variant0(Option<TitleVariant1AnchorVariant0>),
@@ -101360,7 +104712,18 @@ impl From<AnchorValue> for TitleVariant1Anchor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TitleVariant1AnchorVariant0 {
     #[serde(rename = "start")]
     Start,
@@ -101429,7 +104792,7 @@ impl std::convert::TryFrom<String> for TitleVariant1AnchorVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Angle {
     Variant0(f64),
@@ -101474,7 +104837,7 @@ impl From<NumberValue> for TitleVariant1Angle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Baseline {
     Variant0(TitleVariant1BaselineVariant0),
@@ -101512,7 +104875,18 @@ impl From<BaselineValue> for TitleVariant1Baseline {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TitleVariant1BaselineVariant0 {
     #[serde(rename = "top")]
     Top,
@@ -101596,7 +104970,7 @@ impl std::convert::TryFrom<String> for TitleVariant1BaselineVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Color {
     Variant0,
@@ -101630,7 +105004,7 @@ impl From<ColorValue> for TitleVariant1Color {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Dx {
     Variant0(f64),
@@ -101668,7 +105042,7 @@ impl From<NumberValue> for TitleVariant1Dx {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Dy {
     Variant0(f64),
@@ -101724,7 +105098,7 @@ impl From<NumberValue> for TitleVariant1Dy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TitleVariant1Encode {
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub subtype_0: Option<TitleVariant1EncodeSubtype0>,
@@ -101752,7 +105126,7 @@ impl From<&TitleVariant1Encode> for TitleVariant1Encode {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TitleVariant1EncodeSubtype0 {}
 impl From<&TitleVariant1EncodeSubtype0> for TitleVariant1EncodeSubtype0 {
@@ -101782,7 +105156,7 @@ impl From<&TitleVariant1EncodeSubtype0> for TitleVariant1EncodeSubtype0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TitleVariant1EncodeSubtype1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -101814,7 +105188,7 @@ impl From<&TitleVariant1EncodeSubtype1> for TitleVariant1EncodeSubtype1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Font {
     Variant0(String),
@@ -101847,7 +105221,7 @@ impl From<StringValue> for TitleVariant1Font {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1FontSize {
     Variant0(f64),
@@ -101885,7 +105259,7 @@ impl From<NumberValue> for TitleVariant1FontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1FontStyle {
     Variant0(String),
@@ -101942,7 +105316,7 @@ impl From<StringValue> for TitleVariant1FontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1FontWeight {
     Variant0(MyEnum),
@@ -101983,7 +105357,7 @@ impl From<FontWeightValue> for TitleVariant1FontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Frame {
     Variant0(TitleVariant1FrameVariant0),
@@ -102017,7 +105391,18 @@ impl From<StringValue> for TitleVariant1Frame {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TitleVariant1FrameVariant0 {
     #[serde(rename = "group")]
     Group,
@@ -102082,7 +105467,7 @@ impl std::convert::TryFrom<String> for TitleVariant1FrameVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Limit {
     Variant0(f64),
@@ -102120,7 +105505,7 @@ impl From<NumberValue> for TitleVariant1Limit {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1LineHeight {
     Variant0(f64),
@@ -102158,7 +105543,7 @@ impl From<NumberValue> for TitleVariant1LineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Offset {
     Variant0(f64),
@@ -102203,7 +105588,7 @@ impl From<NumberValue> for TitleVariant1Offset {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1Orient {
     Variant0(TitleVariant1OrientVariant0),
@@ -102241,7 +105626,18 @@ impl From<SignalRef> for TitleVariant1Orient {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TitleVariant1OrientVariant0 {
     #[serde(rename = "none")]
     None,
@@ -102321,7 +105717,7 @@ impl std::convert::TryFrom<String> for TitleVariant1OrientVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleColor {
     Variant0,
@@ -102355,7 +105751,7 @@ impl From<ColorValue> for TitleVariant1SubtitleColor {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFont {
     Variant0(String),
@@ -102388,7 +105784,7 @@ impl From<StringValue> for TitleVariant1SubtitleFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontSize {
     Variant0(f64),
@@ -102426,7 +105822,7 @@ impl From<NumberValue> for TitleVariant1SubtitleFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontStyle {
     Variant0(String),
@@ -102483,7 +105879,7 @@ impl From<StringValue> for TitleVariant1SubtitleFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleFontWeight {
     Variant0(MyEnum),
@@ -102521,7 +105917,7 @@ impl From<FontWeightValue> for TitleVariant1SubtitleFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TitleVariant1SubtitleLineHeight {
     Variant0(f64),
@@ -102706,7 +106102,7 @@ impl From<NumberValue> for TitleVariant1SubtitleLineHeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum Transform {
     CrossfilterTransform(CrossfilterTransform),
@@ -103122,7 +106518,7 @@ impl From<WordcloudTransform> for Transform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TransformMark {
     CrossfilterTransform(CrossfilterTransform),
@@ -103448,7 +106844,7 @@ impl From<WordcloudTransform> for TransformMark {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreeTransform {
     #[serde(rename = "as", default = "defaults::tree_transform_as")]
@@ -103510,7 +106906,7 @@ impl From<&TreeTransform> for TreeTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformAs {
     Variant0([TreeTransformAsVariant0Item; 4usize]),
@@ -103558,7 +106954,7 @@ impl From<SignalRef> for TreeTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformAsVariant0Item {
     Variant0(String),
@@ -103594,7 +106990,7 @@ impl From<SignalRef> for TreeTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformField {
     ScaleField(ScaleField),
@@ -103642,7 +107038,7 @@ impl From<Expr> for TreeTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformMethod {
     Variant0(TreeTransformMethodVariant0),
@@ -103681,7 +107077,18 @@ impl From<SignalRef> for TreeTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TreeTransformMethodVariant0 {
     #[serde(rename = "tidy")]
     Tidy,
@@ -103758,7 +107165,7 @@ impl std::convert::TryFrom<String> for TreeTransformMethodVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSize {
     Variant0([TreeTransformNodeSizeVariant0Item; 2usize]),
@@ -103796,7 +107203,7 @@ impl From<SignalRef> for TreeTransformNodeSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSizeVariant0Item {
     Variant0(f64),
@@ -103835,7 +107242,7 @@ impl From<SignalRef> for TreeTransformNodeSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSeparation {
     Variant0(bool),
@@ -103890,7 +107297,7 @@ impl From<SignalRef> for TreeTransformSeparation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSize {
     Variant0([TreeTransformSizeVariant0Item; 2usize]),
@@ -103928,7 +107335,7 @@ impl From<SignalRef> for TreeTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreeTransformSizeVariant0Item {
     Variant0(f64),
@@ -103961,7 +107368,18 @@ impl From<SignalRef> for TreeTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TreeTransformType {
     #[serde(rename = "tree")]
     Tree,
@@ -104029,7 +107447,7 @@ impl std::convert::TryFrom<String> for TreeTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreelinksTransform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -104054,7 +107472,18 @@ impl From<&TreelinksTransform> for TreelinksTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TreelinksTransformType {
     #[serde(rename = "treelinks")]
     Treelinks,
@@ -104299,7 +107728,7 @@ impl std::convert::TryFrom<String> for TreelinksTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TreemapTransform {
     #[serde(rename = "as", default = "defaults::treemap_transform_as")]
@@ -104401,7 +107830,7 @@ impl From<&TreemapTransform> for TreemapTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformAs {
     Variant0([TreemapTransformAsVariant0Item; 6usize]),
@@ -104451,7 +107880,7 @@ impl From<SignalRef> for TreemapTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformAsVariant0Item {
     Variant0(String),
@@ -104487,7 +107916,7 @@ impl From<SignalRef> for TreemapTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformField {
     ScaleField(ScaleField),
@@ -104539,7 +107968,7 @@ impl From<Expr> for TreemapTransformField {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformMethod {
     Variant0(TreemapTransformMethodVariant0),
@@ -104582,7 +108011,18 @@ impl From<SignalRef> for TreemapTransformMethod {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TreemapTransformMethodVariant0 {
     #[serde(rename = "squarify")]
     Squarify,
@@ -104663,7 +108103,7 @@ impl std::convert::TryFrom<String> for TreemapTransformMethodVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPadding {
     Variant0(f64),
@@ -104701,7 +108141,7 @@ impl From<SignalRef> for TreemapTransformPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingBottom {
     Variant0(f64),
@@ -104739,7 +108179,7 @@ impl From<SignalRef> for TreemapTransformPaddingBottom {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingInner {
     Variant0(f64),
@@ -104777,7 +108217,7 @@ impl From<SignalRef> for TreemapTransformPaddingInner {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingLeft {
     Variant0(f64),
@@ -104815,7 +108255,7 @@ impl From<SignalRef> for TreemapTransformPaddingLeft {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingOuter {
     Variant0(f64),
@@ -104853,7 +108293,7 @@ impl From<SignalRef> for TreemapTransformPaddingOuter {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingRight {
     Variant0(f64),
@@ -104891,7 +108331,7 @@ impl From<SignalRef> for TreemapTransformPaddingRight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingTop {
     Variant0(f64),
@@ -104930,7 +108370,7 @@ impl From<SignalRef> for TreemapTransformPaddingTop {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformRatio {
     Variant0(f64),
@@ -104973,7 +108413,7 @@ impl From<SignalRef> for TreemapTransformRatio {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformRound {
     Variant0(bool),
@@ -105023,7 +108463,7 @@ impl From<SignalRef> for TreemapTransformRound {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformSize {
     Variant0([TreemapTransformSizeVariant0Item; 2usize]),
@@ -105061,7 +108501,7 @@ impl From<SignalRef> for TreemapTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum TreemapTransformSizeVariant0Item {
     Variant0(f64),
@@ -105094,7 +108534,18 @@ impl From<SignalRef> for TreemapTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TreemapTransformType {
     #[serde(rename = "treemap")]
     Treemap,
@@ -105246,7 +108697,7 @@ impl std::convert::TryFrom<String> for TreemapTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct VoronoiTransform {
     #[serde(rename = "as", default = "defaults::voronoi_transform_as")]
@@ -105285,7 +108736,7 @@ impl From<&VoronoiTransform> for VoronoiTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformAs {
     Variant0(String),
@@ -105336,7 +108787,7 @@ impl From<SignalRef> for VoronoiTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformExtent {
     Variant0([serde_json::Value; 2usize]),
@@ -105394,7 +108845,7 @@ impl From<SignalRef> for VoronoiTransformExtent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformSize {
     Variant0([VoronoiTransformSizeVariant0Item; 2usize]),
@@ -105432,7 +108883,7 @@ impl From<SignalRef> for VoronoiTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformSizeVariant0Item {
     Variant0(f64),
@@ -105465,7 +108916,18 @@ impl From<SignalRef> for VoronoiTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum VoronoiTransformType {
     #[serde(rename = "voronoi")]
     Voronoi,
@@ -105529,7 +108991,7 @@ impl std::convert::TryFrom<String> for VoronoiTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformX {
     ScaleField(ScaleField),
@@ -105576,7 +109038,7 @@ impl From<Expr> for VoronoiTransformX {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum VoronoiTransformY {
     ScaleField(ScaleField),
@@ -105822,7 +109284,7 @@ impl From<Expr> for VoronoiTransformY {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WindowTransform {
     #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
@@ -105885,7 +109347,7 @@ impl From<&WindowTransform> for WindowTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformAs {
     Variant0(Vec<WindowTransformAsVariant0Item>),
@@ -105926,7 +109388,7 @@ impl From<SignalRef> for WindowTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformAsVariant0Item {
     Variant0(String),
@@ -105976,7 +109438,7 @@ impl From<SignalRef> for WindowTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFields {
     Variant0(Vec<WindowTransformFieldsVariant0Item>),
@@ -106020,7 +109482,7 @@ impl From<SignalRef> for WindowTransformFields {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFieldsVariant0Item {
     Variant0(ScaleField),
@@ -106084,7 +109546,7 @@ impl From<Expr> for WindowTransformFieldsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFrame {
     Variant0([WindowTransformFrameVariant0Item; 2usize]),
@@ -106133,7 +109595,7 @@ impl From<SignalRef> for WindowTransformFrame {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformFrameVariant0Item {
     Variant0(f64),
@@ -106185,7 +109647,7 @@ impl From<SignalRef> for WindowTransformFrameVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformGroupby {
     Variant0(Vec<WindowTransformGroupbyVariant0Item>),
@@ -106226,7 +109688,7 @@ impl From<SignalRef> for WindowTransformGroupby {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformGroupbyVariant0Item {
     ScaleField(ScaleField),
@@ -106270,7 +109732,7 @@ impl From<Expr> for WindowTransformGroupbyVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformIgnorePeers {
     Variant0(bool),
@@ -106356,7 +109818,7 @@ impl From<SignalRef> for WindowTransformIgnorePeers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformOps {
     Variant0(Vec<WindowTransformOpsVariant0Item>),
@@ -106432,7 +109894,7 @@ impl From<SignalRef> for WindowTransformOps {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformOpsVariant0Item {
     Variant0(WindowTransformOpsVariant0ItemVariant0),
@@ -106501,7 +109963,18 @@ impl From<SignalRef> for WindowTransformOpsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WindowTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "row_number")]
     RowNumber,
@@ -106719,7 +110192,7 @@ impl std::convert::TryFrom<String> for WindowTransformOpsVariant0ItemVariant0 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformParams {
     Variant0(Vec<WindowTransformParamsVariant0Item>),
@@ -106760,7 +110233,7 @@ impl From<SignalRef> for WindowTransformParams {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WindowTransformParamsVariant0Item {
     Variant0(f64),
@@ -106794,7 +110267,18 @@ impl From<SignalRef> for WindowTransformParamsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WindowTransformType {
     #[serde(rename = "window")]
     Window,
@@ -107065,7 +110549,7 @@ impl std::convert::TryFrom<String> for WindowTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WordcloudTransform {
     #[serde(rename = "as", default = "defaults::wordcloud_transform_as")]
@@ -107150,7 +110634,7 @@ impl From<&WordcloudTransform> for WordcloudTransform {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformAs {
     Variant0([WordcloudTransformAsVariant0Item; 7usize]),
@@ -107201,7 +110685,7 @@ impl From<SignalRef> for WordcloudTransformAs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformAsVariant0Item {
     Variant0(String),
@@ -107241,7 +110725,7 @@ impl From<SignalRef> for WordcloudTransformAsVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFont {
     Variant0(String),
@@ -107298,7 +110782,7 @@ impl From<ParamField> for WordcloudTransformFont {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSize {
     Variant0(f64),
@@ -107370,7 +110854,7 @@ impl From<ParamField> for WordcloudTransformFontSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRange {
     Variant0(Vec<WordcloudTransformFontSizeRangeVariant0Item>),
@@ -107417,7 +110901,7 @@ impl From<SignalRef> for WordcloudTransformFontSizeRange {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRangeVariant0Item {
     Variant0(f64),
@@ -107464,7 +110948,7 @@ impl From<SignalRef> for WordcloudTransformFontSizeRangeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontStyle {
     Variant0(String),
@@ -107521,7 +111005,7 @@ impl From<ParamField> for WordcloudTransformFontStyle {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontWeight {
     Variant0(String),
@@ -107577,7 +111061,7 @@ impl From<ParamField> for WordcloudTransformFontWeight {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformPadding {
     Variant0(f64),
@@ -107633,7 +111117,7 @@ impl From<ParamField> for WordcloudTransformPadding {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformRotate {
     Variant0(f64),
@@ -107695,7 +111179,7 @@ impl From<ParamField> for WordcloudTransformRotate {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformSize {
     Variant0([WordcloudTransformSizeVariant0Item; 2usize]),
@@ -107733,7 +111217,7 @@ impl From<SignalRef> for WordcloudTransformSize {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformSizeVariant0Item {
     Variant0(f64),
@@ -107771,7 +111255,7 @@ impl From<SignalRef> for WordcloudTransformSizeVariant0Item {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformSpiral {
     Variant0(String),
@@ -107807,7 +111291,7 @@ impl From<SignalRef> for WordcloudTransformSpiral {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WordcloudTransformText {
     ScaleField(ScaleField),
@@ -107846,7 +111330,18 @@ impl From<Expr> for WordcloudTransformText {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum WordcloudTransformType {
     #[serde(rename = "wordcloud")]
     Wordcloud,

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -21,7 +21,6 @@ mod token_utils;
 /// invoked with a structured form:
 /// ```
 /// use typify_macro::import_types;
-/// use serde::{Deserialize,Serialize};
 /// import_types!(
 ///     schema = "../example.json",
 ///     derives = [schemars::JsonSchema],

--- a/typify-test/build.rs
+++ b/typify-test/build.rs
@@ -106,11 +106,8 @@ fn main() {
     UnknownFormat::add(&mut type_space);
     ipnetwork::IpNetwork::add(&mut type_space);
 
-    let contents = format!(
-        "{}\n{}",
-        "use serde::{Deserialize, Serialize};",
-        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap())
-    );
+    let contents =
+        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap());
 
     let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
     out_file.push("codegen.rs");

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -8,7 +8,6 @@
 //! A typical use looks like this:
 //! ```
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!("../example.json");
 //! ```
 //!
@@ -21,7 +20,6 @@
 //! Alternatively, you may use the expanded form:
 //! ```
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(schema = "../example.json");
 //! ```
 //!
@@ -29,7 +27,6 @@
 //! specify them with the `derives` property of the expanded form:
 //! ```
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(
 //!     schema = "../example.json",
 //!     derives = [schemars::JsonSchema],
@@ -40,7 +37,6 @@
 //! ```
 //! # mod x {
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(
 //!     schema = "../example.json",
 //!     struct_builder = true,
@@ -52,7 +48,6 @@
 //! ```
 //! # mod x {
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! # import_types!(
 //! #    schema = "../example.json",
 //! #    struct_builder = true,
@@ -75,7 +70,6 @@
 //! types using the `patch` syntax:
 //! ```
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(
 //!     schema = "../example.json",
 //!     patch = {
@@ -97,7 +91,6 @@
 //! # pub struct Ipv6Cidr(String);
 //! # }
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(
 //!     schema = "../example.json",
 //!     replace = {
@@ -116,7 +109,6 @@
 //! # pub struct MyUuid(String);
 //! # }
 //! # use typify_macro::import_types;
-//! # use serde::{Deserialize,Serialize};
 //! import_types!(
 //!     schema = "../example.json",
 //!     convert = {

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -70,10 +70,6 @@ fn validate_schema(path: std::path::PathBuf) -> Result<(), Box<dyn Error>> {
 
     // Make a file with the generated code.
     let code = quote! {
-        // Some types impl their own Deserialize and fully qualify the name.
-        #[allow(unused_imports)]
-        use serde::{Deserialize, Serialize};
-
         #type_space
 
         fn main() {}

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -38,7 +36,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ArraySansItems(pub Vec<serde_json::Value>);
 impl std::ops::Deref for ArraySansItems {
     type Target = Vec<serde_json::Value>;
@@ -84,7 +82,7 @@ impl From<Vec<serde_json::Value>> for ArraySansItems {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct LessSimpleTwoTuple(pub (String, String));
 impl std::ops::Deref for LessSimpleTwoTuple {
     type Target = (String, String);
@@ -122,7 +120,7 @@ impl From<(String, String)> for LessSimpleTwoTuple {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct SimpleTwoArray(pub [String; 2usize]);
 impl std::ops::Deref for SimpleTwoArray {
     type Target = [String; 2usize];
@@ -165,7 +163,7 @@ impl From<[String; 2usize]> for SimpleTwoArray {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct SimpleTwoTuple(pub (String, String));
 impl std::ops::Deref for SimpleTwoTuple {
     type Target = (String, String);
@@ -208,7 +206,7 @@ impl From<(String, String)> for SimpleTwoTuple {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct UnsimpleTwoTuple(pub (String, String));
 impl std::ops::Deref for UnsimpleTwoTuple {
     type Target = (String, String);
@@ -247,7 +245,7 @@ impl From<(String, String)> for UnsimpleTwoTuple {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct YoloTwoArray(pub [serde_json::Value; 2usize]);
 impl std::ops::Deref for YoloTwoArray {
     type Target = [serde_json::Value; 2usize];

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -61,7 +59,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TestType {
     pub where_not: TestTypeWhereNot,
     pub why_not: TestTypeWhyNot,
@@ -87,7 +85,7 @@ impl From<&TestType> for TestType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct TestTypeWhereNot(String);
 impl std::ops::Deref for TestTypeWhereNot {
     type Target = String;
@@ -139,7 +137,7 @@ impl<'de> serde::Deserialize<'de> for TestTypeWhereNot {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct TestTypeWhyNot(String);
 impl std::ops::Deref for TestTypeWhyNot {
     type Target = String;

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -48,7 +46,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct LetterBox {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub letter: Option<LetterBoxLetter>,
@@ -74,7 +72,18 @@ impl From<&LetterBox> for LetterBox {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum LetterBoxLetter {
     #[serde(rename = "a")]
     A,

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -54,7 +52,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IdOrName {
     Id(uuid::Uuid),
@@ -133,7 +131,7 @@ impl From<Name> for IdOrName {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IdOrNameRedundant {
     Variant0(uuid::Uuid),
@@ -221,7 +219,7 @@ impl From<Name> for IdOrNameRedundant {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IdOrYolo {
     Id(uuid::Uuid),
@@ -291,7 +289,7 @@ impl From<IdOrYoloYolo> for IdOrYolo {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct IdOrYoloYolo(String);
 impl std::ops::Deref for IdOrYoloYolo {
     type Target = String;
@@ -362,7 +360,7 @@ impl<'de> serde::Deserialize<'de> for IdOrYoloYolo {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct Name(String);
 impl std::ops::Deref for Name {
     type Target = String;

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -38,7 +36,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DeadSimple(pub serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for DeadSimple {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -72,7 +70,9 @@ impl From<serde_json::Map<String, serde_json::Value>> for DeadSimple {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Eh(pub String);
 impl std::ops::Deref for Eh {
     type Target = String;
@@ -123,7 +123,7 @@ impl ToString for Eh {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MapWithDateKeys(pub std::collections::HashMap<chrono::naive::NaiveDate, Value>);
 impl std::ops::Deref for MapWithDateKeys {
     type Target = std::collections::HashMap<chrono::naive::NaiveDate, Value>;
@@ -163,7 +163,7 @@ impl From<std::collections::HashMap<chrono::naive::NaiveDate, Value>> for MapWit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MapWithDateTimeKeys(
     pub std::collections::HashMap<chrono::DateTime<chrono::offset::Utc>, Value>,
 );
@@ -210,7 +210,7 @@ impl From<std::collections::HashMap<chrono::DateTime<chrono::offset::Utc>, Value
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MapWithKeys(pub std::collections::HashMap<Eh, Value>);
 impl std::ops::Deref for MapWithKeys {
     type Target = std::collections::HashMap<Eh, Value>;
@@ -243,7 +243,9 @@ impl From<std::collections::HashMap<Eh, Value>> for MapWithKeys {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Value(pub String);
 impl std::ops::Deref for Value {
     type Target = String;

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -40,7 +38,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct BarProp {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bar: Option<serde_json::Value>,
@@ -69,7 +67,7 @@ impl From<&BarProp> for BarProp {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ButNotThat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub this: Option<serde_json::Value>,
@@ -101,7 +99,7 @@ impl From<&ButNotThat> for ButNotThat {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct CommentedTypeMerged {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub x: Option<serde_json::Value>,
@@ -150,7 +148,7 @@ impl From<&CommentedTypeMerged> for CommentedTypeMerged {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum HereAndThere {
     Variant0 {
@@ -186,7 +184,7 @@ impl From<&HereAndThere> for HereAndThere {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct JsonResponseBase {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
@@ -217,7 +215,7 @@ impl From<&JsonResponseBase> for JsonResponseBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonSuccess {
     pub msg: String,
@@ -259,7 +257,7 @@ impl From<&JsonSuccess> for JsonSuccess {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct JsonSuccessBase {
     pub msg: String,
     pub result: JsonSuccessBaseResult,
@@ -282,7 +280,18 @@ impl From<&JsonSuccessBase> for JsonSuccessBase {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum JsonSuccessBaseResult {
     #[serde(rename = "success")]
     Success,
@@ -339,7 +348,18 @@ impl std::convert::TryFrom<String> for JsonSuccessBaseResult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum JsonSuccessResult {
     #[serde(rename = "success")]
     Success,
@@ -400,7 +420,7 @@ impl std::convert::TryFrom<String> for JsonSuccessResult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct NarrowNumber(pub std::num::NonZeroU64);
 impl std::ops::Deref for NarrowNumber {
     type Target = std::num::NonZeroU64;
@@ -476,7 +496,7 @@ impl ToString for NarrowNumber {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct OrderDependentMerge {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bar: Option<serde_json::Value>,
@@ -513,7 +533,7 @@ impl From<&OrderDependentMerge> for OrderDependentMerge {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Pickingone {
     pub suspended_by: PickingoneSuspendedBy,
 }
@@ -544,7 +564,7 @@ impl From<&Pickingone> for Pickingone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct PickingoneInstallation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suspended_by: Option<PickingoneUser>,
@@ -584,7 +604,7 @@ impl From<&PickingoneInstallation> for PickingoneInstallation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct PickingoneSuspendedBy {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
@@ -612,7 +632,7 @@ impl From<&PickingoneSuspendedBy> for PickingoneSuspendedBy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct PickingoneUser {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
@@ -654,7 +674,7 @@ impl From<&PickingoneUser> for PickingoneUser {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TrimFat {
     pub a: serde_json::Value,
 }
@@ -712,7 +732,18 @@ impl From<&TrimFat> for TrimFat {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum Unresolvable {}
 impl From<&Unresolvable> for Unresolvable {
@@ -743,7 +774,18 @@ impl From<&Unresolvable> for Unresolvable {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum Unsatisfiable1 {}
 impl From<&Unsatisfiable1> for Unsatisfiable1 {
@@ -786,7 +828,7 @@ impl From<&Unsatisfiable1> for Unsatisfiable1 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Unsatisfiable2 {}
 impl From<&Unsatisfiable2> for Unsatisfiable2 {
@@ -816,7 +858,7 @@ impl From<&Unsatisfiable2> for Unsatisfiable2 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Unsatisfiable3 {}
 impl From<&Unsatisfiable3> for Unsatisfiable3 {
     fn from(value: &Unsatisfiable3) -> Self {
@@ -842,7 +884,7 @@ impl From<&Unsatisfiable3> for Unsatisfiable3 {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Unsatisfiable3A {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<Unsatisfiable3C>,
@@ -865,7 +907,18 @@ impl From<&Unsatisfiable3A> for Unsatisfiable3A {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum Unsatisfiable3B {
     #[serde(rename = "bar")]
     Bar,
@@ -922,7 +975,18 @@ impl std::convert::TryFrom<String> for Unsatisfiable3B {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum Unsatisfiable3C {
     #[serde(rename = "foo")]
     Foo,
@@ -1088,7 +1152,7 @@ impl std::convert::TryFrom<String> for Unsatisfiable3C {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum WeirdEnum {
     Variant0 {

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -39,7 +37,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IntOrStr {
     String(String),
@@ -110,7 +108,7 @@ impl From<i64> for IntOrStr {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum OneOfSeveral {
     Null,
@@ -161,7 +159,7 @@ impl From<i64> for OneOfSeveral {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ReallyJustNull(pub ());
 impl std::ops::Deref for ReallyJustNull {
     type Target = ();
@@ -202,7 +200,7 @@ impl From<()> for ReallyJustNull {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct SeriouslyAnything(pub serde_json::Value);
 impl std::ops::Deref for SeriouslyAnything {
     type Target = serde_json::Value;
@@ -243,7 +241,7 @@ impl From<serde_json::Value> for SeriouslyAnything {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum YesNoMaybe {
     Boolean(bool),

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -47,7 +45,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ArrayBs(pub Vec<bool>);
 impl std::ops::Deref for ArrayBs {
     type Target = Vec<bool>;
@@ -88,7 +86,7 @@ impl From<Vec<bool>> for ArrayBs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct IntegerBs(pub u64);
 impl std::ops::Deref for IntegerBs {
     type Target = u64;
@@ -158,7 +156,7 @@ impl ToString for IntegerBs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct ObjectBs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ok: Option<bool>,

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -49,7 +47,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Node {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<Node>,

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -39,7 +37,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct AnythingWorks {
     pub value: serde_json::Value,
 }
@@ -64,7 +62,7 @@ impl From<&AnythingWorks> for AnythingWorks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct FloatsArentTerribleImTold {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flush_timeout: Option<f32>,
@@ -86,7 +84,9 @@ impl From<&FloatsArentTerribleImTold> for FloatsArentTerribleImTold {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct JustOne(pub String);
 impl std::ops::Deref for JustOne {
     type Target = String;

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -42,7 +40,18 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TestEnum {
     #[serde(rename = "failure")]
     Failure,

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -57,7 +55,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TestType {
     pub converted_type: serde_json::Value,
     pub patched_type: TypeThatHasMoreDerives,
@@ -81,7 +79,7 @@ impl From<&TestType> for TestType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde :: Deserialize, serde :: Serialize)]
 pub struct TypeThatHasMoreDerives(pub std::collections::HashMap<String, String>);
 impl std::ops::Deref for TypeThatHasMoreDerives {
     type Target = std::collections::HashMap<String, String>;

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -43,7 +41,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct Doodad {
     #[serde(default = "defaults::doodad_when")]
     pub when: chrono::DateTime<chrono::offset::Utc>,
@@ -77,7 +75,7 @@ impl From<&Doodad> for Doodad {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct MrDefaultNumbers {
     #[serde(default = "defaults::default_nzu64::<std::num::NonZeroU16, 3>")]
     pub little_u16: std::num::NonZeroU16,
@@ -117,7 +115,7 @@ impl From<&MrDefaultNumbers> for MrDefaultNumbers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct OuterThing {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thing: Option<ThingWithDefaults>,
@@ -161,7 +159,7 @@ impl From<&OuterThing> for OuterThing {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TestBed {
     #[serde(default = "defaults::test_bed_any")]
     pub any: Vec<serde_json::Value>,
@@ -196,7 +194,7 @@ impl From<&TestBed> for TestBed {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ThingWithDefaults {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -37,7 +35,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Serialize)]
 pub struct PatternString(String);
 impl std::ops::Deref for PatternString {
     type Target = String;
@@ -111,7 +109,7 @@ impl<'de> serde::Deserialize<'de> for PatternString {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, serde :: Serialize)]
 pub struct Sub10Primes(u32);
 impl std::ops::Deref for Sub10Primes {
     type Target = u32;

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -51,7 +49,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct TestType {
     pub value: Option<TestTypeValue>,
 }
@@ -75,7 +73,18 @@ impl From<&TestType> for TestType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum TestTypeValue {
     #[serde(rename = "start")]
     Start,

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -42,7 +40,18 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum AlternativeEnum {
     Choice1,
     Choice2,
@@ -123,7 +132,18 @@ impl Default for AlternativeEnum {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum CommentedVariants {
     #[doc = "An A"]
     A,
@@ -203,7 +223,7 @@ impl std::convert::TryFrom<String> for CommentedVariants {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct DiskAttachment {
     pub alternate: AlternativeEnum,
     pub state: DiskAttachmentState,
@@ -229,7 +249,18 @@ impl From<&DiskAttachment> for DiskAttachment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum DiskAttachmentState {
     Detached,
     Destroyed,
@@ -301,7 +332,7 @@ impl Default for DiskAttachmentState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct EmptyObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prop: Option<EmptyObjectProp>,
@@ -324,7 +355,7 @@ impl From<&EmptyObject> for EmptyObject {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, serde :: Serialize)]
 pub struct EmptyObjectProp(serde_json::Map<String, serde_json::Value>);
 impl std::ops::Deref for EmptyObjectProp {
     type Target = serde_json::Map<String, serde_json::Value>;
@@ -442,7 +473,7 @@ impl<'de> serde::Deserialize<'de> for EmptyObjectProp {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(tag = "petType")]
 pub enum EnumAndConstant {
     #[serde(rename = "dog")]
@@ -487,7 +518,7 @@ impl From<&EnumAndConstant> for EnumAndConstant {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum IpNet {
     V4(Ipv4Net),
@@ -556,7 +587,9 @@ impl From<Ipv6Net> for IpNet {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Ipv4Net(pub String);
 impl std::ops::Deref for Ipv4Net {
     type Target = String;
@@ -600,7 +633,9 @@ impl ToString for Ipv4Net {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct Ipv6Net(pub String);
 impl std::ops::Deref for Ipv6Net {
     type Target = String;
@@ -666,7 +701,7 @@ impl ToString for Ipv6Net {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum JankNames {
     Variant0(String),
@@ -696,7 +731,18 @@ impl From<std::collections::HashMap<String, i64>> for JankNames {
 #[doc = "false"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum Never {}
 impl From<&Never> for Never {
@@ -712,7 +758,18 @@ impl From<&Never> for Never {
 #[doc = "false"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum NeverEver {}
 impl From<&NeverEver> for NeverEver {
@@ -739,7 +796,7 @@ impl From<&NeverEver> for NeverEver {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct NullStringEnumWithUnknownFormat(pub Option<NullStringEnumWithUnknownFormatInner>);
 impl std::ops::Deref for NullStringEnumWithUnknownFormat {
     type Target = Option<NullStringEnumWithUnknownFormatInner>;
@@ -778,7 +835,18 @@ impl From<Option<NullStringEnumWithUnknownFormatInner>> for NullStringEnumWithUn
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 pub enum NullStringEnumWithUnknownFormatInner {
     #[serde(rename = "a")]
     A,
@@ -862,7 +930,7 @@ impl std::convert::TryFrom<String> for NullStringEnumWithUnknownFormatInner {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub enum OneOfTypes {
     #[serde(rename = "bar")]
     Bar(i64),
@@ -889,7 +957,9 @@ impl From<i64> for OneOfTypes {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct ReferenceDef(pub String);
 impl std::ops::Deref for ReferenceDef {
     type Target = String;
@@ -955,7 +1025,7 @@ impl ToString for ReferenceDef {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum References {
     Variant0(Vec<String>),
@@ -993,7 +1063,7 @@ impl From<std::collections::HashMap<String, ReferencesVariant1Value>> for Refere
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ReferencesVariant1Value {
     StringVersion(StringVersion),
@@ -1082,7 +1152,7 @@ impl From<ReferenceDef> for ReferencesVariant1Value {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 #[serde(untagged)]
 pub enum ShouldBeExclusive {
     Variant0 { id: String },
@@ -1103,7 +1173,9 @@ impl From<&ShouldBeExclusive> for ShouldBeExclusive {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde :: Deserialize, serde :: Serialize,
+)]
 pub struct StringVersion(pub String);
 impl std::ops::Deref for StringVersion {
     type Target = String;

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 #[doc = r" Error types."]
 pub mod error {
     #[doc = r" Error from a TryFrom or FromStr implementation."]
@@ -44,7 +42,7 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde :: Deserialize, serde :: Serialize)]
 pub struct AllTheThings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub option_marker: Option<::std::option::Option<Marker>>,
@@ -64,7 +62,18 @@ impl From<&AllTheThings> for AllTheThings {
 #[doc = "false"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde :: Deserialize,
+    serde :: Serialize,
+)]
 #[serde(deny_unknown_fields)]
 pub enum Marker {}
 impl From<&Marker> for Marker {


### PR DESCRIPTION
First-time users may be confused by the requirement to `use serde::{Deserialize, Serialize};` in anything which uses generated types. Instead, this PR fully qualifies the Deserialize and Serialize macros in output such that only `cargo add serde --features=derive` and `cargo add regress serde_json` is needed in consumer crates.