### PR TITLE
Impl Display rather than ToString

### DIFF
--- a/cargo-typify/README.md
+++ b/cargo-typify/README.md
@@ -104,11 +104,11 @@ impl std::convert::TryFrom<String> for IdOrName {
         value.parse()
     }
 }
-impl ToString for IdOrName {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IdOrName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Id(x) => x.to_string(),
-            Self::Name(x) => x.to_string(),
+            Self::Id(x) => x.fmt(f),
+            Self::Name(x) => x.fmt(f),
         }
     }
 }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -733,7 +733,7 @@ impl TypeEntry {
             )
         }
 
-        // ToString and FromStr impls for enums that are made exclusively of
+        // Display and FromStr impls for enums that are made exclusively of
         // simple variants (and are not untagged).
         let simple_enum_impl = bespoke_impls
             .contains(&TypeEntryEnumImpl::AllSimpleVariants)
@@ -751,10 +751,10 @@ impl TypeEntry {
                     .unzip();
 
                 quote! {
-                    impl ToString for #type_name {
-                        fn to_string(&self) -> String {
+                    impl ::std::fmt::Display for #type_name {
+                        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                             match *self {
-                                #(Self::#match_variants => #match_strs.to_string(),)*
+                                #(Self::#match_variants => write!(f, #match_strs),)*
                             }
                         }
                     }
@@ -866,10 +866,10 @@ impl TypeEntry {
                     .map(|variant| format_ident!("{}", variant.name));
 
                 quote! {
-                    impl ToString for #type_name {
-                        fn to_string(&self) -> String {
+                    impl ::std::fmt::Display for #type_name {
+                        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                             match self {
-                                #(Self::#variant_name(x) => x.to_string(),)*
+                                #(Self::#variant_name(x) => x.fmt(f),)*
                             }
                         }
                     }
@@ -1314,9 +1314,9 @@ impl TypeEntry {
                     .has_impl(type_space, TypeSpaceImpl::Display)
                     .then(|| {
                         quote! {
-                            impl ToString for #type_name {
-                                fn to_string(&self) -> String {
-                                    self.0.to_string()
+                            impl ::std::fmt::Display for #type_name {
+                                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                                    self.0.fmt(f)
                                 }
                             }
                         }

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -185,12 +185,12 @@ mod types {
             value.clone()
         }
     }
-    impl ToString for StringEnum {
-        fn to_string(&self) -> String {
+    impl ::std::fmt::Display for StringEnum {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
-                Self::One => "One".to_string(),
-                Self::Two => "Two".to_string(),
-                Self::BuckleMyShoe => "BuckleMyShoe".to_string(),
+                Self::One => write!(f, "One"),
+                Self::Two => write!(f, "Two"),
+                Self::BuckleMyShoe => write!(f, "BuckleMyShoe"),
             }
         }
     }

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -246,12 +246,12 @@ impl From<&AlertInstanceState> for AlertInstanceState {
         value.clone()
     }
 }
-impl ToString for AlertInstanceState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlertInstanceState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Dismissed => "dismissed".to_string(),
-            Self::Fixed => "fixed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Dismissed => write!(f, "dismissed"),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -840,53 +840,53 @@ impl From<&AppEventsItem> for AppEventsItem {
         value.clone()
     }
 }
-impl ToString for AppEventsItem {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppEventsItem {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => "check_run".to_string(),
-            Self::CheckSuite => "check_suite".to_string(),
-            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
-            Self::CommitComment => "commit_comment".to_string(),
-            Self::ContentReference => "content_reference".to_string(),
-            Self::Create => "create".to_string(),
-            Self::Delete => "delete".to_string(),
-            Self::Deployment => "deployment".to_string(),
-            Self::DeploymentReview => "deployment_review".to_string(),
-            Self::DeploymentStatus => "deployment_status".to_string(),
-            Self::DeployKey => "deploy_key".to_string(),
-            Self::Discussion => "discussion".to_string(),
-            Self::DiscussionComment => "discussion_comment".to_string(),
-            Self::Fork => "fork".to_string(),
-            Self::Gollum => "gollum".to_string(),
-            Self::Issues => "issues".to_string(),
-            Self::IssueComment => "issue_comment".to_string(),
-            Self::Label => "label".to_string(),
-            Self::Member => "member".to_string(),
-            Self::Membership => "membership".to_string(),
-            Self::Milestone => "milestone".to_string(),
-            Self::Organization => "organization".to_string(),
-            Self::OrgBlock => "org_block".to_string(),
-            Self::PageBuild => "page_build".to_string(),
-            Self::Project => "project".to_string(),
-            Self::ProjectCard => "project_card".to_string(),
-            Self::ProjectColumn => "project_column".to_string(),
-            Self::Public => "public".to_string(),
-            Self::PullRequest => "pull_request".to_string(),
-            Self::PullRequestReview => "pull_request_review".to_string(),
-            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
-            Self::Push => "push".to_string(),
-            Self::RegistryPackage => "registry_package".to_string(),
-            Self::Release => "release".to_string(),
-            Self::Repository => "repository".to_string(),
-            Self::RepositoryDispatch => "repository_dispatch".to_string(),
-            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
-            Self::Star => "star".to_string(),
-            Self::Status => "status".to_string(),
-            Self::Team => "team".to_string(),
-            Self::TeamAdd => "team_add".to_string(),
-            Self::Watch => "watch".to_string(),
-            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
-            Self::WorkflowRun => "workflow_run".to_string(),
+            Self::CheckRun => write!(f, "check_run"),
+            Self::CheckSuite => write!(f, "check_suite"),
+            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
+            Self::CommitComment => write!(f, "commit_comment"),
+            Self::ContentReference => write!(f, "content_reference"),
+            Self::Create => write!(f, "create"),
+            Self::Delete => write!(f, "delete"),
+            Self::Deployment => write!(f, "deployment"),
+            Self::DeploymentReview => write!(f, "deployment_review"),
+            Self::DeploymentStatus => write!(f, "deployment_status"),
+            Self::DeployKey => write!(f, "deploy_key"),
+            Self::Discussion => write!(f, "discussion"),
+            Self::DiscussionComment => write!(f, "discussion_comment"),
+            Self::Fork => write!(f, "fork"),
+            Self::Gollum => write!(f, "gollum"),
+            Self::Issues => write!(f, "issues"),
+            Self::IssueComment => write!(f, "issue_comment"),
+            Self::Label => write!(f, "label"),
+            Self::Member => write!(f, "member"),
+            Self::Membership => write!(f, "membership"),
+            Self::Milestone => write!(f, "milestone"),
+            Self::Organization => write!(f, "organization"),
+            Self::OrgBlock => write!(f, "org_block"),
+            Self::PageBuild => write!(f, "page_build"),
+            Self::Project => write!(f, "project"),
+            Self::ProjectCard => write!(f, "project_card"),
+            Self::ProjectColumn => write!(f, "project_column"),
+            Self::Public => write!(f, "public"),
+            Self::PullRequest => write!(f, "pull_request"),
+            Self::PullRequestReview => write!(f, "pull_request_review"),
+            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
+            Self::Push => write!(f, "push"),
+            Self::RegistryPackage => write!(f, "registry_package"),
+            Self::Release => write!(f, "release"),
+            Self::Repository => write!(f, "repository"),
+            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
+            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
+            Self::Star => write!(f, "star"),
+            Self::Status => write!(f, "status"),
+            Self::Team => write!(f, "team"),
+            Self::TeamAdd => write!(f, "team_add"),
+            Self::Watch => write!(f, "watch"),
+            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
+            Self::WorkflowRun => write!(f, "workflow_run"),
         }
     }
 }
@@ -1326,11 +1326,11 @@ impl From<&AppPermissionsActions> for AppPermissionsActions {
         value.clone()
     }
 }
-impl ToString for AppPermissionsActions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsActions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1399,11 +1399,11 @@ impl From<&AppPermissionsAdministration> for AppPermissionsAdministration {
         value.clone()
     }
 }
-impl ToString for AppPermissionsAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1472,11 +1472,11 @@ impl From<&AppPermissionsChecks> for AppPermissionsChecks {
         value.clone()
     }
 }
-impl ToString for AppPermissionsChecks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsChecks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1545,11 +1545,11 @@ impl From<&AppPermissionsContentReferences> for AppPermissionsContentReferences 
         value.clone()
     }
 }
-impl ToString for AppPermissionsContentReferences {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsContentReferences {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1618,11 +1618,11 @@ impl From<&AppPermissionsContents> for AppPermissionsContents {
         value.clone()
     }
 }
-impl ToString for AppPermissionsContents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsContents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1691,11 +1691,11 @@ impl From<&AppPermissionsDeployments> for AppPermissionsDeployments {
         value.clone()
     }
 }
-impl ToString for AppPermissionsDeployments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsDeployments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1764,11 +1764,11 @@ impl From<&AppPermissionsDiscussions> for AppPermissionsDiscussions {
         value.clone()
     }
 }
-impl ToString for AppPermissionsDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1837,11 +1837,11 @@ impl From<&AppPermissionsEmails> for AppPermissionsEmails {
         value.clone()
     }
 }
-impl ToString for AppPermissionsEmails {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsEmails {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1910,11 +1910,11 @@ impl From<&AppPermissionsEnvironments> for AppPermissionsEnvironments {
         value.clone()
     }
 }
-impl ToString for AppPermissionsEnvironments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsEnvironments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -1983,11 +1983,11 @@ impl From<&AppPermissionsIssues> for AppPermissionsIssues {
         value.clone()
     }
 }
-impl ToString for AppPermissionsIssues {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsIssues {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2056,11 +2056,11 @@ impl From<&AppPermissionsMembers> for AppPermissionsMembers {
         value.clone()
     }
 }
-impl ToString for AppPermissionsMembers {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsMembers {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2129,11 +2129,11 @@ impl From<&AppPermissionsMetadata> for AppPermissionsMetadata {
         value.clone()
     }
 }
-impl ToString for AppPermissionsMetadata {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsMetadata {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2202,11 +2202,11 @@ impl From<&AppPermissionsOrganizationAdministration> for AppPermissionsOrganizat
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2275,11 +2275,11 @@ impl From<&AppPermissionsOrganizationHooks> for AppPermissionsOrganizationHooks 
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2348,11 +2348,11 @@ impl From<&AppPermissionsOrganizationPackages> for AppPermissionsOrganizationPac
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2421,11 +2421,11 @@ impl From<&AppPermissionsOrganizationPlan> for AppPermissionsOrganizationPlan {
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationPlan {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationPlan {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2494,11 +2494,11 @@ impl From<&AppPermissionsOrganizationProjects> for AppPermissionsOrganizationPro
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2567,11 +2567,11 @@ impl From<&AppPermissionsOrganizationSecrets> for AppPermissionsOrganizationSecr
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2642,11 +2642,11 @@ impl From<&AppPermissionsOrganizationSelfHostedRunners>
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationSelfHostedRunners {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationSelfHostedRunners {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2715,11 +2715,11 @@ impl From<&AppPermissionsOrganizationUserBlocking> for AppPermissionsOrganizatio
         value.clone()
     }
 }
-impl ToString for AppPermissionsOrganizationUserBlocking {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsOrganizationUserBlocking {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2788,11 +2788,11 @@ impl From<&AppPermissionsPackages> for AppPermissionsPackages {
         value.clone()
     }
 }
-impl ToString for AppPermissionsPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2861,11 +2861,11 @@ impl From<&AppPermissionsPages> for AppPermissionsPages {
         value.clone()
     }
 }
-impl ToString for AppPermissionsPages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsPages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -2934,11 +2934,11 @@ impl From<&AppPermissionsPullRequests> for AppPermissionsPullRequests {
         value.clone()
     }
 }
-impl ToString for AppPermissionsPullRequests {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsPullRequests {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3007,11 +3007,11 @@ impl From<&AppPermissionsRepositoryHooks> for AppPermissionsRepositoryHooks {
         value.clone()
     }
 }
-impl ToString for AppPermissionsRepositoryHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsRepositoryHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3080,11 +3080,11 @@ impl From<&AppPermissionsRepositoryProjects> for AppPermissionsRepositoryProject
         value.clone()
     }
 }
-impl ToString for AppPermissionsRepositoryProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsRepositoryProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3153,11 +3153,11 @@ impl From<&AppPermissionsSecretScanningAlerts> for AppPermissionsSecretScanningA
         value.clone()
     }
 }
-impl ToString for AppPermissionsSecretScanningAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsSecretScanningAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3226,11 +3226,11 @@ impl From<&AppPermissionsSecrets> for AppPermissionsSecrets {
         value.clone()
     }
 }
-impl ToString for AppPermissionsSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3299,11 +3299,11 @@ impl From<&AppPermissionsSecurityEvents> for AppPermissionsSecurityEvents {
         value.clone()
     }
 }
-impl ToString for AppPermissionsSecurityEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsSecurityEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3372,11 +3372,11 @@ impl From<&AppPermissionsSecurityScanningAlert> for AppPermissionsSecurityScanni
         value.clone()
     }
 }
-impl ToString for AppPermissionsSecurityScanningAlert {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsSecurityScanningAlert {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3445,11 +3445,11 @@ impl From<&AppPermissionsSingleFile> for AppPermissionsSingleFile {
         value.clone()
     }
 }
-impl ToString for AppPermissionsSingleFile {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsSingleFile {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3518,11 +3518,11 @@ impl From<&AppPermissionsStatuses> for AppPermissionsStatuses {
         value.clone()
     }
 }
-impl ToString for AppPermissionsStatuses {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsStatuses {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3591,11 +3591,11 @@ impl From<&AppPermissionsTeamDiscussions> for AppPermissionsTeamDiscussions {
         value.clone()
     }
 }
-impl ToString for AppPermissionsTeamDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsTeamDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3664,11 +3664,11 @@ impl From<&AppPermissionsVulnerabilityAlerts> for AppPermissionsVulnerabilityAle
         value.clone()
     }
 }
-impl ToString for AppPermissionsVulnerabilityAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsVulnerabilityAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3737,11 +3737,11 @@ impl From<&AppPermissionsWorkflows> for AppPermissionsWorkflows {
         value.clone()
     }
 }
-impl ToString for AppPermissionsWorkflows {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AppPermissionsWorkflows {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -3831,17 +3831,17 @@ impl From<&AuthorAssociation> for AuthorAssociation {
         value.clone()
     }
 }
-impl ToString for AuthorAssociation {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AuthorAssociation {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Collaborator => "COLLABORATOR".to_string(),
-            Self::Contributor => "CONTRIBUTOR".to_string(),
-            Self::FirstTimer => "FIRST_TIMER".to_string(),
-            Self::FirstTimeContributor => "FIRST_TIME_CONTRIBUTOR".to_string(),
-            Self::Mannequin => "MANNEQUIN".to_string(),
-            Self::Member => "MEMBER".to_string(),
-            Self::None => "NONE".to_string(),
-            Self::Owner => "OWNER".to_string(),
+            Self::Collaborator => write!(f, "COLLABORATOR"),
+            Self::Contributor => write!(f, "CONTRIBUTOR"),
+            Self::FirstTimer => write!(f, "FIRST_TIMER"),
+            Self::FirstTimeContributor => write!(f, "FIRST_TIME_CONTRIBUTOR"),
+            Self::Mannequin => write!(f, "MANNEQUIN"),
+            Self::Member => write!(f, "MEMBER"),
+            Self::None => write!(f, "NONE"),
+            Self::Owner => write!(f, "OWNER"),
         }
     }
 }
@@ -4127,12 +4127,12 @@ impl From<&BranchProtectionRuleAllowDeletionsEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleAllowDeletionsEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -4207,12 +4207,12 @@ impl From<&BranchProtectionRuleAllowForcePushesEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleAllowForcePushesEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -4339,10 +4339,10 @@ impl From<&BranchProtectionRuleCreatedAction> for BranchProtectionRuleCreatedAct
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -4467,10 +4467,10 @@ impl From<&BranchProtectionRuleDeletedAction> for BranchProtectionRuleDeletedAct
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -4631,10 +4631,10 @@ impl From<&BranchProtectionRuleEditedAction> for BranchProtectionRuleEditedActio
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -4873,12 +4873,12 @@ impl From<&BranchProtectionRuleLinearHistoryRequirementEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -4957,12 +4957,12 @@ impl From<&BranchProtectionRuleMergeQueueEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleMergeQueueEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleMergeQueueEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5037,12 +5037,12 @@ impl From<&BranchProtectionRulePullRequestReviewsEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRulePullRequestReviewsEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5117,12 +5117,12 @@ impl From<&BranchProtectionRuleRequiredConversationResolutionLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleRequiredConversationResolutionLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleRequiredConversationResolutionLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5197,12 +5197,12 @@ impl From<&BranchProtectionRuleRequiredDeploymentsEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5277,12 +5277,12 @@ impl From<&BranchProtectionRuleRequiredStatusChecksEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5357,12 +5357,12 @@ impl From<&BranchProtectionRuleSignatureRequirementEnforcementLevel>
         value.clone()
     }
 }
-impl ToString for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BranchProtectionRuleSignatureRequirementEnforcementLevel {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => "off".to_string(),
-            Self::NonAdmins => "non_admins".to_string(),
-            Self::Everyone => "everyone".to_string(),
+            Self::Off => write!(f, "off"),
+            Self::NonAdmins => write!(f, "non_admins"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -5732,10 +5732,10 @@ impl From<&CheckRunCompletedAction> for CheckRunCompletedAction {
         value.clone()
     }
 }
-impl ToString for CheckRunCompletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCompletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -6224,16 +6224,16 @@ impl From<&CheckRunCompletedCheckRunCheckSuiteConclusion>
         value.clone()
     }
 }
-impl ToString for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -6312,12 +6312,12 @@ impl From<&CheckRunCompletedCheckRunCheckSuiteStatus>
         value.clone()
     }
 }
-impl ToString for CheckRunCompletedCheckRunCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -6406,17 +6406,17 @@ impl From<&CheckRunCompletedCheckRunConclusion> for CheckRunCompletedCheckRunCon
         value.clone()
     }
 }
-impl ToString for CheckRunCompletedCheckRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCompletedCheckRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
-            Self::Skipped => "skipped".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
+            Self::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -6548,10 +6548,10 @@ impl From<&CheckRunCompletedCheckRunStatus> for CheckRunCompletedCheckRunStatus 
         value.clone()
     }
 }
-impl ToString for CheckRunCompletedCheckRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCompletedCheckRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -6954,10 +6954,10 @@ impl From<&CheckRunCreatedAction> for CheckRunCreatedAction {
         value.clone()
     }
 }
-impl ToString for CheckRunCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -7451,16 +7451,16 @@ impl From<&CheckRunCreatedCheckRunCheckSuiteConclusion>
         value.clone()
     }
 }
-impl ToString for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -7537,12 +7537,12 @@ impl From<&CheckRunCreatedCheckRunCheckSuiteStatus> for CheckRunCreatedCheckRunC
         value.clone()
     }
 }
-impl ToString for CheckRunCreatedCheckRunCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -7631,17 +7631,17 @@ impl From<&CheckRunCreatedCheckRunConclusion> for CheckRunCreatedCheckRunConclus
         value.clone()
     }
 }
-impl ToString for CheckRunCreatedCheckRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCreatedCheckRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
-            Self::Skipped => "skipped".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
+            Self::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -7779,12 +7779,12 @@ impl From<&CheckRunCreatedCheckRunStatus> for CheckRunCreatedCheckRunStatus {
         value.clone()
     }
 }
-impl ToString for CheckRunCreatedCheckRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunCreatedCheckRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -8497,10 +8497,10 @@ impl From<&CheckRunRequestedActionAction> for CheckRunRequestedActionAction {
         value.clone()
     }
 }
-impl ToString for CheckRunRequestedActionAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRequestedActionAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RequestedAction => "requested_action".to_string(),
+            Self::RequestedAction => write!(f, "requested_action"),
         }
     }
 }
@@ -8996,16 +8996,16 @@ impl From<&CheckRunRequestedActionCheckRunCheckSuiteConclusion>
         value.clone()
     }
 }
-impl ToString for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -9084,12 +9084,12 @@ impl From<&CheckRunRequestedActionCheckRunCheckSuiteStatus>
         value.clone()
     }
 }
-impl ToString for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -9180,17 +9180,17 @@ impl From<&CheckRunRequestedActionCheckRunConclusion>
         value.clone()
     }
 }
-impl ToString for CheckRunRequestedActionCheckRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRequestedActionCheckRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
-            Self::Skipped => "skipped".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
+            Self::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -9328,12 +9328,12 @@ impl From<&CheckRunRequestedActionCheckRunStatus> for CheckRunRequestedActionChe
         value.clone()
     }
 }
-impl ToString for CheckRunRequestedActionCheckRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRequestedActionCheckRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -9727,10 +9727,10 @@ impl From<&CheckRunRerequestedAction> for CheckRunRerequestedAction {
         value.clone()
     }
 }
-impl ToString for CheckRunRerequestedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRerequestedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Rerequested => "rerequested".to_string(),
+            Self::Rerequested => write!(f, "rerequested"),
         }
     }
 }
@@ -10207,16 +10207,16 @@ impl From<&CheckRunRerequestedCheckRunCheckSuiteConclusion>
         value.clone()
     }
 }
-impl ToString for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -10289,10 +10289,10 @@ impl From<&CheckRunRerequestedCheckRunCheckSuiteStatus>
         value.clone()
     }
 }
-impl ToString for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -10379,17 +10379,17 @@ impl From<&CheckRunRerequestedCheckRunConclusion> for CheckRunRerequestedCheckRu
         value.clone()
     }
 }
-impl ToString for CheckRunRerequestedCheckRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRerequestedCheckRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
-            Self::Skipped => "skipped".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
+            Self::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -10521,10 +10521,10 @@ impl From<&CheckRunRerequestedCheckRunStatus> for CheckRunRerequestedCheckRunSta
         value.clone()
     }
 }
-impl ToString for CheckRunRerequestedCheckRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckRunRerequestedCheckRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -10790,10 +10790,10 @@ impl From<&CheckSuiteCompletedAction> for CheckSuiteCompletedAction {
         value.clone()
     }
 }
-impl ToString for CheckSuiteCompletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteCompletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -11030,16 +11030,16 @@ impl From<&CheckSuiteCompletedCheckSuiteConclusion> for CheckSuiteCompletedCheck
         value.clone()
     }
 }
-impl ToString for CheckSuiteCompletedCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -11120,13 +11120,13 @@ impl From<&CheckSuiteCompletedCheckSuiteStatus> for CheckSuiteCompletedCheckSuit
         value.clone()
     }
 }
-impl ToString for CheckSuiteCompletedCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::Requested => write!(f, "requested"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -11412,10 +11412,10 @@ impl From<&CheckSuiteRequestedAction> for CheckSuiteRequestedAction {
         value.clone()
     }
 }
-impl ToString for CheckSuiteRequestedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRequestedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
+            Self::Requested => write!(f, "requested"),
         }
     }
 }
@@ -11652,16 +11652,16 @@ impl From<&CheckSuiteRequestedCheckSuiteConclusion> for CheckSuiteRequestedCheck
         value.clone()
     }
 }
-impl ToString for CheckSuiteRequestedCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -11742,13 +11742,13 @@ impl From<&CheckSuiteRequestedCheckSuiteStatus> for CheckSuiteRequestedCheckSuit
         value.clone()
     }
 }
-impl ToString for CheckSuiteRequestedCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::Requested => write!(f, "requested"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -11987,10 +11987,10 @@ impl From<&CheckSuiteRerequestedAction> for CheckSuiteRerequestedAction {
         value.clone()
     }
 }
-impl ToString for CheckSuiteRerequestedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRerequestedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Rerequested => "rerequested".to_string(),
+            Self::Rerequested => write!(f, "rerequested"),
         }
     }
 }
@@ -12229,16 +12229,16 @@ impl From<&CheckSuiteRerequestedCheckSuiteConclusion>
         value.clone()
     }
 }
-impl ToString for CheckSuiteRerequestedCheckSuiteConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -12319,13 +12319,13 @@ impl From<&CheckSuiteRerequestedCheckSuiteStatus> for CheckSuiteRerequestedCheck
         value.clone()
     }
 }
-impl ToString for CheckSuiteRerequestedCheckSuiteStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::Requested => write!(f, "requested"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -12605,10 +12605,10 @@ impl From<&CodeScanningAlertAppearedInBranchAction> for CodeScanningAlertAppeare
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertAppearedInBranchAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AppearedInBranch => "appeared_in_branch".to_string(),
+            Self::AppearedInBranch => write!(f, "appeared_in_branch"),
         }
     }
 }
@@ -12858,12 +12858,12 @@ impl From<&CodeScanningAlertAppearedInBranchAlertDismissedReason>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertDismissedReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => "false positive".to_string(),
-            Self::WontFix => "won't fix".to_string(),
-            Self::UsedInTests => "used in tests".to_string(),
+            Self::FalsePositive => write!(f, "false positive"),
+            Self::WontFix => write!(f, "won't fix"),
+            Self::UsedInTests => write!(f, "used in tests"),
         }
     }
 }
@@ -12999,13 +12999,13 @@ impl From<&CodeScanningAlertAppearedInBranchAlertRuleSeverity>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -13082,12 +13082,12 @@ impl From<&CodeScanningAlertAppearedInBranchAlertState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertAppearedInBranchAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Dismissed => "dismissed".to_string(),
-            Self::Fixed => "fixed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Dismissed => write!(f, "dismissed"),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -13431,10 +13431,10 @@ impl From<&CodeScanningAlertClosedByUserAction> for CodeScanningAlertClosedByUse
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertClosedByUserAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertClosedByUserAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ClosedByUser => "closed_by_user".to_string(),
+            Self::ClosedByUser => write!(f, "closed_by_user"),
         }
     }
 }
@@ -13707,12 +13707,12 @@ impl From<&CodeScanningAlertClosedByUserAlertDismissedReason>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertClosedByUserAlertDismissedReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertDismissedReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => "false positive".to_string(),
-            Self::WontFix => "won't fix".to_string(),
-            Self::UsedInTests => "used in tests".to_string(),
+            Self::FalsePositive => write!(f, "false positive"),
+            Self::WontFix => write!(f, "won't fix"),
+            Self::UsedInTests => write!(f, "used in tests"),
         }
     }
 }
@@ -13915,10 +13915,10 @@ impl From<&CodeScanningAlertClosedByUserAlertInstancesItemState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertInstancesItemState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -14070,13 +14070,13 @@ impl From<&CodeScanningAlertClosedByUserAlertRuleSeverity>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -14145,10 +14145,10 @@ impl From<&CodeScanningAlertClosedByUserAlertState> for CodeScanningAlertClosedB
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertClosedByUserAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -14491,10 +14491,10 @@ impl From<&CodeScanningAlertCreatedAction> for CodeScanningAlertCreatedAction {
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -14892,11 +14892,11 @@ impl From<&CodeScanningAlertCreatedAlertInstancesItemState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertCreatedAlertInstancesItemState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertCreatedAlertInstancesItemState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -15049,13 +15049,13 @@ impl From<&CodeScanningAlertCreatedAlertRuleSeverity>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertCreatedAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertCreatedAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -15127,11 +15127,11 @@ impl From<&CodeScanningAlertCreatedAlertState> for CodeScanningAlertCreatedAlert
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertCreatedAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertCreatedAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -15571,10 +15571,10 @@ impl From<&CodeScanningAlertFixedAction> for CodeScanningAlertFixedAction {
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertFixedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertFixedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => "fixed".to_string(),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -15865,12 +15865,12 @@ impl From<&CodeScanningAlertFixedAlertDismissedReason>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertFixedAlertDismissedReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertFixedAlertDismissedReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => "false positive".to_string(),
-            Self::WontFix => "won't fix".to_string(),
-            Self::UsedInTests => "used in tests".to_string(),
+            Self::FalsePositive => write!(f, "false positive"),
+            Self::WontFix => write!(f, "won't fix"),
+            Self::UsedInTests => write!(f, "used in tests"),
         }
     }
 }
@@ -16071,10 +16071,10 @@ impl From<&CodeScanningAlertFixedAlertInstancesItemState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertFixedAlertInstancesItemState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertFixedAlertInstancesItemState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => "fixed".to_string(),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -16224,13 +16224,13 @@ impl From<&CodeScanningAlertFixedAlertRuleSeverity> for CodeScanningAlertFixedAl
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertFixedAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertFixedAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -16299,10 +16299,10 @@ impl From<&CodeScanningAlertFixedAlertState> for CodeScanningAlertFixedAlertStat
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertFixedAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertFixedAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => "fixed".to_string(),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -16645,10 +16645,10 @@ impl From<&CodeScanningAlertReopenedAction> for CodeScanningAlertReopenedAction 
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => "reopened".to_string(),
+            Self::Reopened => write!(f, "reopened"),
         }
     }
 }
