### PR TITLE
fixes #589 allow min and max to be within range

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -990,36 +990,34 @@ impl TypeSpace {
             (None, None, None)
         };
 
+        // Use NonZero types for minimum 1
+        let min_is_one = min == Some(1.);
+
         // Ordered from most- to least-restrictive.
-        let formats: &[(&str, &str, f64, f64)] = &[
-            ("int8", "i8", i8::MIN as f64, i8::MAX as f64),
-            ("", "::std::num::NonZeroU8", 1.0, u8::MAX as f64),
-            ("uint8", "u8", u8::MIN as f64, u8::MAX as f64),
-            ("int16", "i16", i16::MIN as f64, i16::MAX as f64),
-            ("", "::std::num::NonZeroU16", 1.0, u16::MAX as f64),
-            ("uint16", "u16", u16::MIN as f64, u16::MAX as f64),
-            ("int", "i32", i32::MIN as f64, i32::MAX as f64),
-            ("int32", "i32", i32::MIN as f64, i32::MAX as f64),
-            ("", "::std::num::NonZeroU32", 1.0, u32::MAX as f64),
-            ("uint", "u32", u32::MIN as f64, u32::MAX as f64),
-            ("uint32", "u32", u32::MIN as f64, u32::MAX as f64),
+        // JSONSchema format, Rust Type, Rust NonZero Type, Rust type min, Rust type max
+        let formats: &[(&str, &str, &str, f64, f64)] = &[
+            ("int8", "i8", "::std::num::NonZeroU8", i8::MIN as f64, i8::MAX as f64),
+            ("uint8", "u8", "::std::num::NonZeroU8", u8::MIN as f64, u8::MAX as f64),
+            ("int16", "i16", "::std::num::NonZeroU16", i16::MIN as f64, i16::MAX as f64),
+            ("uint16", "u16", "::std::num::NonZeroU16", u16::MIN as f64, u16::MAX as f64),
+            ("int", "i32", "::std::num::NonZeroU32", i32::MIN as f64, i32::MAX as f64),
+            ("int32", "i32", "::std::num::NonZeroU32", i32::MIN as f64, i32::MAX as f64),
+            ("uint", "u32", "::std::num::NonZeroU32", u32::MIN as f64, u32::MAX as f64),
+            ("uint32", "u32", "::std::num::NonZeroU32", u32::MIN as f64, u32::MAX as f64),
             // TODO all these are wrong as casting to an f64 loses precision.
             // However, schemars stores everything as an f64 so... meh for now.
-            ("int64", "i64", i64::MIN as f64, i64::MAX as f64),
-            ("", "::std::num::NonZeroU64", 1.0, u64::MAX as f64),
-            ("uint64", "u64", u64::MIN as f64, u64::MAX as f64),
+            ("int64", "i64", "::std::num::NonZeroU64", i64::MIN as f64, i64::MAX as f64),
+            ("uint64", "u64", "::std::num::NonZeroU64", u64::MIN as f64, u64::MAX as f64),
         ];
 
         if let Some(format) = format {
-            if let Some((_, ty, imin, imax)) = formats
+            if let Some((_fmt, ty, nz_ty, imin, imax)) = formats
                 .iter()
-                .find(|(int_format, _, _, _)| int_format == format)
+                .find(|(int_format, _, _, _, _)| int_format == format)
             {
-                // If the type matches with other constraints, we're done.
-                if multiple.is_none()
-                    && (min.is_none() || min == Some(*imin))
-                    && (max.is_none() || max == Some(*imax))
-                {
+                let valid_min = min.is_none() || min.map(|fmin| fmin.ge(imin)).unwrap_or(false);
+                let valid_max = max.is_none() || max.map(|fmax| fmax.le(imax)).unwrap_or(true);
+                if multiple.is_none() && valid_min && valid_max {
                     // If there's a default value and it's either not a number
                     // or outside of the range for this format, return an
                     // error.
@@ -1032,7 +1030,11 @@ impl TypeSpace {
                             return Err(Error::InvalidValue);
                         }
                     }
-                    return Ok((TypeEntry::new_integer(ty), metadata));
+                    if min_is_one {
+                        return Ok((TypeEntry::new_integer(nz_ty), metadata));
+                    } else {
+                        return Ok((TypeEntry::new_integer(ty), metadata));
+                    }
                 }
 
                 if min.is_none() {
@@ -1063,21 +1065,23 @@ impl TypeSpace {
 
         // See if the value bounds fit within a known type.
         let maybe_type = match (min, max) {
-            (None, Some(max)) => formats.iter().rev().find_map(|(_, ty, _, imax)| {
+            (None, Some(max)) => formats.iter().rev().find_map(|(_, ty, nz_ty, _, imax)| {
                 if (imax - max).abs() <= f64::EPSILON {
                     Some(ty.to_string())
                 } else {
                     None
                 }
             }),
-            (Some(min), None) => formats.iter().rev().find_map(|(_, ty, imin, _)| {
-                if (imin - min).abs() <= f64::EPSILON {
+            (Some(min), None) => formats.iter().rev().find_map(|(_, ty, nz_ty, imin, _)| {
+                if min == 1. {
+                    Some(nz_ty.to_string())
+                } else if (imin - min).abs() <= f64::EPSILON {
                     Some(ty.to_string())
                 } else {
                     None
                 }
             }),
-            (Some(min), Some(max)) => formats.iter().rev().find_map(|(_, ty, imin, imax)| {
+            (Some(min), Some(max)) => formats.iter().rev().find_map(|(_, ty, nz_ty, imin, imax)| {
                 if (imax - max).abs() <= f64::EPSILON && (imin - min).abs() <= f64::EPSILON {
                     Some(ty.to_string())
                 } else {
@@ -1997,6 +2001,7 @@ mod tests {
     };
     use serde_json::json;
 
+    use crate::type_entry::TypeEntryDetails;
     use crate::{
         test_util::validate_output, validate_builtin, Error, Name, TypeSpace, TypeSpaceImpl,
         TypeSpaceSettings,

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -2066,7 +2066,6 @@ mod tests {
     };
     use serde_json::json;
 
-    use crate::type_entry::TypeEntryDetails;
     use crate::{
         test_util::validate_output, validate_builtin, Error, Name, TypeSpace, TypeSpaceImpl,
         TypeSpaceSettings,

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1064,7 +1064,7 @@ impl TypeSpace {
 
         // See if the value bounds fit within a known type.
         let maybe_type = match (min, max) {
-            (None, Some(max)) => formats.iter().rev().find_map(|(_, ty, nz_ty, _, imax)| {
+            (None, Some(max)) => formats.iter().rev().find_map(|(_, ty, _nz_ty, _, imax)| {
                 if (imax - max).abs() <= f64::EPSILON {
                     Some(ty.to_string())
                 } else {
@@ -1081,7 +1081,9 @@ impl TypeSpace {
                 }
             }),
             (Some(min), Some(max)) => formats.iter().rev().find_map(|(_, ty, nz_ty, imin, imax)| {
-                if (imax - max).abs() <= f64::EPSILON && (imin - min).abs() <= f64::EPSILON {
+                if min == 1. {
+                    Some(nz_ty.to_string())
+                } else if (imax - max).abs() <= f64::EPSILON && (imin - min).abs() <= f64::EPSILON {
                     Some(ty.to_string())
                 } else {
                     None

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -990,9 +990,6 @@ impl TypeSpace {
             (None, None, None)
         };
 
-        // Use NonZero types for minimum 1
-        let min_is_one = min == Some(1.);
-
         // Ordered from most- to least-restrictive.
         // JSONSchema format, Rust Type, Rust NonZero Type, Rust type min, Rust type max
         let formats: &[(&str, &str, &str, f64, f64)] = &[
@@ -1016,7 +1013,7 @@ impl TypeSpace {
                 .find(|(int_format, _, _, _, _)| int_format == format)
             {
                 let valid_min = min.is_none() || min.map(|fmin| fmin.ge(imin)).unwrap_or(false);
-                let valid_max = max.is_none() || max.map(|fmax| fmax.le(imax)).unwrap_or(true);
+                let valid_max = max.is_none() || max.map(|fmax| fmax.le(imax)).unwrap_or(false);
                 if multiple.is_none() && valid_min && valid_max {
                     // If there's a default value and it's either not a number
                     // or outside of the range for this format, return an
@@ -1030,7 +1027,9 @@ impl TypeSpace {
                             return Err(Error::InvalidValue);
                         }
                     }
-                    if min_is_one {
+
+                    // Use NonZero types for minimum 1
+                    if min == Some(1.) {
                         return Ok((TypeEntry::new_integer(nz_ty), metadata));
                     } else {
                         return Ok((TypeEntry::new_integer(ty), metadata));

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -993,18 +993,78 @@ impl TypeSpace {
         // Ordered from most- to least-restrictive.
         // JSONSchema format, Rust Type, Rust NonZero Type, Rust type min, Rust type max
         let formats: &[(&str, &str, &str, f64, f64)] = &[
-            ("int8", "i8", "::std::num::NonZeroU8", i8::MIN as f64, i8::MAX as f64),
-            ("uint8", "u8", "::std::num::NonZeroU8", u8::MIN as f64, u8::MAX as f64),
-            ("int16", "i16", "::std::num::NonZeroU16", i16::MIN as f64, i16::MAX as f64),
-            ("uint16", "u16", "::std::num::NonZeroU16", u16::MIN as f64, u16::MAX as f64),
-            ("int", "i32", "::std::num::NonZeroU32", i32::MIN as f64, i32::MAX as f64),
-            ("int32", "i32", "::std::num::NonZeroU32", i32::MIN as f64, i32::MAX as f64),
-            ("uint", "u32", "::std::num::NonZeroU32", u32::MIN as f64, u32::MAX as f64),
-            ("uint32", "u32", "::std::num::NonZeroU32", u32::MIN as f64, u32::MAX as f64),
+            (
+                "int8",
+                "i8",
+                "::std::num::NonZeroU8",
+                i8::MIN as f64,
+                i8::MAX as f64,
+            ),
+            (
+                "uint8",
+                "u8",
+                "::std::num::NonZeroU8",
+                u8::MIN as f64,
+                u8::MAX as f64,
+            ),
+            (
+                "int16",
+                "i16",
+                "::std::num::NonZeroU16",
+                i16::MIN as f64,
+                i16::MAX as f64,
+            ),
+            (
+                "uint16",
+                "u16",
+                "::std::num::NonZeroU16",
+                u16::MIN as f64,
+                u16::MAX as f64,
+            ),
+            (
+                "int",
+                "i32",
+                "::std::num::NonZeroU32",
+                i32::MIN as f64,
+                i32::MAX as f64,
+            ),
+            (
+                "int32",
+                "i32",
+                "::std::num::NonZeroU32",
+                i32::MIN as f64,
+                i32::MAX as f64,
+            ),
+            (
+                "uint",
+                "u32",
+                "::std::num::NonZeroU32",
+                u32::MIN as f64,
+                u32::MAX as f64,
+            ),
+            (
+                "uint32",
+                "u32",
+                "::std::num::NonZeroU32",
+                u32::MIN as f64,
+                u32::MAX as f64,
+            ),
             // TODO all these are wrong as casting to an f64 loses precision.
             // However, schemars stores everything as an f64 so... meh for now.
-            ("int64", "i64", "::std::num::NonZeroU64", i64::MIN as f64, i64::MAX as f64),
-            ("uint64", "u64", "::std::num::NonZeroU64", u64::MIN as f64, u64::MAX as f64),
+            (
+                "int64",
+                "i64",
+                "::std::num::NonZeroU64",
+                i64::MIN as f64,
+                i64::MAX as f64,
+            ),
+            (
+                "uint64",
+                "u64",
+                "::std::num::NonZeroU64",
+                u64::MIN as f64,
+                u64::MAX as f64,
+            ),
         ];
 
         if let Some(format) = format {
@@ -1080,15 +1140,19 @@ impl TypeSpace {
                     None
                 }
             }),
-            (Some(min), Some(max)) => formats.iter().rev().find_map(|(_, ty, nz_ty, imin, imax)| {
-                if min == 1. {
-                    Some(nz_ty.to_string())
-                } else if (imax - max).abs() <= f64::EPSILON && (imin - min).abs() <= f64::EPSILON {
-                    Some(ty.to_string())
-                } else {
-                    None
-                }
-            }),
+            (Some(min), Some(max)) => {
+                formats.iter().rev().find_map(|(_, ty, nz_ty, imin, imax)| {
+                    if min == 1. {
+                        Some(nz_ty.to_string())
+                    } else if (imax - max).abs() <= f64::EPSILON
+                        && (imin - min).abs() <= f64::EPSILON
+                    {
+                        Some(ty.to_string())
+                    } else {
+                        None
+                    }
+                })
+            }
             (None, None) => None,
         };
 

--- a/typify/tests/schemas/simple-types.json
+++ b/typify/tests/schemas/simple-types.json
@@ -20,6 +20,48 @@
       "required": [
         "value"
       ]
+    },
+    "uint-minimum-and-maximum": {
+      "type": "object",
+      "required": [
+        "max",
+        "min",
+        "min_and_max",
+        "min_non_zero",
+        "min_uint_non_zero",
+        "no_bounds"
+      ],
+      "properties": {
+        "no_bounds": {
+          "type": "integer",
+          "format": "uint64"
+        },
+        "min": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "min_non_zero": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "min_uint_non_zero": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1
+        },
+        "max": {
+          "type": "integer",
+          "format": "uint64",
+          "maximum": 256
+        },
+        "min_and_max": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 256
+        }
+      }
     }
   }
 }

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -147,7 +147,7 @@ impl ::std::fmt::Display for JustOne {
         self.0.fmt(f)
     }
 }
-#[doc = "UintMinimumAndMaximum"]
+#[doc = "`UintMinimumAndMaximum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -200,9 +200,9 @@ impl ::std::fmt::Display for JustOne {
 pub struct UintMinimumAndMaximum {
     pub max: u64,
     pub min: u64,
-    pub min_and_max: std::num::NonZeroU64,
-    pub min_non_zero: std::num::NonZeroU64,
-    pub min_uint_non_zero: std::num::NonZeroU64,
+    pub min_and_max: ::std::num::NonZeroU64,
+    pub min_non_zero: ::std::num::NonZeroU64,
+    pub min_uint_non_zero: ::std::num::NonZeroU64,
     pub no_bounds: u64,
 }
 impl ::std::convert::From<&UintMinimumAndMaximum> for UintMinimumAndMaximum {
@@ -301,9 +301,9 @@ pub mod builder {
     pub struct UintMinimumAndMaximum {
         max: ::std::result::Result<u64, ::std::string::String>,
         min: ::std::result::Result<u64, ::std::string::String>,
-        min_and_max: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
-        min_non_zero: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
-        min_uint_non_zero: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
+        min_and_max: ::std::result::Result<::std::num::NonZeroU64, ::std::string::String>,
+        min_non_zero: ::std::result::Result<::std::num::NonZeroU64, ::std::string::String>,
+        min_uint_non_zero: ::std::result::Result<::std::num::NonZeroU64, ::std::string::String>,
         no_bounds: ::std::result::Result<u64, ::std::string::String>,
     }
     impl ::std::default::Default for UintMinimumAndMaximum {
@@ -341,7 +341,7 @@ pub mod builder {
         }
         pub fn min_and_max<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T: ::std::convert::TryInto<::std::num::NonZeroU64>,
             T::Error: ::std::fmt::Display,
         {
             self.min_and_max = value
@@ -351,7 +351,7 @@ pub mod builder {
         }
         pub fn min_non_zero<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T: ::std::convert::TryInto<::std::num::NonZeroU64>,
             T::Error: ::std::fmt::Display,
         {
             self.min_non_zero = value
@@ -361,7 +361,7 @@ pub mod builder {
         }
         pub fn min_uint_non_zero<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T: ::std::convert::TryInto<::std::num::NonZeroU64>,
             T::Error: ::std::fmt::Display,
         {
             self.min_uint_non_zero = value.try_into().map_err(|e| {

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -147,6 +147,74 @@ impl ::std::fmt::Display for JustOne {
         self.0.fmt(f)
     }
 }
+#[doc = "UintMinimumAndMaximum"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"max\","]
+#[doc = "    \"min\","]
+#[doc = "    \"min_and_max\","]
+#[doc = "    \"min_non_zero\","]
+#[doc = "    \"min_uint_non_zero\","]
+#[doc = "    \"no_bounds\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"max\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"maximum\": 256.0"]
+#[doc = "    },"]
+#[doc = "    \"min\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"min_and_max\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"maximum\": 256.0,"]
+#[doc = "      \"minimum\": 1.0"]
+#[doc = "    },"]
+#[doc = "    \"min_non_zero\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"minimum\": 1.0"]
+#[doc = "    },"]
+#[doc = "    \"min_uint_non_zero\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 1.0"]
+#[doc = "    },"]
+#[doc = "    \"no_bounds\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct UintMinimumAndMaximum {
+    pub max: u64,
+    pub min: u64,
+    pub min_and_max: std::num::NonZeroU64,
+    pub min_non_zero: std::num::NonZeroU64,
+    pub min_uint_non_zero: std::num::NonZeroU64,
+    pub no_bounds: u64,
+}
+impl ::std::convert::From<&UintMinimumAndMaximum> for UintMinimumAndMaximum {
+    fn from(value: &UintMinimumAndMaximum) -> Self {
+        value.clone()
+    }
+}
+impl UintMinimumAndMaximum {
+    pub fn builder() -> builder::UintMinimumAndMaximum {
+        Default::default()
+    }
+}
 #[doc = r" Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
@@ -226,6 +294,119 @@ pub mod builder {
         fn from(value: super::FloatsArentTerribleImTold) -> Self {
             Self {
                 flush_timeout: Ok(value.flush_timeout),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct UintMinimumAndMaximum {
+        max: ::std::result::Result<u64, ::std::string::String>,
+        min: ::std::result::Result<u64, ::std::string::String>,
+        min_and_max: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
+        min_non_zero: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
+        min_uint_non_zero: ::std::result::Result<std::num::NonZeroU64, ::std::string::String>,
+        no_bounds: ::std::result::Result<u64, ::std::string::String>,
+    }
+    impl ::std::default::Default for UintMinimumAndMaximum {
+        fn default() -> Self {
+            Self {
+                max: Err("no value supplied for max".to_string()),
+                min: Err("no value supplied for min".to_string()),
+                min_and_max: Err("no value supplied for min_and_max".to_string()),
+                min_non_zero: Err("no value supplied for min_non_zero".to_string()),
+                min_uint_non_zero: Err("no value supplied for min_uint_non_zero".to_string()),
+                no_bounds: Err("no value supplied for no_bounds".to_string()),
+            }
+        }
+    }
+    impl UintMinimumAndMaximum {
+        pub fn max<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<u64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.max = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for max: {}", e));
+            self
+        }
+        pub fn min<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<u64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.min = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for min: {}", e));
+            self
+        }
+        pub fn min_and_max<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.min_and_max = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for min_and_max: {}", e));
+            self
+        }
+        pub fn min_non_zero<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.min_non_zero = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for min_non_zero: {}", e));
+            self
+        }
+        pub fn min_uint_non_zero<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<std::num::NonZeroU64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.min_uint_non_zero = value.try_into().map_err(|e| {
+                format!(
+                    "error converting supplied value for min_uint_non_zero: {}",
+                    e
+                )
+            });
+            self
+        }
+        pub fn no_bounds<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<u64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.no_bounds = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for no_bounds: {}", e));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<UintMinimumAndMaximum> for super::UintMinimumAndMaximum {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: UintMinimumAndMaximum,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                max: value.max?,
+                min: value.min?,
+                min_and_max: value.min_and_max?,
+                min_non_zero: value.min_non_zero?,
+                min_uint_non_zero: value.min_uint_non_zero?,
+                no_bounds: value.no_bounds?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::UintMinimumAndMaximum> for UintMinimumAndMaximum {
+        fn from(value: super::UintMinimumAndMaximum) -> Self {
+            Self {
+                max: Ok(value.max),
+                min: Ok(value.min),
+                min_and_max: Ok(value.min_and_max),
+                min_non_zero: Ok(value.min_non_zero),
+                min_uint_non_zero: Ok(value.min_uint_non_zero),
+                no_bounds: Ok(value.no_bounds),
             }
         }
     }


### PR DESCRIPTION
fixes #589 

Allow min and max to be within range of the specified format