### PR TITLE
Mark newtype wrappers as `#[serde(transparent)]`

### DIFF
--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -43,6 +43,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Fruit(pub ::std::collections::HashMap<::std::string::String, ::std::string::String>);
 impl ::std::ops::Deref for Fruit {
     type Target = ::std::collections::HashMap<::std::string::String, ::std::string::String>;

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -43,6 +43,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Fruit(pub ::std::collections::BTreeMap<::std::string::String, ::std::string::String>);
 impl ::std::ops::Deref for Fruit {
     type Target = ::std::collections::BTreeMap<::std::string::String, ::std::string::String>;

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -43,6 +43,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, ExtraDerive)]
+#[serde(transparent)]
 pub struct Fruit(pub ::std::collections::HashMap<::std::string::String, ::std::string::String>);
 impl ::std::ops::Deref for Fruit {
     type Target = ::std::collections::HashMap<::std::string::String, ::std::string::String>;

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -45,6 +45,7 @@ pub mod error {
 #[derive(
     :: serde :: Deserialize, :: serde :: Serialize, AnotherDerive, Clone, Debug, ExtraDerive,
 )]
+#[serde(transparent)]
 pub struct Fruit(pub ::std::collections::HashMap<::std::string::String, ::std::string::String>);
 impl ::std::ops::Deref for Fruit {
     type Target = ::std::collections::HashMap<::std::string::String, ::std::string::String>;

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -43,6 +43,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Fruit(pub ::std::collections::HashMap<::std::string::String, ::std::string::String>);
 impl ::std::ops::Deref for Fruit {
     type Target = ::std::collections::HashMap<::std::string::String, ::std::string::String>;

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1538,6 +1538,7 @@ impl TypeEntry {
             #doc
             #[derive(#(#derives),*)]
             #serde
+            #[serde(transparent)]
             pub struct #type_name(#vis #inner_type_name);
 
             impl ::std::ops::Deref for #type_name {

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1232,7 +1232,7 @@ impl TypeEntry {
     ) {
         let TypeEntryNewtype {
             name,
-            rename,
+            rename: _,
             description,
             default,
             type_id,
@@ -1240,12 +1240,6 @@ impl TypeEntry {
             schema: SchemaWrapper(schema),
         } = newtype_details;
         let doc = make_doc(name, description.as_ref(), schema);
-
-        let serde = rename.as_ref().map(|old_name| {
-            quote! {
-                #[serde(rename = #old_name)]
-            }
-        });
 
         let type_name = format_ident!("{}", name);
         let inner_type = type_space.id_to_entry.get(type_id).unwrap();
@@ -1537,7 +1531,6 @@ impl TypeEntry {
         let item = quote! {
             #doc
             #[derive(#(#derives),*)]
-            #serde
             #[serde(transparent)]
             pub struct #type_name(#vis #inner_type_name);
 

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -19227,6 +19227,7 @@ impl From<&CommitCommentCreatedComment> for CommitCommentCreatedComment {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct CommitCommentEvent(pub CommitCommentCreated);
 impl ::std::ops::Deref for CommitCommentEvent {
     type Target = CommitCommentCreated;
@@ -19569,6 +19570,7 @@ impl From<&ContentReferenceCreatedContentReference> for ContentReferenceCreatedC
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct ContentReferenceEvent(pub ContentReferenceCreated);
 impl ::std::ops::Deref for ContentReferenceEvent {
     type Target = ContentReferenceCreated;
@@ -20774,6 +20776,7 @@ impl From<&DeploymentCreatedDeploymentPayload> for DeploymentCreatedDeploymentPa
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct DeploymentEvent(pub DeploymentCreated);
 impl ::std::ops::Deref for DeploymentEvent {
     type Target = DeploymentCreated;
@@ -21340,6 +21343,7 @@ impl From<&DeploymentStatusCreatedDeploymentStatus> for DeploymentStatusCreatedD
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct DeploymentStatusEvent(pub DeploymentStatusCreated);
 impl ::std::ops::Deref for DeploymentStatusEvent {
     type Target = DeploymentStatusCreated;
@@ -27736,6 +27740,7 @@ impl From<chrono::DateTime<chrono::offset::Utc>> for ForkEventForkeePushedAt {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct GithubAppAuthorizationEvent(pub GithubAppAuthorizationRevoked);
 impl ::std::ops::Deref for GithubAppAuthorizationEvent {
     type Target = GithubAppAuthorizationRevoked;
@@ -50033,6 +50038,7 @@ impl From<&IssuesUnlockedIssue> for IssuesUnlockedIssue {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct IssuesUnlockedIssueActiveLockReason(());
 impl ::std::ops::Deref for IssuesUnlockedIssueActiveLockReason {
     type Target = ();
@@ -55851,6 +55857,7 @@ impl std::convert::TryFrom<::std::string::String> for MetaDeletedHookConfigConte
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MetaEvent(pub MetaDeleted);
 impl ::std::ops::Deref for MetaEvent {
     type Target = MetaDeleted;
@@ -68681,6 +68688,7 @@ impl From<&PullRequestOpenedPullRequest> for PullRequestOpenedPullRequest {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct PullRequestOpenedPullRequestActiveLockReason(());
 impl ::std::ops::Deref for PullRequestOpenedPullRequestActiveLockReason {
     type Target = ();
@@ -80247,6 +80255,7 @@ impl std::convert::TryFrom<::std::string::String> for RepositoryDeletedAction {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct RepositoryDispatchEvent(pub RepositoryDispatchOnDemandTest);
 impl ::std::ops::Deref for RepositoryDispatchEvent {
     type Target = RepositoryDispatchOnDemandTest;
@@ -93850,6 +93859,7 @@ impl std::convert::TryFrom<::std::string::String> for UserType {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct WatchEvent(pub WatchStarted);
 impl ::std::ops::Deref for WatchEvent {
     type Target = WatchStarted;
@@ -95798,6 +95808,7 @@ impl From<&WorkflowJobStartedWorkflowJob> for WorkflowJobStartedWorkflowJob {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct WorkflowJobStartedWorkflowJobConclusion(());
 impl ::std::ops::Deref for WorkflowJobStartedWorkflowJobConclusion {
     type Target = ();

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -11353,6 +11353,7 @@ impl From<NumberValue> for AxisTranslate {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Background(pub StringOrSignal);
 impl ::std::ops::Deref for Background {
     type Target = StringOrSignal;
@@ -15295,6 +15296,7 @@ impl std::convert::TryFrom<::std::string::String> for BindVariant2Input {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct BindVariant3Input(::std::string::String);
 impl ::std::ops::Deref for BindVariant3Input {
     type Target = ::std::string::String;
@@ -22264,6 +22266,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -22775,6 +22778,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -23355,6 +23359,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -23944,6 +23949,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -25146,6 +25152,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -25657,6 +25664,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -26237,6 +26245,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -26826,6 +26835,7 @@ impl std::convert::TryFrom<::std::string::String>
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1(::std::string::String);
 impl ::std::ops::Deref for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
     type Target = ::std::string::String;
@@ -30670,6 +30680,7 @@ impl std::convert::TryFrom<::std::string::String> for DotbinTransformType {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Element(pub ::std::string::String);
 impl ::std::ops::Deref for Element {
     type Target = ::std::string::String;
@@ -30720,6 +30731,7 @@ impl ::std::fmt::Display for Element {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Encode(pub ::std::collections::HashMap<EncodeKey, EncodeEntry>);
 impl ::std::ops::Deref for Encode {
     type Target = ::std::collections::HashMap<EncodeKey, EncodeEntry>;
@@ -31236,6 +31248,7 @@ impl From<&EncodeEntry> for EncodeEntry {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct EncodeKey(::std::string::String);
 impl ::std::ops::Deref for EncodeKey {
     type Target = ::std::string::String;
@@ -31491,6 +31504,7 @@ impl From<&Expr> for Expr {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct ExprString(pub ::std::string::String);
 impl ::std::ops::Deref for ExprString {
     type Target = ::std::string::String;
@@ -37787,6 +37801,7 @@ impl std::convert::TryFrom<::std::string::String> for GeoshapeTransformType {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct GradientStops(pub ::std::vec::Vec<GradientStopsItem>);
 impl ::std::ops::Deref for GradientStops {
     type Target = ::std::vec::Vec<GradientStopsItem>;
@@ -71994,6 +72009,7 @@ impl From<BooleanOrSignal> for Markclip {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Marktype(pub ::std::string::String);
 impl ::std::ops::Deref for Marktype {
     type Target = ::std::string::String;
@@ -76238,6 +76254,7 @@ impl From<::std::boxed::Box<NumberValue>> for NumberValueVariant1Variant3Offset 
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct OnEvents(pub ::std::vec::Vec<OnEventsItem>);
 impl ::std::ops::Deref for OnEvents {
     type Target = ::std::vec::Vec<OnEventsItem>;
@@ -76553,6 +76570,7 @@ impl From<SignalRef> for OnEventsItemVariant1Update {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct OnMarkTrigger(pub ::std::vec::Vec<OnMarkTriggerItem>);
 impl ::std::ops::Deref for OnMarkTrigger {
     type Target = ::std::vec::Vec<OnMarkTriggerItem>;
@@ -76659,6 +76677,7 @@ impl From<&OnMarkTriggerItem> for OnMarkTriggerItem {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct OnTrigger(pub ::std::vec::Vec<OnTriggerItem>);
 impl ::std::ops::Deref for OnTrigger {
     type Target = ::std::vec::Vec<OnTriggerItem>;
@@ -87552,6 +87571,7 @@ impl std::convert::TryFrom<::std::string::String> for ScaleDataVariant2SortVaria
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct ScaleField(pub StringOrSignal);
 impl ::std::ops::Deref for ScaleField {
     type Target = StringOrSignal;
@@ -97083,6 +97103,7 @@ impl From<MarkVisual> for ScopeMarksItem {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Selector(pub ::std::string::String);
 impl ::std::ops::Deref for Selector {
     type Target = ::std::string::String;
@@ -97586,6 +97607,7 @@ impl From<&Signal> for Signal {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct SignalName(::std::string::String);
 impl ::std::ops::Deref for SignalName {
     type Target = ::std::string::String;
@@ -107467,6 +107489,7 @@ impl From<&TitleVariant1Encode> for TitleVariant1Encode {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct TitleVariant1EncodeSubtype0Key(::std::string::String);
 impl ::std::ops::Deref for TitleVariant1EncodeSubtype0Key {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -38,6 +38,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct ArraySansItems(pub Vec<::serde_json::Value>);
 impl ::std::ops::Deref for ArraySansItems {
     type Target = Vec<::serde_json::Value>;
@@ -84,6 +85,7 @@ impl From<Vec<::serde_json::Value>> for ArraySansItems {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct LessSimpleTwoTuple(pub (::std::string::String, ::std::string::String));
 impl ::std::ops::Deref for LessSimpleTwoTuple {
     type Target = (::std::string::String, ::std::string::String);
@@ -122,6 +124,7 @@ impl From<(::std::string::String, ::std::string::String)> for LessSimpleTwoTuple
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct SimpleTwoArray(pub [::std::string::String; 2usize]);
 impl ::std::ops::Deref for SimpleTwoArray {
     type Target = [::std::string::String; 2usize];
@@ -165,6 +168,7 @@ impl From<[::std::string::String; 2usize]> for SimpleTwoArray {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct SimpleTwoTuple(pub (::std::string::String, ::std::string::String));
 impl ::std::ops::Deref for SimpleTwoTuple {
     type Target = (::std::string::String, ::std::string::String);
@@ -208,6 +212,7 @@ impl From<(::std::string::String, ::std::string::String)> for SimpleTwoTuple {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct UnsimpleTwoTuple(pub (::std::string::String, ::std::string::String));
 impl ::std::ops::Deref for UnsimpleTwoTuple {
     type Target = (::std::string::String, ::std::string::String);
@@ -247,6 +252,7 @@ impl From<(::std::string::String, ::std::string::String)> for UnsimpleTwoTuple {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct YoloTwoArray(pub [::serde_json::Value; 2usize]);
 impl ::std::ops::Deref for YoloTwoArray {
     type Target = [::serde_json::Value; 2usize];

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -92,6 +92,7 @@ impl TestType {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct TestTypeWhereNot(::std::string::String);
 impl ::std::ops::Deref for TestTypeWhereNot {
     type Target = ::std::string::String;
@@ -146,6 +147,7 @@ impl<'de> ::serde::Deserialize<'de> for TestTypeWhereNot {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct TestTypeWhyNot(::std::string::String);
 impl ::std::ops::Deref for TestTypeWhyNot {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -303,6 +303,7 @@ impl From<IdOrYoloYolo> for IdOrYolo {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct IdOrYoloYolo(::std::string::String);
 impl ::std::ops::Deref for IdOrYoloYolo {
     type Target = ::std::string::String;
@@ -378,6 +379,7 @@ impl<'de> ::serde::Deserialize<'de> for IdOrYoloYolo {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct Name(::std::string::String);
 impl ::std::ops::Deref for Name {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -38,6 +38,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct DeadSimple(pub ::serde_json::Map<::std::string::String, ::serde_json::Value>);
 impl ::std::ops::Deref for DeadSimple {
     type Target = ::serde_json::Map<::std::string::String, ::serde_json::Value>;
@@ -82,6 +83,7 @@ impl From<::serde_json::Map<::std::string::String, ::serde_json::Value>> for Dea
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Eh(pub ::std::string::String);
 impl ::std::ops::Deref for Eh {
     type Target = ::std::string::String;
@@ -133,6 +135,7 @@ impl ::std::fmt::Display for Eh {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithDateKeys(pub ::std::collections::HashMap<chrono::naive::NaiveDate, Value>);
 impl ::std::ops::Deref for MapWithDateKeys {
     type Target = ::std::collections::HashMap<chrono::naive::NaiveDate, Value>;
@@ -173,6 +176,7 @@ impl From<::std::collections::HashMap<chrono::naive::NaiveDate, Value>> for MapW
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithDateTimeKeys(
     pub ::std::collections::HashMap<chrono::DateTime<chrono::offset::Utc>, Value>,
 );
@@ -220,6 +224,7 @@ impl From<::std::collections::HashMap<chrono::DateTime<chrono::offset::Utc>, Val
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithKeys(pub ::std::collections::HashMap<Eh, Value>);
 impl ::std::ops::Deref for MapWithKeys {
     type Target = ::std::collections::HashMap<Eh, Value>;
@@ -263,6 +268,7 @@ impl From<::std::collections::HashMap<Eh, Value>> for MapWithKeys {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Value(pub ::std::string::String);
 impl ::std::ops::Deref for Value {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/maps_custom.rs
+++ b/typify/tests/schemas/maps_custom.rs
@@ -38,6 +38,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct DeadSimple(pub ::serde_json::Map<::std::string::String, ::serde_json::Value>);
 impl ::std::ops::Deref for DeadSimple {
     type Target = ::serde_json::Map<::std::string::String, ::serde_json::Value>;
@@ -82,6 +83,7 @@ impl From<::serde_json::Map<::std::string::String, ::serde_json::Value>> for Dea
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Eh(pub ::std::string::String);
 impl ::std::ops::Deref for Eh {
     type Target = ::std::string::String;
@@ -133,6 +135,7 @@ impl ::std::fmt::Display for Eh {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithDateKeys(pub std::collections::BTreeMap<chrono::naive::NaiveDate, Value>);
 impl ::std::ops::Deref for MapWithDateKeys {
     type Target = std::collections::BTreeMap<chrono::naive::NaiveDate, Value>;
@@ -173,6 +176,7 @@ impl From<std::collections::BTreeMap<chrono::naive::NaiveDate, Value>> for MapWi
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithDateTimeKeys(
     pub std::collections::BTreeMap<chrono::DateTime<chrono::offset::Utc>, Value>,
 );
@@ -220,6 +224,7 @@ impl From<std::collections::BTreeMap<chrono::DateTime<chrono::offset::Utc>, Valu
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct MapWithKeys(pub std::collections::BTreeMap<Eh, Value>);
 impl ::std::ops::Deref for MapWithKeys {
     type Target = std::collections::BTreeMap<Eh, Value>;
@@ -263,6 +268,7 @@ impl From<std::collections::BTreeMap<Eh, Value>> for MapWithKeys {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Value(pub ::std::string::String);
 impl ::std::ops::Deref for Value {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -515,6 +515,7 @@ impl MergeEmpty {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct NarrowNumber(pub std::num::NonZeroU64);
 impl ::std::ops::Deref for NarrowNumber {
     type Target = std::num::NonZeroU64;

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -165,6 +165,7 @@ impl From<i64> for OneOfSeveral {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct ReallyJustNull(pub ());
 impl ::std::ops::Deref for ReallyJustNull {
     type Target = ();
@@ -206,6 +207,7 @@ impl From<()> for ReallyJustNull {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct SeriouslyAnything(pub ::serde_json::Value);
 impl ::std::ops::Deref for SeriouslyAnything {
     type Target = ::serde_json::Value;

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -47,6 +47,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct ArrayBs(pub ::std::vec::Vec<bool>);
 impl ::std::ops::Deref for ArrayBs {
     type Target = ::std::vec::Vec<bool>;
@@ -88,6 +89,7 @@ impl From<::std::vec::Vec<bool>> for ArrayBs {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct IntegerBs(pub u64);
 impl ::std::ops::Deref for IntegerBs {
     type Target = u64;

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -79,6 +79,7 @@ impl TestGrammarForPatternProperties {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct TestGrammarForPatternPropertiesRulesKey(::std::string::String);
 impl ::std::ops::Deref for TestGrammarForPatternPropertiesRulesKey {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -1469,6 +1469,7 @@ impl std::convert::TryFrom<::std::string::String> for StringEnum {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct StringNewtype(::std::string::String);
 impl ::std::ops::Deref for StringNewtype {
     type Target = ::std::string::String;
@@ -1575,6 +1576,7 @@ impl Sync {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords(
     pub ::serde_json::Value,
 );

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -106,6 +106,7 @@ impl FloatsArentTerribleImTold {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct JustOne(pub ::std::string::String);
 impl ::std::ops::Deref for JustOne {
     type Target = ::std::string::String;

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -86,6 +86,7 @@ impl TestType {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Eq, PartialEq)]
+#[serde(transparent)]
 pub struct TypeThatHasMoreDerives(
     pub ::std::collections::HashMap<::std::string::String, ::std::string::String>,
 );

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -37,6 +37,7 @@ pub mod error {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
 pub struct PatternString(::std::string::String);
 impl ::std::ops::Deref for PatternString {
     type Target = ::std::string::String;
@@ -115,6 +116,7 @@ impl<'de> ::serde::Deserialize<'de> for PatternString {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct Sub10Primes(u32);
 impl ::std::ops::Deref for Sub10Primes {
     type Target = u32;

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -379,6 +379,7 @@ impl EmptyObject {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct EmptyObjectProp(::serde_json::Map<::std::string::String, ::serde_json::Value>);
 impl ::std::ops::Deref for EmptyObjectProp {
     type Target = ::serde_json::Map<::std::string::String, ::serde_json::Value>;
@@ -628,6 +629,7 @@ impl From<Ipv6Net> for IpNet {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Ipv4Net(pub ::std::string::String);
 impl ::std::ops::Deref for Ipv4Net {
     type Target = ::std::string::String;
@@ -682,6 +684,7 @@ impl ::std::fmt::Display for Ipv4Net {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct Ipv6Net(pub ::std::string::String);
 impl ::std::ops::Deref for Ipv6Net {
     type Target = ::std::string::String;
@@ -845,6 +848,7 @@ impl From<&NeverEver> for NeverEver {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
 pub struct NullStringEnumWithUnknownFormat(
     pub ::std::option::Option<NullStringEnumWithUnknownFormatInner>,
 );
@@ -1026,6 +1030,7 @@ impl From<i64> for OneOfTypes {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct ReferenceDef(pub ::std::string::String);
 impl ::std::ops::Deref for ReferenceDef {
     type Target = ::std::string::String;
@@ -1258,6 +1263,7 @@ impl From<&ShouldBeExclusive> for ShouldBeExclusive {
     PartialEq,
     PartialOrd,
 )]
+#[serde(transparent)]
 pub struct StringVersion(pub ::std::string::String);
 impl ::std::ops::Deref for StringVersion {
     type Target = ::std::string::String;


### PR DESCRIPTION
In JSON, the difference between a newtype that's transparent or not is unobservable--they both render to the same serialized output. This is not true of other serializations and--more critically--not true of other implementations of `serde::Serializer`.

In particular, I encountered this in https://github.com/oxidecomputer/progenitor/pull/1017 where I observed that the `serde_urlencoded::Serializer` freaks out about our newtype wrappers. Perhaps this freak out is reasonable because the intended representation matches with the intention of `transparent`.

Consider the case where I noticed this: `struct Name(String)`. `Name` wraps a String and imposes constraints on it. It deserializes from a string and its intended serialization is a string--the newtype wrapper is purely a type for enforcing constraints when creating or manipulating the type. This hasn't bit us before, but marking these newtypes as transparent seems like the right thing to do.