@@ -17042,10 +17042,10 @@ impl From<&CodeScanningAlertReopenedAlertInstancesItemState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedAlertInstancesItemState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedAlertInstancesItemState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -17197,13 +17197,13 @@ impl From<&CodeScanningAlertReopenedAlertRuleSeverity>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -17278,12 +17278,12 @@ impl From<&CodeScanningAlertReopenedAlertState> for CodeScanningAlertReopenedAle
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Dismissed => "dismissed".to_string(),
-            Self::Fixed => "fixed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Dismissed => write!(f, "dismissed"),
+            Self::Fixed => write!(f, "fixed"),
         }
     }
 }
@@ -17608,10 +17608,10 @@ impl From<&CodeScanningAlertReopenedByUserAction> for CodeScanningAlertReopenedB
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedByUserAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReopenedByUser => "reopened_by_user".to_string(),
+            Self::ReopenedByUser => write!(f, "reopened_by_user"),
         }
     }
 }
@@ -17985,10 +17985,10 @@ impl From<&CodeScanningAlertReopenedByUserAlertInstancesItemState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertInstancesItemState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -18120,13 +18120,13 @@ impl From<&CodeScanningAlertReopenedByUserAlertRuleSeverity>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertRuleSeverity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Note => "note".to_string(),
-            Self::Warning => "warning".to_string(),
-            Self::Error => "error".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Note => write!(f, "note"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -18197,10 +18197,10 @@ impl From<&CodeScanningAlertReopenedByUserAlertState>
         value.clone()
     }
 }
-impl ToString for CodeScanningAlertReopenedByUserAlertState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -18550,10 +18550,10 @@ impl From<&CommitCommentCreatedAction> for CommitCommentCreatedAction {
         value.clone()
     }
 }
-impl ToString for CommitCommentCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CommitCommentCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -18963,10 +18963,10 @@ impl From<&ContentReferenceCreatedAction> for ContentReferenceCreatedAction {
         value.clone()
     }
 }
-impl ToString for ContentReferenceCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ContentReferenceCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -19202,11 +19202,11 @@ impl From<&CreateEventRefType> for CreateEventRefType {
         value.clone()
     }
 }
-impl ToString for CreateEventRefType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CreateEventRefType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tag => "tag".to_string(),
-            Self::Branch => "branch".to_string(),
+            Self::Tag => write!(f, "tag"),
+            Self::Branch => write!(f, "branch"),
         }
     }
 }
@@ -19349,11 +19349,11 @@ impl From<&DeleteEventRefType> for DeleteEventRefType {
         value.clone()
     }
 }
-impl ToString for DeleteEventRefType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DeleteEventRefType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tag => "tag".to_string(),
-            Self::Branch => "branch".to_string(),
+            Self::Tag => write!(f, "tag"),
+            Self::Branch => write!(f, "branch"),
         }
     }
 }
@@ -19513,10 +19513,10 @@ impl From<&DeployKeyCreatedAction> for DeployKeyCreatedAction {
         value.clone()
     }
 }
-impl ToString for DeployKeyCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DeployKeyCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -19736,10 +19736,10 @@ impl From<&DeployKeyDeletedAction> for DeployKeyDeletedAction {
         value.clone()
     }
 }
-impl ToString for DeployKeyDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DeployKeyDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -20052,10 +20052,10 @@ impl From<&DeploymentCreatedAction> for DeploymentCreatedAction {
         value.clone()
     }
 }
-impl ToString for DeploymentCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DeploymentCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -20508,10 +20508,10 @@ impl From<&DeploymentStatusCreatedAction> for DeploymentStatusCreatedAction {
         value.clone()
     }
 }
-impl ToString for DeploymentStatusCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DeploymentStatusCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -21202,10 +21202,10 @@ impl From<&DiscussionAnsweredAction> for DiscussionAnsweredAction {
         value.clone()
     }
 }
-impl ToString for DiscussionAnsweredAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionAnsweredAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Answered => "answered".to_string(),
+            Self::Answered => write!(f, "answered"),
         }
     }
 }
@@ -21600,12 +21600,12 @@ impl From<&DiscussionAnsweredDiscussionAnswerChosenByType>
         value.clone()
     }
 }
-impl ToString for DiscussionAnsweredDiscussionAnswerChosenByType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionAnsweredDiscussionAnswerChosenByType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -21751,12 +21751,12 @@ impl From<&DiscussionAnsweredDiscussionState> for DiscussionAnsweredDiscussionSt
         value.clone()
     }
 }
-impl ToString for DiscussionAnsweredDiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionAnsweredDiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Locked => "locked".to_string(),
-            Self::Converting => "converting".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Locked => write!(f, "locked"),
+            Self::Converting => write!(f, "converting"),
         }
     }
 }
@@ -22017,10 +22017,10 @@ impl From<&DiscussionCategoryChangedAction> for DiscussionCategoryChangedAction 
         value.clone()
     }
 }
-impl ToString for DiscussionCategoryChangedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCategoryChangedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CategoryChanged => "category_changed".to_string(),
+            Self::CategoryChanged => write!(f, "category_changed"),
         }
     }
 }
@@ -22428,10 +22428,10 @@ impl From<&DiscussionCommentCreatedAction> for DiscussionCommentCreatedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionCommentCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCommentCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -22703,10 +22703,10 @@ impl From<&DiscussionCommentDeletedAction> for DiscussionCommentDeletedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionCommentDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCommentDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -23001,10 +23001,10 @@ impl From<&DiscussionCommentEditedAction> for DiscussionCommentEditedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionCommentEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCommentEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -23368,10 +23368,10 @@ impl From<&DiscussionCreatedAction> for DiscussionCreatedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -23586,11 +23586,11 @@ impl From<&DiscussionCreatedDiscussionState> for DiscussionCreatedDiscussionStat
         value.clone()
     }
 }
-impl ToString for DiscussionCreatedDiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionCreatedDiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Converting => "converting".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Converting => write!(f, "converting"),
         }
     }
 }
@@ -23715,10 +23715,10 @@ impl From<&DiscussionDeletedAction> for DiscussionDeletedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -23874,10 +23874,10 @@ impl From<&DiscussionEditedAction> for DiscussionEditedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -24251,10 +24251,10 @@ impl From<&DiscussionLabeledAction> for DiscussionLabeledAction {
         value.clone()
     }
 }
-impl ToString for DiscussionLabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionLabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => "labeled".to_string(),
+            Self::Labeled => write!(f, "labeled"),
         }
     }
 }
@@ -24404,10 +24404,10 @@ impl From<&DiscussionLockedAction> for DiscussionLockedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionLockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionLockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => "locked".to_string(),
+            Self::Locked => write!(f, "locked"),
         }
     }
 }
@@ -24606,10 +24606,10 @@ impl From<&DiscussionLockedDiscussionState> for DiscussionLockedDiscussionState 
         value.clone()
     }
 }
-impl ToString for DiscussionLockedDiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionLockedDiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => "locked".to_string(),
+            Self::Locked => write!(f, "locked"),
         }
     }
 }
@@ -24733,10 +24733,10 @@ impl From<&DiscussionPinnedAction> for DiscussionPinnedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionPinnedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionPinnedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pinned => "pinned".to_string(),
+            Self::Pinned => write!(f, "pinned"),
         }
     }
 }
@@ -24807,12 +24807,12 @@ impl From<&DiscussionState> for DiscussionState {
         value.clone()
     }
 }
-impl ToString for DiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Locked => "locked".to_string(),
-            Self::Converting => "converting".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Locked => write!(f, "locked"),
+            Self::Converting => write!(f, "converting"),
         }
     }
 }
@@ -24956,10 +24956,10 @@ impl From<&DiscussionTransferredAction> for DiscussionTransferredAction {
         value.clone()
     }
 }
-impl ToString for DiscussionTransferredAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionTransferredAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => "transferred".to_string(),
+            Self::Transferred => write!(f, "transferred"),
         }
     }
 }
@@ -25217,10 +25217,10 @@ impl From<&DiscussionUnansweredAction> for DiscussionUnansweredAction {
         value.clone()
     }
 }
-impl ToString for DiscussionUnansweredAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnansweredAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unanswered => "unanswered".to_string(),
+            Self::Unanswered => write!(f, "unanswered"),
         }
     }
 }
@@ -25442,12 +25442,12 @@ impl From<&DiscussionUnansweredDiscussionState> for DiscussionUnansweredDiscussi
         value.clone()
     }
 }
-impl ToString for DiscussionUnansweredDiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnansweredDiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Locked => "locked".to_string(),
-            Self::Converting => "converting".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Locked => write!(f, "locked"),
+            Self::Converting => write!(f, "converting"),
         }
     }
 }
@@ -25664,10 +25664,10 @@ impl From<&DiscussionUnlabeledAction> for DiscussionUnlabeledAction {
         value.clone()
     }
 }
-impl ToString for DiscussionUnlabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnlabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => "unlabeled".to_string(),
+            Self::Unlabeled => write!(f, "unlabeled"),
         }
     }
 }
@@ -25817,10 +25817,10 @@ impl From<&DiscussionUnlockedAction> for DiscussionUnlockedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionUnlockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnlockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => "unlocked".to_string(),
+            Self::Unlocked => write!(f, "unlocked"),
         }
     }
 }
@@ -26019,10 +26019,10 @@ impl From<&DiscussionUnlockedDiscussionState> for DiscussionUnlockedDiscussionSt
         value.clone()
     }
 }
-impl ToString for DiscussionUnlockedDiscussionState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnlockedDiscussionState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -26146,10 +26146,10 @@ impl From<&DiscussionUnpinnedAction> for DiscussionUnpinnedAction {
         value.clone()
     }
 }
-impl ToString for DiscussionUnpinnedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiscussionUnpinnedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpinned => "unpinned".to_string(),
+            Self::Unpinned => write!(f, "unpinned"),
         }
     }
 }
@@ -26970,11 +26970,11 @@ impl std::convert::TryFrom<String> for ForkEventForkeeCreatedAt {
         value.parse()
     }
 }
-impl ToString for ForkEventForkeeCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ForkEventForkeeCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -27190,10 +27190,10 @@ impl From<&GithubAppAuthorizationRevokedAction> for GithubAppAuthorizationRevoke
         value.clone()
     }
 }
-impl ToString for GithubAppAuthorizationRevokedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GithubAppAuthorizationRevokedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Revoked => "revoked".to_string(),
+            Self::Revoked => write!(f, "revoked"),
         }
     }
 }
@@ -27585,11 +27585,11 @@ impl From<&GollumEventPagesItemAction> for GollumEventPagesItemAction {
         value.clone()
     }
 }
-impl ToString for GollumEventPagesItemAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GollumEventPagesItemAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
-            Self::Edited => "edited".to_string(),
+            Self::Created => write!(f, "created"),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -28212,10 +28212,10 @@ impl From<&InstallationCreatedAction> for InstallationCreatedAction {
         value.clone()
     }
 }
-impl ToString for InstallationCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -28305,11 +28305,11 @@ impl std::convert::TryFrom<String> for InstallationCreatedAt {
         value.parse()
     }
 }
-impl ToString for InstallationCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -28499,10 +28499,10 @@ impl From<&InstallationDeletedAction> for InstallationDeletedAction {
         value.clone()
     }
 }
-impl ToString for InstallationDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -28819,54 +28819,54 @@ impl From<&InstallationEventsItem> for InstallationEventsItem {
         value.clone()
     }
 }
-impl ToString for InstallationEventsItem {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationEventsItem {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => "check_run".to_string(),
-            Self::CheckSuite => "check_suite".to_string(),
-            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
-            Self::CommitComment => "commit_comment".to_string(),
-            Self::ContentReference => "content_reference".to_string(),
-            Self::Create => "create".to_string(),
-            Self::Delete => "delete".to_string(),
-            Self::Deployment => "deployment".to_string(),
-            Self::DeploymentReview => "deployment_review".to_string(),
-            Self::DeploymentStatus => "deployment_status".to_string(),
-            Self::DeployKey => "deploy_key".to_string(),
-            Self::Discussion => "discussion".to_string(),
-            Self::DiscussionComment => "discussion_comment".to_string(),
-            Self::Fork => "fork".to_string(),
-            Self::Gollum => "gollum".to_string(),
-            Self::Issues => "issues".to_string(),
-            Self::IssueComment => "issue_comment".to_string(),
-            Self::Label => "label".to_string(),
-            Self::Member => "member".to_string(),
-            Self::Membership => "membership".to_string(),
-            Self::MergeQueueEntry => "merge_queue_entry".to_string(),
-            Self::Milestone => "milestone".to_string(),
-            Self::Organization => "organization".to_string(),
-            Self::OrgBlock => "org_block".to_string(),
-            Self::PageBuild => "page_build".to_string(),
-            Self::Project => "project".to_string(),
-            Self::ProjectCard => "project_card".to_string(),
-            Self::ProjectColumn => "project_column".to_string(),
-            Self::Public => "public".to_string(),
-            Self::PullRequest => "pull_request".to_string(),
-            Self::PullRequestReview => "pull_request_review".to_string(),
-            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
-            Self::Push => "push".to_string(),
-            Self::RegistryPackage => "registry_package".to_string(),
-            Self::Release => "release".to_string(),
-            Self::Repository => "repository".to_string(),
-            Self::RepositoryDispatch => "repository_dispatch".to_string(),
-            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
-            Self::Star => "star".to_string(),
-            Self::Status => "status".to_string(),
-            Self::Team => "team".to_string(),
-            Self::TeamAdd => "team_add".to_string(),
-            Self::Watch => "watch".to_string(),
-            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
-            Self::WorkflowRun => "workflow_run".to_string(),
+            Self::CheckRun => write!(f, "check_run"),
+            Self::CheckSuite => write!(f, "check_suite"),
+            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
+            Self::CommitComment => write!(f, "commit_comment"),
+            Self::ContentReference => write!(f, "content_reference"),
+            Self::Create => write!(f, "create"),
+            Self::Delete => write!(f, "delete"),
+            Self::Deployment => write!(f, "deployment"),
+            Self::DeploymentReview => write!(f, "deployment_review"),
+            Self::DeploymentStatus => write!(f, "deployment_status"),
+            Self::DeployKey => write!(f, "deploy_key"),
+            Self::Discussion => write!(f, "discussion"),
+            Self::DiscussionComment => write!(f, "discussion_comment"),
+            Self::Fork => write!(f, "fork"),
+            Self::Gollum => write!(f, "gollum"),
+            Self::Issues => write!(f, "issues"),
+            Self::IssueComment => write!(f, "issue_comment"),
+            Self::Label => write!(f, "label"),
+            Self::Member => write!(f, "member"),
+            Self::Membership => write!(f, "membership"),
+            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
+            Self::Milestone => write!(f, "milestone"),
+            Self::Organization => write!(f, "organization"),
+            Self::OrgBlock => write!(f, "org_block"),
+            Self::PageBuild => write!(f, "page_build"),
+            Self::Project => write!(f, "project"),
+            Self::ProjectCard => write!(f, "project_card"),
+            Self::ProjectColumn => write!(f, "project_column"),
+            Self::Public => write!(f, "public"),
+            Self::PullRequest => write!(f, "pull_request"),
+            Self::PullRequestReview => write!(f, "pull_request_review"),
+            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
+            Self::Push => write!(f, "push"),
+            Self::RegistryPackage => write!(f, "registry_package"),
+            Self::Release => write!(f, "release"),
+            Self::Repository => write!(f, "repository"),
+            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
+            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
+            Self::Star => write!(f, "star"),
+            Self::Status => write!(f, "status"),
+            Self::Team => write!(f, "team"),
+            Self::TeamAdd => write!(f, "team_add"),
+            Self::Watch => write!(f, "watch"),
+            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
+            Self::WorkflowRun => write!(f, "workflow_run"),
         }
     }
 }
@@ -29101,10 +29101,10 @@ impl From<&InstallationNewPermissionsAcceptedAction> for InstallationNewPermissi
         value.clone()
     }
 }
-impl ToString for InstallationNewPermissionsAcceptedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationNewPermissionsAcceptedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::NewPermissionsAccepted => "new_permissions_accepted".to_string(),
+            Self::NewPermissionsAccepted => write!(f, "new_permissions_accepted"),
         }
     }
 }
@@ -29567,11 +29567,11 @@ impl From<&InstallationPermissionsActions> for InstallationPermissionsActions {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsActions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsActions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -29640,11 +29640,11 @@ impl From<&InstallationPermissionsAdministration> for InstallationPermissionsAdm
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -29713,11 +29713,11 @@ impl From<&InstallationPermissionsChecks> for InstallationPermissionsChecks {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsChecks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsChecks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -29786,11 +29786,11 @@ impl From<&InstallationPermissionsContentReferences> for InstallationPermissions
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsContentReferences {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsContentReferences {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -29859,11 +29859,11 @@ impl From<&InstallationPermissionsContents> for InstallationPermissionsContents 
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsContents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsContents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -29932,11 +29932,11 @@ impl From<&InstallationPermissionsDeployments> for InstallationPermissionsDeploy
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsDeployments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsDeployments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30005,11 +30005,11 @@ impl From<&InstallationPermissionsDiscussions> for InstallationPermissionsDiscus
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30078,11 +30078,11 @@ impl From<&InstallationPermissionsEmails> for InstallationPermissionsEmails {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsEmails {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsEmails {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30151,11 +30151,11 @@ impl From<&InstallationPermissionsEnvironments> for InstallationPermissionsEnvir
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsEnvironments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsEnvironments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30224,11 +30224,11 @@ impl From<&InstallationPermissionsIssues> for InstallationPermissionsIssues {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsIssues {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsIssues {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30297,11 +30297,11 @@ impl From<&InstallationPermissionsMembers> for InstallationPermissionsMembers {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsMembers {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsMembers {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30370,11 +30370,11 @@ impl From<&InstallationPermissionsMetadata> for InstallationPermissionsMetadata 
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsMetadata {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsMetadata {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30445,11 +30445,11 @@ impl From<&InstallationPermissionsOrganizationAdministration>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30520,11 +30520,11 @@ impl From<&InstallationPermissionsOrganizationEvents>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30593,11 +30593,11 @@ impl From<&InstallationPermissionsOrganizationHooks> for InstallationPermissions
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30668,11 +30668,11 @@ impl From<&InstallationPermissionsOrganizationPackages>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30741,11 +30741,11 @@ impl From<&InstallationPermissionsOrganizationPlan> for InstallationPermissionsO
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationPlan {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationPlan {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30816,11 +30816,11 @@ impl From<&InstallationPermissionsOrganizationProjects>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30891,11 +30891,11 @@ impl From<&InstallationPermissionsOrganizationSecrets>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -30966,11 +30966,11 @@ impl From<&InstallationPermissionsOrganizationSelfHostedRunners>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationSelfHostedRunners {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationSelfHostedRunners {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31041,11 +31041,11 @@ impl From<&InstallationPermissionsOrganizationUserBlocking>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsOrganizationUserBlocking {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsOrganizationUserBlocking {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31114,11 +31114,11 @@ impl From<&InstallationPermissionsPackages> for InstallationPermissionsPackages 
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31187,11 +31187,11 @@ impl From<&InstallationPermissionsPages> for InstallationPermissionsPages {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsPages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsPages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31260,11 +31260,11 @@ impl From<&InstallationPermissionsPullRequests> for InstallationPermissionsPullR
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsPullRequests {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsPullRequests {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31333,11 +31333,11 @@ impl From<&InstallationPermissionsRepositoryHooks> for InstallationPermissionsRe
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsRepositoryHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsRepositoryHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31408,11 +31408,11 @@ impl From<&InstallationPermissionsRepositoryProjects>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsRepositoryProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsRepositoryProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31483,11 +31483,11 @@ impl From<&InstallationPermissionsSecretScanningAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsSecretScanningAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsSecretScanningAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31556,11 +31556,11 @@ impl From<&InstallationPermissionsSecrets> for InstallationPermissionsSecrets {
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31629,11 +31629,11 @@ impl From<&InstallationPermissionsSecurityEvents> for InstallationPermissionsSec
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsSecurityEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsSecurityEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31704,11 +31704,11 @@ impl From<&InstallationPermissionsSecurityScanningAlert>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsSecurityScanningAlert {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsSecurityScanningAlert {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31777,11 +31777,11 @@ impl From<&InstallationPermissionsSingleFile> for InstallationPermissionsSingleF
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsSingleFile {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsSingleFile {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31850,11 +31850,11 @@ impl From<&InstallationPermissionsStatuses> for InstallationPermissionsStatuses 
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsStatuses {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsStatuses {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31923,11 +31923,11 @@ impl From<&InstallationPermissionsTeamDiscussions> for InstallationPermissionsTe
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsTeamDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsTeamDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -31998,11 +31998,11 @@ impl From<&InstallationPermissionsVulnerabilityAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsVulnerabilityAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsVulnerabilityAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -32071,11 +32071,11 @@ impl From<&InstallationPermissionsWorkflows> for InstallationPermissionsWorkflow
         value.clone()
     }
 }
-impl ToString for InstallationPermissionsWorkflows {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationPermissionsWorkflows {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -32278,10 +32278,10 @@ impl From<&InstallationRepositoriesAddedAction> for InstallationRepositoriesAdde
         value.clone()
     }
 }
-impl ToString for InstallationRepositoriesAddedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationRepositoriesAddedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => "added".to_string(),
+            Self::Added => write!(f, "added"),
         }
     }
 }
@@ -32464,11 +32464,11 @@ impl From<&InstallationRepositoriesAddedRepositorySelection>
         value.clone()
     }
 }
-impl ToString for InstallationRepositoriesAddedRepositorySelection {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationRepositoriesAddedRepositorySelection {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Selected => write!(f, "selected"),
         }
     }
 }
@@ -32716,10 +32716,10 @@ impl From<&InstallationRepositoriesRemovedAction> for InstallationRepositoriesRe
         value.clone()
     }
 }
-impl ToString for InstallationRepositoriesRemovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationRepositoriesRemovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => "removed".to_string(),
+            Self::Removed => write!(f, "removed"),
         }
     }
 }
@@ -32904,11 +32904,11 @@ impl From<&InstallationRepositoriesRemovedRepositorySelection>
         value.clone()
     }
 }
-impl ToString for InstallationRepositoriesRemovedRepositorySelection {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationRepositoriesRemovedRepositorySelection {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Selected => write!(f, "selected"),
         }
     }
 }
@@ -32978,11 +32978,11 @@ impl From<&InstallationRepositorySelection> for InstallationRepositorySelection 
         value.clone()
     }
 }
-impl ToString for InstallationRepositorySelection {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationRepositorySelection {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Selected => write!(f, "selected"),
         }
     }
 }
@@ -33156,10 +33156,10 @@ impl From<&InstallationSuspendAction> for InstallationSuspendAction {
         value.clone()
     }
 }
-impl ToString for InstallationSuspendAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Suspend => "suspend".to_string(),
+            Self::Suspend => write!(f, "suspend"),
         }
     }
 }
@@ -33314,11 +33314,11 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationCreatedAt 
         value.parse()
     }
 }
-impl ToString for InstallationSuspendInstallationCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -33500,54 +33500,54 @@ impl From<&InstallationSuspendInstallationEventsItem>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationEventsItem {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationEventsItem {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => "check_run".to_string(),
-            Self::CheckSuite => "check_suite".to_string(),
-            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
-            Self::CommitComment => "commit_comment".to_string(),
-            Self::ContentReference => "content_reference".to_string(),
-            Self::Create => "create".to_string(),
-            Self::Delete => "delete".to_string(),
-            Self::Deployment => "deployment".to_string(),
-            Self::DeploymentReview => "deployment_review".to_string(),
-            Self::DeploymentStatus => "deployment_status".to_string(),
-            Self::DeployKey => "deploy_key".to_string(),
-            Self::Discussion => "discussion".to_string(),
-            Self::DiscussionComment => "discussion_comment".to_string(),
-            Self::Fork => "fork".to_string(),
-            Self::Gollum => "gollum".to_string(),
-            Self::Issues => "issues".to_string(),
-            Self::IssueComment => "issue_comment".to_string(),
-            Self::Label => "label".to_string(),
-            Self::Member => "member".to_string(),
-            Self::Membership => "membership".to_string(),
-            Self::MergeQueueEntry => "merge_queue_entry".to_string(),
-            Self::Milestone => "milestone".to_string(),
-            Self::Organization => "organization".to_string(),
-            Self::OrgBlock => "org_block".to_string(),
-            Self::PageBuild => "page_build".to_string(),
-            Self::Project => "project".to_string(),
-            Self::ProjectCard => "project_card".to_string(),
-            Self::ProjectColumn => "project_column".to_string(),
-            Self::Public => "public".to_string(),
-            Self::PullRequest => "pull_request".to_string(),
-            Self::PullRequestReview => "pull_request_review".to_string(),
-            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
-            Self::Push => "push".to_string(),
-            Self::RegistryPackage => "registry_package".to_string(),
-            Self::Release => "release".to_string(),
-            Self::Repository => "repository".to_string(),
-            Self::RepositoryDispatch => "repository_dispatch".to_string(),
-            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
-            Self::Star => "star".to_string(),
-            Self::Status => "status".to_string(),
-            Self::Team => "team".to_string(),
-            Self::TeamAdd => "team_add".to_string(),
-            Self::Watch => "watch".to_string(),
-            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
-            Self::WorkflowRun => "workflow_run".to_string(),
+            Self::CheckRun => write!(f, "check_run"),
+            Self::CheckSuite => write!(f, "check_suite"),
+            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
+            Self::CommitComment => write!(f, "commit_comment"),
+            Self::ContentReference => write!(f, "content_reference"),
+            Self::Create => write!(f, "create"),
+            Self::Delete => write!(f, "delete"),
+            Self::Deployment => write!(f, "deployment"),
+            Self::DeploymentReview => write!(f, "deployment_review"),
+            Self::DeploymentStatus => write!(f, "deployment_status"),
+            Self::DeployKey => write!(f, "deploy_key"),
+            Self::Discussion => write!(f, "discussion"),
+            Self::DiscussionComment => write!(f, "discussion_comment"),
+            Self::Fork => write!(f, "fork"),
+            Self::Gollum => write!(f, "gollum"),
+            Self::Issues => write!(f, "issues"),
+            Self::IssueComment => write!(f, "issue_comment"),
+            Self::Label => write!(f, "label"),
+            Self::Member => write!(f, "member"),
+            Self::Membership => write!(f, "membership"),
+            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
+            Self::Milestone => write!(f, "milestone"),
+            Self::Organization => write!(f, "organization"),
+            Self::OrgBlock => write!(f, "org_block"),
+            Self::PageBuild => write!(f, "page_build"),
+            Self::Project => write!(f, "project"),
+            Self::ProjectCard => write!(f, "project_card"),
+            Self::ProjectColumn => write!(f, "project_column"),
+            Self::Public => write!(f, "public"),
+            Self::PullRequest => write!(f, "pull_request"),
+            Self::PullRequestReview => write!(f, "pull_request_review"),
+            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
+            Self::Push => write!(f, "push"),
+            Self::RegistryPackage => write!(f, "registry_package"),
+            Self::Release => write!(f, "release"),
+            Self::Repository => write!(f, "repository"),
+            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
+            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
+            Self::Star => write!(f, "star"),
+            Self::Status => write!(f, "status"),
+            Self::Team => write!(f, "team"),
+            Self::TeamAdd => write!(f, "team_add"),
+            Self::Watch => write!(f, "watch"),
+            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
+            Self::WorkflowRun => write!(f, "workflow_run"),
         }
     }
 }
@@ -34007,11 +34007,11 @@ impl From<&InstallationSuspendInstallationPermissionsActions>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsActions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsActions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34082,11 +34082,11 @@ impl From<&InstallationSuspendInstallationPermissionsAdministration>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34157,11 +34157,11 @@ impl From<&InstallationSuspendInstallationPermissionsChecks>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsChecks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsChecks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34232,11 +34232,11 @@ impl From<&InstallationSuspendInstallationPermissionsContentReferences>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsContentReferences {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContentReferences {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34309,11 +34309,11 @@ impl From<&InstallationSuspendInstallationPermissionsContents>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsContents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34384,11 +34384,11 @@ impl From<&InstallationSuspendInstallationPermissionsDeployments>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsDeployments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDeployments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34459,11 +34459,11 @@ impl From<&InstallationSuspendInstallationPermissionsDiscussions>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34534,11 +34534,11 @@ impl From<&InstallationSuspendInstallationPermissionsEmails>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsEmails {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEmails {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34609,11 +34609,11 @@ impl From<&InstallationSuspendInstallationPermissionsEnvironments>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsEnvironments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEnvironments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34684,11 +34684,11 @@ impl From<&InstallationSuspendInstallationPermissionsIssues>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsIssues {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsIssues {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34759,11 +34759,11 @@ impl From<&InstallationSuspendInstallationPermissionsMembers>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsMembers {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMembers {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34834,11 +34834,11 @@ impl From<&InstallationSuspendInstallationPermissionsMetadata>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsMetadata {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMetadata {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34909,11 +34909,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationAdministration>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -34990,11 +34990,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationEvents>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35069,11 +35069,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationHooks>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35146,11 +35146,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationPackages>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35227,11 +35227,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationPlan>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPlan {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35302,11 +35302,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationProjects>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35383,11 +35383,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationSecrets>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35464,11 +35464,13 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunne
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display
+    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35545,11 +35547,11 @@ impl From<&InstallationSuspendInstallationPermissionsOrganizationUserBlocking>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35626,11 +35628,11 @@ impl From<&InstallationSuspendInstallationPermissionsPackages>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35701,11 +35703,11 @@ impl From<&InstallationSuspendInstallationPermissionsPages>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsPages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35776,11 +35778,11 @@ impl From<&InstallationSuspendInstallationPermissionsPullRequests>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsPullRequests {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPullRequests {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35851,11 +35853,11 @@ impl From<&InstallationSuspendInstallationPermissionsRepositoryHooks>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -35926,11 +35928,11 @@ impl From<&InstallationSuspendInstallationPermissionsRepositoryProjects>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsRepositoryProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36005,11 +36007,11 @@ impl From<&InstallationSuspendInstallationPermissionsSecretScanningAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36086,11 +36088,11 @@ impl From<&InstallationSuspendInstallationPermissionsSecrets>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36161,11 +36163,11 @@ impl From<&InstallationSuspendInstallationPermissionsSecurityEvents>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsSecurityEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36236,11 +36238,11 @@ impl From<&InstallationSuspendInstallationPermissionsSecurityScanningAlert>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36317,11 +36319,11 @@ impl From<&InstallationSuspendInstallationPermissionsSingleFile>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsSingleFile {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSingleFile {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36392,11 +36394,11 @@ impl From<&InstallationSuspendInstallationPermissionsStatuses>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsStatuses {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsStatuses {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36467,11 +36469,11 @@ impl From<&InstallationSuspendInstallationPermissionsTeamDiscussions>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsTeamDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36542,11 +36544,11 @@ impl From<&InstallationSuspendInstallationPermissionsVulnerabilityAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36621,11 +36623,11 @@ impl From<&InstallationSuspendInstallationPermissionsWorkflows>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationPermissionsWorkflows {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsWorkflows {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -36697,11 +36699,11 @@ impl From<&InstallationSuspendInstallationRepositorySelection>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationRepositorySelection {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationRepositorySelection {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Selected => write!(f, "selected"),
         }
     }
 }
@@ -36931,12 +36933,12 @@ impl From<&InstallationSuspendInstallationSuspendedByType>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationSuspendedByType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationSuspendedByType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -37006,11 +37008,11 @@ impl From<&InstallationSuspendInstallationTargetType>
         value.clone()
     }
 }
-impl ToString for InstallationSuspendInstallationTargetType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationTargetType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -37101,11 +37103,11 @@ impl std::convert::TryFrom<String> for InstallationSuspendInstallationUpdatedAt 
         value.parse()
     }
 }
-impl ToString for InstallationSuspendInstallationUpdatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationSuspendInstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -37209,11 +37211,11 @@ impl From<&InstallationTargetType> for InstallationTargetType {
         value.clone()
     }
 }
-impl ToString for InstallationTargetType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationTargetType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -37386,10 +37388,10 @@ impl From<&InstallationUnsuspendAction> for InstallationUnsuspendAction {
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unsuspend => "unsuspend".to_string(),
+            Self::Unsuspend => write!(f, "unsuspend"),
         }
     }
 }
@@ -37545,11 +37547,11 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationCreatedA
         value.parse()
     }
 }
-impl ToString for InstallationUnsuspendInstallationCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -37731,54 +37733,54 @@ impl From<&InstallationUnsuspendInstallationEventsItem>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationEventsItem {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationEventsItem {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => "check_run".to_string(),
-            Self::CheckSuite => "check_suite".to_string(),
-            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
-            Self::CommitComment => "commit_comment".to_string(),
-            Self::ContentReference => "content_reference".to_string(),
-            Self::Create => "create".to_string(),
-            Self::Delete => "delete".to_string(),
-            Self::Deployment => "deployment".to_string(),
-            Self::DeploymentReview => "deployment_review".to_string(),
-            Self::DeploymentStatus => "deployment_status".to_string(),
-            Self::DeployKey => "deploy_key".to_string(),
-            Self::Discussion => "discussion".to_string(),
-            Self::DiscussionComment => "discussion_comment".to_string(),
-            Self::Fork => "fork".to_string(),
-            Self::Gollum => "gollum".to_string(),
-            Self::Issues => "issues".to_string(),
-            Self::IssueComment => "issue_comment".to_string(),
-            Self::Label => "label".to_string(),
-            Self::Member => "member".to_string(),
-            Self::Membership => "membership".to_string(),
-            Self::MergeQueueEntry => "merge_queue_entry".to_string(),
-            Self::Milestone => "milestone".to_string(),
-            Self::Organization => "organization".to_string(),
-            Self::OrgBlock => "org_block".to_string(),
-            Self::PageBuild => "page_build".to_string(),
-            Self::Project => "project".to_string(),
-            Self::ProjectCard => "project_card".to_string(),
-            Self::ProjectColumn => "project_column".to_string(),
-            Self::Public => "public".to_string(),
-            Self::PullRequest => "pull_request".to_string(),
-            Self::PullRequestReview => "pull_request_review".to_string(),
-            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
-            Self::Push => "push".to_string(),
-            Self::RegistryPackage => "registry_package".to_string(),
-            Self::Release => "release".to_string(),
-            Self::Repository => "repository".to_string(),
-            Self::RepositoryDispatch => "repository_dispatch".to_string(),
-            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
-            Self::Star => "star".to_string(),
-            Self::Status => "status".to_string(),
-            Self::Team => "team".to_string(),
-            Self::TeamAdd => "team_add".to_string(),
-            Self::Watch => "watch".to_string(),
-            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
-            Self::WorkflowRun => "workflow_run".to_string(),
+            Self::CheckRun => write!(f, "check_run"),
+            Self::CheckSuite => write!(f, "check_suite"),
+            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
+            Self::CommitComment => write!(f, "commit_comment"),
+            Self::ContentReference => write!(f, "content_reference"),
+            Self::Create => write!(f, "create"),
+            Self::Delete => write!(f, "delete"),
+            Self::Deployment => write!(f, "deployment"),
+            Self::DeploymentReview => write!(f, "deployment_review"),
+            Self::DeploymentStatus => write!(f, "deployment_status"),
+            Self::DeployKey => write!(f, "deploy_key"),
+            Self::Discussion => write!(f, "discussion"),
+            Self::DiscussionComment => write!(f, "discussion_comment"),
+            Self::Fork => write!(f, "fork"),
+            Self::Gollum => write!(f, "gollum"),
+            Self::Issues => write!(f, "issues"),
+            Self::IssueComment => write!(f, "issue_comment"),
+            Self::Label => write!(f, "label"),
+            Self::Member => write!(f, "member"),
+            Self::Membership => write!(f, "membership"),
+            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
+            Self::Milestone => write!(f, "milestone"),
+            Self::Organization => write!(f, "organization"),
+            Self::OrgBlock => write!(f, "org_block"),
+            Self::PageBuild => write!(f, "page_build"),
+            Self::Project => write!(f, "project"),
+            Self::ProjectCard => write!(f, "project_card"),
+            Self::ProjectColumn => write!(f, "project_column"),
+            Self::Public => write!(f, "public"),
+            Self::PullRequest => write!(f, "pull_request"),
+            Self::PullRequestReview => write!(f, "pull_request_review"),
+            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
+            Self::Push => write!(f, "push"),
+            Self::RegistryPackage => write!(f, "registry_package"),
+            Self::Release => write!(f, "release"),
+            Self::Repository => write!(f, "repository"),
+            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
+            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
+            Self::Star => write!(f, "star"),
+            Self::Status => write!(f, "status"),
+            Self::Team => write!(f, "team"),
+            Self::TeamAdd => write!(f, "team_add"),
+            Self::Watch => write!(f, "watch"),
+            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
+            Self::WorkflowRun => write!(f, "workflow_run"),
         }
     }
 }
@@ -38240,11 +38242,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsActions>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsActions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsActions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38315,11 +38317,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsAdministration>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsAdministration {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38390,11 +38392,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsChecks>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsChecks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsChecks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38465,11 +38467,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsContentReferences>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsContentReferences {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContentReferences {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38544,11 +38546,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsContents>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsContents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38619,11 +38621,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsDeployments>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsDeployments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDeployments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38694,11 +38696,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsDiscussions>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38769,11 +38771,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsEmails>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsEmails {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEmails {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38844,11 +38846,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsEnvironments>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsEnvironments {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEnvironments {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38919,11 +38921,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsIssues>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsIssues {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsIssues {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -38994,11 +38996,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsMembers>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsMembers {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMembers {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39069,11 +39071,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsMetadata>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsMetadata {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMetadata {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39146,11 +39148,13 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationAdministratio
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationAdministration {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display
+    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
+{
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39227,11 +39231,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationEvents>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39308,11 +39312,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationHooks>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39387,11 +39391,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationPackages>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39468,11 +39472,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationPlan>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39547,11 +39551,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationProjects>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39628,11 +39632,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationSecrets>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39711,11 +39715,13 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRun
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display
+    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
+{
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39794,11 +39800,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39875,11 +39881,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsPackages>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsPackages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPackages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -39950,11 +39956,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsPages>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsPages {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPages {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40025,11 +40031,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsPullRequests>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsPullRequests {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPullRequests {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40100,11 +40106,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsRepositoryHooks>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40177,11 +40183,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsRepositoryProjects>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40258,11 +40264,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsSecretScanningAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40339,11 +40345,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsSecrets>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsSecrets {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecrets {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40414,11 +40420,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsSecurityEvents>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityEvents {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40489,11 +40495,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsSecurityScanningAlert>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40570,11 +40576,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsSingleFile>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsSingleFile {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSingleFile {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40645,11 +40651,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsStatuses>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsStatuses {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsStatuses {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40720,11 +40726,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsTeamDiscussions>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40797,11 +40803,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40878,11 +40884,11 @@ impl From<&InstallationUnsuspendInstallationPermissionsWorkflows>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationPermissionsWorkflows {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsWorkflows {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => "read".to_string(),
-            Self::Write => "write".to_string(),
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
         }
     }
 }
@@ -40954,11 +40960,11 @@ impl From<&InstallationUnsuspendInstallationRepositorySelection>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationRepositorySelection {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationRepositorySelection {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Selected => "selected".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Selected => write!(f, "selected"),
         }
     }
 }
@@ -41027,11 +41033,11 @@ impl From<&InstallationUnsuspendInstallationTargetType>
         value.clone()
     }
 }
-impl ToString for InstallationUnsuspendInstallationTargetType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationTargetType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -41124,11 +41130,11 @@ impl std::convert::TryFrom<String> for InstallationUnsuspendInstallationUpdatedA
         value.parse()
     }
 }
-impl ToString for InstallationUnsuspendInstallationUpdatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUnsuspendInstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -41256,11 +41262,11 @@ impl std::convert::TryFrom<String> for InstallationUpdatedAt {
         value.parse()
     }
 }
-impl ToString for InstallationUpdatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for InstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -41557,13 +41563,13 @@ impl From<&IssueActiveLockReason> for IssueActiveLockReason {
         value.clone()
     }
 }
-impl ToString for IssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -41867,10 +41873,10 @@ impl From<&IssueCommentCreatedAction> for IssueCommentCreatedAction {
         value.clone()
     }
 }
-impl ToString for IssueCommentCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -42066,13 +42072,13 @@ impl From<&IssueCommentCreatedIssueActiveLockReason> for IssueCommentCreatedIssu
         value.clone()
     }
 }
-impl ToString for IssueCommentCreatedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentCreatedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -42204,12 +42210,12 @@ impl From<&IssueCommentCreatedIssueAssigneeType> for IssueCommentCreatedIssueAss
         value.clone()
     }
 }
-impl ToString for IssueCommentCreatedIssueAssigneeType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentCreatedIssueAssigneeType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -42327,11 +42333,11 @@ impl From<&IssueCommentCreatedIssueState> for IssueCommentCreatedIssueState {
         value.clone()
     }
 }
-impl ToString for IssueCommentCreatedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentCreatedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -42533,10 +42539,10 @@ impl From<&IssueCommentDeletedAction> for IssueCommentDeletedAction {
         value.clone()
     }
 }
-impl ToString for IssueCommentDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -42732,13 +42738,13 @@ impl From<&IssueCommentDeletedIssueActiveLockReason> for IssueCommentDeletedIssu
         value.clone()
     }
 }
-impl ToString for IssueCommentDeletedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentDeletedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -42870,12 +42876,12 @@ impl From<&IssueCommentDeletedIssueAssigneeType> for IssueCommentDeletedIssueAss
         value.clone()
     }
 }
-impl ToString for IssueCommentDeletedIssueAssigneeType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentDeletedIssueAssigneeType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -42993,11 +42999,11 @@ impl From<&IssueCommentDeletedIssueState> for IssueCommentDeletedIssueState {
         value.clone()
     }
 }
-impl ToString for IssueCommentDeletedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentDeletedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -43221,10 +43227,10 @@ impl From<&IssueCommentEditedAction> for IssueCommentEditedAction {
         value.clone()
     }
 }
-impl ToString for IssueCommentEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -43489,13 +43495,13 @@ impl From<&IssueCommentEditedIssueActiveLockReason> for IssueCommentEditedIssueA
         value.clone()
     }
 }
-impl ToString for IssueCommentEditedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentEditedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -43627,12 +43633,12 @@ impl From<&IssueCommentEditedIssueAssigneeType> for IssueCommentEditedIssueAssig
         value.clone()
     }
 }
-impl ToString for IssueCommentEditedIssueAssigneeType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentEditedIssueAssigneeType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -43750,11 +43756,11 @@ impl From<&IssueCommentEditedIssueState> for IssueCommentEditedIssueState {
         value.clone()
     }
 }
-impl ToString for IssueCommentEditedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueCommentEditedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -43917,11 +43923,11 @@ impl From<&IssueState> for IssueState {
         value.clone()
     }
 }
-impl ToString for IssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -44064,10 +44070,10 @@ impl From<&IssuesAssignedAction> for IssuesAssignedAction {
         value.clone()
     }
 }
-impl ToString for IssuesAssignedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesAssignedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Assigned => "assigned".to_string(),
+            Self::Assigned => write!(f, "assigned"),
         }
     }
 }
@@ -44218,10 +44224,10 @@ impl From<&IssuesClosedAction> for IssuesClosedAction {
         value.clone()
     }
 }
-impl ToString for IssuesClosedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesClosedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -44372,13 +44378,13 @@ impl From<&IssuesClosedIssueActiveLockReason> for IssuesClosedIssueActiveLockRea
         value.clone()
     }
 }
-impl ToString for IssuesClosedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesClosedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -44492,10 +44498,10 @@ impl From<&IssuesClosedIssueState> for IssuesClosedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesClosedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesClosedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -44619,10 +44625,10 @@ impl From<&IssuesDeletedAction> for IssuesDeletedAction {
         value.clone()
     }
 }
-impl ToString for IssuesDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -44767,10 +44773,10 @@ impl From<&IssuesDemilestonedAction> for IssuesDemilestonedAction {
         value.clone()
     }
 }
-impl ToString for IssuesDemilestonedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesDemilestonedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Demilestoned => "demilestoned".to_string(),
+            Self::Demilestoned => write!(f, "demilestoned"),
         }
     }
 }
@@ -44915,13 +44921,13 @@ impl From<&IssuesDemilestonedIssueActiveLockReason> for IssuesDemilestonedIssueA
         value.clone()
     }
 }
-impl ToString for IssuesDemilestonedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesDemilestonedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -45039,11 +45045,11 @@ impl From<&IssuesDemilestonedIssueState> for IssuesDemilestonedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesDemilestonedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesDemilestonedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -45208,10 +45214,10 @@ impl From<&IssuesEditedAction> for IssuesEditedAction {
         value.clone()
     }
 }
-impl ToString for IssuesEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -45621,10 +45627,10 @@ impl From<&IssuesLabeledAction> for IssuesLabeledAction {
         value.clone()
     }
 }
-impl ToString for IssuesLabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesLabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => "labeled".to_string(),
+            Self::Labeled => write!(f, "labeled"),
         }
     }
 }
@@ -45781,10 +45787,10 @@ impl From<&IssuesLockedAction> for IssuesLockedAction {
         value.clone()
     }
 }
-impl ToString for IssuesLockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesLockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => "locked".to_string(),
+            Self::Locked => write!(f, "locked"),
         }
     }
 }
@@ -45945,13 +45951,13 @@ impl From<&IssuesLockedIssueActiveLockReason> for IssuesLockedIssueActiveLockRea
         value.clone()
     }
 }
-impl ToString for IssuesLockedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesLockedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -46069,11 +46075,11 @@ impl From<&IssuesLockedIssueState> for IssuesLockedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesLockedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesLockedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -46219,10 +46225,10 @@ impl From<&IssuesMilestonedAction> for IssuesMilestonedAction {
         value.clone()
     }
 }
-impl ToString for IssuesMilestonedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesMilestonedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Milestoned => "milestoned".to_string(),
+            Self::Milestoned => write!(f, "milestoned"),
         }
     }
 }
@@ -46367,13 +46373,13 @@ impl From<&IssuesMilestonedIssueActiveLockReason> for IssuesMilestonedIssueActiv
         value.clone()
     }
 }
-impl ToString for IssuesMilestonedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesMilestonedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -46583,11 +46589,11 @@ impl From<&IssuesMilestonedIssueMilestoneState> for IssuesMilestonedIssueMilesto
         value.clone()
     }
 }
-impl ToString for IssuesMilestonedIssueMilestoneState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesMilestonedIssueMilestoneState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -46703,11 +46709,11 @@ impl From<&IssuesMilestonedIssueState> for IssuesMilestonedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesMilestonedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesMilestonedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -46873,10 +46879,10 @@ impl From<&IssuesOpenedAction> for IssuesOpenedAction {
         value.clone()
     }
 }
-impl ToString for IssuesOpenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesOpenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => "opened".to_string(),
+            Self::Opened => write!(f, "opened"),
         }
     }
 }
@@ -47060,13 +47066,13 @@ impl From<&IssuesOpenedIssueActiveLockReason> for IssuesOpenedIssueActiveLockRea
         value.clone()
     }
 }
-impl ToString for IssuesOpenedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesOpenedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -47180,10 +47186,10 @@ impl From<&IssuesOpenedIssueState> for IssuesOpenedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesOpenedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesOpenedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -47307,10 +47313,10 @@ impl From<&IssuesPinnedAction> for IssuesPinnedAction {
         value.clone()
     }
 }
-impl ToString for IssuesPinnedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesPinnedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pinned => "pinned".to_string(),
+            Self::Pinned => write!(f, "pinned"),
         }
     }
 }
@@ -47453,10 +47459,10 @@ impl From<&IssuesReopenedAction> for IssuesReopenedAction {
         value.clone()
     }
 }
-impl ToString for IssuesReopenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesReopenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => "reopened".to_string(),
+            Self::Reopened => write!(f, "reopened"),
         }
     }
 }
@@ -47602,13 +47608,13 @@ impl From<&IssuesReopenedIssueActiveLockReason> for IssuesReopenedIssueActiveLoc
         value.clone()
     }
 }
-impl ToString for IssuesReopenedIssueActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesReopenedIssueActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -47722,10 +47728,10 @@ impl From<&IssuesReopenedIssueState> for IssuesReopenedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesReopenedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesReopenedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -47867,10 +47873,10 @@ impl From<&IssuesTransferredAction> for IssuesTransferredAction {
         value.clone()
     }
 }
-impl ToString for IssuesTransferredAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesTransferredAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => "transferred".to_string(),
+            Self::Transferred => write!(f, "transferred"),
         }
     }
 }
@@ -48045,10 +48051,10 @@ impl From<&IssuesUnassignedAction> for IssuesUnassignedAction {
         value.clone()
     }
 }
-impl ToString for IssuesUnassignedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesUnassignedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unassigned => "unassigned".to_string(),
+            Self::Unassigned => write!(f, "unassigned"),
         }
     }
 }
@@ -48179,10 +48185,10 @@ impl From<&IssuesUnlabeledAction> for IssuesUnlabeledAction {
         value.clone()
     }
 }
-impl ToString for IssuesUnlabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesUnlabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => "unlabeled".to_string(),
+            Self::Unlabeled => write!(f, "unlabeled"),
         }
     }
 }
@@ -48329,10 +48335,10 @@ impl From<&IssuesUnlockedAction> for IssuesUnlockedAction {
         value.clone()
     }
 }
-impl ToString for IssuesUnlockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesUnlockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => "unlocked".to_string(),
+            Self::Unlocked => write!(f, "unlocked"),
         }
     }
 }
@@ -48574,11 +48580,11 @@ impl From<&IssuesUnlockedIssueState> for IssuesUnlockedIssueState {
         value.clone()
     }
 }
-impl ToString for IssuesUnlockedIssueState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesUnlockedIssueState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -48703,10 +48709,10 @@ impl From<&IssuesUnpinnedAction> for IssuesUnpinnedAction {
         value.clone()
     }
 }
-impl ToString for IssuesUnpinnedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IssuesUnpinnedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpinned => "unpinned".to_string(),
+            Self::Unpinned => write!(f, "unpinned"),
         }
     }
 }
@@ -48903,10 +48909,10 @@ impl From<&LabelCreatedAction> for LabelCreatedAction {
         value.clone()
     }
 }
-impl ToString for LabelCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LabelCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -49032,10 +49038,10 @@ impl From<&LabelDeletedAction> for LabelDeletedAction {
         value.clone()
     }
 }
-impl ToString for LabelDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LabelDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -49209,10 +49215,10 @@ impl From<&LabelEditedAction> for LabelEditedAction {
         value.clone()
     }
 }
-impl ToString for LabelEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LabelEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -49914,10 +49920,10 @@ impl From<&MarketplacePurchaseCancelledAction> for MarketplacePurchaseCancelledA
         value.clone()
     }
 }
-impl ToString for MarketplacePurchaseCancelledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarketplacePurchaseCancelledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cancelled => "cancelled".to_string(),
+            Self::Cancelled => write!(f, "cancelled"),
         }
     }
 }
@@ -50441,10 +50447,10 @@ impl From<&MarketplacePurchaseChangedAction> for MarketplacePurchaseChangedActio
         value.clone()
     }
 }
-impl ToString for MarketplacePurchaseChangedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarketplacePurchaseChangedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Changed => "changed".to_string(),
+            Self::Changed => write!(f, "changed"),
         }
     }
 }
@@ -51033,10 +51039,10 @@ impl From<&MarketplacePurchasePendingChangeAction> for MarketplacePurchasePendin
         value.clone()
     }
 }
-impl ToString for MarketplacePurchasePendingChangeAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarketplacePurchasePendingChangeAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingChange => "pending_change".to_string(),
+            Self::PendingChange => write!(f, "pending_change"),
         }
     }
 }
@@ -51264,10 +51270,10 @@ impl From<&MarketplacePurchasePendingChangeCancelledAction>
         value.clone()
     }
 }
-impl ToString for MarketplacePurchasePendingChangeCancelledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarketplacePurchasePendingChangeCancelledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingChangeCancelled => "pending_change_cancelled".to_string(),
+            Self::PendingChangeCancelled => write!(f, "pending_change_cancelled"),
         }
     }
 }
@@ -52168,10 +52174,10 @@ impl From<&MarketplacePurchasePurchasedAction> for MarketplacePurchasePurchasedA
         value.clone()
     }
 }
-impl ToString for MarketplacePurchasePurchasedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarketplacePurchasePurchasedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Purchased => "purchased".to_string(),
+            Self::Purchased => write!(f, "purchased"),
         }
     }
 }
@@ -52617,10 +52623,10 @@ impl From<&MemberAddedAction> for MemberAddedAction {
         value.clone()
     }
 }
-impl ToString for MemberAddedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MemberAddedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => "added".to_string(),
+            Self::Added => write!(f, "added"),
         }
     }
 }
@@ -52761,11 +52767,11 @@ impl From<&MemberAddedChangesPermissionTo> for MemberAddedChangesPermissionTo {
         value.clone()
     }
 }
-impl ToString for MemberAddedChangesPermissionTo {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MemberAddedChangesPermissionTo {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Write => "write".to_string(),
-            Self::Admin => "admin".to_string(),
+            Self::Write => write!(f, "write"),
+            Self::Admin => write!(f, "admin"),
         }
     }
 }
@@ -52912,10 +52918,10 @@ impl From<&MemberEditedAction> for MemberEditedAction {
         value.clone()
     }
 }
-impl ToString for MemberEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MemberEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -53154,10 +53160,10 @@ impl From<&MemberRemovedAction> for MemberRemovedAction {
         value.clone()
     }
 }
-impl ToString for MemberRemovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MemberRemovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => "removed".to_string(),
+            Self::Removed => write!(f, "removed"),
         }
     }
 }
@@ -53349,10 +53355,10 @@ impl From<&MembershipAddedAction> for MembershipAddedAction {
         value.clone()
     }
 }
-impl ToString for MembershipAddedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MembershipAddedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => "added".to_string(),
+            Self::Added => write!(f, "added"),
         }
     }
 }
@@ -53418,10 +53424,10 @@ impl From<&MembershipAddedScope> for MembershipAddedScope {
         value.clone()
     }
 }
-impl ToString for MembershipAddedScope {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MembershipAddedScope {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Team => "team".to_string(),
+            Self::Team => write!(f, "team"),
         }
     }
 }
@@ -53621,10 +53627,10 @@ impl From<&MembershipRemovedAction> for MembershipRemovedAction {
         value.clone()
     }
 }
-impl ToString for MembershipRemovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MembershipRemovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => "removed".to_string(),
+            Self::Removed => write!(f, "removed"),
         }
     }
 }
@@ -53693,11 +53699,11 @@ impl From<&MembershipRemovedScope> for MembershipRemovedScope {
         value.clone()
     }
 }
-impl ToString for MembershipRemovedScope {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MembershipRemovedScope {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Team => "team".to_string(),
-            Self::Organization => "organization".to_string(),
+            Self::Team => write!(f, "team"),
+            Self::Organization => write!(f, "organization"),
         }
     }
 }
@@ -53934,10 +53940,10 @@ impl From<&MetaDeletedAction> for MetaDeletedAction {
         value.clone()
     }
 }
-impl ToString for MetaDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MetaDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -54137,11 +54143,11 @@ impl From<&MetaDeletedHookConfigContentType> for MetaDeletedHookConfigContentTyp
         value.clone()
     }
 }
-impl ToString for MetaDeletedHookConfigContentType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MetaDeletedHookConfigContentType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => "json".to_string(),
-            Self::Form => "form".to_string(),
+            Self::Json => write!(f, "json"),
+            Self::Form => write!(f, "form"),
         }
     }
 }
@@ -54459,10 +54465,10 @@ impl From<&MilestoneClosedAction> for MilestoneClosedAction {
         value.clone()
     }
 }
-impl ToString for MilestoneClosedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneClosedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -54587,10 +54593,10 @@ impl From<&MilestoneClosedMilestoneState> for MilestoneClosedMilestoneState {
         value.clone()
     }
 }
-impl ToString for MilestoneClosedMilestoneState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneClosedMilestoneState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -54737,10 +54743,10 @@ impl From<&MilestoneCreatedAction> for MilestoneCreatedAction {
         value.clone()
     }
 }
-impl ToString for MilestoneCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -54865,10 +54871,10 @@ impl From<&MilestoneCreatedMilestoneState> for MilestoneCreatedMilestoneState {
         value.clone()
     }
 }
-impl ToString for MilestoneCreatedMilestoneState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneCreatedMilestoneState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -54992,10 +54998,10 @@ impl From<&MilestoneDeletedAction> for MilestoneDeletedAction {
         value.clone()
     }
 }
-impl ToString for MilestoneDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -55167,10 +55173,10 @@ impl From<&MilestoneEditedAction> for MilestoneEditedAction {
         value.clone()
     }
 }
-impl ToString for MilestoneEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -55543,10 +55549,10 @@ impl From<&MilestoneOpenedAction> for MilestoneOpenedAction {
         value.clone()
     }
 }
-impl ToString for MilestoneOpenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneOpenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => "opened".to_string(),
+            Self::Opened => write!(f, "opened"),
         }
     }
 }
@@ -55671,10 +55677,10 @@ impl From<&MilestoneOpenedMilestoneState> for MilestoneOpenedMilestoneState {
         value.clone()
     }
 }
-impl ToString for MilestoneOpenedMilestoneState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneOpenedMilestoneState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -55743,11 +55749,11 @@ impl From<&MilestoneState> for MilestoneState {
         value.clone()
     }
 }
-impl ToString for MilestoneState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MilestoneState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -55869,10 +55875,10 @@ impl From<&OrgBlockBlockedAction> for OrgBlockBlockedAction {
         value.clone()
     }
 }
-impl ToString for OrgBlockBlockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrgBlockBlockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Blocked => "blocked".to_string(),
+            Self::Blocked => write!(f, "blocked"),
         }
     }
 }
@@ -56031,10 +56037,10 @@ impl From<&OrgBlockUnblockedAction> for OrgBlockUnblockedAction {
         value.clone()
     }
 }
-impl ToString for OrgBlockUnblockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrgBlockUnblockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unblocked => "unblocked".to_string(),
+            Self::Unblocked => write!(f, "unblocked"),
         }
     }
 }
@@ -56256,10 +56262,10 @@ impl From<&OrganizationDeletedAction> for OrganizationDeletedAction {
         value.clone()
     }
 }
-impl ToString for OrganizationDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrganizationDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -56443,10 +56449,10 @@ impl From<&OrganizationMemberAddedAction> for OrganizationMemberAddedAction {
         value.clone()
     }
 }
-impl ToString for OrganizationMemberAddedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrganizationMemberAddedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberAdded => "member_added".to_string(),
+            Self::MemberAdded => write!(f, "member_added"),
         }
     }
 }
@@ -56636,10 +56642,10 @@ impl From<&OrganizationMemberInvitedAction> for OrganizationMemberInvitedAction 
         value.clone()
     }
 }
-impl ToString for OrganizationMemberInvitedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrganizationMemberInvitedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberInvited => "member_invited".to_string(),
+            Self::MemberInvited => write!(f, "member_invited"),
         }
     }
 }
@@ -56854,10 +56860,10 @@ impl From<&OrganizationMemberRemovedAction> for OrganizationMemberRemovedAction 
         value.clone()
     }
 }
-impl ToString for OrganizationMemberRemovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrganizationMemberRemovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberRemoved => "member_removed".to_string(),
+            Self::MemberRemoved => write!(f, "member_removed"),
         }
     }
 }
@@ -56976,10 +56982,10 @@ impl From<&OrganizationRenamedAction> for OrganizationRenamedAction {
         value.clone()
     }
 }
-impl ToString for OrganizationRenamedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrganizationRenamedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Renamed => "renamed".to_string(),
+            Self::Renamed => write!(f, "renamed"),
         }
     }
 }
@@ -57425,10 +57431,10 @@ impl From<&PackagePublishedAction> for PackagePublishedAction {
         value.clone()
     }
 }
-impl ToString for PackagePublishedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PackagePublishedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => "published".to_string(),
+            Self::Published => write!(f, "published"),
         }
     }
 }
@@ -58620,10 +58626,10 @@ impl From<&PackageUpdatedAction> for PackageUpdatedAction {
         value.clone()
     }
 }
-impl ToString for PackageUpdatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PackageUpdatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Updated => "updated".to_string(),
+            Self::Updated => write!(f, "updated"),
         }
     }
 }
@@ -60040,11 +60046,11 @@ impl From<&PingEventHookConfigContentType> for PingEventHookConfigContentType {
         value.clone()
     }
 }
-impl ToString for PingEventHookConfigContentType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PingEventHookConfigContentType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => "json".to_string(),
-            Self::Form => "form".to_string(),
+            Self::Json => write!(f, "json"),
+            Self::Form => write!(f, "form"),
         }
     }
 }
@@ -60445,10 +60451,10 @@ impl From<&ProjectCardConvertedAction> for ProjectCardConvertedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCardConvertedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCardConvertedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Converted => "converted".to_string(),
+            Self::Converted => write!(f, "converted"),
         }
     }
 }
@@ -60639,10 +60645,10 @@ impl From<&ProjectCardCreatedAction> for ProjectCardCreatedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCardCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCardCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -60766,10 +60772,10 @@ impl From<&ProjectCardDeletedAction> for ProjectCardDeletedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCardDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCardDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -60916,10 +60922,10 @@ impl From<&ProjectCardEditedAction> for ProjectCardEditedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCardEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCardEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -61217,10 +61223,10 @@ impl From<&ProjectCardMovedAction> for ProjectCardMovedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCardMovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCardMovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Moved => "moved".to_string(),
+            Self::Moved => write!(f, "moved"),
         }
     }
 }
@@ -61465,10 +61471,10 @@ impl From<&ProjectClosedAction> for ProjectClosedAction {
         value.clone()
     }
 }
-impl ToString for ProjectClosedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectClosedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -61667,10 +61673,10 @@ impl From<&ProjectColumnCreatedAction> for ProjectColumnCreatedAction {
         value.clone()
     }
 }
-impl ToString for ProjectColumnCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectColumnCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -61794,10 +61800,10 @@ impl From<&ProjectColumnDeletedAction> for ProjectColumnDeletedAction {
         value.clone()
     }
 }
-impl ToString for ProjectColumnDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectColumnDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -61941,10 +61947,10 @@ impl From<&ProjectColumnEditedAction> for ProjectColumnEditedAction {
         value.clone()
     }
 }
-impl ToString for ProjectColumnEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectColumnEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -62189,10 +62195,10 @@ impl From<&ProjectColumnMovedAction> for ProjectColumnMovedAction {
         value.clone()
     }
 }
-impl ToString for ProjectColumnMovedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectColumnMovedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Moved => "moved".to_string(),
+            Self::Moved => write!(f, "moved"),
         }
     }
 }
@@ -62316,10 +62322,10 @@ impl From<&ProjectCreatedAction> for ProjectCreatedAction {
         value.clone()
     }
 }
-impl ToString for ProjectCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -62443,10 +62449,10 @@ impl From<&ProjectDeletedAction> for ProjectDeletedAction {
         value.clone()
     }
 }
-impl ToString for ProjectDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -62605,10 +62611,10 @@ impl From<&ProjectEditedAction> for ProjectEditedAction {
         value.clone()
     }
 }
-impl ToString for ProjectEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -62912,10 +62918,10 @@ impl From<&ProjectReopenedAction> for ProjectReopenedAction {
         value.clone()
     }
 }
-impl ToString for ProjectReopenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectReopenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => "reopened".to_string(),
+            Self::Reopened => write!(f, "reopened"),
         }
     }
 }
@@ -62984,11 +62990,11 @@ impl From<&ProjectState> for ProjectState {
         value.clone()
     }
 }
-impl ToString for ProjectState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -63294,11 +63300,11 @@ impl std::convert::TryFrom<String> for PublicEventRepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for PublicEventRepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PublicEventRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -63900,13 +63906,13 @@ impl From<&PullRequestActiveLockReason> for PullRequestActiveLockReason {
         value.clone()
     }
 }
-impl ToString for PullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -64045,10 +64051,10 @@ impl From<&PullRequestAssignedAction> for PullRequestAssignedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestAssignedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestAssignedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Assigned => "assigned".to_string(),
+            Self::Assigned => write!(f, "assigned"),
         }
     }
 }
@@ -64177,10 +64183,10 @@ impl From<&PullRequestAutoMergeDisabledAction> for PullRequestAutoMergeDisabledA
         value.clone()
     }
 }
-impl ToString for PullRequestAutoMergeDisabledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestAutoMergeDisabledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AutoMergeDisabled => "auto_merge_disabled".to_string(),
+            Self::AutoMergeDisabled => write!(f, "auto_merge_disabled"),
         }
     }
 }
@@ -64309,10 +64315,10 @@ impl From<&PullRequestAutoMergeEnabledAction> for PullRequestAutoMergeEnabledAct
         value.clone()
     }
 }
-impl ToString for PullRequestAutoMergeEnabledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestAutoMergeEnabledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AutoMergeEnabled => "auto_merge_enabled".to_string(),
+            Self::AutoMergeEnabled => write!(f, "auto_merge_enabled"),
         }
     }
 }
@@ -64522,10 +64528,10 @@ impl From<&PullRequestClosedAction> for PullRequestClosedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestClosedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestClosedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -64702,13 +64708,13 @@ impl From<&PullRequestClosedPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestClosedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestClosedPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -64981,10 +64987,10 @@ impl From<&PullRequestClosedPullRequestState> for PullRequestClosedPullRequestSt
         value.clone()
     }
 }
-impl ToString for PullRequestClosedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestClosedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => "closed".to_string(),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -65154,10 +65160,10 @@ impl From<&PullRequestConvertedToDraftAction> for PullRequestConvertedToDraftAct
         value.clone()
     }
 }
-impl ToString for PullRequestConvertedToDraftAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestConvertedToDraftAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ConvertedToDraft => "converted_to_draft".to_string(),
+            Self::ConvertedToDraft => write!(f, "converted_to_draft"),
         }
     }
 }
@@ -65344,13 +65350,13 @@ impl From<&PullRequestConvertedToDraftPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -65635,11 +65641,11 @@ impl From<&PullRequestConvertedToDraftPullRequestState>
         value.clone()
     }
 }
-impl ToString for PullRequestConvertedToDraftPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -65806,10 +65812,10 @@ impl From<&PullRequestEditedAction> for PullRequestEditedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -66283,10 +66289,10 @@ impl From<&PullRequestLabeledAction> for PullRequestLabeledAction {
         value.clone()
     }
 }
-impl ToString for PullRequestLabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestLabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => "labeled".to_string(),
+            Self::Labeled => write!(f, "labeled"),
         }
     }
 }
@@ -66482,10 +66488,10 @@ impl From<&PullRequestLockedAction> for PullRequestLockedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestLockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestLockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => "locked".to_string(),
+            Self::Locked => write!(f, "locked"),
         }
     }
 }
@@ -66655,10 +66661,10 @@ impl From<&PullRequestOpenedAction> for PullRequestOpenedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestOpenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestOpenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => "opened".to_string(),
+            Self::Opened => write!(f, "opened"),
         }
     }
 }
@@ -67091,10 +67097,10 @@ impl From<&PullRequestOpenedPullRequestState> for PullRequestOpenedPullRequestSt
         value.clone()
     }
 }
-impl ToString for PullRequestOpenedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestOpenedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -67268,10 +67274,10 @@ impl From<&PullRequestReadyForReviewAction> for PullRequestReadyForReviewAction 
         value.clone()
     }
 }
-impl ToString for PullRequestReadyForReviewAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReadyForReviewAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReadyForReview => "ready_for_review".to_string(),
+            Self::ReadyForReview => write!(f, "ready_for_review"),
         }
     }
 }
@@ -67461,13 +67467,13 @@ impl From<&PullRequestReadyForReviewPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestReadyForReviewPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -67744,10 +67750,10 @@ impl From<&PullRequestReadyForReviewPullRequestState>
         value.clone()
     }
 }
-impl ToString for PullRequestReadyForReviewPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -67917,10 +67923,10 @@ impl From<&PullRequestReopenedAction> for PullRequestReopenedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestReopenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReopenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => "reopened".to_string(),
+            Self::Reopened => write!(f, "reopened"),
         }
     }
 }
@@ -68107,13 +68113,13 @@ impl From<&PullRequestReopenedPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestReopenedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReopenedPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -68386,10 +68392,10 @@ impl From<&PullRequestReopenedPullRequestState> for PullRequestReopenedPullReque
         value.clone()
     }
 }
-impl ToString for PullRequestReopenedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReopenedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
+            Self::Open => write!(f, "open"),
         }
     }
 }
@@ -69096,10 +69102,10 @@ impl From<&PullRequestReviewCommentCreatedAction> for PullRequestReviewCommentCr
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -69535,13 +69541,13 @@ impl From<&PullRequestReviewCommentCreatedPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -69825,11 +69831,11 @@ impl From<&PullRequestReviewCommentCreatedPullRequestState>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentCreatedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -70259,10 +70265,10 @@ impl From<&PullRequestReviewCommentDeletedAction> for PullRequestReviewCommentDe
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -70698,13 +70704,13 @@ impl From<&PullRequestReviewCommentDeletedPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -70988,11 +70994,11 @@ impl From<&PullRequestReviewCommentDeletedPullRequestState>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentDeletedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -71444,10 +71450,10 @@ impl From<&PullRequestReviewCommentEditedAction> for PullRequestReviewCommentEdi
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -71954,13 +71960,13 @@ impl From<&PullRequestReviewCommentEditedPullRequestActiveLockReason>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -72244,11 +72250,11 @@ impl From<&PullRequestReviewCommentEditedPullRequestState>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentEditedPullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -72405,11 +72411,11 @@ impl From<&PullRequestReviewCommentSide> for PullRequestReviewCommentSide {
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentSide {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentSide {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "LEFT".to_string(),
-            Self::Right => "RIGHT".to_string(),
+            Self::Left => write!(f, "LEFT"),
+            Self::Right => write!(f, "RIGHT"),
         }
     }
 }
@@ -72480,11 +72486,11 @@ impl From<&PullRequestReviewCommentStartSide> for PullRequestReviewCommentStartS
         value.clone()
     }
 }
-impl ToString for PullRequestReviewCommentStartSide {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewCommentStartSide {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "LEFT".to_string(),
-            Self::Right => "RIGHT".to_string(),
+            Self::Left => write!(f, "LEFT"),
+            Self::Right => write!(f, "RIGHT"),
         }
     }
 }
@@ -72689,10 +72695,10 @@ impl From<&PullRequestReviewDismissedAction> for PullRequestReviewDismissedActio
         value.clone()
     }
 }
-impl ToString for PullRequestReviewDismissedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewDismissedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -72900,10 +72906,10 @@ impl From<&PullRequestReviewDismissedReviewState> for PullRequestReviewDismissed
         value.clone()
     }
 }
-impl ToString for PullRequestReviewDismissedReviewState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewDismissedReviewState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => "dismissed".to_string(),
+            Self::Dismissed => write!(f, "dismissed"),
         }
     }
 }
@@ -73125,10 +73131,10 @@ impl From<&PullRequestReviewEditedAction> for PullRequestReviewEditedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestReviewEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -73582,10 +73588,10 @@ impl From<&PullRequestReviewRequestRemovedVariant0Action>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewRequestRemovedVariant0Action {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant0Action {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequestRemoved => "review_request_removed".to_string(),
+            Self::ReviewRequestRemoved => write!(f, "review_request_removed"),
         }
     }
 }
@@ -73652,10 +73658,10 @@ impl From<&PullRequestReviewRequestRemovedVariant1Action>
         value.clone()
     }
 }
-impl ToString for PullRequestReviewRequestRemovedVariant1Action {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant1Action {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequestRemoved => "review_request_removed".to_string(),
+            Self::ReviewRequestRemoved => write!(f, "review_request_removed"),
         }
     }
 }
@@ -73852,10 +73858,10 @@ impl From<&PullRequestReviewRequestedVariant0Action> for PullRequestReviewReques
         value.clone()
     }
 }
-impl ToString for PullRequestReviewRequestedVariant0Action {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewRequestedVariant0Action {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequested => "review_requested".to_string(),
+            Self::ReviewRequested => write!(f, "review_requested"),
         }
     }
 }
@@ -73920,10 +73926,10 @@ impl From<&PullRequestReviewRequestedVariant1Action> for PullRequestReviewReques
         value.clone()
     }
 }
-impl ToString for PullRequestReviewRequestedVariant1Action {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewRequestedVariant1Action {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequested => "review_requested".to_string(),
+            Self::ReviewRequested => write!(f, "review_requested"),
         }
     }
 }
@@ -74124,10 +74130,10 @@ impl From<&PullRequestReviewSubmittedAction> for PullRequestReviewSubmittedActio
         value.clone()
     }
 }
-impl ToString for PullRequestReviewSubmittedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestReviewSubmittedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Submitted => "submitted".to_string(),
+            Self::Submitted => write!(f, "submitted"),
         }
     }
 }
@@ -74336,11 +74342,11 @@ impl From<&PullRequestState> for PullRequestState {
         value.clone()
     }
 }
-impl ToString for PullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -74482,10 +74488,10 @@ impl From<&PullRequestSynchronizeAction> for PullRequestSynchronizeAction {
         value.clone()
     }
 }
-impl ToString for PullRequestSynchronizeAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestSynchronizeAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Synchronize => "synchronize".to_string(),
+            Self::Synchronize => write!(f, "synchronize"),
         }
     }
 }
@@ -74621,10 +74627,10 @@ impl From<&PullRequestUnassignedAction> for PullRequestUnassignedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestUnassignedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestUnassignedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unassigned => "unassigned".to_string(),
+            Self::Unassigned => write!(f, "unassigned"),
         }
     }
 }
@@ -74760,10 +74766,10 @@ impl From<&PullRequestUnlabeledAction> for PullRequestUnlabeledAction {
         value.clone()
     }
 }
-impl ToString for PullRequestUnlabeledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestUnlabeledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => "unlabeled".to_string(),
+            Self::Unlabeled => write!(f, "unlabeled"),
         }
     }
 }
@@ -74894,10 +74900,10 @@ impl From<&PullRequestUnlockedAction> for PullRequestUnlockedAction {
         value.clone()
     }
 }
-impl ToString for PullRequestUnlockedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PullRequestUnlockedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => "unlocked".to_string(),
+            Self::Unlocked => write!(f, "unlocked"),
         }
     }
 }
@@ -75340,10 +75346,10 @@ impl From<&ReleaseAssetState> for ReleaseAssetState {
         value.clone()
     }
 }
-impl ToString for ReleaseAssetState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseAssetState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Uploaded => "uploaded".to_string(),
+            Self::Uploaded => write!(f, "uploaded"),
         }
     }
 }
@@ -75467,10 +75473,10 @@ impl From<&ReleaseCreatedAction> for ReleaseCreatedAction {
         value.clone()
     }
 }
-impl ToString for ReleaseCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -75594,10 +75600,10 @@ impl From<&ReleaseDeletedAction> for ReleaseDeletedAction {
         value.clone()
     }
 }
-impl ToString for ReleaseDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -75755,10 +75761,10 @@ impl From<&ReleaseEditedAction> for ReleaseEditedAction {
         value.clone()
     }
 }
-impl ToString for ReleaseEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -76099,10 +76105,10 @@ impl From<&ReleasePrereleasedAction> for ReleasePrereleasedAction {
         value.clone()
     }
 }
-impl ToString for ReleasePrereleasedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleasePrereleasedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Prereleased => "prereleased".to_string(),
+            Self::Prereleased => write!(f, "prereleased"),
         }
     }
 }
@@ -76303,10 +76309,10 @@ impl From<&ReleasePublishedAction> for ReleasePublishedAction {
         value.clone()
     }
 }
-impl ToString for ReleasePublishedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleasePublishedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => "published".to_string(),
+            Self::Published => write!(f, "published"),
         }
     }
 }
@@ -76488,10 +76494,10 @@ impl From<&ReleaseReleasedAction> for ReleaseReleasedAction {
         value.clone()
     }
 }
-impl ToString for ReleaseReleasedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseReleasedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Released => "released".to_string(),
+            Self::Released => write!(f, "released"),
         }
     }
 }
@@ -76631,10 +76637,10 @@ impl From<&ReleaseUnpublishedAction> for ReleaseUnpublishedAction {
         value.clone()
     }
 }
-impl ToString for ReleaseUnpublishedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReleaseUnpublishedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpublished => "unpublished".to_string(),
+            Self::Unpublished => write!(f, "unpublished"),
         }
     }
 }
@@ -77466,10 +77472,10 @@ impl From<&RepositoryArchivedAction> for RepositoryArchivedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryArchivedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryArchivedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Archived => "archived".to_string(),
+            Self::Archived => write!(f, "archived"),
         }
     }
 }
@@ -77710,11 +77716,11 @@ impl std::convert::TryFrom<String> for RepositoryArchivedRepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for RepositoryArchivedRepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryArchivedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -77908,10 +77914,10 @@ impl From<&RepositoryCreatedAction> for RepositoryCreatedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -78001,11 +78007,11 @@ impl std::convert::TryFrom<String> for RepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for RepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -78107,10 +78113,10 @@ impl From<&RepositoryDeletedAction> for RepositoryDeletedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -78277,10 +78283,10 @@ impl From<&RepositoryDispatchOnDemandTestAction> for RepositoryDispatchOnDemandT
         value.clone()
     }
 }
-impl ToString for RepositoryDispatchOnDemandTestAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryDispatchOnDemandTestAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::OnDemandTest => "on-demand-test".to_string(),
+            Self::OnDemandTest => write!(f, "on-demand-test"),
         }
     }
 }
@@ -78449,10 +78455,10 @@ impl From<&RepositoryEditedAction> for RepositoryEditedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -78843,12 +78849,12 @@ impl From<&RepositoryImportEventStatus> for RepositoryImportEventStatus {
         value.clone()
     }
 }
-impl ToString for RepositoryImportEventStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryImportEventStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::Failure => "failure".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::Failure => write!(f, "failure"),
         }
     }
 }
@@ -79341,10 +79347,10 @@ impl From<&RepositoryPrivatizedAction> for RepositoryPrivatizedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryPrivatizedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryPrivatizedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Privatized => "privatized".to_string(),
+            Self::Privatized => write!(f, "privatized"),
         }
     }
 }
@@ -79584,11 +79590,11 @@ impl std::convert::TryFrom<String> for RepositoryPrivatizedRepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for RepositoryPrivatizedRepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryPrivatizedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -79804,10 +79810,10 @@ impl From<&RepositoryPublicizedAction> for RepositoryPublicizedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryPublicizedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryPublicizedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Publicized => "publicized".to_string(),
+            Self::Publicized => write!(f, "publicized"),
         }
     }
 }
@@ -80047,11 +80053,11 @@ impl std::convert::TryFrom<String> for RepositoryPublicizedRepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for RepositoryPublicizedRepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryPublicizedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -80322,10 +80328,10 @@ impl From<&RepositoryRenamedAction> for RepositoryRenamedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryRenamedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryRenamedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Renamed => "renamed".to_string(),
+            Self::Renamed => write!(f, "renamed"),
         }
     }
 }
@@ -80587,10 +80593,10 @@ impl From<&RepositoryTransferredAction> for RepositoryTransferredAction {
         value.clone()
     }
 }
-impl ToString for RepositoryTransferredAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryTransferredAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => "transferred".to_string(),
+            Self::Transferred => write!(f, "transferred"),
         }
     }
 }
@@ -80836,10 +80842,10 @@ impl From<&RepositoryUnarchivedAction> for RepositoryUnarchivedAction {
         value.clone()
     }
 }
-impl ToString for RepositoryUnarchivedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryUnarchivedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unarchived => "unarchived".to_string(),
+            Self::Unarchived => write!(f, "unarchived"),
         }
     }
 }
@@ -81080,11 +81086,11 @@ impl std::convert::TryFrom<String> for RepositoryUnarchivedRepositoryCreatedAt {
         value.parse()
     }
 }
-impl ToString for RepositoryUnarchivedRepositoryCreatedAt {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryUnarchivedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -81329,10 +81335,10 @@ impl From<&RepositoryVulnerabilityAlertCreateAction> for RepositoryVulnerability
         value.clone()
     }
 }
-impl ToString for RepositoryVulnerabilityAlertCreateAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryVulnerabilityAlertCreateAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Create => "create".to_string(),
+            Self::Create => write!(f, "create"),
         }
     }
 }
@@ -81591,10 +81597,10 @@ impl From<&RepositoryVulnerabilityAlertDismissAction>
         value.clone()
     }
 }
-impl ToString for RepositoryVulnerabilityAlertDismissAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryVulnerabilityAlertDismissAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismiss => "dismiss".to_string(),
+            Self::Dismiss => write!(f, "dismiss"),
         }
     }
 }
@@ -81897,10 +81903,10 @@ impl From<&RepositoryVulnerabilityAlertResolveAction>
         value.clone()
     }
 }
-impl ToString for RepositoryVulnerabilityAlertResolveAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RepositoryVulnerabilityAlertResolveAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolve => "resolve".to_string(),
+            Self::Resolve => write!(f, "resolve"),
         }
     }
 }
@@ -82131,10 +82137,10 @@ impl From<&SecretScanningAlertCreatedAction> for SecretScanningAlertCreatedActio
         value.clone()
     }
 }
-impl ToString for SecretScanningAlertCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecretScanningAlertCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -82381,10 +82387,10 @@ impl From<&SecretScanningAlertReopenedAction> for SecretScanningAlertReopenedAct
         value.clone()
     }
 }
-impl ToString for SecretScanningAlertReopenedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecretScanningAlertReopenedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => "reopened".to_string(),
+            Self::Reopened => write!(f, "reopened"),
         }
     }
 }
@@ -82590,10 +82596,10 @@ impl From<&SecretScanningAlertResolvedAction> for SecretScanningAlertResolvedAct
         value.clone()
     }
 }
-impl ToString for SecretScanningAlertResolvedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecretScanningAlertResolvedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
+            Self::Resolved => write!(f, "resolved"),
         }
     }
 }
@@ -82725,13 +82731,13 @@ impl From<&SecretScanningAlertResolvedAlertResolution>
         value.clone()
     }
 }
-impl ToString for SecretScanningAlertResolvedAlertResolution {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecretScanningAlertResolvedAlertResolution {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => "false_positive".to_string(),
-            Self::Wontfix => "wontfix".to_string(),
-            Self::Revoked => "revoked".to_string(),
-            Self::UsedInTests => "used_in_tests".to_string(),
+            Self::FalsePositive => write!(f, "false_positive"),
+            Self::Wontfix => write!(f, "wontfix"),
+            Self::Revoked => write!(f, "revoked"),
+            Self::UsedInTests => write!(f, "used_in_tests"),
         }
     }
 }
@@ -83061,10 +83067,10 @@ impl From<&SecurityAdvisoryPerformedAction> for SecurityAdvisoryPerformedAction 
         value.clone()
     }
 }
-impl ToString for SecurityAdvisoryPerformedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecurityAdvisoryPerformedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Performed => "performed".to_string(),
+            Self::Performed => write!(f, "performed"),
         }
     }
 }
@@ -83820,10 +83826,10 @@ impl From<&SecurityAdvisoryPublishedAction> for SecurityAdvisoryPublishedAction 
         value.clone()
     }
 }
-impl ToString for SecurityAdvisoryPublishedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecurityAdvisoryPublishedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => "published".to_string(),
+            Self::Published => write!(f, "published"),
         }
     }
 }
@@ -84579,10 +84585,10 @@ impl From<&SecurityAdvisoryUpdatedAction> for SecurityAdvisoryUpdatedAction {
         value.clone()
     }
 }
-impl ToString for SecurityAdvisoryUpdatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecurityAdvisoryUpdatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Updated => "updated".to_string(),
+            Self::Updated => write!(f, "updated"),
         }
     }
 }
@@ -85333,10 +85339,10 @@ impl From<&SecurityAdvisoryWithdrawnAction> for SecurityAdvisoryWithdrawnAction 
         value.clone()
     }
 }
-impl ToString for SecurityAdvisoryWithdrawnAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SecurityAdvisoryWithdrawnAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Withdrawn => "withdrawn".to_string(),
+            Self::Withdrawn => write!(f, "withdrawn"),
         }
     }
 }
@@ -86252,13 +86258,13 @@ impl From<&SimplePullRequestActiveLockReason> for SimplePullRequestActiveLockRea
         value.clone()
     }
 }
-impl ToString for SimplePullRequestActiveLockReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SimplePullRequestActiveLockReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => "resolved".to_string(),
-            Self::OffTopic => "off-topic".to_string(),
-            Self::TooHeated => "too heated".to_string(),
-            Self::Spam => "spam".to_string(),
+            Self::Resolved => write!(f, "resolved"),
+            Self::OffTopic => write!(f, "off-topic"),
+            Self::TooHeated => write!(f, "too heated"),
+            Self::Spam => write!(f, "spam"),
         }
     }
 }
@@ -86532,11 +86538,11 @@ impl From<&SimplePullRequestState> for SimplePullRequestState {
         value.clone()
     }
 }
-impl ToString for SimplePullRequestState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SimplePullRequestState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
         }
     }
 }
@@ -86675,10 +86681,10 @@ impl From<&SponsorshipCancelledAction> for SponsorshipCancelledAction {
         value.clone()
     }
 }
-impl ToString for SponsorshipCancelledAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipCancelledAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cancelled => "cancelled".to_string(),
+            Self::Cancelled => write!(f, "cancelled"),
         }
     }
 }
@@ -86870,10 +86876,10 @@ impl From<&SponsorshipCreatedAction> for SponsorshipCreatedAction {
         value.clone()
     }
 }
-impl ToString for SponsorshipCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -87086,10 +87092,10 @@ impl From<&SponsorshipEditedAction> for SponsorshipEditedAction {
         value.clone()
     }
 }
-impl ToString for SponsorshipEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -87430,10 +87436,10 @@ impl From<&SponsorshipPendingCancellationAction> for SponsorshipPendingCancellat
         value.clone()
     }
 }
-impl ToString for SponsorshipPendingCancellationAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipPendingCancellationAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingCancellation => "pending_cancellation".to_string(),
+            Self::PendingCancellation => write!(f, "pending_cancellation"),
         }
     }
 }
@@ -87657,10 +87663,10 @@ impl From<&SponsorshipPendingTierChangeAction> for SponsorshipPendingTierChangeA
         value.clone()
     }
 }
-impl ToString for SponsorshipPendingTierChangeAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipPendingTierChangeAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingTierChange => "pending_tier_change".to_string(),
+            Self::PendingTierChange => write!(f, "pending_tier_change"),
         }
     }
 }
@@ -88009,10 +88015,10 @@ impl From<&SponsorshipTierChangedAction> for SponsorshipTierChangedAction {
         value.clone()
     }
 }
-impl ToString for SponsorshipTierChangedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SponsorshipTierChangedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::TierChanged => "tier_changed".to_string(),
+            Self::TierChanged => write!(f, "tier_changed"),
         }
     }
 }
@@ -88259,10 +88265,10 @@ impl From<&StarCreatedAction> for StarCreatedAction {
         value.clone()
     }
 }
-impl ToString for StarCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StarCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -88388,10 +88394,10 @@ impl From<&StarDeletedAction> for StarDeletedAction {
         value.clone()
     }
 }
-impl ToString for StarDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StarDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -89552,22 +89558,22 @@ impl From<&StatusEventCommitCommitVerificationReason>
         value.clone()
     }
 }
-impl ToString for StatusEventCommitCommitVerificationReason {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StatusEventCommitCommitVerificationReason {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ExpiredKey => "expired_key".to_string(),
-            Self::NotSigningKey => "not_signing_key".to_string(),
-            Self::GpgverifyError => "gpgverify_error".to_string(),
-            Self::GpgverifyUnavailable => "gpgverify_unavailable".to_string(),
-            Self::Unsigned => "unsigned".to_string(),
-            Self::UnknownSignatureType => "unknown_signature_type".to_string(),
-            Self::NoUser => "no_user".to_string(),
-            Self::UnverifiedEmail => "unverified_email".to_string(),
-            Self::BadEmail => "bad_email".to_string(),
-            Self::UnknownKey => "unknown_key".to_string(),
-            Self::MalformedSignature => "malformed_signature".to_string(),
-            Self::Invalid => "invalid".to_string(),
-            Self::Valid => "valid".to_string(),
+            Self::ExpiredKey => write!(f, "expired_key"),
+            Self::NotSigningKey => write!(f, "not_signing_key"),
+            Self::GpgverifyError => write!(f, "gpgverify_error"),
+            Self::GpgverifyUnavailable => write!(f, "gpgverify_unavailable"),
+            Self::Unsigned => write!(f, "unsigned"),
+            Self::UnknownSignatureType => write!(f, "unknown_signature_type"),
+            Self::NoUser => write!(f, "no_user"),
+            Self::UnverifiedEmail => write!(f, "unverified_email"),
+            Self::BadEmail => write!(f, "bad_email"),
+            Self::UnknownKey => write!(f, "unknown_key"),
+            Self::MalformedSignature => write!(f, "malformed_signature"),
+            Self::Invalid => write!(f, "invalid"),
+            Self::Valid => write!(f, "valid"),
         }
     }
 }
@@ -89695,13 +89701,13 @@ impl From<&StatusEventState> for StatusEventState {
         value.clone()
     }
 }
-impl ToString for StatusEventState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StatusEventState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pending => "pending".to_string(),
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Error => "error".to_string(),
+            Self::Pending => write!(f, "pending"),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -90057,10 +90063,10 @@ impl From<&TeamAddedToRepositoryAction> for TeamAddedToRepositoryAction {
         value.clone()
     }
 }
-impl ToString for TeamAddedToRepositoryAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamAddedToRepositoryAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AddedToRepository => "added_to_repository".to_string(),
+            Self::AddedToRepository => write!(f, "added_to_repository"),
         }
     }
 }
@@ -90184,10 +90190,10 @@ impl From<&TeamCreatedAction> for TeamCreatedAction {
         value.clone()
     }
 }
-impl ToString for TeamCreatedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamCreatedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => "created".to_string(),
+            Self::Created => write!(f, "created"),
         }
     }
 }
@@ -90311,10 +90317,10 @@ impl From<&TeamDeletedAction> for TeamDeletedAction {
         value.clone()
     }
 }
-impl ToString for TeamDeletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamDeletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => "deleted".to_string(),
+            Self::Deleted => write!(f, "deleted"),
         }
     }
 }
@@ -90522,10 +90528,10 @@ impl From<&TeamEditedAction> for TeamEditedAction {
         value.clone()
     }
 }
-impl ToString for TeamEditedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamEditedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => "edited".to_string(),
+            Self::Edited => write!(f, "edited"),
         }
     }
 }
@@ -91103,12 +91109,12 @@ impl From<&TeamParentPrivacy> for TeamParentPrivacy {
         value.clone()
     }
 }
-impl ToString for TeamParentPrivacy {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamParentPrivacy {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
-            Self::Secret => "secret".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
+            Self::Secret => write!(f, "secret"),
         }
     }
 }
@@ -91181,12 +91187,12 @@ impl From<&TeamPrivacy> for TeamPrivacy {
         value.clone()
     }
 }
-impl ToString for TeamPrivacy {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamPrivacy {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
-            Self::Secret => "secret".to_string(),
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
+            Self::Secret => write!(f, "secret"),
         }
     }
 }
@@ -91312,10 +91318,10 @@ impl From<&TeamRemovedFromRepositoryAction> for TeamRemovedFromRepositoryAction 
         value.clone()
     }
 }
-impl ToString for TeamRemovedFromRepositoryAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TeamRemovedFromRepositoryAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RemovedFromRepository => "removed_from_repository".to_string(),
+            Self::RemovedFromRepository => write!(f, "removed_from_repository"),
         }
     }
 }
@@ -91530,12 +91536,12 @@ impl From<&UserType> for UserType {
         value.clone()
     }
 }
-impl ToString for UserType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for UserType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => "Bot".to_string(),
-            Self::User => "User".to_string(),
-            Self::Organization => "Organization".to_string(),
+            Self::Bot => write!(f, "Bot"),
+            Self::User => write!(f, "User"),
+            Self::Organization => write!(f, "Organization"),
         }
     }
 }
@@ -91693,10 +91699,10 @@ impl From<&WatchStartedAction> for WatchStartedAction {
         value.clone()
     }
 }
-impl ToString for WatchStartedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WatchStartedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Started => "started".to_string(),
+            Self::Started => write!(f, "started"),
         }
     }
 }
@@ -91997,56 +92003,56 @@ impl From<&WebhookEventsVariant0Item> for WebhookEventsVariant0Item {
         value.clone()
     }
 }
-impl ToString for WebhookEventsVariant0Item {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WebhookEventsVariant0Item {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => "check_run".to_string(),
-            Self::CheckSuite => "check_suite".to_string(),
-            Self::CodeScanningAlert => "code_scanning_alert".to_string(),
-            Self::CommitComment => "commit_comment".to_string(),
-            Self::ContentReference => "content_reference".to_string(),
-            Self::Create => "create".to_string(),
-            Self::Delete => "delete".to_string(),
-            Self::Deployment => "deployment".to_string(),
-            Self::DeploymentReview => "deployment_review".to_string(),
-            Self::DeploymentStatus => "deployment_status".to_string(),
-            Self::DeployKey => "deploy_key".to_string(),
-            Self::Discussion => "discussion".to_string(),
-            Self::DiscussionComment => "discussion_comment".to_string(),
-            Self::Fork => "fork".to_string(),
-            Self::Gollum => "gollum".to_string(),
-            Self::Issues => "issues".to_string(),
-            Self::IssueComment => "issue_comment".to_string(),
-            Self::Label => "label".to_string(),
-            Self::Member => "member".to_string(),
-            Self::Membership => "membership".to_string(),
-            Self::Meta => "meta".to_string(),
-            Self::Milestone => "milestone".to_string(),
-            Self::Organization => "organization".to_string(),
-            Self::OrgBlock => "org_block".to_string(),
-            Self::PageBuild => "page_build".to_string(),
-            Self::Project => "project".to_string(),
-            Self::ProjectCard => "project_card".to_string(),
-            Self::ProjectColumn => "project_column".to_string(),
-            Self::Public => "public".to_string(),
-            Self::PullRequest => "pull_request".to_string(),
-            Self::PullRequestReview => "pull_request_review".to_string(),
-            Self::PullRequestReviewComment => "pull_request_review_comment".to_string(),
-            Self::Push => "push".to_string(),
-            Self::RegistryPackage => "registry_package".to_string(),
-            Self::Release => "release".to_string(),
-            Self::Repository => "repository".to_string(),
-            Self::RepositoryDispatch => "repository_dispatch".to_string(),
-            Self::RepositoryImport => "repository_import".to_string(),
-            Self::RepositoryVulnerabilityAlert => "repository_vulnerability_alert".to_string(),
-            Self::SecretScanningAlert => "secret_scanning_alert".to_string(),
-            Self::Star => "star".to_string(),
-            Self::Status => "status".to_string(),
-            Self::Team => "team".to_string(),
-            Self::TeamAdd => "team_add".to_string(),
-            Self::Watch => "watch".to_string(),
-            Self::WorkflowDispatch => "workflow_dispatch".to_string(),
-            Self::WorkflowRun => "workflow_run".to_string(),
+            Self::CheckRun => write!(f, "check_run"),
+            Self::CheckSuite => write!(f, "check_suite"),
+            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
+            Self::CommitComment => write!(f, "commit_comment"),
+            Self::ContentReference => write!(f, "content_reference"),
+            Self::Create => write!(f, "create"),
+            Self::Delete => write!(f, "delete"),
+            Self::Deployment => write!(f, "deployment"),
+            Self::DeploymentReview => write!(f, "deployment_review"),
+            Self::DeploymentStatus => write!(f, "deployment_status"),
+            Self::DeployKey => write!(f, "deploy_key"),
+            Self::Discussion => write!(f, "discussion"),
+            Self::DiscussionComment => write!(f, "discussion_comment"),
+            Self::Fork => write!(f, "fork"),
+            Self::Gollum => write!(f, "gollum"),
+            Self::Issues => write!(f, "issues"),
+            Self::IssueComment => write!(f, "issue_comment"),
+            Self::Label => write!(f, "label"),
+            Self::Member => write!(f, "member"),
+            Self::Membership => write!(f, "membership"),
+            Self::Meta => write!(f, "meta"),
+            Self::Milestone => write!(f, "milestone"),
+            Self::Organization => write!(f, "organization"),
+            Self::OrgBlock => write!(f, "org_block"),
+            Self::PageBuild => write!(f, "page_build"),
+            Self::Project => write!(f, "project"),
+            Self::ProjectCard => write!(f, "project_card"),
+            Self::ProjectColumn => write!(f, "project_column"),
+            Self::Public => write!(f, "public"),
+            Self::PullRequest => write!(f, "pull_request"),
+            Self::PullRequestReview => write!(f, "pull_request_review"),
+            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
+            Self::Push => write!(f, "push"),
+            Self::RegistryPackage => write!(f, "registry_package"),
+            Self::Release => write!(f, "release"),
+            Self::Repository => write!(f, "repository"),
+            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
+            Self::RepositoryImport => write!(f, "repository_import"),
+            Self::RepositoryVulnerabilityAlert => write!(f, "repository_vulnerability_alert"),
+            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
+            Self::Star => write!(f, "star"),
+            Self::Status => write!(f, "status"),
+            Self::Team => write!(f, "team"),
+            Self::TeamAdd => write!(f, "team_add"),
+            Self::Watch => write!(f, "watch"),
+            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
+            Self::WorkflowRun => write!(f, "workflow_run"),
         }
     }
 }
@@ -92513,10 +92519,10 @@ impl From<&WorkflowJobCompletedAction> for WorkflowJobCompletedAction {
         value.clone()
     }
 }
-impl ToString for WorkflowJobCompletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobCompletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -92640,11 +92646,11 @@ impl From<&WorkflowJobCompletedWorkflowJobConclusion>
         value.clone()
     }
 }
-impl ToString for WorkflowJobCompletedWorkflowJobConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
         }
     }
 }
@@ -92716,12 +92722,12 @@ impl From<&WorkflowJobCompletedWorkflowJobStatus> for WorkflowJobCompletedWorkfl
         value.clone()
     }
 }
-impl ToString for WorkflowJobCompletedWorkflowJobStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -92791,11 +92797,11 @@ impl From<&WorkflowJobConclusion> for WorkflowJobConclusion {
         value.clone()
     }
 }
-impl ToString for WorkflowJobConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
         }
     }
 }
@@ -93046,10 +93052,10 @@ impl From<&WorkflowJobQueuedAction> for WorkflowJobQueuedAction {
         value.clone()
     }
 }
-impl ToString for WorkflowJobQueuedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobQueuedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -93227,10 +93233,10 @@ impl From<&WorkflowJobQueuedWorkflowJobStatus> for WorkflowJobQueuedWorkflowJobS
         value.clone()
     }
 }
-impl ToString for WorkflowJobQueuedWorkflowJobStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobQueuedWorkflowJobStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -93383,10 +93389,10 @@ impl From<&WorkflowJobStartedAction> for WorkflowJobStartedAction {
         value.clone()
     }
 }
-impl ToString for WorkflowJobStartedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobStartedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Started => "started".to_string(),
+            Self::Started => write!(f, "started"),
         }
     }
 }
@@ -93570,12 +93576,12 @@ impl From<&WorkflowJobStartedWorkflowJobStatus> for WorkflowJobStartedWorkflowJo
         value.clone()
     }
 }
-impl ToString for WorkflowJobStartedWorkflowJobStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobStartedWorkflowJobStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -93648,12 +93654,12 @@ impl From<&WorkflowJobStatus> for WorkflowJobStatus {
         value.clone()
     }
 }
-impl ToString for WorkflowJobStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowJobStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => "queued".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
+            Self::Queued => write!(f, "queued"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -94063,10 +94069,10 @@ impl From<&WorkflowRunCompletedAction> for WorkflowRunCompletedAction {
         value.clone()
     }
 }
-impl ToString for WorkflowRunCompletedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunCompletedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -94222,16 +94228,16 @@ impl From<&WorkflowRunCompletedWorkflowRunConclusion>
         value.clone()
     }
 }
-impl ToString for WorkflowRunCompletedWorkflowRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -94481,13 +94487,13 @@ impl From<&WorkflowRunCompletedWorkflowRunStatus> for WorkflowRunCompletedWorkfl
         value.clone()
     }
 }
-impl ToString for WorkflowRunCompletedWorkflowRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::Requested => write!(f, "requested"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -94573,16 +94579,16 @@ impl From<&WorkflowRunConclusion> for WorkflowRunConclusion {
         value.clone()
     }
 }
-impl ToString for WorkflowRunConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
-            Self::Failure => "failure".to_string(),
-            Self::Neutral => "neutral".to_string(),
-            Self::Cancelled => "cancelled".to_string(),
-            Self::TimedOut => "timed_out".to_string(),
-            Self::ActionRequired => "action_required".to_string(),
-            Self::Stale => "stale".to_string(),
+            Self::Success => write!(f, "success"),
+            Self::Failure => write!(f, "failure"),
+            Self::Neutral => write!(f, "neutral"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+            Self::ActionRequired => write!(f, "action_required"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }
@@ -94919,10 +94925,10 @@ impl From<&WorkflowRunRequestedAction> for WorkflowRunRequestedAction {
         value.clone()
     }
 }
-impl ToString for WorkflowRunRequestedAction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunRequestedAction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
+            Self::Requested => write!(f, "requested"),
         }
     }
 }
@@ -94996,13 +95002,13 @@ impl From<&WorkflowRunStatus> for WorkflowRunStatus {
         value.clone()
     }
 }
-impl ToString for WorkflowRunStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowRunStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => "requested".to_string(),
-            Self::InProgress => "in_progress".to_string(),
-            Self::Completed => "completed".to_string(),
-            Self::Queued => "queued".to_string(),
+            Self::Requested => write!(f, "requested"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Queued => write!(f, "queued"),
         }
     }
 }
@@ -95181,12 +95187,12 @@ impl From<&WorkflowStepCompletedConclusion> for WorkflowStepCompletedConclusion 
         value.clone()
     }
 }
-impl ToString for WorkflowStepCompletedConclusion {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowStepCompletedConclusion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Failure => "failure".to_string(),
-            Self::Skipped => "skipped".to_string(),
-            Self::Success => "success".to_string(),
+            Self::Failure => write!(f, "failure"),
+            Self::Skipped => write!(f, "skipped"),
+            Self::Success => write!(f, "success"),
         }
     }
 }
@@ -95253,10 +95259,10 @@ impl From<&WorkflowStepCompletedStatus> for WorkflowStepCompletedStatus {
         value.clone()
     }
 }
-impl ToString for WorkflowStepCompletedStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowStepCompletedStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => "completed".to_string(),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }
@@ -95380,10 +95386,10 @@ impl From<&WorkflowStepInProgressStatus> for WorkflowStepInProgressStatus {
         value.clone()
     }
 }
-impl ToString for WorkflowStepInProgressStatus {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WorkflowStepInProgressStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::InProgress => "in_progress".to_string(),
+            Self::InProgress => write!(f, "in_progress"),
         }
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -886,33 +886,33 @@ impl From<&AggregateTransformOpsVariant0ItemVariant0>
         value.clone()
     }
 }
-impl ToString for AggregateTransformOpsVariant0ItemVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AggregateTransformOpsVariant0ItemVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => "values".to_string(),
-            Self::Count => "count".to_string(),
-            Self::Count => "__count__".to_string(),
-            Self::Missing => "missing".to_string(),
-            Self::Valid => "valid".to_string(),
-            Self::Sum => "sum".to_string(),
-            Self::Product => "product".to_string(),
-            Self::Mean => "mean".to_string(),
-            Self::Average => "average".to_string(),
-            Self::Variance => "variance".to_string(),
-            Self::Variancep => "variancep".to_string(),
-            Self::Stdev => "stdev".to_string(),
-            Self::Stdevp => "stdevp".to_string(),
-            Self::Stderr => "stderr".to_string(),
-            Self::Distinct => "distinct".to_string(),
-            Self::Ci0 => "ci0".to_string(),
-            Self::Ci1 => "ci1".to_string(),
-            Self::Median => "median".to_string(),
-            Self::Q1 => "q1".to_string(),
-            Self::Q3 => "q3".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Argmin => "argmin".to_string(),
-            Self::Argmax => "argmax".to_string(),
+            Self::Values => write!(f, "values"),
+            Self::Count => write!(f, "count"),
+            Self::Count => write!(f, "__count__"),
+            Self::Missing => write!(f, "missing"),
+            Self::Valid => write!(f, "valid"),
+            Self::Sum => write!(f, "sum"),
+            Self::Product => write!(f, "product"),
+            Self::Mean => write!(f, "mean"),
+            Self::Average => write!(f, "average"),
+            Self::Variance => write!(f, "variance"),
+            Self::Variancep => write!(f, "variancep"),
+            Self::Stdev => write!(f, "stdev"),
+            Self::Stdevp => write!(f, "stdevp"),
+            Self::Stderr => write!(f, "stderr"),
+            Self::Distinct => write!(f, "distinct"),
+            Self::Ci0 => write!(f, "ci0"),
+            Self::Ci1 => write!(f, "ci1"),
+            Self::Median => write!(f, "median"),
+            Self::Q1 => write!(f, "q1"),
+            Self::Q3 => write!(f, "q3"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+            Self::Argmin => write!(f, "argmin"),
+            Self::Argmax => write!(f, "argmax"),
         }
     }
 }
@@ -999,10 +999,10 @@ impl From<&AggregateTransformType> for AggregateTransformType {
         value.clone()
     }
 }
-impl ToString for AggregateTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AggregateTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Aggregate => "aggregate".to_string(),
+            Self::Aggregate => write!(f, "aggregate"),
         }
     }
 }
@@ -1544,12 +1544,12 @@ impl From<&AlignValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for AlignValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -1642,11 +1642,11 @@ impl std::convert::TryFrom<String> for AlignValueVariant0ItemVariant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for AlignValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -2177,12 +2177,12 @@ impl From<&AlignValueVariant1Variant0Variant1Value> for AlignValueVariant1Varian
         value.clone()
     }
 }
-impl ToString for AlignValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlignValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -2273,11 +2273,11 @@ impl std::convert::TryFrom<String> for AlignValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ToString for AlignValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlignValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -3032,12 +3032,12 @@ impl From<&AnchorValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for AnchorValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -3130,11 +3130,11 @@ impl std::convert::TryFrom<String> for AnchorValueVariant0ItemVariant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for AnchorValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -3665,12 +3665,12 @@ impl From<&AnchorValueVariant1Variant0Variant1Value> for AnchorValueVariant1Vari
         value.clone()
     }
 }
-impl ToString for AnchorValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -3761,11 +3761,11 @@ impl std::convert::TryFrom<String> for AnchorValueVariant1Variant0Variant3Range 
         value.parse()
     }
 }
-impl ToString for AnchorValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -4515,11 +4515,11 @@ impl std::convert::TryFrom<String> for AnyValueVariant0ItemVariant0Variant3Range
         value.parse()
     }
 }
-impl ToString for AnyValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnyValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -5045,11 +5045,11 @@ impl std::convert::TryFrom<String> for AnyValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ToString for AnyValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AnyValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -5833,11 +5833,11 @@ impl std::convert::TryFrom<String> for ArrayValueVariant0ItemVariant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for ArrayValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ArrayValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -6371,11 +6371,11 @@ impl std::convert::TryFrom<String> for ArrayValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ToString for ArrayValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ArrayValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -6738,14 +6738,14 @@ impl From<&AutosizeVariant0> for AutosizeVariant0 {
         value.clone()
     }
 }
-impl ToString for AutosizeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AutosizeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pad => "pad".to_string(),
-            Self::Fit => "fit".to_string(),
-            Self::FitX => "fit-x".to_string(),
-            Self::FitY => "fit-y".to_string(),
-            Self::None => "none".to_string(),
+            Self::Pad => write!(f, "pad"),
+            Self::Fit => write!(f, "fit"),
+            Self::FitX => write!(f, "fit-x"),
+            Self::FitY => write!(f, "fit-y"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -6816,11 +6816,11 @@ impl From<&AutosizeVariant1Contains> for AutosizeVariant1Contains {
         value.clone()
     }
 }
-impl ToString for AutosizeVariant1Contains {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AutosizeVariant1Contains {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Content => "content".to_string(),
-            Self::Padding => "padding".to_string(),
+            Self::Content => write!(f, "content"),
+            Self::Padding => write!(f, "padding"),
         }
     }
 }
@@ -6898,14 +6898,14 @@ impl From<&AutosizeVariant1Type> for AutosizeVariant1Type {
         value.clone()
     }
 }
-impl ToString for AutosizeVariant1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AutosizeVariant1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pad => "pad".to_string(),
-            Self::Fit => "fit".to_string(),
-            Self::FitX => "fit-x".to_string(),
-            Self::FitY => "fit-y".to_string(),
-            Self::None => "none".to_string(),
+            Self::Pad => write!(f, "pad"),
+            Self::Fit => write!(f, "fit"),
+            Self::FitX => write!(f, "fit-x"),
+            Self::FitY => write!(f, "fit-y"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -8610,12 +8610,12 @@ impl From<&AxisFormatTypeVariant0> for AxisFormatTypeVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisFormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisFormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -8954,12 +8954,12 @@ impl From<&AxisLabelAlignVariant0> for AxisLabelAlignVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisLabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisLabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -9123,15 +9123,15 @@ impl From<&AxisLabelBaselineVariant0> for AxisLabelBaselineVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisLabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisLabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -9853,13 +9853,13 @@ impl From<&AxisOrientVariant0> for AxisOrientVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
         }
     }
 }
@@ -10351,12 +10351,12 @@ impl From<&AxisTitleAlignVariant0> for AxisTitleAlignVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisTitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisTitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -10472,12 +10472,12 @@ impl From<&AxisTitleAnchorVariant0> for AxisTitleAnchorVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisTitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisTitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -10641,15 +10641,15 @@ impl From<&AxisTitleBaselineVariant0> for AxisTitleBaselineVariant0 {
         value.clone()
     }
 }
-impl ToString for AxisTitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AxisTitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -11704,11 +11704,11 @@ impl std::convert::TryFrom<String> for BaseColorValueVariant0Variant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for BaseColorValueVariant0Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BaseColorValueVariant0Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -12532,13 +12532,13 @@ impl From<&BaselineValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for BaselineValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
         }
     }
 }
@@ -12632,11 +12632,11 @@ impl std::convert::TryFrom<String> for BaselineValueVariant0ItemVariant0Variant3
         value.parse()
     }
 }
-impl ToString for BaselineValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -13176,13 +13176,13 @@ impl From<&BaselineValueVariant1Variant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for BaselineValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
         }
     }
 }
@@ -13276,11 +13276,11 @@ impl std::convert::TryFrom<String> for BaselineValueVariant1Variant0Variant3Rang
         value.parse()
     }
 }
-impl ToString for BaselineValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -14598,10 +14598,10 @@ impl From<&BinTransformType> for BinTransformType {
         value.clone()
     }
 }
-impl ToString for BinTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BinTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bin => "bin".to_string(),
+            Self::Bin => write!(f, "bin"),
         }
     }
 }
@@ -14872,10 +14872,10 @@ impl From<&BindVariant0Input> for BindVariant0Input {
         value.clone()
     }
 }
-impl ToString for BindVariant0Input {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BindVariant0Input {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Checkbox => "checkbox".to_string(),
+            Self::Checkbox => write!(f, "checkbox"),
         }
     }
 }
@@ -14942,11 +14942,11 @@ impl From<&BindVariant1Input> for BindVariant1Input {
         value.clone()
     }
 }
-impl ToString for BindVariant1Input {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BindVariant1Input {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Radio => "radio".to_string(),
-            Self::Select => "select".to_string(),
+            Self::Radio => write!(f, "radio"),
+            Self::Select => write!(f, "select"),
         }
     }
 }
@@ -15011,10 +15011,10 @@ impl From<&BindVariant2Input> for BindVariant2Input {
         value.clone()
     }
 }
-impl ToString for BindVariant2Input {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BindVariant2Input {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Range => "range".to_string(),
+            Self::Range => write!(f, "range"),
         }
     }
 }
@@ -15706,24 +15706,24 @@ impl From<&BlendValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for BlendValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Multiply => "multiply".to_string(),
-            Self::Screen => "screen".to_string(),
-            Self::Overlay => "overlay".to_string(),
-            Self::Darken => "darken".to_string(),
-            Self::Lighten => "lighten".to_string(),
-            Self::ColorDodge => "color-dodge".to_string(),
-            Self::ColorBurn => "color-burn".to_string(),
-            Self::HardLight => "hard-light".to_string(),
-            Self::SoftLight => "soft-light".to_string(),
-            Self::Difference => "difference".to_string(),
-            Self::Exclusion => "exclusion".to_string(),
-            Self::Hue => "hue".to_string(),
-            Self::Saturation => "saturation".to_string(),
-            Self::Color => "color".to_string(),
-            Self::Luminosity => "luminosity".to_string(),
+            Self::Multiply => write!(f, "multiply"),
+            Self::Screen => write!(f, "screen"),
+            Self::Overlay => write!(f, "overlay"),
+            Self::Darken => write!(f, "darken"),
+            Self::Lighten => write!(f, "lighten"),
+            Self::ColorDodge => write!(f, "color-dodge"),
+            Self::ColorBurn => write!(f, "color-burn"),
+            Self::HardLight => write!(f, "hard-light"),
+            Self::SoftLight => write!(f, "soft-light"),
+            Self::Difference => write!(f, "difference"),
+            Self::Exclusion => write!(f, "exclusion"),
+            Self::Hue => write!(f, "hue"),
+            Self::Saturation => write!(f, "saturation"),
+            Self::Color => write!(f, "color"),
+            Self::Luminosity => write!(f, "luminosity"),
         }
     }
 }
@@ -15828,11 +15828,11 @@ impl std::convert::TryFrom<String> for BlendValueVariant0ItemVariant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for BlendValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -16452,24 +16452,24 @@ impl From<&BlendValueVariant1Variant0Variant1Value> for BlendValueVariant1Varian
         value.clone()
     }
 }
-impl ToString for BlendValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BlendValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Multiply => "multiply".to_string(),
-            Self::Screen => "screen".to_string(),
-            Self::Overlay => "overlay".to_string(),
-            Self::Darken => "darken".to_string(),
-            Self::Lighten => "lighten".to_string(),
-            Self::ColorDodge => "color-dodge".to_string(),
-            Self::ColorBurn => "color-burn".to_string(),
-            Self::HardLight => "hard-light".to_string(),
-            Self::SoftLight => "soft-light".to_string(),
-            Self::Difference => "difference".to_string(),
-            Self::Exclusion => "exclusion".to_string(),
-            Self::Hue => "hue".to_string(),
-            Self::Saturation => "saturation".to_string(),
-            Self::Color => "color".to_string(),
-            Self::Luminosity => "luminosity".to_string(),
+            Self::Multiply => write!(f, "multiply"),
+            Self::Screen => write!(f, "screen"),
+            Self::Overlay => write!(f, "overlay"),
+            Self::Darken => write!(f, "darken"),
+            Self::Lighten => write!(f, "lighten"),
+            Self::ColorDodge => write!(f, "color-dodge"),
+            Self::ColorBurn => write!(f, "color-burn"),
+            Self::HardLight => write!(f, "hard-light"),
+            Self::SoftLight => write!(f, "soft-light"),
+            Self::Difference => write!(f, "difference"),
+            Self::Exclusion => write!(f, "exclusion"),
+            Self::Hue => write!(f, "hue"),
+            Self::Saturation => write!(f, "saturation"),
+            Self::Color => write!(f, "color"),
+            Self::Luminosity => write!(f, "luminosity"),
         }
     }
 }
@@ -16572,11 +16572,11 @@ impl std::convert::TryFrom<String> for BlendValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ToString for BlendValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BlendValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -17398,11 +17398,11 @@ impl std::convert::TryFrom<String> for BooleanValueVariant0ItemVariant0Variant3R
         value.parse()
     }
 }
-impl ToString for BooleanValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BooleanValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -17938,11 +17938,11 @@ impl std::convert::TryFrom<String> for BooleanValueVariant1Variant0Variant3Range
         value.parse()
     }
 }
-impl ToString for BooleanValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for BooleanValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -18253,10 +18253,10 @@ impl From<&CollectTransformType> for CollectTransformType {
         value.clone()
     }
 }
-impl ToString for CollectTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CollectTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Collect => "collect".to_string(),
+            Self::Collect => write!(f, "collect"),
         }
     }
 }
@@ -19201,10 +19201,10 @@ impl From<&ContourTransformType> for ContourTransformType {
         value.clone()
     }
 }
-impl ToString for ContourTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ContourTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Contour => "contour".to_string(),
+            Self::Contour => write!(f, "contour"),
         }
     }
 }
@@ -19766,12 +19766,12 @@ impl From<&CountpatternTransformCaseVariant0> for CountpatternTransformCaseVaria
         value.clone()
     }
 }
-impl ToString for CountpatternTransformCaseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CountpatternTransformCaseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Upper => "upper".to_string(),
-            Self::Lower => "lower".to_string(),
-            Self::Mixed => "mixed".to_string(),
+            Self::Upper => write!(f, "upper"),
+            Self::Lower => write!(f, "lower"),
+            Self::Mixed => write!(f, "mixed"),
         }
     }
 }
@@ -19956,10 +19956,10 @@ impl From<&CountpatternTransformType> for CountpatternTransformType {
         value.clone()
     }
 }
-impl ToString for CountpatternTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CountpatternTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Countpattern => "countpattern".to_string(),
+            Self::Countpattern => write!(f, "countpattern"),
         }
     }
 }
@@ -20188,10 +20188,10 @@ impl From<&CrossTransformType> for CrossTransformType {
         value.clone()
     }
 }
-impl ToString for CrossTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CrossTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cross => "cross".to_string(),
+            Self::Cross => write!(f, "cross"),
         }
     }
 }
@@ -20467,10 +20467,10 @@ impl From<&CrossfilterTransformType> for CrossfilterTransformType {
         value.clone()
     }
 }
-impl ToString for CrossfilterTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CrossfilterTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Crossfilter => "crossfilter".to_string(),
+            Self::Crossfilter => write!(f, "crossfilter"),
         }
     }
 }
@@ -21692,10 +21692,10 @@ impl From<&DataVariant2FormatVariant0Subtype0ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -21792,11 +21792,11 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype0ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -21858,13 +21858,13 @@ impl From<&DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -22167,10 +22167,10 @@ impl From<&DataVariant2FormatVariant0Subtype1ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -22267,11 +22267,11 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype1ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -22333,13 +22333,13 @@ impl From<&DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -22492,10 +22492,10 @@ impl From<&DataVariant2FormatVariant0Subtype1Type> for DataVariant2FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => "json".to_string(),
+            Self::Json => write!(f, "json"),
         }
     }
 }
@@ -22711,10 +22711,10 @@ impl From<&DataVariant2FormatVariant0Subtype2ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -22811,11 +22811,11 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype2ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -22877,13 +22877,13 @@ impl From<&DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -23039,11 +23039,11 @@ impl From<&DataVariant2FormatVariant0Subtype2Type> for DataVariant2FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype2Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Csv => "csv".to_string(),
-            Self::Tsv => "tsv".to_string(),
+            Self::Csv => write!(f, "csv"),
+            Self::Tsv => write!(f, "tsv"),
         }
     }
 }
@@ -23264,10 +23264,10 @@ impl From<&DataVariant2FormatVariant0Subtype3ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -23364,11 +23364,11 @@ impl std::convert::TryFrom<String> for DataVariant2FormatVariant0Subtype3ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -23430,13 +23430,13 @@ impl From<&DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -23589,10 +23589,10 @@ impl From<&DataVariant2FormatVariant0Subtype3Type> for DataVariant2FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype3Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dsv => "dsv".to_string(),
+            Self::Dsv => write!(f, "dsv"),
         }
     }
 }
@@ -23743,10 +23743,10 @@ impl From<&DataVariant2FormatVariant0Subtype4Variant0Type>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype4Variant0Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant0Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => "topojson".to_string(),
+            Self::Topojson => write!(f, "topojson"),
         }
     }
 }
@@ -23816,11 +23816,11 @@ impl From<&DataVariant2FormatVariant0Subtype4Variant1Filter>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Filter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Interior => "interior".to_string(),
-            Self::Exterior => "exterior".to_string(),
+            Self::Interior => write!(f, "interior"),
+            Self::Exterior => write!(f, "exterior"),
         }
     }
 }
@@ -23887,10 +23887,10 @@ impl From<&DataVariant2FormatVariant0Subtype4Variant1Type>
         value.clone()
     }
 }
-impl ToString for DataVariant2FormatVariant0Subtype4Variant1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => "topojson".to_string(),
+            Self::Topojson => write!(f, "topojson"),
         }
     }
 }
@@ -24382,10 +24382,10 @@ impl From<&DataVariant3FormatVariant0Subtype0ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -24482,11 +24482,11 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype0ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -24548,13 +24548,13 @@ impl From<&DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -24857,10 +24857,10 @@ impl From<&DataVariant3FormatVariant0Subtype1ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -24957,11 +24957,11 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype1ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -25023,13 +25023,13 @@ impl From<&DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -25182,10 +25182,10 @@ impl From<&DataVariant3FormatVariant0Subtype1Type> for DataVariant3FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => "json".to_string(),
+            Self::Json => write!(f, "json"),
         }
     }
 }
@@ -25401,10 +25401,10 @@ impl From<&DataVariant3FormatVariant0Subtype2ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -25501,11 +25501,11 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype2ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -25567,13 +25567,13 @@ impl From<&DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -25729,11 +25729,11 @@ impl From<&DataVariant3FormatVariant0Subtype2Type> for DataVariant3FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype2Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Csv => "csv".to_string(),
-            Self::Tsv => "tsv".to_string(),
+            Self::Csv => write!(f, "csv"),
+            Self::Tsv => write!(f, "tsv"),
         }
     }
 }
@@ -25954,10 +25954,10 @@ impl From<&DataVariant3FormatVariant0Subtype3ParseVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => "auto".to_string(),
+            Self::Auto => write!(f, "auto"),
         }
     }
 }
@@ -26054,11 +26054,11 @@ impl std::convert::TryFrom<String> for DataVariant3FormatVariant0Subtype3ParseVa
         value.parse()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -26120,13 +26120,13 @@ impl From<&DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => "boolean".to_string(),
-            Self::Number => "number".to_string(),
-            Self::Date => "date".to_string(),
-            Self::String => "string".to_string(),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Number => write!(f, "number"),
+            Self::Date => write!(f, "date"),
+            Self::String => write!(f, "string"),
         }
     }
 }
@@ -26279,10 +26279,10 @@ impl From<&DataVariant3FormatVariant0Subtype3Type> for DataVariant3FormatVariant
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype3Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dsv => "dsv".to_string(),
+            Self::Dsv => write!(f, "dsv"),
         }
     }
 }
@@ -26433,10 +26433,10 @@ impl From<&DataVariant3FormatVariant0Subtype4Variant0Type>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype4Variant0Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant0Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => "topojson".to_string(),
+            Self::Topojson => write!(f, "topojson"),
         }
     }
 }
@@ -26506,11 +26506,11 @@ impl From<&DataVariant3FormatVariant0Subtype4Variant1Filter>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Filter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Interior => "interior".to_string(),
-            Self::Exterior => "exterior".to_string(),
+            Self::Interior => write!(f, "interior"),
+            Self::Exterior => write!(f, "exterior"),
         }
     }
 }
@@ -26577,10 +26577,10 @@ impl From<&DataVariant3FormatVariant0Subtype4Variant1Type>
         value.clone()
     }
 }
-impl ToString for DataVariant3FormatVariant0Subtype4Variant1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => "topojson".to_string(),
+            Self::Topojson => write!(f, "topojson"),
         }
     }
 }
@@ -27988,10 +27988,10 @@ impl From<&DensityTransformType> for DensityTransformType {
         value.clone()
     }
 }
-impl ToString for DensityTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DensityTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Density => "density".to_string(),
+            Self::Density => write!(f, "density"),
         }
     }
 }
@@ -28526,11 +28526,11 @@ impl From<&DirectionValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for DirectionValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => "horizontal".to_string(),
-            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => write!(f, "vertical"),
         }
     }
 }
@@ -28622,11 +28622,11 @@ impl std::convert::TryFrom<String> for DirectionValueVariant0ItemVariant0Variant
         value.parse()
     }
 }
-impl ToString for DirectionValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -29152,11 +29152,11 @@ impl From<&DirectionValueVariant1Variant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for DirectionValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => "horizontal".to_string(),
-            Self::Vertical => "vertical".to_string(),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => write!(f, "vertical"),
         }
     }
 }
@@ -29248,11 +29248,11 @@ impl std::convert::TryFrom<String> for DirectionValueVariant1Variant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for DirectionValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -29901,10 +29901,10 @@ impl From<&DotbinTransformType> for DotbinTransformType {
         value.clone()
     }
 }
-impl ToString for DotbinTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DotbinTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dotbin => "dotbin".to_string(),
+            Self::Dotbin => write!(f, "dotbin"),
         }
     }
 }
@@ -29984,9 +29984,9 @@ impl std::str::FromStr for Element {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Element {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Element {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "Encode"]
@@ -30757,9 +30757,9 @@ impl std::str::FromStr for ExprString {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for ExprString {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for ExprString {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "ExtentTransform"]
@@ -30894,10 +30894,10 @@ impl From<&ExtentTransformType> for ExtentTransformType {
         value.clone()
     }
 }
-impl ToString for ExtentTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ExtentTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Extent => "extent".to_string(),
+            Self::Extent => write!(f, "extent"),
         }
     }
 }
@@ -31399,10 +31399,10 @@ impl From<&FilterTransformType> for FilterTransformType {
         value.clone()
     }
 }
-impl ToString for FilterTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FilterTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Filter => "filter".to_string(),
+            Self::Filter => write!(f, "filter"),
         }
     }
 }
@@ -31774,10 +31774,10 @@ impl From<&FlattenTransformType> for FlattenTransformType {
         value.clone()
     }
 }
-impl ToString for FlattenTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FlattenTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Flatten => "flatten".to_string(),
+            Self::Flatten => write!(f, "flatten"),
         }
     }
 }
@@ -32124,10 +32124,10 @@ impl From<&FoldTransformType> for FoldTransformType {
         value.clone()
     }
 }
-impl ToString for FoldTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FoldTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fold => "fold".to_string(),
+            Self::Fold => write!(f, "fold"),
         }
     }
 }
@@ -32768,11 +32768,11 @@ impl std::convert::TryFrom<String> for FontWeightValueVariant0ItemVariant0Varian
         value.parse()
     }
 }
-impl ToString for FontWeightValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FontWeightValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -33404,11 +33404,11 @@ impl std::convert::TryFrom<String> for FontWeightValueVariant1Variant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for FontWeightValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FontWeightValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -35359,10 +35359,10 @@ impl From<&ForceTransformType> for ForceTransformType {
         value.clone()
     }
 }
-impl ToString for ForceTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ForceTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Force => "force".to_string(),
+            Self::Force => write!(f, "force"),
         }
     }
 }
@@ -35608,10 +35608,10 @@ impl From<&FormulaTransformType> for FormulaTransformType {
         value.clone()
     }
 }
-impl ToString for FormulaTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for FormulaTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Formula => "formula".to_string(),
+            Self::Formula => write!(f, "formula"),
         }
     }
 }
@@ -35928,10 +35928,10 @@ impl From<&GeojsonTransformType> for GeojsonTransformType {
         value.clone()
     }
 }
-impl ToString for GeojsonTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GeojsonTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geojson => "geojson".to_string(),
+            Self::Geojson => write!(f, "geojson"),
         }
     }
 }
@@ -36229,10 +36229,10 @@ impl From<&GeopathTransformType> for GeopathTransformType {
         value.clone()
     }
 }
-impl ToString for GeopathTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GeopathTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geopath => "geopath".to_string(),
+            Self::Geopath => write!(f, "geopath"),
         }
     }
 }
@@ -36588,10 +36588,10 @@ impl From<&GeopointTransformType> for GeopointTransformType {
         value.clone()
     }
 }
-impl ToString for GeopointTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GeopointTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geopoint => "geopoint".to_string(),
+            Self::Geopoint => write!(f, "geopoint"),
         }
     }
 }
@@ -36898,10 +36898,10 @@ impl From<&GeoshapeTransformType> for GeoshapeTransformType {
         value.clone()
     }
 }
-impl ToString for GeoshapeTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GeoshapeTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geoshape => "geoshape".to_string(),
+            Self::Geoshape => write!(f, "geoshape"),
         }
     }
 }
@@ -37692,10 +37692,10 @@ impl From<&GraticuleTransformType> for GraticuleTransformType {
         value.clone()
     }
 }
-impl ToString for GraticuleTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for GraticuleTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Graticule => "graticule".to_string(),
+            Self::Graticule => write!(f, "graticule"),
         }
     }
 }
@@ -38162,11 +38162,11 @@ impl From<&HeatmapTransformResolveVariant0> for HeatmapTransformResolveVariant0 
         value.clone()
     }
 }
-impl ToString for HeatmapTransformResolveVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for HeatmapTransformResolveVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => "shared".to_string(),
-            Self::Independent => "independent".to_string(),
+            Self::Shared => write!(f, "shared"),
+            Self::Independent => write!(f, "independent"),
         }
     }
 }
@@ -38231,10 +38231,10 @@ impl From<&HeatmapTransformType> for HeatmapTransformType {
         value.clone()
     }
 }
-impl ToString for HeatmapTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for HeatmapTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -38381,10 +38381,10 @@ impl From<&IdentifierTransformType> for IdentifierTransformType {
         value.clone()
     }
 }
-impl ToString for IdentifierTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IdentifierTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Identifier => "identifier".to_string(),
+            Self::Identifier => write!(f, "identifier"),
         }
     }
 }
@@ -38868,14 +38868,14 @@ impl From<&ImputeTransformMethodVariant0> for ImputeTransformMethodVariant0 {
         value.clone()
     }
 }
-impl ToString for ImputeTransformMethodVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ImputeTransformMethodVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Value => "value".to_string(),
-            Self::Mean => "mean".to_string(),
-            Self::Median => "median".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Min => "min".to_string(),
+            Self::Value => write!(f, "value"),
+            Self::Mean => write!(f, "mean"),
+            Self::Median => write!(f, "median"),
+            Self::Max => write!(f, "max"),
+            Self::Min => write!(f, "min"),
         }
     }
 }
@@ -38943,10 +38943,10 @@ impl From<&ImputeTransformType> for ImputeTransformType {
         value.clone()
     }
 }
-impl ToString for ImputeTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ImputeTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Impute => "impute".to_string(),
+            Self::Impute => write!(f, "impute"),
         }
     }
 }
@@ -39428,11 +39428,11 @@ impl From<&IsocontourTransformResolveVariant0> for IsocontourTransformResolveVar
         value.clone()
     }
 }
-impl ToString for IsocontourTransformResolveVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IsocontourTransformResolveVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => "shared".to_string(),
-            Self::Independent => "independent".to_string(),
+            Self::Shared => write!(f, "shared"),
+            Self::Independent => write!(f, "independent"),
         }
     }
 }
@@ -39795,10 +39795,10 @@ impl From<&IsocontourTransformType> for IsocontourTransformType {
         value.clone()
     }
 }
-impl ToString for IsocontourTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IsocontourTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Isocontour => "isocontour".to_string(),
+            Self::Isocontour => write!(f, "isocontour"),
         }
     }
 }
@@ -40630,33 +40630,33 @@ impl From<&JoinaggregateTransformOpsVariant0ItemVariant0>
         value.clone()
     }
 }
-impl ToString for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for JoinaggregateTransformOpsVariant0ItemVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => "values".to_string(),
-            Self::Count => "count".to_string(),
-            Self::Count => "__count__".to_string(),
-            Self::Missing => "missing".to_string(),
-            Self::Valid => "valid".to_string(),
-            Self::Sum => "sum".to_string(),
-            Self::Product => "product".to_string(),
-            Self::Mean => "mean".to_string(),
-            Self::Average => "average".to_string(),
-            Self::Variance => "variance".to_string(),
-            Self::Variancep => "variancep".to_string(),
-            Self::Stdev => "stdev".to_string(),
-            Self::Stdevp => "stdevp".to_string(),
-            Self::Stderr => "stderr".to_string(),
-            Self::Distinct => "distinct".to_string(),
-            Self::Ci0 => "ci0".to_string(),
-            Self::Ci1 => "ci1".to_string(),
-            Self::Median => "median".to_string(),
-            Self::Q1 => "q1".to_string(),
-            Self::Q3 => "q3".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Argmin => "argmin".to_string(),
-            Self::Argmax => "argmax".to_string(),
+            Self::Values => write!(f, "values"),
+            Self::Count => write!(f, "count"),
+            Self::Count => write!(f, "__count__"),
+            Self::Missing => write!(f, "missing"),
+            Self::Valid => write!(f, "valid"),
+            Self::Sum => write!(f, "sum"),
+            Self::Product => write!(f, "product"),
+            Self::Mean => write!(f, "mean"),
+            Self::Average => write!(f, "average"),
+            Self::Variance => write!(f, "variance"),
+            Self::Variancep => write!(f, "variancep"),
+            Self::Stdev => write!(f, "stdev"),
+            Self::Stdevp => write!(f, "stdevp"),
+            Self::Stderr => write!(f, "stderr"),
+            Self::Distinct => write!(f, "distinct"),
+            Self::Ci0 => write!(f, "ci0"),
+            Self::Ci1 => write!(f, "ci1"),
+            Self::Median => write!(f, "median"),
+            Self::Q1 => write!(f, "q1"),
+            Self::Q3 => write!(f, "q3"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+            Self::Argmin => write!(f, "argmin"),
+            Self::Argmax => write!(f, "argmax"),
         }
     }
 }
@@ -40743,10 +40743,10 @@ impl From<&JoinaggregateTransformType> for JoinaggregateTransformType {
         value.clone()
     }
 }
-impl ToString for JoinaggregateTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for JoinaggregateTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Joinaggregate => "joinaggregate".to_string(),
+            Self::Joinaggregate => write!(f, "joinaggregate"),
         }
     }
 }
@@ -41391,10 +41391,10 @@ impl From<&Kde2dTransformType> for Kde2dTransformType {
         value.clone()
     }
 }
-impl ToString for Kde2dTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for Kde2dTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Kde2d => "kde2d".to_string(),
+            Self::Kde2d => write!(f, "kde2d"),
         }
     }
 }
@@ -42394,11 +42394,11 @@ impl From<&KdeTransformResolveVariant0> for KdeTransformResolveVariant0 {
         value.clone()
     }
 }
-impl ToString for KdeTransformResolveVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for KdeTransformResolveVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => "shared".to_string(),
-            Self::Independent => "independent".to_string(),
+            Self::Shared => write!(f, "shared"),
+            Self::Independent => write!(f, "independent"),
         }
     }
 }
@@ -42501,10 +42501,10 @@ impl From<&KdeTransformType> for KdeTransformType {
         value.clone()
     }
 }
-impl ToString for KdeTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for KdeTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Kde => "kde".to_string(),
+            Self::Kde => write!(f, "kde"),
         }
     }
 }
@@ -42621,11 +42621,11 @@ impl From<&LabelOverlapVariant1> for LabelOverlapVariant1 {
         value.clone()
     }
 }
-impl ToString for LabelOverlapVariant1 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LabelOverlapVariant1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Parity => "parity".to_string(),
-            Self::Greedy => "greedy".to_string(),
+            Self::Parity => write!(f, "parity"),
+            Self::Greedy => write!(f, "greedy"),
         }
     }
 }
@@ -43566,10 +43566,10 @@ impl From<&LabelTransformType> for LabelTransformType {
         value.clone()
     }
 }
-impl ToString for LabelTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LabelTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Label => "label".to_string(),
+            Self::Label => write!(f, "label"),
         }
     }
 }
@@ -44091,12 +44091,12 @@ impl From<&LayoutVariant0AlignVariant0Variant0> for LayoutVariant0AlignVariant0V
         value.clone()
     }
 }
-impl ToString for LayoutVariant0AlignVariant0Variant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0AlignVariant0Variant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -44212,12 +44212,12 @@ impl From<&LayoutVariant0AlignVariant1ColumnVariant0>
         value.clone()
     }
 }
-impl ToString for LayoutVariant0AlignVariant1ColumnVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0AlignVariant1ColumnVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -44331,12 +44331,12 @@ impl From<&LayoutVariant0AlignVariant1RowVariant0> for LayoutVariant0AlignVarian
         value.clone()
     }
 }
-impl ToString for LayoutVariant0AlignVariant1RowVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0AlignVariant1RowVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -44446,11 +44446,11 @@ impl From<&LayoutVariant0BoundsVariant0> for LayoutVariant0BoundsVariant0 {
         value.clone()
     }
 }
-impl ToString for LayoutVariant0BoundsVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0BoundsVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Full => "full".to_string(),
-            Self::Flush => "flush".to_string(),
+            Self::Full => write!(f, "full"),
+            Self::Flush => write!(f, "flush"),
         }
     }
 }
@@ -44940,11 +44940,11 @@ impl From<&LayoutVariant0TitleAnchorVariant0Variant0>
         value.clone()
     }
 }
-impl ToString for LayoutVariant0TitleAnchorVariant0Variant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant0Variant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -45057,11 +45057,11 @@ impl From<&LayoutVariant0TitleAnchorVariant1ColumnVariant0>
         value.clone()
     }
 }
-impl ToString for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -45172,11 +45172,11 @@ impl From<&LayoutVariant0TitleAnchorVariant1RowVariant0>
         value.clone()
     }
 }
-impl ToString for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -48322,11 +48322,11 @@ impl From<&LegendVariant0Direction> for LegendVariant0Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant0Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -48619,12 +48619,12 @@ impl From<&LegendVariant0FormatTypeVariant0> for LegendVariant0FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant0FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -48851,12 +48851,12 @@ impl From<&LegendVariant0GridAlignVariant0> for LegendVariant0GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant0GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -48970,12 +48970,12 @@ impl From<&LegendVariant0LabelAlignVariant0> for LegendVariant0LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant0LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -49101,15 +49101,15 @@ impl From<&LegendVariant0LabelBaselineVariant0> for LegendVariant0LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant0LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -49683,18 +49683,18 @@ impl From<&LegendVariant0OrientVariant0> for LegendVariant0OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant0OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -50227,12 +50227,12 @@ impl From<&LegendVariant0TitleAlignVariant0> for LegendVariant0TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant0TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -50348,12 +50348,12 @@ impl From<&LegendVariant0TitleAnchorVariant0> for LegendVariant0TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant0TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -50479,15 +50479,15 @@ impl From<&LegendVariant0TitleBaselineVariant0> for LegendVariant0TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant0TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -50925,13 +50925,13 @@ impl From<&LegendVariant0TitleOrientVariant0> for LegendVariant0TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant0TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -51039,11 +51039,11 @@ impl From<&LegendVariant0Type> for LegendVariant0Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant0Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant0Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -51149,11 +51149,11 @@ impl From<&LegendVariant1Direction> for LegendVariant1Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant1Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -51446,12 +51446,12 @@ impl From<&LegendVariant1FormatTypeVariant0> for LegendVariant1FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant1FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -51678,12 +51678,12 @@ impl From<&LegendVariant1GridAlignVariant0> for LegendVariant1GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant1GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -51797,12 +51797,12 @@ impl From<&LegendVariant1LabelAlignVariant0> for LegendVariant1LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant1LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -51928,15 +51928,15 @@ impl From<&LegendVariant1LabelBaselineVariant0> for LegendVariant1LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant1LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -52510,18 +52510,18 @@ impl From<&LegendVariant1OrientVariant0> for LegendVariant1OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant1OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -53054,12 +53054,12 @@ impl From<&LegendVariant1TitleAlignVariant0> for LegendVariant1TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant1TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -53175,12 +53175,12 @@ impl From<&LegendVariant1TitleAnchorVariant0> for LegendVariant1TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant1TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -53306,15 +53306,15 @@ impl From<&LegendVariant1TitleBaselineVariant0> for LegendVariant1TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant1TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -53752,13 +53752,13 @@ impl From<&LegendVariant1TitleOrientVariant0> for LegendVariant1TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant1TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -53866,11 +53866,11 @@ impl From<&LegendVariant1Type> for LegendVariant1Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -53976,11 +53976,11 @@ impl From<&LegendVariant2Direction> for LegendVariant2Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant2Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -54273,12 +54273,12 @@ impl From<&LegendVariant2FormatTypeVariant0> for LegendVariant2FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant2FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -54505,12 +54505,12 @@ impl From<&LegendVariant2GridAlignVariant0> for LegendVariant2GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant2GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -54624,12 +54624,12 @@ impl From<&LegendVariant2LabelAlignVariant0> for LegendVariant2LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant2LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -54755,15 +54755,15 @@ impl From<&LegendVariant2LabelBaselineVariant0> for LegendVariant2LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant2LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -55337,18 +55337,18 @@ impl From<&LegendVariant2OrientVariant0> for LegendVariant2OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant2OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -55881,12 +55881,12 @@ impl From<&LegendVariant2TitleAlignVariant0> for LegendVariant2TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant2TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -56002,12 +56002,12 @@ impl From<&LegendVariant2TitleAnchorVariant0> for LegendVariant2TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant2TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -56133,15 +56133,15 @@ impl From<&LegendVariant2TitleBaselineVariant0> for LegendVariant2TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant2TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -56579,13 +56579,13 @@ impl From<&LegendVariant2TitleOrientVariant0> for LegendVariant2TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant2TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -56693,11 +56693,11 @@ impl From<&LegendVariant2Type> for LegendVariant2Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant2Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant2Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -56803,11 +56803,11 @@ impl From<&LegendVariant3Direction> for LegendVariant3Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant3Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -57100,12 +57100,12 @@ impl From<&LegendVariant3FormatTypeVariant0> for LegendVariant3FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant3FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -57332,12 +57332,12 @@ impl From<&LegendVariant3GridAlignVariant0> for LegendVariant3GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant3GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -57451,12 +57451,12 @@ impl From<&LegendVariant3LabelAlignVariant0> for LegendVariant3LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant3LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -57582,15 +57582,15 @@ impl From<&LegendVariant3LabelBaselineVariant0> for LegendVariant3LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant3LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -58164,18 +58164,18 @@ impl From<&LegendVariant3OrientVariant0> for LegendVariant3OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant3OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -58708,12 +58708,12 @@ impl From<&LegendVariant3TitleAlignVariant0> for LegendVariant3TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant3TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -58829,12 +58829,12 @@ impl From<&LegendVariant3TitleAnchorVariant0> for LegendVariant3TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant3TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -58960,15 +58960,15 @@ impl From<&LegendVariant3TitleBaselineVariant0> for LegendVariant3TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant3TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -59406,13 +59406,13 @@ impl From<&LegendVariant3TitleOrientVariant0> for LegendVariant3TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant3TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -59520,11 +59520,11 @@ impl From<&LegendVariant3Type> for LegendVariant3Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant3Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant3Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -59630,11 +59630,11 @@ impl From<&LegendVariant4Direction> for LegendVariant4Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant4Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -59927,12 +59927,12 @@ impl From<&LegendVariant4FormatTypeVariant0> for LegendVariant4FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant4FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -60159,12 +60159,12 @@ impl From<&LegendVariant4GridAlignVariant0> for LegendVariant4GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant4GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -60278,12 +60278,12 @@ impl From<&LegendVariant4LabelAlignVariant0> for LegendVariant4LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant4LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -60409,15 +60409,15 @@ impl From<&LegendVariant4LabelBaselineVariant0> for LegendVariant4LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant4LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -60991,18 +60991,18 @@ impl From<&LegendVariant4OrientVariant0> for LegendVariant4OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant4OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -61535,12 +61535,12 @@ impl From<&LegendVariant4TitleAlignVariant0> for LegendVariant4TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant4TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -61656,12 +61656,12 @@ impl From<&LegendVariant4TitleAnchorVariant0> for LegendVariant4TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant4TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -61787,15 +61787,15 @@ impl From<&LegendVariant4TitleBaselineVariant0> for LegendVariant4TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant4TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -62233,13 +62233,13 @@ impl From<&LegendVariant4TitleOrientVariant0> for LegendVariant4TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant4TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -62347,11 +62347,11 @@ impl From<&LegendVariant4Type> for LegendVariant4Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant4Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant4Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -62457,11 +62457,11 @@ impl From<&LegendVariant5Direction> for LegendVariant5Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant5Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -62754,12 +62754,12 @@ impl From<&LegendVariant5FormatTypeVariant0> for LegendVariant5FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant5FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -62986,12 +62986,12 @@ impl From<&LegendVariant5GridAlignVariant0> for LegendVariant5GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant5GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -63105,12 +63105,12 @@ impl From<&LegendVariant5LabelAlignVariant0> for LegendVariant5LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant5LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -63236,15 +63236,15 @@ impl From<&LegendVariant5LabelBaselineVariant0> for LegendVariant5LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant5LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -63818,18 +63818,18 @@ impl From<&LegendVariant5OrientVariant0> for LegendVariant5OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant5OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -64362,12 +64362,12 @@ impl From<&LegendVariant5TitleAlignVariant0> for LegendVariant5TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant5TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -64483,12 +64483,12 @@ impl From<&LegendVariant5TitleAnchorVariant0> for LegendVariant5TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant5TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -64614,15 +64614,15 @@ impl From<&LegendVariant5TitleBaselineVariant0> for LegendVariant5TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant5TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -65060,13 +65060,13 @@ impl From<&LegendVariant5TitleOrientVariant0> for LegendVariant5TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant5TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -65174,11 +65174,11 @@ impl From<&LegendVariant5Type> for LegendVariant5Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant5Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant5Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -65284,11 +65284,11 @@ impl From<&LegendVariant6Direction> for LegendVariant6Direction {
         value.clone()
     }
 }
-impl ToString for LegendVariant6Direction {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6Direction {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => "vertical".to_string(),
-            Self::Horizontal => "horizontal".to_string(),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
         }
     }
 }
@@ -65581,12 +65581,12 @@ impl From<&LegendVariant6FormatTypeVariant0> for LegendVariant6FormatTypeVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant6FormatTypeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6FormatTypeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => "number".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Number => write!(f, "number"),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -65813,12 +65813,12 @@ impl From<&LegendVariant6GridAlignVariant0> for LegendVariant6GridAlignVariant0 
         value.clone()
     }
 }
-impl ToString for LegendVariant6GridAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6GridAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => "all".to_string(),
-            Self::Each => "each".to_string(),
-            Self::None => "none".to_string(),
+            Self::All => write!(f, "all"),
+            Self::Each => write!(f, "each"),
+            Self::None => write!(f, "none"),
         }
     }
 }
@@ -65932,12 +65932,12 @@ impl From<&LegendVariant6LabelAlignVariant0> for LegendVariant6LabelAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant6LabelAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6LabelAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -66063,15 +66063,15 @@ impl From<&LegendVariant6LabelBaselineVariant0> for LegendVariant6LabelBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant6LabelBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6LabelBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -66645,18 +66645,18 @@ impl From<&LegendVariant6OrientVariant0> for LegendVariant6OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for LegendVariant6OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::TopLeft => "top-left".to_string(),
-            Self::TopRight => "top-right".to_string(),
-            Self::BottomLeft => "bottom-left".to_string(),
-            Self::BottomRight => "bottom-right".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::TopLeft => write!(f, "top-left"),
+            Self::TopRight => write!(f, "top-right"),
+            Self::BottomLeft => write!(f, "bottom-left"),
+            Self::BottomRight => write!(f, "bottom-right"),
         }
     }
 }
@@ -67189,12 +67189,12 @@ impl From<&LegendVariant6TitleAlignVariant0> for LegendVariant6TitleAlignVariant
         value.clone()
     }
 }
-impl ToString for LegendVariant6TitleAlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6TitleAlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -67310,12 +67310,12 @@ impl From<&LegendVariant6TitleAnchorVariant0> for LegendVariant6TitleAnchorVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant6TitleAnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6TitleAnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -67441,15 +67441,15 @@ impl From<&LegendVariant6TitleBaselineVariant0> for LegendVariant6TitleBaselineV
         value.clone()
     }
 }
-impl ToString for LegendVariant6TitleBaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6TitleBaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -67887,13 +67887,13 @@ impl From<&LegendVariant6TitleOrientVariant0> for LegendVariant6TitleOrientVaria
         value.clone()
     }
 }
-impl ToString for LegendVariant6TitleOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6TitleOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -68001,11 +68001,11 @@ impl From<&LegendVariant6Type> for LegendVariant6Type {
         value.clone()
     }
 }
-impl ToString for LegendVariant6Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LegendVariant6Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => "gradient".to_string(),
-            Self::Symbol => "symbol".to_string(),
+            Self::Gradient => write!(f, "gradient"),
+            Self::Symbol => write!(f, "symbol"),
         }
     }
 }
@@ -68131,10 +68131,10 @@ impl From<&LinearGradientGradient> for LinearGradientGradient {
         value.clone()
     }
 }
-impl ToString for LinearGradientGradient {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LinearGradientGradient {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linear => "linear".to_string(),
+            Self::Linear => write!(f, "linear"),
         }
     }
 }
@@ -68446,12 +68446,12 @@ impl From<&LinkpathTransformOrientVariant0> for LinkpathTransformOrientVariant0 
         value.clone()
     }
 }
-impl ToString for LinkpathTransformOrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LinkpathTransformOrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => "horizontal".to_string(),
-            Self::Vertical => "vertical".to_string(),
-            Self::Radial => "radial".to_string(),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Radial => write!(f, "radial"),
         }
     }
 }
@@ -68579,14 +68579,14 @@ impl From<&LinkpathTransformShapeVariant0> for LinkpathTransformShapeVariant0 {
         value.clone()
     }
 }
-impl ToString for LinkpathTransformShapeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LinkpathTransformShapeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Line => "line".to_string(),
-            Self::Arc => "arc".to_string(),
-            Self::Curve => "curve".to_string(),
-            Self::Diagonal => "diagonal".to_string(),
-            Self::Orthogonal => "orthogonal".to_string(),
+            Self::Line => write!(f, "line"),
+            Self::Arc => write!(f, "arc"),
+            Self::Curve => write!(f, "curve"),
+            Self::Diagonal => write!(f, "diagonal"),
+            Self::Orthogonal => write!(f, "orthogonal"),
         }
     }
 }
@@ -68874,10 +68874,10 @@ impl From<&LinkpathTransformType> for LinkpathTransformType {
         value.clone()
     }
 }
-impl ToString for LinkpathTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LinkpathTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linkpath => "linkpath".to_string(),
+            Self::Linkpath => write!(f, "linkpath"),
         }
     }
 }
@@ -69341,10 +69341,10 @@ impl From<&LoessTransformType> for LoessTransformType {
         value.clone()
     }
 }
-impl ToString for LoessTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LoessTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Loess => "loess".to_string(),
+            Self::Loess => write!(f, "loess"),
         }
     }
 }
@@ -69860,10 +69860,10 @@ impl From<&LookupTransformType> for LookupTransformType {
         value.clone()
     }
 }
-impl ToString for LookupTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LookupTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Lookup => "lookup".to_string(),
+            Self::Lookup => write!(f, "lookup"),
         }
     }
 }
@@ -70289,10 +70289,10 @@ impl From<&MarkGroupType> for MarkGroupType {
         value.clone()
     }
 }
-impl ToString for MarkGroupType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for MarkGroupType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Group => "group".to_string(),
+            Self::Group => write!(f, "group"),
         }
     }
 }
@@ -70492,9 +70492,9 @@ impl std::str::FromStr for Marktype {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Marktype {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Marktype {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "NestTransform"]
@@ -70740,10 +70740,10 @@ impl From<&NestTransformType> for NestTransformType {
         value.clone()
     }
 }
-impl ToString for NestTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NestTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Nest => "nest".to_string(),
+            Self::Nest => write!(f, "nest"),
         }
     }
 }
@@ -70916,11 +70916,11 @@ impl std::convert::TryFrom<String> for NumberModifiersBand {
         value.parse()
     }
 }
-impl ToString for NumberModifiersBand {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberModifiersBand {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -71703,11 +71703,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant0ItemVariant0Variant0Ba
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemVariant0Variant0Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant0Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -71901,11 +71901,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant0ItemVariant0Variant1Ba
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemVariant0Variant1Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant1Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -72099,11 +72099,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant0ItemVariant0Variant2Ba
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemVariant0Variant2Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant2Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -72297,11 +72297,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant0ItemVariant0Variant3Ba
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemVariant0Variant3Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -72495,11 +72495,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant0ItemVariant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for NumberValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -73346,11 +73346,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant1Variant0Variant0Band {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Variant0Variant0Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant0Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -73540,11 +73540,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant1Variant0Variant1Band {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Variant0Variant1Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant1Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -73734,11 +73734,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant1Variant0Variant2Band {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Variant0Variant2Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant2Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -73928,11 +73928,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant1Variant0Variant3Band {
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Variant0Variant3Band {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -74122,11 +74122,11 @@ impl std::convert::TryFrom<String> for NumberValueVariant1Variant0Variant3Range 
         value.parse()
     }
 }
-impl ToString for NumberValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -75220,11 +75220,11 @@ impl std::convert::TryFrom<String> for OnTriggerItemRemove {
         value.parse()
     }
 }
-impl ToString for OnTriggerItemRemove {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OnTriggerItemRemove {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -75756,13 +75756,13 @@ impl From<&OrientValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for OrientValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -75856,11 +75856,11 @@ impl std::convert::TryFrom<String> for OrientValueVariant0ItemVariant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for OrientValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -76398,13 +76398,13 @@ impl From<&OrientValueVariant1Variant0Variant1Value> for OrientValueVariant1Vari
         value.clone()
     }
 }
-impl ToString for OrientValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrientValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -76496,11 +76496,11 @@ impl std::convert::TryFrom<String> for OrientValueVariant1Variant0Variant3Range 
         value.parse()
     }
 }
-impl ToString for OrientValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for OrientValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -77239,10 +77239,10 @@ impl From<&PackTransformType> for PackTransformType {
         value.clone()
     }
 }
-impl ToString for PackTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PackTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pack => "pack".to_string(),
+            Self::Pack => write!(f, "pack"),
         }
     }
 }
@@ -77857,10 +77857,10 @@ impl From<&PartitionTransformType> for PartitionTransformType {
         value.clone()
     }
 }
-impl ToString for PartitionTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PartitionTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Partition => "partition".to_string(),
+            Self::Partition => write!(f, "partition"),
         }
     }
 }
@@ -78307,10 +78307,10 @@ impl From<&PieTransformType> for PieTransformType {
         value.clone()
     }
 }
-impl ToString for PieTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PieTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pie => "pie".to_string(),
+            Self::Pie => write!(f, "pie"),
         }
     }
 }
@@ -78899,33 +78899,33 @@ impl From<&PivotTransformOpVariant0> for PivotTransformOpVariant0 {
         value.clone()
     }
 }
-impl ToString for PivotTransformOpVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PivotTransformOpVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => "values".to_string(),
-            Self::Count => "count".to_string(),
-            Self::Count => "__count__".to_string(),
-            Self::Missing => "missing".to_string(),
-            Self::Valid => "valid".to_string(),
-            Self::Sum => "sum".to_string(),
-            Self::Product => "product".to_string(),
-            Self::Mean => "mean".to_string(),
-            Self::Average => "average".to_string(),
-            Self::Variance => "variance".to_string(),
-            Self::Variancep => "variancep".to_string(),
-            Self::Stdev => "stdev".to_string(),
-            Self::Stdevp => "stdevp".to_string(),
-            Self::Stderr => "stderr".to_string(),
-            Self::Distinct => "distinct".to_string(),
-            Self::Ci0 => "ci0".to_string(),
-            Self::Ci1 => "ci1".to_string(),
-            Self::Median => "median".to_string(),
-            Self::Q1 => "q1".to_string(),
-            Self::Q3 => "q3".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Argmin => "argmin".to_string(),
-            Self::Argmax => "argmax".to_string(),
+            Self::Values => write!(f, "values"),
+            Self::Count => write!(f, "count"),
+            Self::Count => write!(f, "__count__"),
+            Self::Missing => write!(f, "missing"),
+            Self::Valid => write!(f, "valid"),
+            Self::Sum => write!(f, "sum"),
+            Self::Product => write!(f, "product"),
+            Self::Mean => write!(f, "mean"),
+            Self::Average => write!(f, "average"),
+            Self::Variance => write!(f, "variance"),
+            Self::Variancep => write!(f, "variancep"),
+            Self::Stdev => write!(f, "stdev"),
+            Self::Stdevp => write!(f, "stdevp"),
+            Self::Stderr => write!(f, "stderr"),
+            Self::Distinct => write!(f, "distinct"),
+            Self::Ci0 => write!(f, "ci0"),
+            Self::Ci1 => write!(f, "ci1"),
+            Self::Median => write!(f, "median"),
+            Self::Q1 => write!(f, "q1"),
+            Self::Q3 => write!(f, "q3"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+            Self::Argmin => write!(f, "argmin"),
+            Self::Argmax => write!(f, "argmax"),
         }
     }
 }
@@ -79012,10 +79012,10 @@ impl From<&PivotTransformType> for PivotTransformType {
         value.clone()
     }
 }
-impl ToString for PivotTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for PivotTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pivot => "pivot".to_string(),
+            Self::Pivot => write!(f, "pivot"),
         }
     }
 }
@@ -79399,10 +79399,10 @@ impl From<&ProjectTransformType> for ProjectTransformType {
         value.clone()
     }
 }
-impl ToString for ProjectTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ProjectTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Project => "project".to_string(),
+            Self::Project => write!(f, "project"),
         }
     }
 }
@@ -80637,10 +80637,10 @@ impl From<&QuantileTransformType> for QuantileTransformType {
         value.clone()
     }
 }
-impl ToString for QuantileTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for QuantileTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantile => "quantile".to_string(),
+            Self::Quantile => write!(f, "quantile"),
         }
     }
 }
@@ -80775,10 +80775,10 @@ impl From<&RadialGradientGradient> for RadialGradientGradient {
         value.clone()
     }
 }
-impl ToString for RadialGradientGradient {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RadialGradientGradient {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Radial => "radial".to_string(),
+            Self::Radial => write!(f, "radial"),
         }
     }
 }
@@ -81406,10 +81406,10 @@ impl From<&RegressionTransformType> for RegressionTransformType {
         value.clone()
     }
 }
-impl ToString for RegressionTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for RegressionTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Regression => "regression".to_string(),
+            Self::Regression => write!(f, "regression"),
         }
     }
 }
@@ -81657,10 +81657,10 @@ impl From<&ResolvefilterTransformType> for ResolvefilterTransformType {
         value.clone()
     }
 }
-impl ToString for ResolvefilterTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ResolvefilterTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolvefilter => "resolvefilter".to_string(),
+            Self::Resolvefilter => write!(f, "resolvefilter"),
         }
     }
 }
@@ -81843,10 +81843,10 @@ impl From<&SampleTransformType> for SampleTransformType {
         value.clone()
     }
 }
-impl ToString for SampleTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SampleTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Sample => "sample".to_string(),
+            Self::Sample => write!(f, "sample"),
         }
     }
 }
@@ -85168,10 +85168,10 @@ impl From<&ScaleDataVariant1SortVariant1Op> for ScaleDataVariant1SortVariant1Op 
         value.clone()
     }
 }
-impl ToString for ScaleDataVariant1SortVariant1Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleDataVariant1SortVariant1Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
+            Self::Count => write!(f, "count"),
         }
     }
 }
@@ -85241,12 +85241,12 @@ impl From<&ScaleDataVariant1SortVariant2Op> for ScaleDataVariant1SortVariant2Op 
         value.clone()
     }
 }
-impl ToString for ScaleDataVariant1SortVariant2Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleDataVariant1SortVariant2Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
+            Self::Count => write!(f, "count"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
         }
     }
 }
@@ -85411,12 +85411,12 @@ impl std::convert::TryFrom<String> for ScaleDataVariant2FieldsItemVariant1Item {
         value.parse()
     }
 }
-impl ToString for ScaleDataVariant2FieldsItemVariant1Item {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleDataVariant2FieldsItemVariant1Item {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-            Self::Variant2(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+            Self::Variant2(x) => x.fmt(f),
         }
     }
 }
@@ -85541,10 +85541,10 @@ impl From<&ScaleDataVariant2SortVariant1Op> for ScaleDataVariant2SortVariant1Op 
         value.clone()
     }
 }
-impl ToString for ScaleDataVariant2SortVariant1Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleDataVariant2SortVariant1Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
+            Self::Count => write!(f, "count"),
         }
     }
 }
@@ -85614,12 +85614,12 @@ impl From<&ScaleDataVariant2SortVariant2Op> for ScaleDataVariant2SortVariant2Op 
         value.clone()
     }
 }
-impl ToString for ScaleDataVariant2SortVariant2Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleDataVariant2SortVariant2Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
+            Self::Count => write!(f, "count"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
         }
     }
 }
@@ -85953,10 +85953,10 @@ impl From<&ScaleVariant0Type> for ScaleVariant0Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant0Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant0Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Identity => "identity".to_string(),
+            Self::Identity => write!(f, "identity"),
         }
     }
 }
@@ -86407,17 +86407,17 @@ impl From<&ScaleVariant10RangeVariant0> for ScaleVariant10RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant10RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant10RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -86687,10 +86687,10 @@ impl From<&ScaleVariant10Type> for ScaleVariant10Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant10Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant10Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pow => "pow".to_string(),
+            Self::Pow => write!(f, "pow"),
         }
     }
 }
@@ -87141,17 +87141,17 @@ impl From<&ScaleVariant11RangeVariant0> for ScaleVariant11RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant11RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant11RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -87421,10 +87421,10 @@ impl From<&ScaleVariant11Type> for ScaleVariant11Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant11Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant11Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Symlog => "symlog".to_string(),
+            Self::Symlog => write!(f, "symlog"),
         }
     }
 }
@@ -88036,17 +88036,17 @@ impl From<&ScaleVariant1RangeVariant0> for ScaleVariant1RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant1RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -88681,10 +88681,10 @@ impl From<&ScaleVariant1RangeVariant3Variant1SortVariant1Op>
         value.clone()
     }
 }
-impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
+            Self::Count => write!(f, "count"),
         }
     }
 }
@@ -88756,12 +88756,12 @@ impl From<&ScaleVariant1RangeVariant3Variant1SortVariant2Op>
         value.clone()
     }
 }
-impl ToString for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
+            Self::Count => write!(f, "count"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
         }
     }
 }
@@ -88932,12 +88932,12 @@ impl std::convert::TryFrom<String> for ScaleVariant1RangeVariant3Variant2FieldsI
         value.parse()
     }
 }
-impl ToString for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
-            Self::Variant2(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+            Self::Variant2(x) => x.fmt(f),
         }
     }
 }
@@ -89064,10 +89064,10 @@ impl From<&ScaleVariant1RangeVariant3Variant2SortVariant1Op>
         value.clone()
     }
 }
-impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
+            Self::Count => write!(f, "count"),
         }
     }
 }
@@ -89139,12 +89139,12 @@ impl From<&ScaleVariant1RangeVariant3Variant2SortVariant2Op>
         value.clone()
     }
 }
-impl ToString for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => "count".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
+            Self::Count => write!(f, "count"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
         }
     }
 }
@@ -89210,10 +89210,10 @@ impl From<&ScaleVariant1Type> for ScaleVariant1Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant1Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant1Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Ordinal => "ordinal".to_string(),
+            Self::Ordinal => write!(f, "ordinal"),
         }
     }
 }
@@ -89573,17 +89573,17 @@ impl From<&ScaleVariant2RangeVariant0> for ScaleVariant2RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant2RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant2RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -89721,10 +89721,10 @@ impl From<&ScaleVariant2Type> for ScaleVariant2Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant2Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant2Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Band => "band".to_string(),
+            Self::Band => write!(f, "band"),
         }
     }
 }
@@ -90084,17 +90084,17 @@ impl From<&ScaleVariant3RangeVariant0> for ScaleVariant3RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant3RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant3RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -90232,10 +90232,10 @@ impl From<&ScaleVariant3Type> for ScaleVariant3Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant3Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant3Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Point => "point".to_string(),
+            Self::Point => write!(f, "point"),
         }
     }
 }
@@ -90686,17 +90686,17 @@ impl From<&ScaleVariant4RangeVariant0> for ScaleVariant4RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant4RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant4RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -90967,11 +90967,11 @@ impl From<&ScaleVariant4Type> for ScaleVariant4Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant4Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant4Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantize => "quantize".to_string(),
-            Self::Threshold => "threshold".to_string(),
+            Self::Quantize => write!(f, "quantize"),
+            Self::Threshold => write!(f, "threshold"),
         }
     }
 }
@@ -91376,17 +91376,17 @@ impl From<&ScaleVariant5RangeVariant0> for ScaleVariant5RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant5RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant5RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -91654,10 +91654,10 @@ impl From<&ScaleVariant5Type> for ScaleVariant5Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant5Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant5Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantile => "quantile".to_string(),
+            Self::Quantile => write!(f, "quantile"),
         }
     }
 }
@@ -92061,17 +92061,17 @@ impl From<&ScaleVariant6RangeVariant0> for ScaleVariant6RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant6RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant6RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -92339,10 +92339,10 @@ impl From<&ScaleVariant6Type> for ScaleVariant6Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant6Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant6Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::BinOrdinal => "bin-ordinal".to_string(),
+            Self::BinOrdinal => write!(f, "bin-ordinal"),
         }
     }
 }
@@ -92691,17 +92691,17 @@ impl From<&ScaleVariant7NiceVariant1> for ScaleVariant7NiceVariant1 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant7NiceVariant1 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant7NiceVariant1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => "millisecond".to_string(),
-            Self::Second => "second".to_string(),
-            Self::Minute => "minute".to_string(),
-            Self::Hour => "hour".to_string(),
-            Self::Day => "day".to_string(),
-            Self::Week => "week".to_string(),
-            Self::Month => "month".to_string(),
-            Self::Year => "year".to_string(),
+            Self::Millisecond => write!(f, "millisecond"),
+            Self::Second => write!(f, "second"),
+            Self::Minute => write!(f, "minute"),
+            Self::Hour => write!(f, "hour"),
+            Self::Day => write!(f, "day"),
+            Self::Week => write!(f, "week"),
+            Self::Month => write!(f, "month"),
+            Self::Year => write!(f, "year"),
         }
     }
 }
@@ -92842,17 +92842,17 @@ impl From<&ScaleVariant7NiceVariant2IntervalVariant0>
         value.clone()
     }
 }
-impl ToString for ScaleVariant7NiceVariant2IntervalVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant7NiceVariant2IntervalVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => "millisecond".to_string(),
-            Self::Second => "second".to_string(),
-            Self::Minute => "minute".to_string(),
-            Self::Hour => "hour".to_string(),
-            Self::Day => "day".to_string(),
-            Self::Week => "week".to_string(),
-            Self::Month => "month".to_string(),
-            Self::Year => "year".to_string(),
+            Self::Millisecond => write!(f, "millisecond"),
+            Self::Second => write!(f, "second"),
+            Self::Minute => write!(f, "minute"),
+            Self::Hour => write!(f, "hour"),
+            Self::Day => write!(f, "day"),
+            Self::Week => write!(f, "week"),
+            Self::Month => write!(f, "month"),
+            Self::Year => write!(f, "year"),
         }
     }
 }
@@ -93082,17 +93082,17 @@ impl From<&ScaleVariant7RangeVariant0> for ScaleVariant7RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant7RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant7RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -93363,11 +93363,11 @@ impl From<&ScaleVariant7Type> for ScaleVariant7Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant7Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant7Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Time => "time".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Time => write!(f, "time"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -93819,17 +93819,17 @@ impl From<&ScaleVariant8RangeVariant0> for ScaleVariant8RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant8RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant8RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -94103,12 +94103,12 @@ impl From<&ScaleVariant8Type> for ScaleVariant8Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant8Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant8Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linear => "linear".to_string(),
-            Self::Sqrt => "sqrt".to_string(),
-            Self::Sequential => "sequential".to_string(),
+            Self::Linear => write!(f, "linear"),
+            Self::Sqrt => write!(f, "sqrt"),
+            Self::Sequential => write!(f, "sequential"),
         }
     }
 }
@@ -94561,17 +94561,17 @@ impl From<&ScaleVariant9RangeVariant0> for ScaleVariant9RangeVariant0 {
         value.clone()
     }
 }
-impl ToString for ScaleVariant9RangeVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant9RangeVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => "width".to_string(),
-            Self::Height => "height".to_string(),
-            Self::Symbol => "symbol".to_string(),
-            Self::Category => "category".to_string(),
-            Self::Ordinal => "ordinal".to_string(),
-            Self::Ramp => "ramp".to_string(),
-            Self::Diverging => "diverging".to_string(),
-            Self::Heatmap => "heatmap".to_string(),
+            Self::Width => write!(f, "width"),
+            Self::Height => write!(f, "height"),
+            Self::Symbol => write!(f, "symbol"),
+            Self::Category => write!(f, "category"),
+            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ramp => write!(f, "ramp"),
+            Self::Diverging => write!(f, "diverging"),
+            Self::Heatmap => write!(f, "heatmap"),
         }
     }
 }
@@ -94839,10 +94839,10 @@ impl From<&ScaleVariant9Type> for ScaleVariant9Type {
         value.clone()
     }
 }
-impl ToString for ScaleVariant9Type {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ScaleVariant9Type {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Log => "log".to_string(),
+            Self::Log => write!(f, "log"),
         }
     }
 }
@@ -95063,9 +95063,9 @@ impl std::str::FromStr for Selector {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Selector {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Selector {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "SequenceTransform"]
@@ -95347,10 +95347,10 @@ impl From<&SequenceTransformType> for SequenceTransformType {
         value.clone()
     }
 }
-impl ToString for SequenceTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SequenceTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Sequence => "sequence".to_string(),
+            Self::Sequence => write!(f, "sequence"),
         }
     }
 }
@@ -95637,10 +95637,10 @@ impl From<&SignalVariant0Push> for SignalVariant0Push {
         value.clone()
     }
 }
-impl ToString for SignalVariant0Push {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SignalVariant0Push {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Outer => "outer".to_string(),
+            Self::Outer => write!(f, "outer"),
         }
     }
 }
@@ -95748,11 +95748,11 @@ impl From<&SortOrderVariant0> for SortOrderVariant0 {
         value.clone()
     }
 }
-impl ToString for SortOrderVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for SortOrderVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Ascending => "ascending".to_string(),
-            Self::Descending => "descending".to_string(),
+            Self::Ascending => write!(f, "ascending"),
+            Self::Descending => write!(f, "descending"),
         }
     }
 }
@@ -96238,12 +96238,12 @@ impl From<&StackTransformOffsetVariant0> for StackTransformOffsetVariant0 {
         value.clone()
     }
 }
-impl ToString for StackTransformOffsetVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StackTransformOffsetVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Zero => "zero".to_string(),
-            Self::Center => "center".to_string(),
-            Self::Normalize => "normalize".to_string(),
+            Self::Zero => write!(f, "zero"),
+            Self::Center => write!(f, "center"),
+            Self::Normalize => write!(f, "normalize"),
         }
     }
 }
@@ -96309,10 +96309,10 @@ impl From<&StackTransformType> for StackTransformType {
         value.clone()
     }
 }
-impl ToString for StackTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StackTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Stack => "stack".to_string(),
+            Self::Stack => write!(f, "stack"),
         }
     }
 }
@@ -96538,10 +96538,10 @@ impl From<&StratifyTransformType> for StratifyTransformType {
         value.clone()
     }
 }
-impl ToString for StratifyTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StratifyTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Stratify => "stratify".to_string(),
+            Self::Stratify => write!(f, "stratify"),
         }
     }
 }
@@ -97430,11 +97430,11 @@ impl std::convert::TryFrom<String> for StringValueVariant0ItemVariant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for StringValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StringValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -97968,11 +97968,11 @@ impl std::convert::TryFrom<String> for StringValueVariant1Variant0Variant3Range 
         value.parse()
     }
 }
-impl ToString for StringValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StringValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -98719,12 +98719,12 @@ impl From<&StrokeCapValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for StrokeCapValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Butt => "butt".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Square => "square".to_string(),
+            Self::Butt => write!(f, "butt"),
+            Self::Round => write!(f, "round"),
+            Self::Square => write!(f, "square"),
         }
     }
 }
@@ -98817,11 +98817,11 @@ impl std::convert::TryFrom<String> for StrokeCapValueVariant0ItemVariant0Variant
         value.parse()
     }
 }
-impl ToString for StrokeCapValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -99354,12 +99354,12 @@ impl From<&StrokeCapValueVariant1Variant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for StrokeCapValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Butt => "butt".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Square => "square".to_string(),
+            Self::Butt => write!(f, "butt"),
+            Self::Round => write!(f, "round"),
+            Self::Square => write!(f, "square"),
         }
     }
 }
@@ -99452,11 +99452,11 @@ impl std::convert::TryFrom<String> for StrokeCapValueVariant1Variant0Variant3Ran
         value.parse()
     }
 }
-impl ToString for StrokeCapValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -100211,12 +100211,12 @@ impl From<&StrokeJoinValueVariant0ItemVariant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for StrokeJoinValueVariant0ItemVariant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Miter => "miter".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Bevel => "bevel".to_string(),
+            Self::Miter => write!(f, "miter"),
+            Self::Round => write!(f, "round"),
+            Self::Bevel => write!(f, "bevel"),
         }
     }
 }
@@ -100309,11 +100309,11 @@ impl std::convert::TryFrom<String> for StrokeJoinValueVariant0ItemVariant0Varian
         value.parse()
     }
 }
-impl ToString for StrokeJoinValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -100846,12 +100846,12 @@ impl From<&StrokeJoinValueVariant1Variant0Variant1Value>
         value.clone()
     }
 }
-impl ToString for StrokeJoinValueVariant1Variant0Variant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Miter => "miter".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Bevel => "bevel".to_string(),
+            Self::Miter => write!(f, "miter"),
+            Self::Round => write!(f, "round"),
+            Self::Bevel => write!(f, "bevel"),
         }
     }
 }
@@ -100944,11 +100944,11 @@ impl std::convert::TryFrom<String> for StrokeJoinValueVariant1Variant0Variant3Ra
         value.parse()
     }
 }
-impl ToString for StrokeJoinValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -101904,11 +101904,11 @@ impl std::convert::TryFrom<String> for TextValueVariant0ItemVariant0Variant3Rang
         value.parse()
     }
 }
-impl ToString for TextValueVariant0ItemVariant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TextValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -102518,11 +102518,11 @@ impl std::convert::TryFrom<String> for TextValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ToString for TextValueVariant1Variant0Variant3Range {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TextValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -102855,11 +102855,11 @@ impl From<&TickBandVariant0> for TickBandVariant0 {
         value.clone()
     }
 }
-impl ToString for TickBandVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TickBandVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Center => "center".to_string(),
-            Self::Extent => "extent".to_string(),
+            Self::Center => write!(f, "center"),
+            Self::Extent => write!(f, "extent"),
         }
     }
 }
@@ -103037,17 +103037,17 @@ impl From<&TickCountVariant1> for TickCountVariant1 {
         value.clone()
     }
 }
-impl ToString for TickCountVariant1 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TickCountVariant1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => "millisecond".to_string(),
-            Self::Second => "second".to_string(),
-            Self::Minute => "minute".to_string(),
-            Self::Hour => "hour".to_string(),
-            Self::Day => "day".to_string(),
-            Self::Week => "week".to_string(),
-            Self::Month => "month".to_string(),
-            Self::Year => "year".to_string(),
+            Self::Millisecond => write!(f, "millisecond"),
+            Self::Second => write!(f, "second"),
+            Self::Minute => write!(f, "minute"),
+            Self::Hour => write!(f, "hour"),
+            Self::Day => write!(f, "day"),
+            Self::Week => write!(f, "week"),
+            Self::Month => write!(f, "month"),
+            Self::Year => write!(f, "year"),
         }
     }
 }
@@ -103186,17 +103186,17 @@ impl From<&TickCountVariant2IntervalVariant0> for TickCountVariant2IntervalVaria
         value.clone()
     }
 }
-impl ToString for TickCountVariant2IntervalVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TickCountVariant2IntervalVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => "millisecond".to_string(),
-            Self::Second => "second".to_string(),
-            Self::Minute => "minute".to_string(),
-            Self::Hour => "hour".to_string(),
-            Self::Day => "day".to_string(),
-            Self::Week => "week".to_string(),
-            Self::Month => "month".to_string(),
-            Self::Year => "year".to_string(),
+            Self::Millisecond => write!(f, "millisecond"),
+            Self::Second => write!(f, "second"),
+            Self::Minute => write!(f, "minute"),
+            Self::Hour => write!(f, "hour"),
+            Self::Day => write!(f, "day"),
+            Self::Week => write!(f, "week"),
+            Self::Month => write!(f, "month"),
+            Self::Year => write!(f, "year"),
         }
     }
 }
@@ -103868,11 +103868,11 @@ impl From<&TimeunitTransformTimezoneVariant0> for TimeunitTransformTimezoneVaria
         value.clone()
     }
 }
-impl ToString for TimeunitTransformTimezoneVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TimeunitTransformTimezoneVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Local => "local".to_string(),
-            Self::Utc => "utc".to_string(),
+            Self::Local => write!(f, "local"),
+            Self::Utc => write!(f, "utc"),
         }
     }
 }
@@ -103937,10 +103937,10 @@ impl From<&TimeunitTransformType> for TimeunitTransformType {
         value.clone()
     }
 }
-impl ToString for TimeunitTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TimeunitTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Timeunit => "timeunit".to_string(),
+            Self::Timeunit => write!(f, "timeunit"),
         }
     }
 }
@@ -104146,20 +104146,20 @@ impl From<&TimeunitTransformUnitsVariant0ItemVariant0>
         value.clone()
     }
 }
-impl ToString for TimeunitTransformUnitsVariant0ItemVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TimeunitTransformUnitsVariant0ItemVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Year => "year".to_string(),
-            Self::Quarter => "quarter".to_string(),
-            Self::Month => "month".to_string(),
-            Self::Week => "week".to_string(),
-            Self::Date => "date".to_string(),
-            Self::Day => "day".to_string(),
-            Self::Dayofyear => "dayofyear".to_string(),
-            Self::Hours => "hours".to_string(),
-            Self::Minutes => "minutes".to_string(),
-            Self::Seconds => "seconds".to_string(),
-            Self::Milliseconds => "milliseconds".to_string(),
+            Self::Year => write!(f, "year"),
+            Self::Quarter => write!(f, "quarter"),
+            Self::Month => write!(f, "month"),
+            Self::Week => write!(f, "week"),
+            Self::Date => write!(f, "date"),
+            Self::Day => write!(f, "day"),
+            Self::Dayofyear => write!(f, "dayofyear"),
+            Self::Hours => write!(f, "hours"),
+            Self::Minutes => write!(f, "minutes"),
+            Self::Seconds => write!(f, "seconds"),
+            Self::Milliseconds => write!(f, "milliseconds"),
         }
     }
 }
@@ -104763,12 +104763,12 @@ impl From<&TitleVariant1AlignVariant0> for TitleVariant1AlignVariant0 {
         value.clone()
     }
 }
-impl ToString for TitleVariant1AlignVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TitleVariant1AlignVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Center => "center".to_string(),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Center => write!(f, "center"),
         }
     }
 }
@@ -104884,12 +104884,12 @@ impl From<&TitleVariant1AnchorVariant0> for TitleVariant1AnchorVariant0 {
         value.clone()
     }
 }
-impl ToString for TitleVariant1AnchorVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TitleVariant1AnchorVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }
@@ -105053,15 +105053,15 @@ impl From<&TitleVariant1BaselineVariant0> for TitleVariant1BaselineVariant0 {
         value.clone()
     }
 }
-impl ToString for TitleVariant1BaselineVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TitleVariant1BaselineVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => "top".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::Bottom => "bottom".to_string(),
-            Self::Alphabetic => "alphabetic".to_string(),
-            Self::LineTop => "line-top".to_string(),
-            Self::LineBottom => "line-bottom".to_string(),
+            Self::Top => write!(f, "top"),
+            Self::Middle => write!(f, "middle"),
+            Self::Bottom => write!(f, "bottom"),
+            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::LineTop => write!(f, "line-top"),
+            Self::LineBottom => write!(f, "line-bottom"),
         }
     }
 }
@@ -105609,11 +105609,11 @@ impl From<&TitleVariant1FrameVariant0> for TitleVariant1FrameVariant0 {
         value.clone()
     }
 }
-impl ToString for TitleVariant1FrameVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TitleVariant1FrameVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Group => "group".to_string(),
-            Self::Bounds => "bounds".to_string(),
+            Self::Group => write!(f, "group"),
+            Self::Bounds => write!(f, "bounds"),
         }
     }
 }
@@ -105850,14 +105850,14 @@ impl From<&TitleVariant1OrientVariant0> for TitleVariant1OrientVariant0 {
         value.clone()
     }
 }
-impl ToString for TitleVariant1OrientVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TitleVariant1OrientVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => "none".to_string(),
-            Self::Left => "left".to_string(),
-            Self::Right => "right".to_string(),
-            Self::Top => "top".to_string(),
-            Self::Bottom => "bottom".to_string(),
+            Self::None => write!(f, "none"),
+            Self::Left => write!(f, "left"),
+            Self::Right => write!(f, "right"),
+            Self::Top => write!(f, "top"),
+            Self::Bottom => write!(f, "bottom"),
         }
     }
 }
@@ -107295,11 +107295,11 @@ impl From<&TreeTransformMethodVariant0> for TreeTransformMethodVariant0 {
         value.clone()
     }
 }
-impl ToString for TreeTransformMethodVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TreeTransformMethodVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tidy => "tidy".to_string(),
-            Self::Cluster => "cluster".to_string(),
+            Self::Tidy => write!(f, "tidy"),
+            Self::Cluster => write!(f, "cluster"),
         }
     }
 }
@@ -107584,10 +107584,10 @@ impl From<&TreeTransformType> for TreeTransformType {
         value.clone()
     }
 }
-impl ToString for TreeTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TreeTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tree => "tree".to_string(),
+            Self::Tree => write!(f, "tree"),
         }
     }
 }
@@ -107688,10 +107688,10 @@ impl From<&TreelinksTransformType> for TreelinksTransformType {
         value.clone()
     }
 }
-impl ToString for TreelinksTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TreelinksTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Treelinks => "treelinks".to_string(),
+            Self::Treelinks => write!(f, "treelinks"),
         }
     }
 }
@@ -108237,15 +108237,15 @@ impl From<&TreemapTransformMethodVariant0> for TreemapTransformMethodVariant0 {
         value.clone()
     }
 }
-impl ToString for TreemapTransformMethodVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TreemapTransformMethodVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Squarify => "squarify".to_string(),
-            Self::Resquarify => "resquarify".to_string(),
-            Self::Binary => "binary".to_string(),
-            Self::Dice => "dice".to_string(),
-            Self::Slice => "slice".to_string(),
-            Self::Slicedice => "slicedice".to_string(),
+            Self::Squarify => write!(f, "squarify"),
+            Self::Resquarify => write!(f, "resquarify"),
+            Self::Binary => write!(f, "binary"),
+            Self::Dice => write!(f, "dice"),
+            Self::Slice => write!(f, "slice"),
+            Self::Slicedice => write!(f, "slicedice"),
         }
     }
 }
@@ -108750,10 +108750,10 @@ impl From<&TreemapTransformType> for TreemapTransformType {
         value.clone()
     }
 }
-impl ToString for TreemapTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TreemapTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Treemap => "treemap".to_string(),
+            Self::Treemap => write!(f, "treemap"),
         }
     }
 }
@@ -109132,10 +109132,10 @@ impl From<&VoronoiTransformType> for VoronoiTransformType {
         value.clone()
     }
 }
-impl ToString for VoronoiTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for VoronoiTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Voronoi => "voronoi".to_string(),
+            Self::Voronoi => write!(f, "voronoi"),
         }
     }
 }
@@ -110251,46 +110251,46 @@ impl From<&WindowTransformOpsVariant0ItemVariant0> for WindowTransformOpsVariant
         value.clone()
     }
 }
-impl ToString for WindowTransformOpsVariant0ItemVariant0 {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WindowTransformOpsVariant0ItemVariant0 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RowNumber => "row_number".to_string(),
-            Self::Rank => "rank".to_string(),
-            Self::DenseRank => "dense_rank".to_string(),
-            Self::PercentRank => "percent_rank".to_string(),
-            Self::CumeDist => "cume_dist".to_string(),
-            Self::Ntile => "ntile".to_string(),
-            Self::Lag => "lag".to_string(),
-            Self::Lead => "lead".to_string(),
-            Self::FirstValue => "first_value".to_string(),
-            Self::LastValue => "last_value".to_string(),
-            Self::NthValue => "nth_value".to_string(),
-            Self::PrevValue => "prev_value".to_string(),
-            Self::NextValue => "next_value".to_string(),
-            Self::Values => "values".to_string(),
-            Self::Count => "count".to_string(),
-            Self::Count => "__count__".to_string(),
-            Self::Missing => "missing".to_string(),
-            Self::Valid => "valid".to_string(),
-            Self::Sum => "sum".to_string(),
-            Self::Product => "product".to_string(),
-            Self::Mean => "mean".to_string(),
-            Self::Average => "average".to_string(),
-            Self::Variance => "variance".to_string(),
-            Self::Variancep => "variancep".to_string(),
-            Self::Stdev => "stdev".to_string(),
-            Self::Stdevp => "stdevp".to_string(),
-            Self::Stderr => "stderr".to_string(),
-            Self::Distinct => "distinct".to_string(),
-            Self::Ci0 => "ci0".to_string(),
-            Self::Ci1 => "ci1".to_string(),
-            Self::Median => "median".to_string(),
-            Self::Q1 => "q1".to_string(),
-            Self::Q3 => "q3".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Argmin => "argmin".to_string(),
-            Self::Argmax => "argmax".to_string(),
+            Self::RowNumber => write!(f, "row_number"),
+            Self::Rank => write!(f, "rank"),
+            Self::DenseRank => write!(f, "dense_rank"),
+            Self::PercentRank => write!(f, "percent_rank"),
+            Self::CumeDist => write!(f, "cume_dist"),
+            Self::Ntile => write!(f, "ntile"),
+            Self::Lag => write!(f, "lag"),
+            Self::Lead => write!(f, "lead"),
+            Self::FirstValue => write!(f, "first_value"),
+            Self::LastValue => write!(f, "last_value"),
+            Self::NthValue => write!(f, "nth_value"),
+            Self::PrevValue => write!(f, "prev_value"),
+            Self::NextValue => write!(f, "next_value"),
+            Self::Values => write!(f, "values"),
+            Self::Count => write!(f, "count"),
+            Self::Count => write!(f, "__count__"),
+            Self::Missing => write!(f, "missing"),
+            Self::Valid => write!(f, "valid"),
+            Self::Sum => write!(f, "sum"),
+            Self::Product => write!(f, "product"),
+            Self::Mean => write!(f, "mean"),
+            Self::Average => write!(f, "average"),
+            Self::Variance => write!(f, "variance"),
+            Self::Variancep => write!(f, "variancep"),
+            Self::Stdev => write!(f, "stdev"),
+            Self::Stdevp => write!(f, "stdevp"),
+            Self::Stderr => write!(f, "stderr"),
+            Self::Distinct => write!(f, "distinct"),
+            Self::Ci0 => write!(f, "ci0"),
+            Self::Ci1 => write!(f, "ci1"),
+            Self::Median => write!(f, "median"),
+            Self::Q1 => write!(f, "q1"),
+            Self::Q3 => write!(f, "q3"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+            Self::Argmin => write!(f, "argmin"),
+            Self::Argmax => write!(f, "argmax"),
         }
     }
 }
@@ -110483,10 +110483,10 @@ impl From<&WindowTransformType> for WindowTransformType {
         value.clone()
     }
 }
-impl ToString for WindowTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WindowTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Window => "window".to_string(),
+            Self::Window => write!(f, "window"),
         }
     }
 }
@@ -111546,10 +111546,10 @@ impl From<&WordcloudTransformType> for WordcloudTransformType {
         value.clone()
     }
 }
-impl ToString for WordcloudTransformType {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for WordcloudTransformType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Wordcloud => "wordcloud".to_string(),
+            Self::Wordcloud => write!(f, "wordcloud"),
         }
     }
 }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -95,11 +95,11 @@ impl From<&LetterBoxLetter> for LetterBoxLetter {
         value.clone()
     }
 }
-impl ToString for LetterBoxLetter {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for LetterBoxLetter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => "a".to_string(),
-            Self::B => "b".to_string(),
+            Self::A => write!(f, "a"),
+            Self::B => write!(f, "b"),
         }
     }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -93,11 +93,11 @@ impl std::convert::TryFrom<String> for IdOrName {
         value.parse()
     }
 }
-impl ToString for IdOrName {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IdOrName {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Id(x) => x.to_string(),
-            Self::Name(x) => x.to_string(),
+            Self::Id(x) => x.fmt(f),
+            Self::Name(x) => x.fmt(f),
         }
     }
 }
@@ -172,11 +172,11 @@ impl std::convert::TryFrom<String> for IdOrNameRedundant {
         value.parse()
     }
 }
-impl ToString for IdOrNameRedundant {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IdOrNameRedundant {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.to_string(),
-            Self::Variant1(x) => x.to_string(),
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
         }
     }
 }
@@ -260,11 +260,11 @@ impl std::convert::TryFrom<String> for IdOrYolo {
         value.parse()
     }
 }
-impl ToString for IdOrYolo {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IdOrYolo {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Id(x) => x.to_string(),
-            Self::Yolo(x) => x.to_string(),
+            Self::Id(x) => x.fmt(f),
+            Self::Yolo(x) => x.fmt(f),
         }
     }
 }

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -109,9 +109,9 @@ impl std::str::FromStr for Eh {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Eh {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Eh {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "MapWithDateKeys"]
@@ -290,9 +290,9 @@ impl std::str::FromStr for Value {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Value {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 fn main() {}

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -301,10 +301,10 @@ impl From<&JsonSuccessBaseResult> for JsonSuccessBaseResult {
         value.clone()
     }
 }
-impl ToString for JsonSuccessBaseResult {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for JsonSuccessBaseResult {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
+            Self::Success => write!(f, "success"),
         }
     }
 }
@@ -369,10 +369,10 @@ impl From<&JsonSuccessResult> for JsonSuccessResult {
         value.clone()
     }
 }
-impl ToString for JsonSuccessResult {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for JsonSuccessResult {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => "success".to_string(),
+            Self::Success => write!(f, "success"),
         }
     }
 }
@@ -467,9 +467,9 @@ impl std::convert::TryFrom<String> for NarrowNumber {
         value.parse()
     }
 }
-impl ToString for NarrowNumber {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for NarrowNumber {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "OrderDependentMerge"]
@@ -928,10 +928,10 @@ impl From<&Unsatisfiable3B> for Unsatisfiable3B {
         value.clone()
     }
 }
-impl ToString for Unsatisfiable3B {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for Unsatisfiable3B {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bar => "bar".to_string(),
+            Self::Bar => write!(f, "bar"),
         }
     }
 }
@@ -996,10 +996,10 @@ impl From<&Unsatisfiable3C> for Unsatisfiable3C {
         value.clone()
     }
 }
-impl ToString for Unsatisfiable3C {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for Unsatisfiable3C {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Foo => "foo".to_string(),
+            Self::Foo => write!(f, "foo"),
         }
     }
 }

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -78,11 +78,11 @@ impl std::convert::TryFrom<String> for IntOrStr {
         value.parse()
     }
 }
-impl ToString for IntOrStr {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IntOrStr {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::String(x) => x.to_string(),
-            Self::Integer(x) => x.to_string(),
+            Self::String(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -133,9 +133,9 @@ impl std::convert::TryFrom<String> for IntegerBs {
         value.parse()
     }
 }
-impl ToString for IntegerBs {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for IntegerBs {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "ObjectBs"]

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -123,9 +123,9 @@ impl std::str::FromStr for JustOne {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for JustOne {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for JustOne {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 fn main() {}

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -65,12 +65,12 @@ impl From<&TestEnum> for TestEnum {
         value.clone()
     }
 }
-impl ToString for TestEnum {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TestEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Failure => "failure".to_string(),
-            Self::Skipped => "skipped".to_string(),
-            Self::Success => "success".to_string(),
+            Self::Failure => write!(f, "failure"),
+            Self::Skipped => write!(f, "skipped"),
+            Self::Success => write!(f, "success"),
         }
     }
 }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -98,12 +98,12 @@ impl From<&TestTypeValue> for TestTypeValue {
         value.clone()
     }
 }
-impl ToString for TestTypeValue {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for TestTypeValue {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => "start".to_string(),
-            Self::Middle => "middle".to_string(),
-            Self::End => "end".to_string(),
+            Self::Start => write!(f, "start"),
+            Self::Middle => write!(f, "middle"),
+            Self::End => write!(f, "end"),
         }
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -62,12 +62,12 @@ impl From<&AlternativeEnum> for AlternativeEnum {
         value.clone()
     }
 }
-impl ToString for AlternativeEnum {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for AlternativeEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Choice1 => "Choice1".to_string(),
-            Self::Choice2 => "Choice2".to_string(),
-            Self::Choice3 => "Choice3".to_string(),
+            Self::Choice1 => write!(f, "Choice1"),
+            Self::Choice2 => write!(f, "Choice2"),
+            Self::Choice3 => write!(f, "Choice3"),
         }
     }
 }
@@ -157,12 +157,12 @@ impl From<&CommentedVariants> for CommentedVariants {
         value.clone()
     }
 }
-impl ToString for CommentedVariants {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for CommentedVariants {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => "A".to_string(),
-            Self::B => "B".to_string(),
-            Self::C => "C".to_string(),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::C => write!(f, "C"),
         }
     }
 }
@@ -271,12 +271,12 @@ impl From<&DiskAttachmentState> for DiskAttachmentState {
         value.clone()
     }
 }
-impl ToString for DiskAttachmentState {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for DiskAttachmentState {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Detached => "Detached".to_string(),
-            Self::Destroyed => "Destroyed".to_string(),
-            Self::Faulted => "Faulted".to_string(),
+            Self::Detached => write!(f, "Detached"),
+            Self::Destroyed => write!(f, "Destroyed"),
+            Self::Faulted => write!(f, "Faulted"),
         }
     }
 }
@@ -557,11 +557,11 @@ impl std::convert::TryFrom<String> for IpNet {
         value.parse()
     }
 }
-impl ToString for IpNet {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for IpNet {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::V4(x) => x.to_string(),
-            Self::V6(x) => x.to_string(),
+            Self::V4(x) => x.fmt(f),
+            Self::V6(x) => x.fmt(f),
         }
     }
 }
@@ -624,9 +624,9 @@ impl std::str::FromStr for Ipv4Net {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Ipv4Net {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Ipv4Net {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "Ipv6Net"]
@@ -678,9 +678,9 @@ impl std::str::FromStr for Ipv6Net {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for Ipv6Net {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for Ipv6Net {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "JankNames"]
@@ -874,12 +874,12 @@ impl From<&NullStringEnumWithUnknownFormatInner> for NullStringEnumWithUnknownFo
         value.clone()
     }
 }
-impl ToString for NullStringEnumWithUnknownFormatInner {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for NullStringEnumWithUnknownFormatInner {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => "a".to_string(),
-            Self::B => "b".to_string(),
-            Self::C => "c".to_string(),
+            Self::A => write!(f, "a"),
+            Self::B => write!(f, "b"),
+            Self::C => write!(f, "c"),
         }
     }
 }
@@ -1010,9 +1010,9 @@ impl std::str::FromStr for ReferenceDef {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for ReferenceDef {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for ReferenceDef {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = "issue 280"]
@@ -1126,11 +1126,11 @@ impl std::convert::TryFrom<String> for ReferencesVariant1Value {
         value.parse()
     }
 }
-impl ToString for ReferencesVariant1Value {
-    fn to_string(&self) -> String {
+impl ::std::fmt::Display for ReferencesVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::StringVersion(x) => x.to_string(),
-            Self::ReferenceDef(x) => x.to_string(),
+            Self::StringVersion(x) => x.fmt(f),
+            Self::ReferenceDef(x) => x.fmt(f),
         }
     }
 }
@@ -1234,9 +1234,9 @@ impl std::str::FromStr for StringVersion {
         Ok(Self(value.to_string()))
     }
 }
-impl ToString for StringVersion {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl ::std::fmt::Display for StringVersion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 fn main() {}


### PR DESCRIPTION
I've been getting clippy warnings in my project that includes generated cargo-typify code due to the ToString impl so I decided to make a quick PR to fix it. I noticed #198 is the relevant issue. If you'd rather implement this slightly differently I'm more than happy to make substantial changes, this was just a quickly thrown together fix.

### Description

Updated the 3 places where ToString impls were generated (in `type_entry.rs`) and replaced them with an equivalent Display impl. ToString is implemented for all types that implement Display and for this reason the docs recommend not to implement ToString directly [0] and is actually linted against by clippy in the default groups [1].

The snapshots were updated by running `EXPECTORATE=overwrite cargo test --workspace` and then afterwards I did a brief manual verification that the generated results seemed sensible.

Updated the README for `cargo-typify` to switch out the ToString impl for the Display version. Since the output in the README is a simplified version of the real output (the real output has a lot more fields and noise), I manually added the Display impl in the style of the rest of the example (nb. the Display impl does correctly appear in the real output).

0: https://doc.rust-lang.org/std/string/trait.ToString.html
1: https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_trait_impl

