### PR TITLE
Use backticks for the type name in generated comments

### DIFF
--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -29,7 +29,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Fruit"]
+#[doc = "`Fruit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72,7 +72,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
         Self(value)
     }
 }
-#[doc = "FruitOrVeg"]
+#[doc = "`FruitOrVeg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -120,7 +120,7 @@ impl ::std::convert::From<Fruit> for FruitOrVeg {
         Self::Fruit(value)
     }
 }
-#[doc = "Veggie"]
+#[doc = "`Veggie`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -29,7 +29,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Fruit"]
+#[doc = "`Fruit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73,7 +73,7 @@ impl
         Self(value)
     }
 }
-#[doc = "FruitOrVeg"]
+#[doc = "`FruitOrVeg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -121,7 +121,7 @@ impl ::std::convert::From<Fruit> for FruitOrVeg {
         Self::Fruit(value)
     }
 }
-#[doc = "Veggie"]
+#[doc = "`Veggie`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -29,7 +29,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Fruit"]
+#[doc = "`Fruit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72,7 +72,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
         Self(value)
     }
 }
-#[doc = "FruitOrVeg"]
+#[doc = "`FruitOrVeg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -120,7 +120,7 @@ impl ::std::convert::From<Fruit> for FruitOrVeg {
         Self::Fruit(value)
     }
 }
-#[doc = "Veggie"]
+#[doc = "`Veggie`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -29,7 +29,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Fruit"]
+#[doc = "`Fruit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74,7 +74,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
         Self(value)
     }
 }
-#[doc = "FruitOrVeg"]
+#[doc = "`FruitOrVeg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -124,7 +124,7 @@ impl ::std::convert::From<Fruit> for FruitOrVeg {
         Self::Fruit(value)
     }
 }
-#[doc = "Veggie"]
+#[doc = "`Veggie`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -29,7 +29,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Fruit"]
+#[doc = "`Fruit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72,7 +72,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
         Self(value)
     }
 }
-#[doc = "FruitOrVeg"]
+#[doc = "`FruitOrVeg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -120,7 +120,7 @@ impl ::std::convert::From<Fruit> for FruitOrVeg {
         Self::Fruit(value)
     }
 }
-#[doc = "Veggie"]
+#[doc = "`Veggie`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1457,7 +1457,7 @@ mod tests {
         let schema_json = serde_json::to_string_pretty(&original_schema).unwrap();
         let schema_lines = schema_json.lines();
         let expected = quote! {
-            #[doc = "ResultX"]
+            #[doc = "`ResultX`"]
             ///
             /// <details><summary>JSON schema</summary>
             ///
@@ -1511,7 +1511,7 @@ mod tests {
         type_entry.output(&type_space, &mut output);
         let actual = output.into_stream();
         let expected = quote! {
-            #[doc = "ResultX"]
+            #[doc = "`ResultX`"]
             ///
             /// <details><summary>JSON schema</summary>
             ///

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1888,7 +1888,10 @@ impl TypeEntry {
 }
 
 fn make_doc(name: &str, description: Option<&String>, schema: &Schema) -> TokenStream {
-    let desc = description.map_or(name, |desc| desc.as_str());
+    let desc = match description {
+        Some(desc) => desc,
+        None => &format!("`{}`", name),
+    };
     let schema_json = serde_json::to_string_pretty(schema).unwrap();
     let schema_lines = schema_json.lines();
     quote! {

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -25,7 +25,7 @@ mod types {
             }
         }
     }
-    #[doc = "AllTheTraits"]
+    #[doc = "`AllTheTraits`"]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
     #[doc = r""]
@@ -69,7 +69,7 @@ mod types {
             Default::default()
         }
     }
-    #[doc = "CompoundType"]
+    #[doc = "`CompoundType`"]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
     #[doc = r""]
@@ -109,7 +109,7 @@ mod types {
             Default::default()
         }
     }
-    #[doc = "Pair"]
+    #[doc = "`Pair`"]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
     #[doc = r""]
@@ -155,7 +155,7 @@ mod types {
             Default::default()
         }
     }
-    #[doc = "StringEnum"]
+    #[doc = "`StringEnum`"]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
     #[doc = r""]

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -24,7 +24,7 @@ pub mod error {
         }
     }
 }
-#[doc = "AlertInstance"]
+#[doc = "`AlertInstance`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -131,7 +131,7 @@ impl ::std::convert::From<&AlertInstance> for AlertInstance {
         value.clone()
     }
 }
-#[doc = "AlertInstanceLocation"]
+#[doc = "`AlertInstanceLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -189,7 +189,7 @@ impl ::std::default::Default for AlertInstanceLocation {
         }
     }
 }
-#[doc = "AlertInstanceMessage"]
+#[doc = "`AlertInstanceMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -699,7 +699,7 @@ impl ::std::convert::From<&App> for App {
         value.clone()
     }
 }
-#[doc = "AppEventsItem"]
+#[doc = "`AppEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1357,7 +1357,7 @@ impl ::std::default::Default for AppPermissions {
         }
     }
 }
-#[doc = "AppPermissionsActions"]
+#[doc = "`AppPermissionsActions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1434,7 +1434,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsActions {
         value.parse()
     }
 }
-#[doc = "AppPermissionsAdministration"]
+#[doc = "`AppPermissionsAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1511,7 +1511,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsAdministra
         value.parse()
     }
 }
-#[doc = "AppPermissionsChecks"]
+#[doc = "`AppPermissionsChecks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1588,7 +1588,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsChecks {
         value.parse()
     }
 }
-#[doc = "AppPermissionsContentReferences"]
+#[doc = "`AppPermissionsContentReferences`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1665,7 +1665,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsContentRef
         value.parse()
     }
 }
-#[doc = "AppPermissionsContents"]
+#[doc = "`AppPermissionsContents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1742,7 +1742,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsContents {
         value.parse()
     }
 }
-#[doc = "AppPermissionsDeployments"]
+#[doc = "`AppPermissionsDeployments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1819,7 +1819,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsDeployment
         value.parse()
     }
 }
-#[doc = "AppPermissionsDiscussions"]
+#[doc = "`AppPermissionsDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1896,7 +1896,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsDiscussion
         value.parse()
     }
 }
-#[doc = "AppPermissionsEmails"]
+#[doc = "`AppPermissionsEmails`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1973,7 +1973,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsEmails {
         value.parse()
     }
 }
-#[doc = "AppPermissionsEnvironments"]
+#[doc = "`AppPermissionsEnvironments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2050,7 +2050,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsEnvironmen
         value.parse()
     }
 }
-#[doc = "AppPermissionsIssues"]
+#[doc = "`AppPermissionsIssues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2127,7 +2127,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsIssues {
         value.parse()
     }
 }
-#[doc = "AppPermissionsMembers"]
+#[doc = "`AppPermissionsMembers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2204,7 +2204,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsMembers {
         value.parse()
     }
 }
-#[doc = "AppPermissionsMetadata"]
+#[doc = "`AppPermissionsMetadata`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2281,7 +2281,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsMetadata {
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationAdministration"]
+#[doc = "`AppPermissionsOrganizationAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2358,7 +2358,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationHooks"]
+#[doc = "`AppPermissionsOrganizationHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2435,7 +2435,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationPackages"]
+#[doc = "`AppPermissionsOrganizationPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2512,7 +2512,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationPlan"]
+#[doc = "`AppPermissionsOrganizationPlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2589,7 +2589,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationProjects"]
+#[doc = "`AppPermissionsOrganizationProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2666,7 +2666,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationSecrets"]
+#[doc = "`AppPermissionsOrganizationSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2743,7 +2743,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationSelfHostedRunners"]
+#[doc = "`AppPermissionsOrganizationSelfHostedRunners`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2824,7 +2824,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "AppPermissionsOrganizationUserBlocking"]
+#[doc = "`AppPermissionsOrganizationUserBlocking`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2901,7 +2901,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizati
         value.parse()
     }
 }
-#[doc = "AppPermissionsPackages"]
+#[doc = "`AppPermissionsPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2978,7 +2978,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsPackages {
         value.parse()
     }
 }
-#[doc = "AppPermissionsPages"]
+#[doc = "`AppPermissionsPages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3055,7 +3055,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsPages {
         value.parse()
     }
 }
-#[doc = "AppPermissionsPullRequests"]
+#[doc = "`AppPermissionsPullRequests`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3132,7 +3132,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsPullReques
         value.parse()
     }
 }
-#[doc = "AppPermissionsRepositoryHooks"]
+#[doc = "`AppPermissionsRepositoryHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3209,7 +3209,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsRepository
         value.parse()
     }
 }
-#[doc = "AppPermissionsRepositoryProjects"]
+#[doc = "`AppPermissionsRepositoryProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3286,7 +3286,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsRepository
         value.parse()
     }
 }
-#[doc = "AppPermissionsSecretScanningAlerts"]
+#[doc = "`AppPermissionsSecretScanningAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3363,7 +3363,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecretScan
         value.parse()
     }
 }
-#[doc = "AppPermissionsSecrets"]
+#[doc = "`AppPermissionsSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3440,7 +3440,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecrets {
         value.parse()
     }
 }
-#[doc = "AppPermissionsSecurityEvents"]
+#[doc = "`AppPermissionsSecurityEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3517,7 +3517,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecurityEv
         value.parse()
     }
 }
-#[doc = "AppPermissionsSecurityScanningAlert"]
+#[doc = "`AppPermissionsSecurityScanningAlert`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3594,7 +3594,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecuritySc
         value.parse()
     }
 }
-#[doc = "AppPermissionsSingleFile"]
+#[doc = "`AppPermissionsSingleFile`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3671,7 +3671,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSingleFile
         value.parse()
     }
 }
-#[doc = "AppPermissionsStatuses"]
+#[doc = "`AppPermissionsStatuses`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3748,7 +3748,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsStatuses {
         value.parse()
     }
 }
-#[doc = "AppPermissionsTeamDiscussions"]
+#[doc = "`AppPermissionsTeamDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3825,7 +3825,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsTeamDiscus
         value.parse()
     }
 }
-#[doc = "AppPermissionsVulnerabilityAlerts"]
+#[doc = "`AppPermissionsVulnerabilityAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3902,7 +3902,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsVulnerabil
         value.parse()
     }
 }
-#[doc = "AppPermissionsWorkflows"]
+#[doc = "`AppPermissionsWorkflows`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4295,7 +4295,7 @@ impl ::std::convert::From<&BranchProtectionRule> for BranchProtectionRule {
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleAllowDeletionsEnforcementLevel"]
+#[doc = "`BranchProtectionRuleAllowDeletionsEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4381,7 +4381,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleAllowForcePushesEnforcementLevel"]
+#[doc = "`BranchProtectionRuleAllowForcePushesEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4527,7 +4527,7 @@ impl ::std::convert::From<&BranchProtectionRuleCreated> for BranchProtectionRule
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleCreatedAction"]
+#[doc = "`BranchProtectionRuleCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4659,7 +4659,7 @@ impl ::std::convert::From<&BranchProtectionRuleDeleted> for BranchProtectionRule
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleDeletedAction"]
+#[doc = "`BranchProtectionRuleDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4827,7 +4827,7 @@ impl ::std::convert::From<&BranchProtectionRuleEdited> for BranchProtectionRuleE
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleEditedAction"]
+#[doc = "`BranchProtectionRuleEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4965,7 +4965,7 @@ impl ::std::default::Default for BranchProtectionRuleEditedChanges {
         }
     }
 }
-#[doc = "BranchProtectionRuleEditedChangesAuthorizedActorNames"]
+#[doc = "`BranchProtectionRuleEditedChangesAuthorizedActorNames`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4999,7 +4999,7 @@ impl ::std::convert::From<&BranchProtectionRuleEditedChangesAuthorizedActorNames
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleEditedChangesAuthorizedActorsOnly"]
+#[doc = "`BranchProtectionRuleEditedChangesAuthorizedActorsOnly`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5030,7 +5030,7 @@ impl ::std::convert::From<&BranchProtectionRuleEditedChangesAuthorizedActorsOnly
         value.clone()
     }
 }
-#[doc = "BranchProtectionRuleEvent"]
+#[doc = "`BranchProtectionRuleEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5077,7 +5077,7 @@ impl ::std::convert::From<BranchProtectionRuleEdited> for BranchProtectionRuleEv
         Self::Edited(value)
     }
 }
-#[doc = "BranchProtectionRuleLinearHistoryRequirementEnforcementLevel"]
+#[doc = "`BranchProtectionRuleLinearHistoryRequirementEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5165,7 +5165,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleMergeQueueEnforcementLevel"]
+#[doc = "`BranchProtectionRuleMergeQueueEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5251,7 +5251,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRulePullRequestReviewsEnforcementLevel"]
+#[doc = "`BranchProtectionRulePullRequestReviewsEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5337,7 +5337,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleRequiredConversationResolutionLevel"]
+#[doc = "`BranchProtectionRuleRequiredConversationResolutionLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5423,7 +5423,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleRequiredDeploymentsEnforcementLevel"]
+#[doc = "`BranchProtectionRuleRequiredDeploymentsEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5509,7 +5509,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleRequiredStatusChecksEnforcementLevel"]
+#[doc = "`BranchProtectionRuleRequiredStatusChecksEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5595,7 +5595,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BranchProtectionRuleSignatureRequirementEnforcementLevel"]
+#[doc = "`BranchProtectionRuleSignatureRequirementEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5681,7 +5681,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CheckRunCompleted"]
+#[doc = "`CheckRunCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5984,7 +5984,7 @@ impl ::std::convert::From<&CheckRunCompleted> for CheckRunCompleted {
         value.clone()
     }
 }
-#[doc = "CheckRunCompletedAction"]
+#[doc = "`CheckRunCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6327,7 +6327,7 @@ impl ::std::convert::From<&CheckRunCompletedCheckRun> for CheckRunCompletedCheck
         value.clone()
     }
 }
-#[doc = "CheckRunCompletedCheckRunCheckSuite"]
+#[doc = "`CheckRunCompletedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6462,7 +6462,7 @@ impl ::std::convert::From<&CheckRunCompletedCheckRunCheckSuite>
         value.clone()
     }
 }
-#[doc = "CheckRunCompletedCheckRunCheckSuiteConclusion"]
+#[doc = "`CheckRunCompletedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6568,7 +6568,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CheckRunCompletedCheckRunCheckSuiteStatus"]
+#[doc = "`CheckRunCompletedCheckRunCheckSuiteStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6758,7 +6758,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCompletedCheckRu
         value.parse()
     }
 }
-#[doc = "CheckRunCompletedCheckRunOutput"]
+#[doc = "`CheckRunCompletedCheckRunOutput`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6927,7 +6927,7 @@ impl ::std::default::Default for CheckRunCompletedRequestedAction {
         }
     }
 }
-#[doc = "CheckRunCreated"]
+#[doc = "`CheckRunCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -7235,7 +7235,7 @@ impl ::std::convert::From<&CheckRunCreated> for CheckRunCreated {
         value.clone()
     }
 }
-#[doc = "CheckRunCreatedAction"]
+#[doc = "`CheckRunCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -7583,7 +7583,7 @@ impl ::std::convert::From<&CheckRunCreatedCheckRun> for CheckRunCreatedCheckRun 
         value.clone()
     }
 }
-#[doc = "CheckRunCreatedCheckRunCheckSuite"]
+#[doc = "`CheckRunCreatedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -7718,7 +7718,7 @@ impl ::std::convert::From<&CheckRunCreatedCheckRunCheckSuite>
         value.clone()
     }
 }
-#[doc = "CheckRunCreatedCheckRunCheckSuiteConclusion"]
+#[doc = "`CheckRunCreatedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -7824,7 +7824,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CheckRunCreatedCheckRunCheckSuiteStatus"]
+#[doc = "`CheckRunCreatedCheckRunCheckSuiteStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8014,7 +8014,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCreatedCheckRunC
         value.parse()
     }
 }
-#[doc = "CheckRunCreatedCheckRunOutput"]
+#[doc = "`CheckRunCreatedCheckRunOutput`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8283,7 +8283,7 @@ impl ::std::convert::From<&CheckRunDeployment> for CheckRunDeployment {
         value.clone()
     }
 }
-#[doc = "CheckRunEvent"]
+#[doc = "`CheckRunEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8339,7 +8339,7 @@ impl ::std::convert::From<CheckRunRerequested> for CheckRunEvent {
         Self::Rerequested(value)
     }
 }
-#[doc = "CheckRunPullRequest"]
+#[doc = "`CheckRunPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8425,7 +8425,7 @@ impl ::std::convert::From<&CheckRunPullRequest> for CheckRunPullRequest {
         value.clone()
     }
 }
-#[doc = "CheckRunPullRequestBase"]
+#[doc = "`CheckRunPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8465,7 +8465,7 @@ impl ::std::convert::From<&CheckRunPullRequestBase> for CheckRunPullRequestBase 
         value.clone()
     }
 }
-#[doc = "CheckRunPullRequestHead"]
+#[doc = "`CheckRunPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8505,7 +8505,7 @@ impl ::std::convert::From<&CheckRunPullRequestHead> for CheckRunPullRequestHead 
         value.clone()
     }
 }
-#[doc = "CheckRunRequestedAction"]
+#[doc = "`CheckRunRequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8809,7 +8809,7 @@ impl ::std::convert::From<&CheckRunRequestedAction> for CheckRunRequestedAction 
         value.clone()
     }
 }
-#[doc = "CheckRunRequestedActionAction"]
+#[doc = "`CheckRunRequestedActionAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9157,7 +9157,7 @@ impl ::std::convert::From<&CheckRunRequestedActionCheckRun> for CheckRunRequeste
         value.clone()
     }
 }
-#[doc = "CheckRunRequestedActionCheckRunCheckSuite"]
+#[doc = "`CheckRunRequestedActionCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9292,7 +9292,7 @@ impl ::std::convert::From<&CheckRunRequestedActionCheckRunCheckSuite>
         value.clone()
     }
 }
-#[doc = "CheckRunRequestedActionCheckRunCheckSuiteConclusion"]
+#[doc = "`CheckRunRequestedActionCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9398,7 +9398,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CheckRunRequestedActionCheckRunCheckSuiteStatus"]
+#[doc = "`CheckRunRequestedActionCheckRunCheckSuiteStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9592,7 +9592,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRequestedActionC
         value.parse()
     }
 }
-#[doc = "CheckRunRequestedActionCheckRunOutput"]
+#[doc = "`CheckRunRequestedActionCheckRunOutput`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9775,7 +9775,7 @@ impl ::std::default::Default for CheckRunRequestedActionRequestedAction {
         }
     }
 }
-#[doc = "CheckRunRerequested"]
+#[doc = "`CheckRunRerequested`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10072,7 +10072,7 @@ impl ::std::convert::From<&CheckRunRerequested> for CheckRunRerequested {
         value.clone()
     }
 }
-#[doc = "CheckRunRerequestedAction"]
+#[doc = "`CheckRunRerequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10409,7 +10409,7 @@ impl ::std::convert::From<&CheckRunRerequestedCheckRun> for CheckRunRerequestedC
         value.clone()
     }
 }
-#[doc = "CheckRunRerequestedCheckRunCheckSuite"]
+#[doc = "`CheckRunRerequestedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10538,7 +10538,7 @@ impl ::std::convert::From<&CheckRunRerequestedCheckRunCheckSuite>
         value.clone()
     }
 }
-#[doc = "CheckRunRerequestedCheckRunCheckSuiteConclusion"]
+#[doc = "`CheckRunRerequestedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10644,7 +10644,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CheckRunRerequestedCheckRunCheckSuiteStatus"]
+#[doc = "`CheckRunRerequestedCheckRunCheckSuiteStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10828,7 +10828,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRerequestedCheck
         value.parse()
     }
 }
-#[doc = "CheckRunRerequestedCheckRunOutput"]
+#[doc = "`CheckRunRerequestedCheckRunOutput`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11001,7 +11001,7 @@ impl ::std::default::Default for CheckRunRerequestedRequestedAction {
         }
     }
 }
-#[doc = "CheckSuiteCompleted"]
+#[doc = "`CheckSuiteCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11172,7 +11172,7 @@ impl ::std::convert::From<&CheckSuiteCompleted> for CheckSuiteCompleted {
         value.clone()
     }
 }
-#[doc = "CheckSuiteCompletedAction"]
+#[doc = "`CheckSuiteCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11588,7 +11588,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteCompletedCheck
         value.parse()
     }
 }
-#[doc = "CheckSuiteEvent"]
+#[doc = "`CheckSuiteEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11635,7 +11635,7 @@ impl ::std::convert::From<CheckSuiteRerequested> for CheckSuiteEvent {
         Self::Rerequested(value)
     }
 }
-#[doc = "CheckSuiteRequested"]
+#[doc = "`CheckSuiteRequested`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11806,7 +11806,7 @@ impl ::std::convert::From<&CheckSuiteRequested> for CheckSuiteRequested {
         value.clone()
     }
 }
-#[doc = "CheckSuiteRequestedAction"]
+#[doc = "`CheckSuiteRequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12222,7 +12222,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRequestedCheck
         value.parse()
     }
 }
-#[doc = "CheckSuiteRerequested"]
+#[doc = "`CheckSuiteRerequested`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12393,7 +12393,7 @@ impl ::std::convert::From<&CheckSuiteRerequested> for CheckSuiteRerequested {
         value.clone()
     }
 }
-#[doc = "CheckSuiteRerequestedAction"]
+#[doc = "`CheckSuiteRerequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12809,7 +12809,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRerequestedChe
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertAppearedInBranch"]
+#[doc = "`CodeScanningAlertAppearedInBranch`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13023,7 +13023,7 @@ impl ::std::convert::From<&CodeScanningAlertAppearedInBranch>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertAppearedInBranchAction"]
+#[doc = "`CodeScanningAlertAppearedInBranchAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13361,7 +13361,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertAppearedInBranchAlertRule"]
+#[doc = "`CodeScanningAlertAppearedInBranchAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13597,7 +13597,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertAppearedInBranchAlertTool"]
+#[doc = "`CodeScanningAlertAppearedInBranchAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13640,7 +13640,7 @@ impl ::std::convert::From<&CodeScanningAlertAppearedInBranchAlertTool>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertClosedByUser"]
+#[doc = "`CodeScanningAlertClosedByUser`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13874,7 +13874,7 @@ impl ::std::convert::From<&CodeScanningAlertClosedByUser> for CodeScanningAlertC
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAction"]
+#[doc = "`CodeScanningAlertClosedByUserAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14234,7 +14234,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertInstancesItem"]
+#[doc = "`CodeScanningAlertClosedByUserAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14290,7 +14290,7 @@ impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertInstancesItem>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertInstancesItemLocation"]
+#[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14350,7 +14350,7 @@ impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItem
         }
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertInstancesItemMessage"]
+#[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14386,7 +14386,7 @@ impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItem
         }
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertInstancesItemState"]
+#[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14462,7 +14462,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertRule"]
+#[doc = "`CodeScanningAlertClosedByUserAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14704,7 +14704,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertClosedB
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertClosedByUserAlertTool"]
+#[doc = "`CodeScanningAlertClosedByUserAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14755,7 +14755,7 @@ impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertTool>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertCreated"]
+#[doc = "`CodeScanningAlertCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14984,7 +14984,7 @@ impl ::std::convert::From<&CodeScanningAlertCreated> for CodeScanningAlertCreate
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertCreatedAction"]
+#[doc = "`CodeScanningAlertCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15249,7 +15249,7 @@ impl ::std::convert::From<&CodeScanningAlertCreatedAlert> for CodeScanningAlertC
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertInstancesItem"]
+#[doc = "`CodeScanningAlertCreatedAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15306,7 +15306,7 @@ impl ::std::convert::From<&CodeScanningAlertCreatedAlertInstancesItem>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertInstancesItemLocation"]
+#[doc = "`CodeScanningAlertCreatedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15366,7 +15366,7 @@ impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemLocat
         }
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertInstancesItemMessage"]
+#[doc = "`CodeScanningAlertCreatedAlertInstancesItemMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15402,7 +15402,7 @@ impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemMessa
         }
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertInstancesItemState"]
+#[doc = "`CodeScanningAlertCreatedAlertInstancesItemState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15483,7 +15483,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertRule"]
+#[doc = "`CodeScanningAlertCreatedAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15726,7 +15726,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertCreated
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertCreatedAlertTool"]
+#[doc = "`CodeScanningAlertCreatedAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15777,7 +15777,7 @@ impl ::std::convert::From<&CodeScanningAlertCreatedAlertTool>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertEvent"]
+#[doc = "`CodeScanningAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15851,7 +15851,7 @@ impl ::std::convert::From<CodeScanningAlertReopenedByUser> for CodeScanningAlert
         Self::ReopenedByUser(value)
     }
 }
-#[doc = "CodeScanningAlertFixed"]
+#[doc = "`CodeScanningAlertFixed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16102,7 +16102,7 @@ impl ::std::convert::From<&CodeScanningAlertFixed> for CodeScanningAlertFixed {
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertFixedAction"]
+#[doc = "`CodeScanningAlertFixedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16476,7 +16476,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAl
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertFixedAlertInstancesItem"]
+#[doc = "`CodeScanningAlertFixedAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16532,7 +16532,7 @@ impl ::std::convert::From<&CodeScanningAlertFixedAlertInstancesItem>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertFixedAlertInstancesItemLocation"]
+#[doc = "`CodeScanningAlertFixedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16592,7 +16592,7 @@ impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemLocatio
         }
     }
 }
-#[doc = "CodeScanningAlertFixedAlertInstancesItemMessage"]
+#[doc = "`CodeScanningAlertFixedAlertInstancesItemMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16628,7 +16628,7 @@ impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemMessage
         }
     }
 }
-#[doc = "CodeScanningAlertFixedAlertInstancesItemState"]
+#[doc = "`CodeScanningAlertFixedAlertInstancesItemState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16704,7 +16704,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertFixedAlertRule"]
+#[doc = "`CodeScanningAlertFixedAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16940,7 +16940,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAl
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertFixedAlertTool"]
+#[doc = "`CodeScanningAlertFixedAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16989,7 +16989,7 @@ impl ::std::convert::From<&CodeScanningAlertFixedAlertTool> for CodeScanningAler
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopened"]
+#[doc = "`CodeScanningAlertReopened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17218,7 +17218,7 @@ impl ::std::convert::From<&CodeScanningAlertReopened> for CodeScanningAlertReope
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedAction"]
+#[doc = "`CodeScanningAlertReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17483,7 +17483,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedAlert> for CodeScanningAlert
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertInstancesItem"]
+#[doc = "`CodeScanningAlertReopenedAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17539,7 +17539,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedAlertInstancesItem>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertInstancesItemLocation"]
+#[doc = "`CodeScanningAlertReopenedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17599,7 +17599,7 @@ impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemLoca
         }
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertInstancesItemMessage"]
+#[doc = "`CodeScanningAlertReopenedAlertInstancesItemMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17635,7 +17635,7 @@ impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemMess
         }
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertInstancesItemState"]
+#[doc = "`CodeScanningAlertReopenedAlertInstancesItemState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17711,7 +17711,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertRule"]
+#[doc = "`CodeScanningAlertReopenedAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17961,7 +17961,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertReopene
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertReopenedAlertTool"]
+#[doc = "`CodeScanningAlertReopenedAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18012,7 +18012,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedAlertTool>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUser"]
+#[doc = "`CodeScanningAlertReopenedByUser`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18221,7 +18221,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedByUser> for CodeScanningAler
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAction"]
+#[doc = "`CodeScanningAlertReopenedByUserAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18468,7 +18468,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlert>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertInstancesItem"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18524,7 +18524,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertInstancesItem>
         value.clone()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertInstancesItemLocation"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18584,7 +18584,7 @@ impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesIt
         }
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertInstancesItemMessage"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemMessage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18620,7 +18620,7 @@ impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesIt
         }
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertInstancesItemState"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18696,7 +18696,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertRule"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertRule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18918,7 +18918,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertReopene
         value.parse()
     }
 }
-#[doc = "CodeScanningAlertReopenedByUserAlertTool"]
+#[doc = "`CodeScanningAlertReopenedByUserAlertTool`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18961,7 +18961,7 @@ impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertTool>
         value.clone()
     }
 }
-#[doc = "Commit"]
+#[doc = "`Commit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19392,7 +19392,7 @@ impl ::std::convert::From<&CommitCommentCreatedComment> for CommitCommentCreated
         value.clone()
     }
 }
-#[doc = "CommitCommentEvent"]
+#[doc = "`CommitCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19430,7 +19430,7 @@ impl ::std::convert::From<CommitCommentCreated> for CommitCommentEvent {
         Self(value)
     }
 }
-#[doc = "CommitSimple"]
+#[doc = "`CommitSimple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19546,7 +19546,7 @@ impl ::std::convert::From<&Committer> for Committer {
         value.clone()
     }
 }
-#[doc = "ContentReferenceCreated"]
+#[doc = "`ContentReferenceCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19623,7 +19623,7 @@ impl ::std::convert::From<&ContentReferenceCreated> for ContentReferenceCreated 
         value.clone()
     }
 }
-#[doc = "ContentReferenceCreatedAction"]
+#[doc = "`ContentReferenceCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19695,7 +19695,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ContentReferenceCreatedA
         value.parse()
     }
 }
-#[doc = "ContentReferenceCreatedContentReference"]
+#[doc = "`ContentReferenceCreatedContentReference`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19737,7 +19737,7 @@ impl ::std::convert::From<&ContentReferenceCreatedContentReference>
         value.clone()
     }
 }
-#[doc = "ContentReferenceEvent"]
+#[doc = "`ContentReferenceEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20094,7 +20094,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DeleteEventRefType {
         value.parse()
     }
 }
-#[doc = "DeployKeyCreated"]
+#[doc = "`DeployKeyCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20188,7 +20188,7 @@ impl ::std::convert::From<&DeployKeyCreated> for DeployKeyCreated {
         value.clone()
     }
 }
-#[doc = "DeployKeyCreatedAction"]
+#[doc = "`DeployKeyCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20321,7 +20321,7 @@ impl ::std::convert::From<&DeployKeyCreatedKey> for DeployKeyCreatedKey {
         value.clone()
     }
 }
-#[doc = "DeployKeyDeleted"]
+#[doc = "`DeployKeyDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20415,7 +20415,7 @@ impl ::std::convert::From<&DeployKeyDeleted> for DeployKeyDeleted {
         value.clone()
     }
 }
-#[doc = "DeployKeyDeletedAction"]
+#[doc = "`DeployKeyDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20548,7 +20548,7 @@ impl ::std::convert::From<&DeployKeyDeletedKey> for DeployKeyDeletedKey {
         value.clone()
     }
 }
-#[doc = "DeployKeyEvent"]
+#[doc = "`DeployKeyEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20586,7 +20586,7 @@ impl ::std::convert::From<DeployKeyDeleted> for DeployKeyEvent {
         Self::Deleted(value)
     }
 }
-#[doc = "DeploymentCreated"]
+#[doc = "`DeploymentCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20735,7 +20735,7 @@ impl ::std::convert::From<&DeploymentCreated> for DeploymentCreated {
         value.clone()
     }
 }
-#[doc = "DeploymentCreatedAction"]
+#[doc = "`DeploymentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20924,7 +20924,7 @@ impl ::std::convert::From<&DeploymentCreatedDeployment> for DeploymentCreatedDep
         value.clone()
     }
 }
-#[doc = "DeploymentCreatedDeploymentPayload"]
+#[doc = "`DeploymentCreatedDeploymentPayload`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20950,7 +20950,7 @@ impl ::std::default::Default for DeploymentCreatedDeploymentPayload {
         Self {}
     }
 }
-#[doc = "DeploymentEvent"]
+#[doc = "`DeploymentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20988,7 +20988,7 @@ impl ::std::convert::From<DeploymentCreated> for DeploymentEvent {
         Self(value)
     }
 }
-#[doc = "DeploymentStatusCreated"]
+#[doc = "`DeploymentStatusCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21203,7 +21203,7 @@ impl ::std::convert::From<&DeploymentStatusCreated> for DeploymentStatusCreated 
         value.clone()
     }
 }
-#[doc = "DeploymentStatusCreatedAction"]
+#[doc = "`DeploymentStatusCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21394,7 +21394,7 @@ impl ::std::convert::From<&DeploymentStatusCreatedDeployment>
         value.clone()
     }
 }
-#[doc = "DeploymentStatusCreatedDeploymentPayload"]
+#[doc = "`DeploymentStatusCreatedDeploymentPayload`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21528,7 +21528,7 @@ impl ::std::convert::From<&DeploymentStatusCreatedDeploymentStatus>
         value.clone()
     }
 }
-#[doc = "DeploymentStatusEvent"]
+#[doc = "`DeploymentStatusEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21566,7 +21566,7 @@ impl ::std::convert::From<DeploymentStatusCreated> for DeploymentStatusEvent {
         Self(value)
     }
 }
-#[doc = "Discussion"]
+#[doc = "`Discussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21752,7 +21752,7 @@ impl ::std::convert::From<&Discussion> for Discussion {
         value.clone()
     }
 }
-#[doc = "DiscussionAnswered"]
+#[doc = "`DiscussionAnswered`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21913,7 +21913,7 @@ impl ::std::convert::From<&DiscussionAnswered> for DiscussionAnswered {
         value.clone()
     }
 }
-#[doc = "DiscussionAnsweredAction"]
+#[doc = "`DiscussionAnsweredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21985,7 +21985,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionAnsweredAction
         value.parse()
     }
 }
-#[doc = "DiscussionAnsweredAnswer"]
+#[doc = "`DiscussionAnsweredAnswer`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22071,7 +22071,7 @@ impl ::std::convert::From<&DiscussionAnsweredAnswer> for DiscussionAnsweredAnswe
         value.clone()
     }
 }
-#[doc = "DiscussionAnsweredDiscussion"]
+#[doc = "`DiscussionAnsweredDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22151,7 +22151,7 @@ impl ::std::convert::From<&DiscussionAnsweredDiscussion> for DiscussionAnsweredD
         value.clone()
     }
 }
-#[doc = "DiscussionAnsweredDiscussionAnswerChosenBy"]
+#[doc = "`DiscussionAnsweredDiscussionAnswerChosenBy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22310,7 +22310,7 @@ impl ::std::convert::From<&DiscussionAnsweredDiscussionAnswerChosenBy>
         value.clone()
     }
 }
-#[doc = "DiscussionAnsweredDiscussionAnswerChosenByType"]
+#[doc = "`DiscussionAnsweredDiscussionAnswerChosenByType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22393,7 +22393,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DiscussionAnsweredDiscussionCategory"]
+#[doc = "`DiscussionAnsweredDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22468,7 +22468,7 @@ impl ::std::convert::From<&DiscussionAnsweredDiscussionCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionAnsweredDiscussionState"]
+#[doc = "`DiscussionAnsweredDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22550,7 +22550,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionAnsweredDiscus
         value.parse()
     }
 }
-#[doc = "DiscussionCategory"]
+#[doc = "`DiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22620,7 +22620,7 @@ impl ::std::convert::From<&DiscussionCategory> for DiscussionCategory {
         value.clone()
     }
 }
-#[doc = "DiscussionCategoryChanged"]
+#[doc = "`DiscussionCategoryChanged`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22744,7 +22744,7 @@ impl ::std::convert::From<&DiscussionCategoryChanged> for DiscussionCategoryChan
         value.clone()
     }
 }
-#[doc = "DiscussionCategoryChangedAction"]
+#[doc = "`DiscussionCategoryChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22816,7 +22816,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCategoryChange
         value.parse()
     }
 }
-#[doc = "DiscussionCategoryChangedChanges"]
+#[doc = "`DiscussionCategoryChangedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22896,7 +22896,7 @@ impl ::std::convert::From<&DiscussionCategoryChangedChanges> for DiscussionCateg
         value.clone()
     }
 }
-#[doc = "DiscussionCategoryChangedChangesCategory"]
+#[doc = "`DiscussionCategoryChangedChangesCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22969,7 +22969,7 @@ impl ::std::convert::From<&DiscussionCategoryChangedChangesCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionCategoryChangedChangesCategoryFrom"]
+#[doc = "`DiscussionCategoryChangedChangesCategoryFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23041,7 +23041,7 @@ impl ::std::convert::From<&DiscussionCategoryChangedChangesCategoryFrom>
         value.clone()
     }
 }
-#[doc = "DiscussionCommentCreated"]
+#[doc = "`DiscussionCommentCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23161,7 +23161,7 @@ impl ::std::convert::From<&DiscussionCommentCreated> for DiscussionCommentCreate
         value.clone()
     }
 }
-#[doc = "DiscussionCommentCreatedAction"]
+#[doc = "`DiscussionCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23233,7 +23233,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCommentCreated
         value.parse()
     }
 }
-#[doc = "DiscussionCommentCreatedComment"]
+#[doc = "`DiscussionCommentCreatedComment`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23320,7 +23320,7 @@ impl ::std::convert::From<&DiscussionCommentCreatedComment> for DiscussionCommen
         value.clone()
     }
 }
-#[doc = "DiscussionCommentDeleted"]
+#[doc = "`DiscussionCommentDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23440,7 +23440,7 @@ impl ::std::convert::From<&DiscussionCommentDeleted> for DiscussionCommentDelete
         value.clone()
     }
 }
-#[doc = "DiscussionCommentDeletedAction"]
+#[doc = "`DiscussionCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23512,7 +23512,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCommentDeleted
         value.parse()
     }
 }
-#[doc = "DiscussionCommentDeletedComment"]
+#[doc = "`DiscussionCommentDeletedComment`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23599,7 +23599,7 @@ impl ::std::convert::From<&DiscussionCommentDeletedComment> for DiscussionCommen
         value.clone()
     }
 }
-#[doc = "DiscussionCommentEdited"]
+#[doc = "`DiscussionCommentEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23742,7 +23742,7 @@ impl ::std::convert::From<&DiscussionCommentEdited> for DiscussionCommentEdited 
         value.clone()
     }
 }
-#[doc = "DiscussionCommentEditedAction"]
+#[doc = "`DiscussionCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23814,7 +23814,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCommentEditedA
         value.parse()
     }
 }
-#[doc = "DiscussionCommentEditedChanges"]
+#[doc = "`DiscussionCommentEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23852,7 +23852,7 @@ impl ::std::convert::From<&DiscussionCommentEditedChanges> for DiscussionComment
         value.clone()
     }
 }
-#[doc = "DiscussionCommentEditedChangesBody"]
+#[doc = "`DiscussionCommentEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23883,7 +23883,7 @@ impl ::std::convert::From<&DiscussionCommentEditedChangesBody>
         value.clone()
     }
 }
-#[doc = "DiscussionCommentEditedComment"]
+#[doc = "`DiscussionCommentEditedComment`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23970,7 +23970,7 @@ impl ::std::convert::From<&DiscussionCommentEditedComment> for DiscussionComment
         value.clone()
     }
 }
-#[doc = "DiscussionCommentEvent"]
+#[doc = "`DiscussionCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24017,7 +24017,7 @@ impl ::std::convert::From<DiscussionCommentEdited> for DiscussionCommentEvent {
         Self::Edited(value)
     }
 }
-#[doc = "DiscussionCreated"]
+#[doc = "`DiscussionCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24115,7 +24115,7 @@ impl ::std::convert::From<&DiscussionCreated> for DiscussionCreated {
         value.clone()
     }
 }
-#[doc = "DiscussionCreatedAction"]
+#[doc = "`DiscussionCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24187,7 +24187,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedAction 
         value.parse()
     }
 }
-#[doc = "DiscussionCreatedDiscussion"]
+#[doc = "`DiscussionCreatedDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24264,7 +24264,7 @@ impl ::std::convert::From<&DiscussionCreatedDiscussion> for DiscussionCreatedDis
         value.clone()
     }
 }
-#[doc = "DiscussionCreatedDiscussionCategory"]
+#[doc = "`DiscussionCreatedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24336,7 +24336,7 @@ impl ::std::convert::From<&DiscussionCreatedDiscussionCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionCreatedDiscussionState"]
+#[doc = "`DiscussionCreatedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24413,7 +24413,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedDiscuss
         value.parse()
     }
 }
-#[doc = "DiscussionDeleted"]
+#[doc = "`DiscussionDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24472,7 +24472,7 @@ impl ::std::convert::From<&DiscussionDeleted> for DiscussionDeleted {
         value.clone()
     }
 }
-#[doc = "DiscussionDeletedAction"]
+#[doc = "`DiscussionDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24544,7 +24544,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionDeletedAction 
         value.parse()
     }
 }
-#[doc = "DiscussionEdited"]
+#[doc = "`DiscussionEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24635,7 +24635,7 @@ impl ::std::convert::From<&DiscussionEdited> for DiscussionEdited {
         value.clone()
     }
 }
-#[doc = "DiscussionEditedAction"]
+#[doc = "`DiscussionEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24707,7 +24707,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionEditedAction {
         value.parse()
     }
 }
-#[doc = "DiscussionEditedChanges"]
+#[doc = "`DiscussionEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24765,7 +24765,7 @@ impl ::std::default::Default for DiscussionEditedChanges {
         }
     }
 }
-#[doc = "DiscussionEditedChangesBody"]
+#[doc = "`DiscussionEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24794,7 +24794,7 @@ impl ::std::convert::From<&DiscussionEditedChangesBody> for DiscussionEditedChan
         value.clone()
     }
 }
-#[doc = "DiscussionEditedChangesTitle"]
+#[doc = "`DiscussionEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24823,7 +24823,7 @@ impl ::std::convert::From<&DiscussionEditedChangesTitle> for DiscussionEditedCha
         value.clone()
     }
 }
-#[doc = "DiscussionEvent"]
+#[doc = "`DiscussionEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24960,7 +24960,7 @@ impl ::std::convert::From<DiscussionUnpinned> for DiscussionEvent {
         Self::Unpinned(value)
     }
 }
-#[doc = "DiscussionLabeled"]
+#[doc = "`DiscussionLabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25024,7 +25024,7 @@ impl ::std::convert::From<&DiscussionLabeled> for DiscussionLabeled {
         value.clone()
     }
 }
-#[doc = "DiscussionLabeledAction"]
+#[doc = "`DiscussionLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25096,7 +25096,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLabeledAction 
         value.parse()
     }
 }
-#[doc = "DiscussionLocked"]
+#[doc = "`DiscussionLocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25181,7 +25181,7 @@ impl ::std::convert::From<&DiscussionLocked> for DiscussionLocked {
         value.clone()
     }
 }
-#[doc = "DiscussionLockedAction"]
+#[doc = "`DiscussionLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25253,7 +25253,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLockedAction {
         value.parse()
     }
 }
-#[doc = "DiscussionLockedDiscussion"]
+#[doc = "`DiscussionLockedDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25317,7 +25317,7 @@ impl ::std::convert::From<&DiscussionLockedDiscussion> for DiscussionLockedDiscu
         value.clone()
     }
 }
-#[doc = "DiscussionLockedDiscussionCategory"]
+#[doc = "`DiscussionLockedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25389,7 +25389,7 @@ impl ::std::convert::From<&DiscussionLockedDiscussionCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionLockedDiscussionState"]
+#[doc = "`DiscussionLockedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25461,7 +25461,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLockedDiscussi
         value.parse()
     }
 }
-#[doc = "DiscussionPinned"]
+#[doc = "`DiscussionPinned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25520,7 +25520,7 @@ impl ::std::convert::From<&DiscussionPinned> for DiscussionPinned {
         value.clone()
     }
 }
-#[doc = "DiscussionPinnedAction"]
+#[doc = "`DiscussionPinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25592,7 +25592,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionPinnedAction {
         value.parse()
     }
 }
-#[doc = "DiscussionState"]
+#[doc = "`DiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25674,7 +25674,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionState {
         value.parse()
     }
 }
-#[doc = "DiscussionTransferred"]
+#[doc = "`DiscussionTransferred`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25751,7 +25751,7 @@ impl ::std::convert::From<&DiscussionTransferred> for DiscussionTransferred {
         value.clone()
     }
 }
-#[doc = "DiscussionTransferredAction"]
+#[doc = "`DiscussionTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25823,7 +25823,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionTransferredAct
         value.parse()
     }
 }
-#[doc = "DiscussionTransferredChanges"]
+#[doc = "`DiscussionTransferredChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25857,7 +25857,7 @@ impl ::std::convert::From<&DiscussionTransferredChanges> for DiscussionTransferr
         value.clone()
     }
 }
-#[doc = "DiscussionUnanswered"]
+#[doc = "`DiscussionUnanswered`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26016,7 +26016,7 @@ impl ::std::convert::From<&DiscussionUnanswered> for DiscussionUnanswered {
         value.clone()
     }
 }
-#[doc = "DiscussionUnansweredAction"]
+#[doc = "`DiscussionUnansweredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26088,7 +26088,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnansweredActi
         value.parse()
     }
 }
-#[doc = "DiscussionUnansweredDiscussion"]
+#[doc = "`DiscussionUnansweredDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26166,7 +26166,7 @@ impl ::std::convert::From<&DiscussionUnansweredDiscussion> for DiscussionUnanswe
         value.clone()
     }
 }
-#[doc = "DiscussionUnansweredDiscussionCategory"]
+#[doc = "`DiscussionUnansweredDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26241,7 +26241,7 @@ impl ::std::convert::From<&DiscussionUnansweredDiscussionCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionUnansweredDiscussionState"]
+#[doc = "`DiscussionUnansweredDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26323,7 +26323,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnansweredDisc
         value.parse()
     }
 }
-#[doc = "DiscussionUnansweredOldAnswer"]
+#[doc = "`DiscussionUnansweredOldAnswer`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26409,7 +26409,7 @@ impl ::std::convert::From<&DiscussionUnansweredOldAnswer> for DiscussionUnanswer
         value.clone()
     }
 }
-#[doc = "DiscussionUnlabeled"]
+#[doc = "`DiscussionUnlabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26473,7 +26473,7 @@ impl ::std::convert::From<&DiscussionUnlabeled> for DiscussionUnlabeled {
         value.clone()
     }
 }
-#[doc = "DiscussionUnlabeledAction"]
+#[doc = "`DiscussionUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26545,7 +26545,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlabeledActio
         value.parse()
     }
 }
-#[doc = "DiscussionUnlocked"]
+#[doc = "`DiscussionUnlocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26630,7 +26630,7 @@ impl ::std::convert::From<&DiscussionUnlocked> for DiscussionUnlocked {
         value.clone()
     }
 }
-#[doc = "DiscussionUnlockedAction"]
+#[doc = "`DiscussionUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26702,7 +26702,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlockedAction
         value.parse()
     }
 }
-#[doc = "DiscussionUnlockedDiscussion"]
+#[doc = "`DiscussionUnlockedDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26766,7 +26766,7 @@ impl ::std::convert::From<&DiscussionUnlockedDiscussion> for DiscussionUnlockedD
         value.clone()
     }
 }
-#[doc = "DiscussionUnlockedDiscussionCategory"]
+#[doc = "`DiscussionUnlockedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26838,7 +26838,7 @@ impl ::std::convert::From<&DiscussionUnlockedDiscussionCategory>
         value.clone()
     }
 }
-#[doc = "DiscussionUnlockedDiscussionState"]
+#[doc = "`DiscussionUnlockedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26910,7 +26910,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlockedDiscus
         value.parse()
     }
 }
-#[doc = "DiscussionUnpinned"]
+#[doc = "`DiscussionUnpinned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26969,7 +26969,7 @@ impl ::std::convert::From<&DiscussionUnpinned> for DiscussionUnpinned {
         value.clone()
     }
 }
-#[doc = "DiscussionUnpinnedAction"]
+#[doc = "`DiscussionUnpinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27041,7 +27041,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnpinnedAction
         value.parse()
     }
 }
-#[doc = "Everything"]
+#[doc = "`Everything`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27772,7 +27772,7 @@ impl ::std::convert::From<&ForkEventForkee> for ForkEventForkee {
         value.clone()
     }
 }
-#[doc = "ForkEventForkeeCreatedAt"]
+#[doc = "`ForkEventForkeeCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27853,7 +27853,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>> for ForkEventFo
         Self::Variant1(value)
     }
 }
-#[doc = "ForkEventForkeePermissions"]
+#[doc = "`ForkEventForkeePermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27902,7 +27902,7 @@ impl ::std::convert::From<&ForkEventForkeePermissions> for ForkEventForkeePermis
         value.clone()
     }
 }
-#[doc = "ForkEventForkeePushedAt"]
+#[doc = "`ForkEventForkeePushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27945,7 +27945,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>> for ForkEventFo
         Self::Variant1(value)
     }
 }
-#[doc = "GithubAppAuthorizationEvent"]
+#[doc = "`GithubAppAuthorizationEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27983,7 +27983,7 @@ impl ::std::convert::From<GithubAppAuthorizationRevoked> for GithubAppAuthorizat
         Self(value)
     }
 }
-#[doc = "GithubAppAuthorizationRevoked"]
+#[doc = "`GithubAppAuthorizationRevoked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28022,7 +28022,7 @@ impl ::std::convert::From<&GithubAppAuthorizationRevoked> for GithubAppAuthoriza
         value.clone()
     }
 }
-#[doc = "GithubAppAuthorizationRevokedAction"]
+#[doc = "`GithubAppAuthorizationRevokedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28094,7 +28094,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GithubAppAuthorizationRe
         value.parse()
     }
 }
-#[doc = "GithubOrg"]
+#[doc = "`GithubOrg`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28348,7 +28348,7 @@ impl ::std::convert::From<&GollumEvent> for GollumEvent {
         value.clone()
     }
 }
-#[doc = "GollumEventPagesItem"]
+#[doc = "`GollumEventPagesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28965,7 +28965,7 @@ impl ::std::convert::From<&Installation> for Installation {
         value.clone()
     }
 }
-#[doc = "InstallationCreated"]
+#[doc = "`InstallationCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29052,7 +29052,7 @@ impl ::std::convert::From<&InstallationCreated> for InstallationCreated {
         value.clone()
     }
 }
-#[doc = "InstallationCreatedAction"]
+#[doc = "`InstallationCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29124,7 +29124,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedActio
         value.parse()
     }
 }
-#[doc = "InstallationCreatedAt"]
+#[doc = "`InstallationCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29205,7 +29205,7 @@ impl ::std::convert::From<i64> for InstallationCreatedAt {
         Self::Variant1(value)
     }
 }
-#[doc = "InstallationCreatedRepositoriesItem"]
+#[doc = "`InstallationCreatedRepositoriesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29262,7 +29262,7 @@ impl ::std::convert::From<&InstallationCreatedRepositoriesItem>
         value.clone()
     }
 }
-#[doc = "InstallationDeleted"]
+#[doc = "`InstallationDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29349,7 +29349,7 @@ impl ::std::convert::From<&InstallationDeleted> for InstallationDeleted {
         value.clone()
     }
 }
-#[doc = "InstallationDeletedAction"]
+#[doc = "`InstallationDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29421,7 +29421,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationDeletedActio
         value.parse()
     }
 }
-#[doc = "InstallationDeletedRepositoriesItem"]
+#[doc = "`InstallationDeletedRepositoriesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29478,7 +29478,7 @@ impl ::std::convert::From<&InstallationDeletedRepositoriesItem>
         value.clone()
     }
 }
-#[doc = "InstallationEvent"]
+#[doc = "`InstallationEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29543,7 +29543,7 @@ impl ::std::convert::From<InstallationUnsuspend> for InstallationEvent {
         Self::Unsuspend(value)
     }
 }
-#[doc = "InstallationEventsItem"]
+#[doc = "`InstallationEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29874,7 +29874,7 @@ impl ::std::convert::From<&InstallationLite> for InstallationLite {
         value.clone()
     }
 }
-#[doc = "InstallationNewPermissionsAccepted"]
+#[doc = "`InstallationNewPermissionsAccepted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29963,7 +29963,7 @@ impl ::std::convert::From<&InstallationNewPermissionsAccepted>
         value.clone()
     }
 }
-#[doc = "InstallationNewPermissionsAcceptedAction"]
+#[doc = "`InstallationNewPermissionsAcceptedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30035,7 +30035,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationNewPermissio
         value.parse()
     }
 }
-#[doc = "InstallationNewPermissionsAcceptedRepositoriesItem"]
+#[doc = "`InstallationNewPermissionsAcceptedRepositoriesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30092,7 +30092,7 @@ impl ::std::convert::From<&InstallationNewPermissionsAcceptedRepositoriesItem>
         value.clone()
     }
 }
-#[doc = "InstallationPermissions"]
+#[doc = "`InstallationPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30474,7 +30474,7 @@ impl ::std::default::Default for InstallationPermissions {
         }
     }
 }
-#[doc = "InstallationPermissionsActions"]
+#[doc = "`InstallationPermissionsActions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30551,7 +30551,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsA
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsAdministration"]
+#[doc = "`InstallationPermissionsAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30628,7 +30628,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsA
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsChecks"]
+#[doc = "`InstallationPermissionsChecks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30705,7 +30705,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsC
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsContentReferences"]
+#[doc = "`InstallationPermissionsContentReferences`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30782,7 +30782,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsC
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsContents"]
+#[doc = "`InstallationPermissionsContents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30859,7 +30859,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsC
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsDeployments"]
+#[doc = "`InstallationPermissionsDeployments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30936,7 +30936,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsD
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsDiscussions"]
+#[doc = "`InstallationPermissionsDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31013,7 +31013,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsD
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsEmails"]
+#[doc = "`InstallationPermissionsEmails`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31090,7 +31090,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsE
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsEnvironments"]
+#[doc = "`InstallationPermissionsEnvironments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31167,7 +31167,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsE
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsIssues"]
+#[doc = "`InstallationPermissionsIssues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31244,7 +31244,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsI
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsMembers"]
+#[doc = "`InstallationPermissionsMembers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31321,7 +31321,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsM
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsMetadata"]
+#[doc = "`InstallationPermissionsMetadata`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31398,7 +31398,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsM
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationAdministration"]
+#[doc = "`InstallationPermissionsOrganizationAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31479,7 +31479,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationEvents"]
+#[doc = "`InstallationPermissionsOrganizationEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31556,7 +31556,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsO
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationHooks"]
+#[doc = "`InstallationPermissionsOrganizationHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31633,7 +31633,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsO
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationPackages"]
+#[doc = "`InstallationPermissionsOrganizationPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31714,7 +31714,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationPlan"]
+#[doc = "`InstallationPermissionsOrganizationPlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31791,7 +31791,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsO
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationProjects"]
+#[doc = "`InstallationPermissionsOrganizationProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31872,7 +31872,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationSecrets"]
+#[doc = "`InstallationPermissionsOrganizationSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31951,7 +31951,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsO
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationSelfHostedRunners"]
+#[doc = "`InstallationPermissionsOrganizationSelfHostedRunners`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32032,7 +32032,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsOrganizationUserBlocking"]
+#[doc = "`InstallationPermissionsOrganizationUserBlocking`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32113,7 +32113,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsPackages"]
+#[doc = "`InstallationPermissionsPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32190,7 +32190,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsP
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsPages"]
+#[doc = "`InstallationPermissionsPages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32267,7 +32267,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsP
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsPullRequests"]
+#[doc = "`InstallationPermissionsPullRequests`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32344,7 +32344,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsP
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsRepositoryHooks"]
+#[doc = "`InstallationPermissionsRepositoryHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32421,7 +32421,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsR
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsRepositoryProjects"]
+#[doc = "`InstallationPermissionsRepositoryProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32498,7 +32498,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsR
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsSecretScanningAlerts"]
+#[doc = "`InstallationPermissionsSecretScanningAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32579,7 +32579,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsSecrets"]
+#[doc = "`InstallationPermissionsSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32656,7 +32656,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsS
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsSecurityEvents"]
+#[doc = "`InstallationPermissionsSecurityEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32733,7 +32733,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsS
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsSecurityScanningAlert"]
+#[doc = "`InstallationPermissionsSecurityScanningAlert`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32814,7 +32814,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsSingleFile"]
+#[doc = "`InstallationPermissionsSingleFile`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32891,7 +32891,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsS
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsStatuses"]
+#[doc = "`InstallationPermissionsStatuses`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32968,7 +32968,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsS
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsTeamDiscussions"]
+#[doc = "`InstallationPermissionsTeamDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33045,7 +33045,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsT
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsVulnerabilityAlerts"]
+#[doc = "`InstallationPermissionsVulnerabilityAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33124,7 +33124,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsV
         value.parse()
     }
 }
-#[doc = "InstallationPermissionsWorkflows"]
+#[doc = "`InstallationPermissionsWorkflows`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33201,7 +33201,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsW
         value.parse()
     }
 }
-#[doc = "InstallationRepositoriesAdded"]
+#[doc = "`InstallationRepositoriesAdded`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33338,7 +33338,7 @@ impl ::std::convert::From<&InstallationRepositoriesAdded> for InstallationReposi
         value.clone()
     }
 }
-#[doc = "InstallationRepositoriesAddedAction"]
+#[doc = "`InstallationRepositoriesAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33410,7 +33410,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationRepositories
         value.parse()
     }
 }
-#[doc = "InstallationRepositoriesAddedRepositoriesAddedItem"]
+#[doc = "`InstallationRepositoriesAddedRepositoriesAddedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33467,7 +33467,7 @@ impl ::std::convert::From<&InstallationRepositoriesAddedRepositoriesAddedItem>
         value.clone()
     }
 }
-#[doc = "InstallationRepositoriesAddedRepositoriesRemovedItem"]
+#[doc = "`InstallationRepositoriesAddedRepositoriesRemovedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33615,7 +33615,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationRepositoriesEvent"]
+#[doc = "`InstallationRepositoriesEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33653,7 +33653,7 @@ impl ::std::convert::From<InstallationRepositoriesRemoved> for InstallationRepos
         Self::Removed(value)
     }
 }
-#[doc = "InstallationRepositoriesRemoved"]
+#[doc = "`InstallationRepositoriesRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33798,7 +33798,7 @@ impl ::std::convert::From<&InstallationRepositoriesRemoved> for InstallationRepo
         value.clone()
     }
 }
-#[doc = "InstallationRepositoriesRemovedAction"]
+#[doc = "`InstallationRepositoriesRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33870,7 +33870,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationRepositories
         value.parse()
     }
 }
-#[doc = "InstallationRepositoriesRemovedRepositoriesAddedItem"]
+#[doc = "`InstallationRepositoriesRemovedRepositoriesAddedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33927,7 +33927,7 @@ impl ::std::convert::From<&InstallationRepositoriesRemovedRepositoriesAddedItem>
         value.clone()
     }
 }
-#[doc = "InstallationRepositoriesRemovedRepositoriesRemovedItem"]
+#[doc = "`InstallationRepositoriesRemovedRepositoriesRemovedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34144,7 +34144,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationRepositorySe
         value.parse()
     }
 }
-#[doc = "InstallationSuspend"]
+#[doc = "`InstallationSuspend`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34252,7 +34252,7 @@ impl ::std::convert::From<&InstallationSuspend> for InstallationSuspend {
         value.clone()
     }
 }
-#[doc = "InstallationSuspendAction"]
+#[doc = "`InstallationSuspendAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34324,7 +34324,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendActio
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallation"]
+#[doc = "`InstallationSuspendInstallation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34389,7 +34389,7 @@ impl ::std::convert::From<&InstallationSuspendInstallation> for InstallationSusp
         value.clone()
     }
 }
-#[doc = "InstallationSuspendInstallationCreatedAt"]
+#[doc = "`InstallationSuspendInstallationCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34472,7 +34472,7 @@ impl ::std::convert::From<i64> for InstallationSuspendInstallationCreatedAt {
         Self::Variant1(value)
     }
 }
-#[doc = "InstallationSuspendInstallationEventsItem"]
+#[doc = "`InstallationSuspendInstallationEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34764,7 +34764,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissions"]
+#[doc = "`InstallationSuspendInstallationPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35164,7 +35164,7 @@ impl ::std::default::Default for InstallationSuspendInstallationPermissions {
         }
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsActions"]
+#[doc = "`InstallationSuspendInstallationPermissionsActions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35245,7 +35245,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsAdministration"]
+#[doc = "`InstallationSuspendInstallationPermissionsAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35326,7 +35326,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsChecks"]
+#[doc = "`InstallationSuspendInstallationPermissionsChecks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35407,7 +35407,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsContentReferences"]
+#[doc = "`InstallationSuspendInstallationPermissionsContentReferences`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35488,7 +35488,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsContents"]
+#[doc = "`InstallationSuspendInstallationPermissionsContents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35569,7 +35569,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsDeployments"]
+#[doc = "`InstallationSuspendInstallationPermissionsDeployments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35650,7 +35650,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsDiscussions"]
+#[doc = "`InstallationSuspendInstallationPermissionsDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35731,7 +35731,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsEmails"]
+#[doc = "`InstallationSuspendInstallationPermissionsEmails`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35812,7 +35812,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsEnvironments"]
+#[doc = "`InstallationSuspendInstallationPermissionsEnvironments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35893,7 +35893,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsIssues"]
+#[doc = "`InstallationSuspendInstallationPermissionsIssues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35974,7 +35974,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsMembers"]
+#[doc = "`InstallationSuspendInstallationPermissionsMembers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36055,7 +36055,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsMetadata"]
+#[doc = "`InstallationSuspendInstallationPermissionsMetadata`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36136,7 +36136,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationAdministration"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36221,7 +36221,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationEvents"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36304,7 +36304,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationHooks"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36385,7 +36385,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationPackages"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36470,7 +36470,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationPlan"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationPlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36551,7 +36551,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationProjects"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36636,7 +36636,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationSecrets"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36719,7 +36719,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36810,7 +36810,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsOrganizationUserBlocking"]
+#[doc = "`InstallationSuspendInstallationPermissionsOrganizationUserBlocking`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36895,7 +36895,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsPackages"]
+#[doc = "`InstallationSuspendInstallationPermissionsPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36976,7 +36976,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsPages"]
+#[doc = "`InstallationSuspendInstallationPermissionsPages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37057,7 +37057,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsPullRequests"]
+#[doc = "`InstallationSuspendInstallationPermissionsPullRequests`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37138,7 +37138,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsRepositoryHooks"]
+#[doc = "`InstallationSuspendInstallationPermissionsRepositoryHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37219,7 +37219,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsRepositoryProjects"]
+#[doc = "`InstallationSuspendInstallationPermissionsRepositoryProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37302,7 +37302,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsSecretScanningAlerts"]
+#[doc = "`InstallationSuspendInstallationPermissionsSecretScanningAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37387,7 +37387,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsSecrets"]
+#[doc = "`InstallationSuspendInstallationPermissionsSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37468,7 +37468,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsSecurityEvents"]
+#[doc = "`InstallationSuspendInstallationPermissionsSecurityEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37549,7 +37549,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsSecurityScanningAlert"]
+#[doc = "`InstallationSuspendInstallationPermissionsSecurityScanningAlert`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37634,7 +37634,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsSingleFile"]
+#[doc = "`InstallationSuspendInstallationPermissionsSingleFile`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37715,7 +37715,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsStatuses"]
+#[doc = "`InstallationSuspendInstallationPermissionsStatuses`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37796,7 +37796,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsTeamDiscussions"]
+#[doc = "`InstallationSuspendInstallationPermissionsTeamDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37877,7 +37877,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsVulnerabilityAlerts"]
+#[doc = "`InstallationSuspendInstallationPermissionsVulnerabilityAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37960,7 +37960,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationPermissionsWorkflows"]
+#[doc = "`InstallationSuspendInstallationPermissionsWorkflows`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38123,7 +38123,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationSuspendedBy"]
+#[doc = "`InstallationSuspendInstallationSuspendedBy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38282,7 +38282,7 @@ impl ::std::convert::From<&InstallationSuspendInstallationSuspendedBy>
         value.clone()
     }
 }
-#[doc = "InstallationSuspendInstallationSuspendedByType"]
+#[doc = "`InstallationSuspendInstallationSuspendedByType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38365,7 +38365,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationTargetType"]
+#[doc = "`InstallationSuspendInstallationTargetType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38440,7 +38440,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
         value.parse()
     }
 }
-#[doc = "InstallationSuspendInstallationUpdatedAt"]
+#[doc = "`InstallationSuspendInstallationUpdatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38523,7 +38523,7 @@ impl ::std::convert::From<i64> for InstallationSuspendInstallationUpdatedAt {
         Self::Variant1(value)
     }
 }
-#[doc = "InstallationSuspendRepositoriesItem"]
+#[doc = "`InstallationSuspendRepositoriesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38580,7 +38580,7 @@ impl ::std::convert::From<&InstallationSuspendRepositoriesItem>
         value.clone()
     }
 }
-#[doc = "InstallationTargetType"]
+#[doc = "`InstallationTargetType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38655,7 +38655,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationTargetType {
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspend"]
+#[doc = "`InstallationUnsuspend`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38762,7 +38762,7 @@ impl ::std::convert::From<&InstallationUnsuspend> for InstallationUnsuspend {
         value.clone()
     }
 }
-#[doc = "InstallationUnsuspendAction"]
+#[doc = "`InstallationUnsuspendAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38834,7 +38834,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendAct
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallation"]
+#[doc = "`InstallationUnsuspendInstallation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38900,7 +38900,7 @@ impl ::std::convert::From<&InstallationUnsuspendInstallation>
         value.clone()
     }
 }
-#[doc = "InstallationUnsuspendInstallationCreatedAt"]
+#[doc = "`InstallationUnsuspendInstallationCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38985,7 +38985,7 @@ impl ::std::convert::From<i64> for InstallationUnsuspendInstallationCreatedAt {
         Self::Variant1(value)
     }
 }
-#[doc = "InstallationUnsuspendInstallationEventsItem"]
+#[doc = "`InstallationUnsuspendInstallationEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39281,7 +39281,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissions"]
+#[doc = "`InstallationUnsuspendInstallationPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39683,7 +39683,7 @@ impl ::std::default::Default for InstallationUnsuspendInstallationPermissions {
         }
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsActions"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsActions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39764,7 +39764,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsAdministration"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39845,7 +39845,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsChecks"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsChecks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39926,7 +39926,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsContentReferences"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsContentReferences`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40009,7 +40009,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsContents"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsContents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40090,7 +40090,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsDeployments"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsDeployments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40171,7 +40171,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsDiscussions"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40252,7 +40252,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsEmails"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsEmails`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40333,7 +40333,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsEnvironments"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsEnvironments`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40414,7 +40414,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsIssues"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsIssues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40495,7 +40495,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsMembers"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsMembers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40576,7 +40576,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsMetadata"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsMetadata`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40657,7 +40657,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationAdministration"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationAdministration`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40748,7 +40748,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationEvents"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40833,7 +40833,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationHooks"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40916,7 +40916,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationPackages"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41001,7 +41001,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationPlan"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationPlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41084,7 +41084,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationProjects"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41169,7 +41169,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationSecrets"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41254,7 +41254,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41345,7 +41345,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41430,7 +41430,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsPackages"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsPackages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41511,7 +41511,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsPages"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsPages`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41592,7 +41592,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsPullRequests"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsPullRequests`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41673,7 +41673,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsRepositoryHooks"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsRepositoryHooks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41754,7 +41754,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsRepositoryProjects"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsRepositoryProjects`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41839,7 +41839,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsSecretScanningAlerts"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsSecretScanningAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41924,7 +41924,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsSecrets"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsSecrets`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42005,7 +42005,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsSecurityEvents"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsSecurityEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42086,7 +42086,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsSecurityScanningAlert"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsSecurityScanningAlert`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42171,7 +42171,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsSingleFile"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsSingleFile`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42252,7 +42252,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsStatuses"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsStatuses`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42333,7 +42333,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsTeamDiscussions"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsTeamDiscussions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42414,7 +42414,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42499,7 +42499,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationPermissionsWorkflows"]
+#[doc = "`InstallationUnsuspendInstallationPermissionsWorkflows`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42662,7 +42662,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationTargetType"]
+#[doc = "`InstallationUnsuspendInstallationTargetType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42741,7 +42741,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "InstallationUnsuspendInstallationUpdatedAt"]
+#[doc = "`InstallationUnsuspendInstallationUpdatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42826,7 +42826,7 @@ impl ::std::convert::From<i64> for InstallationUnsuspendInstallationUpdatedAt {
         Self::Variant1(value)
     }
 }
-#[doc = "InstallationUnsuspendRepositoriesItem"]
+#[doc = "`InstallationUnsuspendRepositoriesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42883,7 +42883,7 @@ impl ::std::convert::From<&InstallationUnsuspendRepositoriesItem>
         value.clone()
     }
 }
-#[doc = "InstallationUpdatedAt"]
+#[doc = "`InstallationUpdatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43204,7 +43204,7 @@ impl ::std::convert::From<&Issue> for Issue {
         value.clone()
     }
 }
-#[doc = "IssueActiveLockReason"]
+#[doc = "`IssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43391,7 +43391,7 @@ impl ::std::convert::From<&IssueComment> for IssueComment {
         value.clone()
     }
 }
-#[doc = "IssueCommentCreated"]
+#[doc = "`IssueCommentCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43527,7 +43527,7 @@ impl ::std::convert::From<&IssueCommentCreated> for IssueCommentCreated {
         value.clone()
     }
 }
-#[doc = "IssueCommentCreatedAction"]
+#[doc = "`IssueCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43721,7 +43721,7 @@ impl ::std::convert::From<&IssueCommentCreatedIssue> for IssueCommentCreatedIssu
         value.clone()
     }
 }
-#[doc = "IssueCommentCreatedIssueActiveLockReason"]
+#[doc = "`IssueCommentCreatedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43808,7 +43808,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentCreatedIssueAssignee"]
+#[doc = "`IssueCommentCreatedIssueAssignee`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43869,7 +43869,7 @@ impl ::std::convert::From<&IssueCommentCreatedIssueAssignee> for IssueCommentCre
         value.clone()
     }
 }
-#[doc = "IssueCommentCreatedIssueAssigneeType"]
+#[doc = "`IssueCommentCreatedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43948,7 +43948,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentCreatedIssuePullRequest"]
+#[doc = "`IssueCommentCreatedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43998,7 +43998,7 @@ impl ::std::convert::From<&IssueCommentCreatedIssuePullRequest>
         value.clone()
     }
 }
-#[doc = "IssueCommentCreatedIssueState"]
+#[doc = "`IssueCommentCreatedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44075,7 +44075,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentDeleted"]
+#[doc = "`IssueCommentDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44211,7 +44211,7 @@ impl ::std::convert::From<&IssueCommentDeleted> for IssueCommentDeleted {
         value.clone()
     }
 }
-#[doc = "IssueCommentDeletedAction"]
+#[doc = "`IssueCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44405,7 +44405,7 @@ impl ::std::convert::From<&IssueCommentDeletedIssue> for IssueCommentDeletedIssu
         value.clone()
     }
 }
-#[doc = "IssueCommentDeletedIssueActiveLockReason"]
+#[doc = "`IssueCommentDeletedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44492,7 +44492,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentDeletedIssueAssignee"]
+#[doc = "`IssueCommentDeletedIssueAssignee`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44553,7 +44553,7 @@ impl ::std::convert::From<&IssueCommentDeletedIssueAssignee> for IssueCommentDel
         value.clone()
     }
 }
-#[doc = "IssueCommentDeletedIssueAssigneeType"]
+#[doc = "`IssueCommentDeletedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44632,7 +44632,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentDeletedIssuePullRequest"]
+#[doc = "`IssueCommentDeletedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44682,7 +44682,7 @@ impl ::std::convert::From<&IssueCommentDeletedIssuePullRequest>
         value.clone()
     }
 }
-#[doc = "IssueCommentDeletedIssueState"]
+#[doc = "`IssueCommentDeletedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44759,7 +44759,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssue
         value.parse()
     }
 }
-#[doc = "IssueCommentEdited"]
+#[doc = "`IssueCommentEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44917,7 +44917,7 @@ impl ::std::convert::From<&IssueCommentEdited> for IssueCommentEdited {
         value.clone()
     }
 }
-#[doc = "IssueCommentEditedAction"]
+#[doc = "`IssueCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45034,7 +45034,7 @@ impl ::std::default::Default for IssueCommentEditedChanges {
         }
     }
 }
-#[doc = "IssueCommentEditedChangesBody"]
+#[doc = "`IssueCommentEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45187,7 +45187,7 @@ impl ::std::convert::From<&IssueCommentEditedIssue> for IssueCommentEditedIssue 
         value.clone()
     }
 }
-#[doc = "IssueCommentEditedIssueActiveLockReason"]
+#[doc = "`IssueCommentEditedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45274,7 +45274,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueA
         value.parse()
     }
 }
-#[doc = "IssueCommentEditedIssueAssignee"]
+#[doc = "`IssueCommentEditedIssueAssignee`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45335,7 +45335,7 @@ impl ::std::convert::From<&IssueCommentEditedIssueAssignee> for IssueCommentEdit
         value.clone()
     }
 }
-#[doc = "IssueCommentEditedIssueAssigneeType"]
+#[doc = "`IssueCommentEditedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45414,7 +45414,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueA
         value.parse()
     }
 }
-#[doc = "IssueCommentEditedIssuePullRequest"]
+#[doc = "`IssueCommentEditedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45464,7 +45464,7 @@ impl ::std::convert::From<&IssueCommentEditedIssuePullRequest>
         value.clone()
     }
 }
-#[doc = "IssueCommentEditedIssueState"]
+#[doc = "`IssueCommentEditedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45541,7 +45541,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueS
         value.parse()
     }
 }
-#[doc = "IssueCommentEvent"]
+#[doc = "`IssueCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45588,7 +45588,7 @@ impl ::std::convert::From<IssueCommentEdited> for IssueCommentEvent {
         Self::Edited(value)
     }
 }
-#[doc = "IssuePullRequest"]
+#[doc = "`IssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45871,7 +45871,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesAssignedAction {
         value.parse()
     }
 }
-#[doc = "IssuesClosed"]
+#[doc = "`IssuesClosed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46106,7 +46106,7 @@ impl ::std::convert::From<&IssuesClosedIssue> for IssuesClosedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesClosedIssueActiveLockReason"]
+#[doc = "`IssuesClosedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46193,7 +46193,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueActiveL
         value.parse()
     }
 }
-#[doc = "IssuesClosedIssuePullRequest"]
+#[doc = "`IssuesClosedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46249,7 +46249,7 @@ impl ::std::default::Default for IssuesClosedIssuePullRequest {
         }
     }
 }
-#[doc = "IssuesClosedIssueState"]
+#[doc = "`IssuesClosedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46321,7 +46321,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueState {
         value.parse()
     }
 }
-#[doc = "IssuesDeleted"]
+#[doc = "`IssuesDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46380,7 +46380,7 @@ impl ::std::convert::From<&IssuesDeleted> for IssuesDeleted {
         value.clone()
     }
 }
-#[doc = "IssuesDeletedAction"]
+#[doc = "`IssuesDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46452,7 +46452,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDeletedAction {
         value.parse()
     }
 }
-#[doc = "IssuesDemilestoned"]
+#[doc = "`IssuesDemilestoned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46532,7 +46532,7 @@ impl ::std::convert::From<&IssuesDemilestoned> for IssuesDemilestoned {
         value.clone()
     }
 }
-#[doc = "IssuesDemilestonedAction"]
+#[doc = "`IssuesDemilestonedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46604,7 +46604,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedAction
         value.parse()
     }
 }
-#[doc = "IssuesDemilestonedIssue"]
+#[doc = "`IssuesDemilestonedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46675,7 +46675,7 @@ impl ::std::convert::From<&IssuesDemilestonedIssue> for IssuesDemilestonedIssue 
         value.clone()
     }
 }
-#[doc = "IssuesDemilestonedIssueActiveLockReason"]
+#[doc = "`IssuesDemilestonedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46762,7 +46762,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueA
         value.parse()
     }
 }
-#[doc = "IssuesDemilestonedIssuePullRequest"]
+#[doc = "`IssuesDemilestonedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46898,7 +46898,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueS
         value.parse()
     }
 }
-#[doc = "IssuesEdited"]
+#[doc = "`IssuesEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46997,7 +46997,7 @@ impl ::std::convert::From<&IssuesEdited> for IssuesEdited {
         value.clone()
     }
 }
-#[doc = "IssuesEditedAction"]
+#[doc = "`IssuesEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47130,7 +47130,7 @@ impl ::std::default::Default for IssuesEditedChanges {
         }
     }
 }
-#[doc = "IssuesEditedChangesBody"]
+#[doc = "`IssuesEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47161,7 +47161,7 @@ impl ::std::convert::From<&IssuesEditedChangesBody> for IssuesEditedChangesBody 
         value.clone()
     }
 }
-#[doc = "IssuesEditedChangesTitle"]
+#[doc = "`IssuesEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47192,7 +47192,7 @@ impl ::std::convert::From<&IssuesEditedChangesTitle> for IssuesEditedChangesTitl
         value.clone()
     }
 }
-#[doc = "IssuesEvent"]
+#[doc = "`IssuesEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47356,7 +47356,7 @@ impl ::std::convert::From<IssuesUnpinned> for IssuesEvent {
         Self::Unpinned(value)
     }
 }
-#[doc = "IssuesLabeled"]
+#[doc = "`IssuesLabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47422,7 +47422,7 @@ impl ::std::convert::From<&IssuesLabeled> for IssuesLabeled {
         value.clone()
     }
 }
-#[doc = "IssuesLabeledAction"]
+#[doc = "`IssuesLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47494,7 +47494,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLabeledAction {
         value.parse()
     }
 }
-#[doc = "IssuesLocked"]
+#[doc = "`IssuesLocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47586,7 +47586,7 @@ impl ::std::convert::From<&IssuesLocked> for IssuesLocked {
         value.clone()
     }
 }
-#[doc = "IssuesLockedAction"]
+#[doc = "`IssuesLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47658,7 +47658,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedAction {
         value.parse()
     }
 }
-#[doc = "IssuesLockedIssue"]
+#[doc = "`IssuesLockedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47745,7 +47745,7 @@ impl ::std::convert::From<&IssuesLockedIssue> for IssuesLockedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesLockedIssueActiveLockReason"]
+#[doc = "`IssuesLockedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47832,7 +47832,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueActiveL
         value.parse()
     }
 }
-#[doc = "IssuesLockedIssuePullRequest"]
+#[doc = "`IssuesLockedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -47966,7 +47966,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueState {
         value.parse()
     }
 }
-#[doc = "IssuesMilestoned"]
+#[doc = "`IssuesMilestoned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48046,7 +48046,7 @@ impl ::std::convert::From<&IssuesMilestoned> for IssuesMilestoned {
         value.clone()
     }
 }
-#[doc = "IssuesMilestonedAction"]
+#[doc = "`IssuesMilestonedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48118,7 +48118,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedAction {
         value.parse()
     }
 }
-#[doc = "IssuesMilestonedIssue"]
+#[doc = "`IssuesMilestonedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48189,7 +48189,7 @@ impl ::std::convert::From<&IssuesMilestonedIssue> for IssuesMilestonedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesMilestonedIssueActiveLockReason"]
+#[doc = "`IssuesMilestonedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48276,7 +48276,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueAct
         value.parse()
     }
 }
-#[doc = "IssuesMilestonedIssueMilestone"]
+#[doc = "`IssuesMilestonedIssueMilestone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48415,7 +48415,7 @@ impl ::std::convert::From<&IssuesMilestonedIssueMilestone> for IssuesMilestonedI
         value.clone()
     }
 }
-#[doc = "IssuesMilestonedIssueMilestoneState"]
+#[doc = "`IssuesMilestonedIssueMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48492,7 +48492,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueMil
         value.parse()
     }
 }
-#[doc = "IssuesMilestonedIssuePullRequest"]
+#[doc = "`IssuesMilestonedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48626,7 +48626,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueSta
         value.parse()
     }
 }
-#[doc = "IssuesOpened"]
+#[doc = "`IssuesOpened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48726,7 +48726,7 @@ impl ::std::convert::From<&IssuesOpened> for IssuesOpened {
         value.clone()
     }
 }
-#[doc = "IssuesOpenedAction"]
+#[doc = "`IssuesOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48798,7 +48798,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedAction {
         value.parse()
     }
 }
-#[doc = "IssuesOpenedChanges"]
+#[doc = "`IssuesOpenedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48832,7 +48832,7 @@ impl ::std::convert::From<&IssuesOpenedChanges> for IssuesOpenedChanges {
         value.clone()
     }
 }
-#[doc = "IssuesOpenedIssue"]
+#[doc = "`IssuesOpenedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48908,7 +48908,7 @@ impl ::std::convert::From<&IssuesOpenedIssue> for IssuesOpenedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesOpenedIssueActiveLockReason"]
+#[doc = "`IssuesOpenedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -48995,7 +48995,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueActiveL
         value.parse()
     }
 }
-#[doc = "IssuesOpenedIssuePullRequest"]
+#[doc = "`IssuesOpenedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49051,7 +49051,7 @@ impl ::std::default::Default for IssuesOpenedIssuePullRequest {
         }
     }
 }
-#[doc = "IssuesOpenedIssueState"]
+#[doc = "`IssuesOpenedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49123,7 +49123,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueState {
         value.parse()
     }
 }
-#[doc = "IssuesPinned"]
+#[doc = "`IssuesPinned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49182,7 +49182,7 @@ impl ::std::convert::From<&IssuesPinned> for IssuesPinned {
         value.clone()
     }
 }
-#[doc = "IssuesPinnedAction"]
+#[doc = "`IssuesPinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49254,7 +49254,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesPinnedAction {
         value.parse()
     }
 }
-#[doc = "IssuesReopened"]
+#[doc = "`IssuesReopened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49332,7 +49332,7 @@ impl ::std::convert::From<&IssuesReopened> for IssuesReopened {
         value.clone()
     }
 }
-#[doc = "IssuesReopenedAction"]
+#[doc = "`IssuesReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49404,7 +49404,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedAction {
         value.parse()
     }
 }
-#[doc = "IssuesReopenedIssue"]
+#[doc = "`IssuesReopenedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49476,7 +49476,7 @@ impl ::std::convert::From<&IssuesReopenedIssue> for IssuesReopenedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesReopenedIssueActiveLockReason"]
+#[doc = "`IssuesReopenedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49563,7 +49563,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueActiv
         value.parse()
     }
 }
-#[doc = "IssuesReopenedIssuePullRequest"]
+#[doc = "`IssuesReopenedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49619,7 +49619,7 @@ impl ::std::default::Default for IssuesReopenedIssuePullRequest {
         }
     }
 }
-#[doc = "IssuesReopenedIssueState"]
+#[doc = "`IssuesReopenedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49691,7 +49691,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueState
         value.parse()
     }
 }
-#[doc = "IssuesTransferred"]
+#[doc = "`IssuesTransferred`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49768,7 +49768,7 @@ impl ::std::convert::From<&IssuesTransferred> for IssuesTransferred {
         value.clone()
     }
 }
-#[doc = "IssuesTransferredAction"]
+#[doc = "`IssuesTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49840,7 +49840,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesTransferredAction 
         value.parse()
     }
 }
-#[doc = "IssuesTransferredChanges"]
+#[doc = "`IssuesTransferredChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49874,7 +49874,7 @@ impl ::std::convert::From<&IssuesTransferredChanges> for IssuesTransferredChange
         value.clone()
     }
 }
-#[doc = "IssuesUnassigned"]
+#[doc = "`IssuesUnassigned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50022,7 +50022,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnassignedAction {
         value.parse()
     }
 }
-#[doc = "IssuesUnlabeled"]
+#[doc = "`IssuesUnlabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50088,7 +50088,7 @@ impl ::std::convert::From<&IssuesUnlabeled> for IssuesUnlabeled {
         value.clone()
     }
 }
-#[doc = "IssuesUnlabeledAction"]
+#[doc = "`IssuesUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50160,7 +50160,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlabeledAction {
         value.parse()
     }
 }
-#[doc = "IssuesUnlocked"]
+#[doc = "`IssuesUnlocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50242,7 +50242,7 @@ impl ::std::convert::From<&IssuesUnlocked> for IssuesUnlocked {
         value.clone()
     }
 }
-#[doc = "IssuesUnlockedAction"]
+#[doc = "`IssuesUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50314,7 +50314,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlockedAction {
         value.parse()
     }
 }
-#[doc = "IssuesUnlockedIssue"]
+#[doc = "`IssuesUnlockedIssue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50391,7 +50391,7 @@ impl ::std::convert::From<&IssuesUnlockedIssue> for IssuesUnlockedIssue {
         value.clone()
     }
 }
-#[doc = "IssuesUnlockedIssueActiveLockReason"]
+#[doc = "`IssuesUnlockedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50444,7 +50444,7 @@ impl<'de> ::serde::Deserialize<'de> for IssuesUnlockedIssueActiveLockReason {
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "IssuesUnlockedIssuePullRequest"]
+#[doc = "`IssuesUnlockedIssuePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50578,7 +50578,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlockedIssueState
         value.parse()
     }
 }
-#[doc = "IssuesUnpinned"]
+#[doc = "`IssuesUnpinned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50637,7 +50637,7 @@ impl ::std::convert::From<&IssuesUnpinned> for IssuesUnpinned {
         value.clone()
     }
 }
-#[doc = "IssuesUnpinnedAction"]
+#[doc = "`IssuesUnpinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50709,7 +50709,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnpinnedAction {
         value.parse()
     }
 }
-#[doc = "Label"]
+#[doc = "`Label`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50780,7 +50780,7 @@ impl ::std::convert::From<&Label> for Label {
         value.clone()
     }
 }
-#[doc = "LabelCreated"]
+#[doc = "`LabelCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50841,7 +50841,7 @@ impl ::std::convert::From<&LabelCreated> for LabelCreated {
         value.clone()
     }
 }
-#[doc = "LabelCreatedAction"]
+#[doc = "`LabelCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50913,7 +50913,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelCreatedAction {
         value.parse()
     }
 }
-#[doc = "LabelDeleted"]
+#[doc = "`LabelDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50974,7 +50974,7 @@ impl ::std::convert::From<&LabelDeleted> for LabelDeleted {
         value.clone()
     }
 }
-#[doc = "LabelDeletedAction"]
+#[doc = "`LabelDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51046,7 +51046,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelDeletedAction {
         value.parse()
     }
 }
-#[doc = "LabelEdited"]
+#[doc = "`LabelEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51155,7 +51155,7 @@ impl ::std::convert::From<&LabelEdited> for LabelEdited {
         value.clone()
     }
 }
-#[doc = "LabelEditedAction"]
+#[doc = "`LabelEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51304,7 +51304,7 @@ impl ::std::default::Default for LabelEditedChanges {
         }
     }
 }
-#[doc = "LabelEditedChangesColor"]
+#[doc = "`LabelEditedChangesColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51335,7 +51335,7 @@ impl ::std::convert::From<&LabelEditedChangesColor> for LabelEditedChangesColor 
         value.clone()
     }
 }
-#[doc = "LabelEditedChangesDescription"]
+#[doc = "`LabelEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51366,7 +51366,7 @@ impl ::std::convert::From<&LabelEditedChangesDescription> for LabelEditedChanges
         value.clone()
     }
 }
-#[doc = "LabelEditedChangesName"]
+#[doc = "`LabelEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51397,7 +51397,7 @@ impl ::std::convert::From<&LabelEditedChangesName> for LabelEditedChangesName {
         value.clone()
     }
 }
-#[doc = "LabelEvent"]
+#[doc = "`LabelEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51444,7 +51444,7 @@ impl ::std::convert::From<LabelEdited> for LabelEvent {
         Self::Edited(value)
     }
 }
-#[doc = "License"]
+#[doc = "`License`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51499,7 +51499,7 @@ impl ::std::convert::From<&License> for License {
         value.clone()
     }
 }
-#[doc = "Link"]
+#[doc = "`Link`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51531,7 +51531,7 @@ impl ::std::convert::From<&Link> for Link {
         value.clone()
     }
 }
-#[doc = "MarketplacePurchase"]
+#[doc = "`MarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51664,7 +51664,7 @@ impl ::std::convert::From<&MarketplacePurchase> for MarketplacePurchase {
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51714,7 +51714,7 @@ impl ::std::convert::From<&MarketplacePurchaseAccount> for MarketplacePurchaseAc
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseCancelled"]
+#[doc = "`MarketplacePurchaseCancelled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51873,7 +51873,7 @@ impl ::std::convert::From<&MarketplacePurchaseCancelled> for MarketplacePurchase
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseCancelledAction"]
+#[doc = "`MarketplacePurchaseCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51945,7 +51945,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchaseCance
         value.parse()
     }
 }
-#[doc = "MarketplacePurchaseCancelledMarketplacePurchase"]
+#[doc = "`MarketplacePurchaseCancelledMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51989,7 +51989,7 @@ impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchase>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseCancelledMarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchaseCancelledMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52041,7 +52041,7 @@ impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchaseAccoun
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseCancelledMarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchaseCancelledMarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52118,7 +52118,7 @@ impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchasePlan>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseCancelledSender"]
+#[doc = "`MarketplacePurchaseCancelledSender`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52247,7 +52247,7 @@ impl ::std::convert::From<&MarketplacePurchaseCancelledSender>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseChanged"]
+#[doc = "`MarketplacePurchaseChanged`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52406,7 +52406,7 @@ impl ::std::convert::From<&MarketplacePurchaseChanged> for MarketplacePurchaseCh
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseChangedAction"]
+#[doc = "`MarketplacePurchaseChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52478,7 +52478,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchaseChang
         value.parse()
     }
 }
-#[doc = "MarketplacePurchaseChangedMarketplacePurchase"]
+#[doc = "`MarketplacePurchaseChangedMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52522,7 +52522,7 @@ impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchase>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseChangedMarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchaseChangedMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52574,7 +52574,7 @@ impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchaseAccount>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseChangedMarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchaseChangedMarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52651,7 +52651,7 @@ impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchasePlan>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseChangedSender"]
+#[doc = "`MarketplacePurchaseChangedSender`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52778,7 +52778,7 @@ impl ::std::convert::From<&MarketplacePurchaseChangedSender> for MarketplacePurc
         value.clone()
     }
 }
-#[doc = "MarketplacePurchaseEvent"]
+#[doc = "`MarketplacePurchaseEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52843,7 +52843,7 @@ impl ::std::convert::From<MarketplacePurchasePurchased> for MarketplacePurchaseE
         Self::Purchased(value)
     }
 }
-#[doc = "MarketplacePurchasePendingChange"]
+#[doc = "`MarketplacePurchasePendingChange`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53002,7 +53002,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChange> for MarketplacePurc
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeAction"]
+#[doc = "`MarketplacePurchasePendingChangeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53074,7 +53074,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchasePendi
         value.parse()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelled"]
+#[doc = "`MarketplacePurchasePendingChangeCancelled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53235,7 +53235,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelled>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelledAction"]
+#[doc = "`MarketplacePurchasePendingChangeCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53311,7 +53311,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelledMarketplacePurchase"]
+#[doc = "`MarketplacePurchasePendingChangeCancelledMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53355,7 +53355,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplaceP
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53407,7 +53407,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplaceP
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53484,7 +53484,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplaceP
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeCancelledSender"]
+#[doc = "`MarketplacePurchasePendingChangeCancelledSender`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53613,7 +53613,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledSender>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeMarketplacePurchase"]
+#[doc = "`MarketplacePurchasePendingChangeMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53657,7 +53657,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchase>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeMarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchasePendingChangeMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53709,7 +53709,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchaseAc
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeMarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchasePendingChangeMarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53786,7 +53786,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchasePl
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePendingChangeSender"]
+#[doc = "`MarketplacePurchasePendingChangeSender`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53915,7 +53915,7 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeSender>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53990,7 +53990,7 @@ impl ::std::convert::From<&MarketplacePurchasePlan> for MarketplacePurchasePlan 
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePurchased"]
+#[doc = "`MarketplacePurchasePurchased`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54149,7 +54149,7 @@ impl ::std::convert::From<&MarketplacePurchasePurchased> for MarketplacePurchase
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePurchasedAction"]
+#[doc = "`MarketplacePurchasePurchasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54221,7 +54221,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchasePurch
         value.parse()
     }
 }
-#[doc = "MarketplacePurchasePurchasedMarketplacePurchase"]
+#[doc = "`MarketplacePurchasePurchasedMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54265,7 +54265,7 @@ impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchase>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePurchasedMarketplacePurchaseAccount"]
+#[doc = "`MarketplacePurchasePurchasedMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54317,7 +54317,7 @@ impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchaseAccoun
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePurchasedMarketplacePurchasePlan"]
+#[doc = "`MarketplacePurchasePurchasedMarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54394,7 +54394,7 @@ impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchasePlan>
         value.clone()
     }
 }
-#[doc = "MarketplacePurchasePurchasedSender"]
+#[doc = "`MarketplacePurchasePurchasedSender`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54604,7 +54604,7 @@ impl ::std::convert::From<&MemberAdded> for MemberAdded {
         value.clone()
     }
 }
-#[doc = "MemberAddedAction"]
+#[doc = "`MemberAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54676,7 +54676,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberAddedAction {
         value.parse()
     }
 }
-#[doc = "MemberAddedChanges"]
+#[doc = "`MemberAddedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54723,7 +54723,7 @@ impl ::std::default::Default for MemberAddedChanges {
         }
     }
 }
-#[doc = "MemberAddedChangesPermission"]
+#[doc = "`MemberAddedChangesPermission`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54756,7 +54756,7 @@ impl ::std::convert::From<&MemberAddedChangesPermission> for MemberAddedChangesP
         value.clone()
     }
 }
-#[doc = "MemberAddedChangesPermissionTo"]
+#[doc = "`MemberAddedChangesPermissionTo`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54833,7 +54833,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberAddedChangesPermis
         value.parse()
     }
 }
-#[doc = "MemberEdited"]
+#[doc = "`MemberEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54914,7 +54914,7 @@ impl ::std::convert::From<&MemberEdited> for MemberEdited {
         value.clone()
     }
 }
-#[doc = "MemberEditedAction"]
+#[doc = "`MemberEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55026,7 +55026,7 @@ impl ::std::convert::From<&MemberEditedChanges> for MemberEditedChanges {
         value.clone()
     }
 }
-#[doc = "MemberEditedChangesOldPermission"]
+#[doc = "`MemberEditedChangesOldPermission`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55057,7 +55057,7 @@ impl ::std::convert::From<&MemberEditedChangesOldPermission> for MemberEditedCha
         value.clone()
     }
 }
-#[doc = "MemberEvent"]
+#[doc = "`MemberEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55104,7 +55104,7 @@ impl ::std::convert::From<MemberRemoved> for MemberEvent {
         Self::Removed(value)
     }
 }
-#[doc = "MemberRemoved"]
+#[doc = "`MemberRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55160,7 +55160,7 @@ impl ::std::convert::From<&MemberRemoved> for MemberRemoved {
         value.clone()
     }
 }
-#[doc = "MemberRemovedAction"]
+#[doc = "`MemberRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55286,7 +55286,7 @@ impl ::std::convert::From<&Membership> for Membership {
         value.clone()
     }
 }
-#[doc = "MembershipAdded"]
+#[doc = "`MembershipAdded`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55359,7 +55359,7 @@ impl ::std::convert::From<&MembershipAdded> for MembershipAdded {
         value.clone()
     }
 }
-#[doc = "MembershipAddedAction"]
+#[doc = "`MembershipAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55504,7 +55504,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MembershipAddedScope {
         value.parse()
     }
 }
-#[doc = "MembershipEvent"]
+#[doc = "`MembershipEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55542,7 +55542,7 @@ impl ::std::convert::From<MembershipRemoved> for MembershipEvent {
         Self::Removed(value)
     }
 }
-#[doc = "MembershipRemoved"]
+#[doc = "`MembershipRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55639,7 +55639,7 @@ impl ::std::convert::From<&MembershipRemoved> for MembershipRemoved {
         value.clone()
     }
 }
-#[doc = "MembershipRemovedAction"]
+#[doc = "`MembershipRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55844,7 +55844,7 @@ impl ::std::convert::From<Team> for MembershipRemovedTeam {
         Self::Variant0(value)
     }
 }
-#[doc = "MetaDeleted"]
+#[doc = "`MetaDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55960,7 +55960,7 @@ impl ::std::convert::From<&MetaDeleted> for MetaDeleted {
         value.clone()
     }
 }
-#[doc = "MetaDeletedAction"]
+#[doc = "`MetaDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56120,7 +56120,7 @@ impl ::std::convert::From<&MetaDeletedHook> for MetaDeletedHook {
         value.clone()
     }
 }
-#[doc = "MetaDeletedHookConfig"]
+#[doc = "`MetaDeletedHookConfig`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56164,7 +56164,7 @@ impl ::std::convert::From<&MetaDeletedHookConfig> for MetaDeletedHookConfig {
         value.clone()
     }
 }
-#[doc = "MetaDeletedHookConfigContentType"]
+#[doc = "`MetaDeletedHookConfigContentType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56241,7 +56241,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MetaDeletedHookConfigCon
         value.parse()
     }
 }
-#[doc = "MetaEvent"]
+#[doc = "`MetaEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56412,7 +56412,7 @@ impl ::std::convert::From<&Milestone> for Milestone {
         value.clone()
     }
 }
-#[doc = "MilestoneClosed"]
+#[doc = "`MilestoneClosed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56494,7 +56494,7 @@ impl ::std::convert::From<&MilestoneClosed> for MilestoneClosed {
         value.clone()
     }
 }
-#[doc = "MilestoneClosedAction"]
+#[doc = "`MilestoneClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56566,7 +56566,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneClosedAction {
         value.parse()
     }
 }
-#[doc = "MilestoneClosedMilestone"]
+#[doc = "`MilestoneClosedMilestone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56626,7 +56626,7 @@ impl ::std::convert::From<&MilestoneClosedMilestone> for MilestoneClosedMileston
         value.clone()
     }
 }
-#[doc = "MilestoneClosedMilestoneState"]
+#[doc = "`MilestoneClosedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56698,7 +56698,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneClosedMilestone
         value.parse()
     }
 }
-#[doc = "MilestoneCreated"]
+#[doc = "`MilestoneCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56780,7 +56780,7 @@ impl ::std::convert::From<&MilestoneCreated> for MilestoneCreated {
         value.clone()
     }
 }
-#[doc = "MilestoneCreatedAction"]
+#[doc = "`MilestoneCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56852,7 +56852,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneCreatedAction {
         value.parse()
     }
 }
-#[doc = "MilestoneCreatedMilestone"]
+#[doc = "`MilestoneCreatedMilestone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56912,7 +56912,7 @@ impl ::std::convert::From<&MilestoneCreatedMilestone> for MilestoneCreatedMilest
         value.clone()
     }
 }
-#[doc = "MilestoneCreatedMilestoneState"]
+#[doc = "`MilestoneCreatedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56984,7 +56984,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneCreatedMileston
         value.parse()
     }
 }
-#[doc = "MilestoneDeleted"]
+#[doc = "`MilestoneDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57043,7 +57043,7 @@ impl ::std::convert::From<&MilestoneDeleted> for MilestoneDeleted {
         value.clone()
     }
 }
-#[doc = "MilestoneDeletedAction"]
+#[doc = "`MilestoneDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57115,7 +57115,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneDeletedAction {
         value.parse()
     }
 }
-#[doc = "MilestoneEdited"]
+#[doc = "`MilestoneEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57222,7 +57222,7 @@ impl ::std::convert::From<&MilestoneEdited> for MilestoneEdited {
         value.clone()
     }
 }
-#[doc = "MilestoneEditedAction"]
+#[doc = "`MilestoneEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57371,7 +57371,7 @@ impl ::std::default::Default for MilestoneEditedChanges {
         }
     }
 }
-#[doc = "MilestoneEditedChangesDescription"]
+#[doc = "`MilestoneEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57404,7 +57404,7 @@ impl ::std::convert::From<&MilestoneEditedChangesDescription>
         value.clone()
     }
 }
-#[doc = "MilestoneEditedChangesDueOn"]
+#[doc = "`MilestoneEditedChangesDueOn`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57435,7 +57435,7 @@ impl ::std::convert::From<&MilestoneEditedChangesDueOn> for MilestoneEditedChang
         value.clone()
     }
 }
-#[doc = "MilestoneEditedChangesTitle"]
+#[doc = "`MilestoneEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57466,7 +57466,7 @@ impl ::std::convert::From<&MilestoneEditedChangesTitle> for MilestoneEditedChang
         value.clone()
     }
 }
-#[doc = "MilestoneEvent"]
+#[doc = "`MilestoneEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57531,7 +57531,7 @@ impl ::std::convert::From<MilestoneOpened> for MilestoneEvent {
         Self::Opened(value)
     }
 }
-#[doc = "MilestoneOpened"]
+#[doc = "`MilestoneOpened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57613,7 +57613,7 @@ impl ::std::convert::From<&MilestoneOpened> for MilestoneOpened {
         value.clone()
     }
 }
-#[doc = "MilestoneOpenedAction"]
+#[doc = "`MilestoneOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57685,7 +57685,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneOpenedAction {
         value.parse()
     }
 }
-#[doc = "MilestoneOpenedMilestone"]
+#[doc = "`MilestoneOpenedMilestone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57745,7 +57745,7 @@ impl ::std::convert::From<&MilestoneOpenedMilestone> for MilestoneOpenedMileston
         value.clone()
     }
 }
-#[doc = "MilestoneOpenedMilestoneState"]
+#[doc = "`MilestoneOpenedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57895,7 +57895,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneState {
         value.parse()
     }
 }
-#[doc = "OrgBlockBlocked"]
+#[doc = "`OrgBlockBlocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57951,7 +57951,7 @@ impl ::std::convert::From<&OrgBlockBlocked> for OrgBlockBlocked {
         value.clone()
     }
 }
-#[doc = "OrgBlockBlockedAction"]
+#[doc = "`OrgBlockBlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58023,7 +58023,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrgBlockBlockedAction {
         value.parse()
     }
 }
-#[doc = "OrgBlockEvent"]
+#[doc = "`OrgBlockEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58061,7 +58061,7 @@ impl ::std::convert::From<OrgBlockUnblocked> for OrgBlockEvent {
         Self::Unblocked(value)
     }
 }
-#[doc = "OrgBlockUnblocked"]
+#[doc = "`OrgBlockUnblocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58117,7 +58117,7 @@ impl ::std::convert::From<&OrgBlockUnblocked> for OrgBlockUnblocked {
         value.clone()
     }
 }
-#[doc = "OrgBlockUnblockedAction"]
+#[doc = "`OrgBlockUnblockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58189,7 +58189,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrgBlockUnblockedAction 
         value.parse()
     }
 }
-#[doc = "Organization"]
+#[doc = "`Organization`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58292,7 +58292,7 @@ impl ::std::convert::From<&Organization> for Organization {
         value.clone()
     }
 }
-#[doc = "OrganizationDeleted"]
+#[doc = "`OrganizationDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58346,7 +58346,7 @@ impl ::std::convert::From<&OrganizationDeleted> for OrganizationDeleted {
         value.clone()
     }
 }
-#[doc = "OrganizationDeletedAction"]
+#[doc = "`OrganizationDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58418,7 +58418,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationDeletedActio
         value.parse()
     }
 }
-#[doc = "OrganizationEvent"]
+#[doc = "`OrganizationEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58483,7 +58483,7 @@ impl ::std::convert::From<OrganizationRenamed> for OrganizationEvent {
         Self::Renamed(value)
     }
 }
-#[doc = "OrganizationMemberAdded"]
+#[doc = "`OrganizationMemberAdded`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58537,7 +58537,7 @@ impl ::std::convert::From<&OrganizationMemberAdded> for OrganizationMemberAdded 
         value.clone()
     }
 }
-#[doc = "OrganizationMemberAddedAction"]
+#[doc = "`OrganizationMemberAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58609,7 +58609,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberAddedA
         value.parse()
     }
 }
-#[doc = "OrganizationMemberInvited"]
+#[doc = "`OrganizationMemberInvited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58734,7 +58734,7 @@ impl ::std::convert::From<&OrganizationMemberInvited> for OrganizationMemberInvi
         value.clone()
     }
 }
-#[doc = "OrganizationMemberInvitedAction"]
+#[doc = "`OrganizationMemberInvitedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58904,7 +58904,7 @@ impl ::std::convert::From<&OrganizationMemberInvitedInvitation>
         value.clone()
     }
 }
-#[doc = "OrganizationMemberRemoved"]
+#[doc = "`OrganizationMemberRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58958,7 +58958,7 @@ impl ::std::convert::From<&OrganizationMemberRemoved> for OrganizationMemberRemo
         value.clone()
     }
 }
-#[doc = "OrganizationMemberRemovedAction"]
+#[doc = "`OrganizationMemberRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59030,7 +59030,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberRemove
         value.parse()
     }
 }
-#[doc = "OrganizationRenamed"]
+#[doc = "`OrganizationRenamed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59084,7 +59084,7 @@ impl ::std::convert::From<&OrganizationRenamed> for OrganizationRenamed {
         value.clone()
     }
 }
-#[doc = "OrganizationRenamedAction"]
+#[doc = "`OrganizationRenamedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59156,7 +59156,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationRenamedActio
         value.parse()
     }
 }
-#[doc = "PackageEvent"]
+#[doc = "`PackageEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59194,7 +59194,7 @@ impl ::std::convert::From<PackageUpdated> for PackageEvent {
         Self::Updated(value)
     }
 }
-#[doc = "PackagePublished"]
+#[doc = "`PackagePublished`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59537,7 +59537,7 @@ impl ::std::convert::From<&PackagePublished> for PackagePublished {
         value.clone()
     }
 }
-#[doc = "PackagePublishedAction"]
+#[doc = "`PackagePublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59929,7 +59929,7 @@ impl ::std::convert::From<&PackagePublishedPackage> for PackagePublishedPackage 
         value.clone()
     }
 }
-#[doc = "PackagePublishedPackagePackageVersion"]
+#[doc = "`PackagePublishedPackagePackageVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60177,7 +60177,7 @@ impl ::std::convert::From<&PackagePublishedPackagePackageVersion>
         value.clone()
     }
 }
-#[doc = "PackagePublishedPackagePackageVersionPackageFilesItem"]
+#[doc = "`PackagePublishedPackagePackageVersionPackageFilesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60259,7 +60259,7 @@ impl ::std::convert::From<&PackagePublishedPackagePackageVersionPackageFilesItem
         value.clone()
     }
 }
-#[doc = "PackagePublishedPackagePackageVersionRelease"]
+#[doc = "`PackagePublishedPackagePackageVersionRelease`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60342,7 +60342,7 @@ impl ::std::convert::From<&PackagePublishedPackagePackageVersionRelease>
         value.clone()
     }
 }
-#[doc = "PackagePublishedPackageRegistry"]
+#[doc = "`PackagePublishedPackageRegistry`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60394,7 +60394,7 @@ impl ::std::convert::From<&PackagePublishedPackageRegistry> for PackagePublished
         value.clone()
     }
 }
-#[doc = "PackageUpdated"]
+#[doc = "`PackageUpdated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60738,7 +60738,7 @@ impl ::std::convert::From<&PackageUpdated> for PackageUpdated {
         value.clone()
     }
 }
-#[doc = "PackageUpdatedAction"]
+#[doc = "`PackageUpdatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61131,7 +61131,7 @@ impl ::std::convert::From<&PackageUpdatedPackage> for PackageUpdatedPackage {
         value.clone()
     }
 }
-#[doc = "PackageUpdatedPackagePackageVersion"]
+#[doc = "`PackageUpdatedPackagePackageVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61380,7 +61380,7 @@ impl ::std::convert::From<&PackageUpdatedPackagePackageVersion>
         value.clone()
     }
 }
-#[doc = "PackageUpdatedPackagePackageVersionPackageFilesItem"]
+#[doc = "`PackageUpdatedPackagePackageVersionPackageFilesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61462,7 +61462,7 @@ impl ::std::convert::From<&PackageUpdatedPackagePackageVersionPackageFilesItem>
         value.clone()
     }
 }
-#[doc = "PackageUpdatedPackagePackageVersionRelease"]
+#[doc = "`PackageUpdatedPackagePackageVersionRelease`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61545,7 +61545,7 @@ impl ::std::convert::From<&PackageUpdatedPackagePackageVersionRelease>
         value.clone()
     }
 }
-#[doc = "PackageUpdatedPackageRegistry"]
+#[doc = "`PackageUpdatedPackageRegistry`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61783,7 +61783,7 @@ impl ::std::convert::From<&PageBuildEventBuild> for PageBuildEventBuild {
         value.clone()
     }
 }
-#[doc = "PageBuildEventBuildError"]
+#[doc = "`PageBuildEventBuildError`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61815,7 +61815,7 @@ impl ::std::convert::From<&PageBuildEventBuildError> for PageBuildEventBuildErro
         value.clone()
     }
 }
-#[doc = "PingEvent"]
+#[doc = "`PingEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62112,7 +62112,7 @@ impl ::std::convert::From<&PingEventHook> for PingEventHook {
         value.clone()
     }
 }
-#[doc = "PingEventHookConfig"]
+#[doc = "`PingEventHookConfig`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62161,7 +62161,7 @@ impl ::std::convert::From<&PingEventHookConfig> for PingEventHookConfig {
         value.clone()
     }
 }
-#[doc = "PingEventHookConfigContentType"]
+#[doc = "`PingEventHookConfigContentType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62238,7 +62238,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PingEventHookConfigConte
         value.parse()
     }
 }
-#[doc = "PingEventHookLastResponse"]
+#[doc = "`PingEventHookLastResponse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62277,7 +62277,7 @@ impl ::std::convert::From<&PingEventHookLastResponse> for PingEventHookLastRespo
         value.clone()
     }
 }
-#[doc = "Project"]
+#[doc = "`Project`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62387,7 +62387,7 @@ impl ::std::convert::From<&Project> for Project {
         value.clone()
     }
 }
-#[doc = "ProjectCard"]
+#[doc = "`ProjectCard`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62491,7 +62491,7 @@ impl ::std::convert::From<&ProjectCard> for ProjectCard {
         value.clone()
     }
 }
-#[doc = "ProjectCardConverted"]
+#[doc = "`ProjectCardConverted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62573,7 +62573,7 @@ impl ::std::convert::From<&ProjectCardConverted> for ProjectCardConverted {
         value.clone()
     }
 }
-#[doc = "ProjectCardConvertedAction"]
+#[doc = "`ProjectCardConvertedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62645,7 +62645,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardConvertedActi
         value.parse()
     }
 }
-#[doc = "ProjectCardConvertedChanges"]
+#[doc = "`ProjectCardConvertedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62683,7 +62683,7 @@ impl ::std::convert::From<&ProjectCardConvertedChanges> for ProjectCardConverted
         value.clone()
     }
 }
-#[doc = "ProjectCardConvertedChangesNote"]
+#[doc = "`ProjectCardConvertedChangesNote`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62712,7 +62712,7 @@ impl ::std::convert::From<&ProjectCardConvertedChangesNote> for ProjectCardConve
         value.clone()
     }
 }
-#[doc = "ProjectCardCreated"]
+#[doc = "`ProjectCardCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62771,7 +62771,7 @@ impl ::std::convert::From<&ProjectCardCreated> for ProjectCardCreated {
         value.clone()
     }
 }
-#[doc = "ProjectCardCreatedAction"]
+#[doc = "`ProjectCardCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62843,7 +62843,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardCreatedAction
         value.parse()
     }
 }
-#[doc = "ProjectCardDeleted"]
+#[doc = "`ProjectCardDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62902,7 +62902,7 @@ impl ::std::convert::From<&ProjectCardDeleted> for ProjectCardDeleted {
         value.clone()
     }
 }
-#[doc = "ProjectCardDeletedAction"]
+#[doc = "`ProjectCardDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62974,7 +62974,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardDeletedAction
         value.parse()
     }
 }
-#[doc = "ProjectCardEdited"]
+#[doc = "`ProjectCardEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63056,7 +63056,7 @@ impl ::std::convert::From<&ProjectCardEdited> for ProjectCardEdited {
         value.clone()
     }
 }
-#[doc = "ProjectCardEditedAction"]
+#[doc = "`ProjectCardEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63128,7 +63128,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardEditedAction 
         value.parse()
     }
 }
-#[doc = "ProjectCardEditedChanges"]
+#[doc = "`ProjectCardEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63166,7 +63166,7 @@ impl ::std::convert::From<&ProjectCardEditedChanges> for ProjectCardEditedChange
         value.clone()
     }
 }
-#[doc = "ProjectCardEditedChangesNote"]
+#[doc = "`ProjectCardEditedChangesNote`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63195,7 +63195,7 @@ impl ::std::convert::From<&ProjectCardEditedChangesNote> for ProjectCardEditedCh
         value.clone()
     }
 }
-#[doc = "ProjectCardEvent"]
+#[doc = "`ProjectCardEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63260,7 +63260,7 @@ impl ::std::convert::From<ProjectCardMoved> for ProjectCardEvent {
         Self::Moved(value)
     }
 }
-#[doc = "ProjectCardMoved"]
+#[doc = "`ProjectCardMoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63361,7 +63361,7 @@ impl ::std::convert::From<&ProjectCardMoved> for ProjectCardMoved {
         value.clone()
     }
 }
-#[doc = "ProjectCardMovedAction"]
+#[doc = "`ProjectCardMovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63433,7 +63433,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardMovedAction {
         value.parse()
     }
 }
-#[doc = "ProjectCardMovedChanges"]
+#[doc = "`ProjectCardMovedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63471,7 +63471,7 @@ impl ::std::convert::From<&ProjectCardMovedChanges> for ProjectCardMovedChanges 
         value.clone()
     }
 }
-#[doc = "ProjectCardMovedChangesColumnId"]
+#[doc = "`ProjectCardMovedChangesColumnId`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63500,7 +63500,7 @@ impl ::std::convert::From<&ProjectCardMovedChangesColumnId> for ProjectCardMoved
         value.clone()
     }
 }
-#[doc = "ProjectCardMovedProjectCard"]
+#[doc = "`ProjectCardMovedProjectCard`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63554,7 +63554,7 @@ impl ::std::convert::From<&ProjectCardMovedProjectCard> for ProjectCardMovedProj
         value.clone()
     }
 }
-#[doc = "ProjectClosed"]
+#[doc = "`ProjectClosed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63613,7 +63613,7 @@ impl ::std::convert::From<&ProjectClosed> for ProjectClosed {
         value.clone()
     }
 }
-#[doc = "ProjectClosedAction"]
+#[doc = "`ProjectClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63685,7 +63685,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectClosedAction {
         value.parse()
     }
 }
-#[doc = "ProjectColumn"]
+#[doc = "`ProjectColumn`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63760,7 +63760,7 @@ impl ::std::convert::From<&ProjectColumn> for ProjectColumn {
         value.clone()
     }
 }
-#[doc = "ProjectColumnCreated"]
+#[doc = "`ProjectColumnCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63819,7 +63819,7 @@ impl ::std::convert::From<&ProjectColumnCreated> for ProjectColumnCreated {
         value.clone()
     }
 }
-#[doc = "ProjectColumnCreatedAction"]
+#[doc = "`ProjectColumnCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63891,7 +63891,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnCreatedActi
         value.parse()
     }
 }
-#[doc = "ProjectColumnDeleted"]
+#[doc = "`ProjectColumnDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63950,7 +63950,7 @@ impl ::std::convert::From<&ProjectColumnDeleted> for ProjectColumnDeleted {
         value.clone()
     }
 }
-#[doc = "ProjectColumnDeletedAction"]
+#[doc = "`ProjectColumnDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64022,7 +64022,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnDeletedActi
         value.parse()
     }
 }
-#[doc = "ProjectColumnEdited"]
+#[doc = "`ProjectColumnEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64101,7 +64101,7 @@ impl ::std::convert::From<&ProjectColumnEdited> for ProjectColumnEdited {
         value.clone()
     }
 }
-#[doc = "ProjectColumnEditedAction"]
+#[doc = "`ProjectColumnEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64173,7 +64173,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnEditedActio
         value.parse()
     }
 }
-#[doc = "ProjectColumnEditedChanges"]
+#[doc = "`ProjectColumnEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64216,7 +64216,7 @@ impl ::std::default::Default for ProjectColumnEditedChanges {
         }
     }
 }
-#[doc = "ProjectColumnEditedChangesName"]
+#[doc = "`ProjectColumnEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64245,7 +64245,7 @@ impl ::std::convert::From<&ProjectColumnEditedChangesName> for ProjectColumnEdit
         value.clone()
     }
 }
-#[doc = "ProjectColumnEvent"]
+#[doc = "`ProjectColumnEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64301,7 +64301,7 @@ impl ::std::convert::From<ProjectColumnMoved> for ProjectColumnEvent {
         Self::Moved(value)
     }
 }
-#[doc = "ProjectColumnMoved"]
+#[doc = "`ProjectColumnMoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64360,7 +64360,7 @@ impl ::std::convert::From<&ProjectColumnMoved> for ProjectColumnMoved {
         value.clone()
     }
 }
-#[doc = "ProjectColumnMovedAction"]
+#[doc = "`ProjectColumnMovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64432,7 +64432,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnMovedAction
         value.parse()
     }
 }
-#[doc = "ProjectCreated"]
+#[doc = "`ProjectCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64491,7 +64491,7 @@ impl ::std::convert::From<&ProjectCreated> for ProjectCreated {
         value.clone()
     }
 }
-#[doc = "ProjectCreatedAction"]
+#[doc = "`ProjectCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64563,7 +64563,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCreatedAction {
         value.parse()
     }
 }
-#[doc = "ProjectDeleted"]
+#[doc = "`ProjectDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64622,7 +64622,7 @@ impl ::std::convert::From<&ProjectDeleted> for ProjectDeleted {
         value.clone()
     }
 }
-#[doc = "ProjectDeletedAction"]
+#[doc = "`ProjectDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64694,7 +64694,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectDeletedAction {
         value.parse()
     }
 }
-#[doc = "ProjectEdited"]
+#[doc = "`ProjectEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64788,7 +64788,7 @@ impl ::std::convert::From<&ProjectEdited> for ProjectEdited {
         value.clone()
     }
 }
-#[doc = "ProjectEditedAction"]
+#[doc = "`ProjectEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64921,7 +64921,7 @@ impl ::std::default::Default for ProjectEditedChanges {
         }
     }
 }
-#[doc = "ProjectEditedChangesBody"]
+#[doc = "`ProjectEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64952,7 +64952,7 @@ impl ::std::convert::From<&ProjectEditedChangesBody> for ProjectEditedChangesBod
         value.clone()
     }
 }
-#[doc = "ProjectEditedChangesName"]
+#[doc = "`ProjectEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64983,7 +64983,7 @@ impl ::std::convert::From<&ProjectEditedChangesName> for ProjectEditedChangesNam
         value.clone()
     }
 }
-#[doc = "ProjectEvent"]
+#[doc = "`ProjectEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65048,7 +65048,7 @@ impl ::std::convert::From<ProjectReopened> for ProjectEvent {
         Self::Reopened(value)
     }
 }
-#[doc = "ProjectReopened"]
+#[doc = "`ProjectReopened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65107,7 +65107,7 @@ impl ::std::convert::From<&ProjectReopened> for ProjectReopened {
         value.clone()
     }
 }
-#[doc = "ProjectReopenedAction"]
+#[doc = "`ProjectReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65323,7 +65323,7 @@ impl ::std::convert::From<&PublicEvent> for PublicEvent {
         value.clone()
     }
 }
-#[doc = "PublicEventRepository"]
+#[doc = "`PublicEventRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65472,7 +65472,7 @@ impl ::std::convert::From<&PublicEventRepository> for PublicEventRepository {
         value.clone()
     }
 }
-#[doc = "PublicEventRepositoryCreatedAt"]
+#[doc = "`PublicEventRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65555,7 +65555,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "PublicEventRepositoryPermissions"]
+#[doc = "`PublicEventRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65604,7 +65604,7 @@ impl ::std::convert::From<&PublicEventRepositoryPermissions> for PublicEventRepo
         value.clone()
     }
 }
-#[doc = "PublicEventRepositoryPushedAt"]
+#[doc = "`PublicEventRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65647,7 +65647,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>> for PublicEvent
         Self::Variant1(value)
     }
 }
-#[doc = "PullRequest"]
+#[doc = "`PullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66100,7 +66100,7 @@ impl ::std::convert::From<&PullRequest> for PullRequest {
         value.clone()
     }
 }
-#[doc = "PullRequestActiveLockReason"]
+#[doc = "`PullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66187,7 +66187,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestActiveLockRea
         value.parse()
     }
 }
-#[doc = "PullRequestAssigned"]
+#[doc = "`PullRequestAssigned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66258,7 +66258,7 @@ impl ::std::convert::From<&PullRequestAssigned> for PullRequestAssigned {
         value.clone()
     }
 }
-#[doc = "PullRequestAssignedAction"]
+#[doc = "`PullRequestAssignedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66330,7 +66330,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestAssignedActio
         value.parse()
     }
 }
-#[doc = "PullRequestAutoMergeDisabled"]
+#[doc = "`PullRequestAutoMergeDisabled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66394,7 +66394,7 @@ impl ::std::convert::From<&PullRequestAutoMergeDisabled> for PullRequestAutoMerg
         value.clone()
     }
 }
-#[doc = "PullRequestAutoMergeDisabledAction"]
+#[doc = "`PullRequestAutoMergeDisabledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66466,7 +66466,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestAutoMergeDisa
         value.parse()
     }
 }
-#[doc = "PullRequestAutoMergeEnabled"]
+#[doc = "`PullRequestAutoMergeEnabled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66530,7 +66530,7 @@ impl ::std::convert::From<&PullRequestAutoMergeEnabled> for PullRequestAutoMerge
         value.clone()
     }
 }
-#[doc = "PullRequestAutoMergeEnabledAction"]
+#[doc = "`PullRequestAutoMergeEnabledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66602,7 +66602,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestAutoMergeEnab
         value.parse()
     }
 }
-#[doc = "PullRequestBase"]
+#[doc = "`PullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66652,7 +66652,7 @@ impl ::std::convert::From<&PullRequestBase> for PullRequestBase {
         value.clone()
     }
 }
-#[doc = "PullRequestClosed"]
+#[doc = "`PullRequestClosed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66747,7 +66747,7 @@ impl ::std::convert::From<&PullRequestClosed> for PullRequestClosed {
         value.clone()
     }
 }
-#[doc = "PullRequestClosedAction"]
+#[doc = "`PullRequestClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66819,7 +66819,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedAction 
         value.parse()
     }
 }
-#[doc = "PullRequestClosedPullRequest"]
+#[doc = "`PullRequestClosedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66920,7 +66920,7 @@ impl ::std::convert::From<&PullRequestClosedPullRequest> for PullRequestClosedPu
         value.clone()
     }
 }
-#[doc = "PullRequestClosedPullRequestActiveLockReason"]
+#[doc = "`PullRequestClosedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67011,7 +67011,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestClosedPullRequestBase"]
+#[doc = "`PullRequestClosedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67061,7 +67061,7 @@ impl ::std::convert::From<&PullRequestClosedPullRequestBase> for PullRequestClos
         value.clone()
     }
 }
-#[doc = "PullRequestClosedPullRequestHead"]
+#[doc = "`PullRequestClosedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67111,7 +67111,7 @@ impl ::std::convert::From<&PullRequestClosedPullRequestHead> for PullRequestClos
         value.clone()
     }
 }
-#[doc = "PullRequestClosedPullRequestLinks"]
+#[doc = "`PullRequestClosedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67178,7 +67178,7 @@ impl ::std::convert::From<&PullRequestClosedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestClosedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestClosedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67216,7 +67216,7 @@ impl ::std::convert::From<Team> for PullRequestClosedPullRequestRequestedReviewe
         Self::Team(value)
     }
 }
-#[doc = "PullRequestClosedPullRequestState"]
+#[doc = "`PullRequestClosedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67288,7 +67288,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedPullReq
         value.parse()
     }
 }
-#[doc = "PullRequestConvertedToDraft"]
+#[doc = "`PullRequestConvertedToDraft`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67393,7 +67393,7 @@ impl ::std::convert::From<&PullRequestConvertedToDraft> for PullRequestConverted
         value.clone()
     }
 }
-#[doc = "PullRequestConvertedToDraftAction"]
+#[doc = "`PullRequestConvertedToDraftAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67465,7 +67465,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestConvertedToDr
         value.parse()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequest"]
+#[doc = "`PullRequestConvertedToDraftPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67580,7 +67580,7 @@ impl ::std::convert::From<&PullRequestConvertedToDraftPullRequest>
         value.clone()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequestActiveLockReason"]
+#[doc = "`PullRequestConvertedToDraftPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67671,7 +67671,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequestBase"]
+#[doc = "`PullRequestConvertedToDraftPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67723,7 +67723,7 @@ impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequestHead"]
+#[doc = "`PullRequestConvertedToDraftPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67775,7 +67775,7 @@ impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequestLinks"]
+#[doc = "`PullRequestConvertedToDraftPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67842,7 +67842,7 @@ impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestConvertedToDraftPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestConvertedToDraftPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67962,7 +67962,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestEdited"]
+#[doc = "`PullRequestEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68063,7 +68063,7 @@ impl ::std::convert::From<&PullRequestEdited> for PullRequestEdited {
         value.clone()
     }
 }
-#[doc = "PullRequestEditedAction"]
+#[doc = "`PullRequestEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68196,7 +68196,7 @@ impl ::std::default::Default for PullRequestEditedChanges {
         }
     }
 }
-#[doc = "PullRequestEditedChangesBody"]
+#[doc = "`PullRequestEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68227,7 +68227,7 @@ impl ::std::convert::From<&PullRequestEditedChangesBody> for PullRequestEditedCh
         value.clone()
     }
 }
-#[doc = "PullRequestEditedChangesTitle"]
+#[doc = "`PullRequestEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68258,7 +68258,7 @@ impl ::std::convert::From<&PullRequestEditedChangesTitle> for PullRequestEditedC
         value.clone()
     }
 }
-#[doc = "PullRequestEvent"]
+#[doc = "`PullRequestEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68431,7 +68431,7 @@ impl ::std::convert::From<PullRequestUnlocked> for PullRequestEvent {
         Self::Unlocked(value)
     }
 }
-#[doc = "PullRequestHead"]
+#[doc = "`PullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68481,7 +68481,7 @@ impl ::std::convert::From<&PullRequestHead> for PullRequestHead {
         value.clone()
     }
 }
-#[doc = "PullRequestLabeled"]
+#[doc = "`PullRequestLabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68552,7 +68552,7 @@ impl ::std::convert::From<&PullRequestLabeled> for PullRequestLabeled {
         value.clone()
     }
 }
-#[doc = "PullRequestLabeledAction"]
+#[doc = "`PullRequestLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68624,7 +68624,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestLabeledAction
         value.parse()
     }
 }
-#[doc = "PullRequestLinks"]
+#[doc = "`PullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68689,7 +68689,7 @@ impl ::std::convert::From<&PullRequestLinks> for PullRequestLinks {
         value.clone()
     }
 }
-#[doc = "PullRequestLocked"]
+#[doc = "`PullRequestLocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68755,7 +68755,7 @@ impl ::std::convert::From<&PullRequestLocked> for PullRequestLocked {
         value.clone()
     }
 }
-#[doc = "PullRequestLockedAction"]
+#[doc = "`PullRequestLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68827,7 +68827,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestLockedAction 
         value.parse()
     }
 }
-#[doc = "PullRequestOpened"]
+#[doc = "`PullRequestOpened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68932,7 +68932,7 @@ impl ::std::convert::From<&PullRequestOpened> for PullRequestOpened {
         value.clone()
     }
 }
-#[doc = "PullRequestOpenedAction"]
+#[doc = "`PullRequestOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69004,7 +69004,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestOpenedAction 
         value.parse()
     }
 }
-#[doc = "PullRequestOpenedPullRequest"]
+#[doc = "`PullRequestOpenedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69115,7 +69115,7 @@ impl ::std::convert::From<&PullRequestOpenedPullRequest> for PullRequestOpenedPu
         value.clone()
     }
 }
-#[doc = "PullRequestOpenedPullRequestActiveLockReason"]
+#[doc = "`PullRequestOpenedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69168,7 +69168,7 @@ impl<'de> ::serde::Deserialize<'de> for PullRequestOpenedPullRequestActiveLockRe
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "PullRequestOpenedPullRequestBase"]
+#[doc = "`PullRequestOpenedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69218,7 +69218,7 @@ impl ::std::convert::From<&PullRequestOpenedPullRequestBase> for PullRequestOpen
         value.clone()
     }
 }
-#[doc = "PullRequestOpenedPullRequestHead"]
+#[doc = "`PullRequestOpenedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69268,7 +69268,7 @@ impl ::std::convert::From<&PullRequestOpenedPullRequestHead> for PullRequestOpen
         value.clone()
     }
 }
-#[doc = "PullRequestOpenedPullRequestLinks"]
+#[doc = "`PullRequestOpenedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69335,7 +69335,7 @@ impl ::std::convert::From<&PullRequestOpenedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestOpenedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestOpenedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69373,7 +69373,7 @@ impl ::std::convert::From<Team> for PullRequestOpenedPullRequestRequestedReviewe
         Self::Team(value)
     }
 }
-#[doc = "PullRequestOpenedPullRequestState"]
+#[doc = "`PullRequestOpenedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69445,7 +69445,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestOpenedPullReq
         value.parse()
     }
 }
-#[doc = "PullRequestReadyForReview"]
+#[doc = "`PullRequestReadyForReview`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69554,7 +69554,7 @@ impl ::std::convert::From<&PullRequestReadyForReview> for PullRequestReadyForRev
         value.clone()
     }
 }
-#[doc = "PullRequestReadyForReviewAction"]
+#[doc = "`PullRequestReadyForReviewAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69626,7 +69626,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReadyForRevie
         value.parse()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequest"]
+#[doc = "`PullRequestReadyForReviewPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69744,7 +69744,7 @@ impl ::std::convert::From<&PullRequestReadyForReviewPullRequest>
         value.clone()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestActiveLockReason"]
+#[doc = "`PullRequestReadyForReviewPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69835,7 +69835,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestBase"]
+#[doc = "`PullRequestReadyForReviewPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69887,7 +69887,7 @@ impl ::std::convert::From<&PullRequestReadyForReviewPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestHead"]
+#[doc = "`PullRequestReadyForReviewPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69939,7 +69939,7 @@ impl ::std::convert::From<&PullRequestReadyForReviewPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestLinks"]
+#[doc = "`PullRequestReadyForReviewPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70006,7 +70006,7 @@ impl ::std::convert::From<&PullRequestReadyForReviewPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestReadyForReviewPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70044,7 +70044,7 @@ impl ::std::convert::From<Team> for PullRequestReadyForReviewPullRequestRequeste
         Self::Team(value)
     }
 }
-#[doc = "PullRequestReadyForReviewPullRequestState"]
+#[doc = "`PullRequestReadyForReviewPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70116,7 +70116,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReadyForRevie
         value.parse()
     }
 }
-#[doc = "PullRequestReopened"]
+#[doc = "`PullRequestReopened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70221,7 +70221,7 @@ impl ::std::convert::From<&PullRequestReopened> for PullRequestReopened {
         value.clone()
     }
 }
-#[doc = "PullRequestReopenedAction"]
+#[doc = "`PullRequestReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70293,7 +70293,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReopenedActio
         value.parse()
     }
 }
-#[doc = "PullRequestReopenedPullRequest"]
+#[doc = "`PullRequestReopenedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70404,7 +70404,7 @@ impl ::std::convert::From<&PullRequestReopenedPullRequest> for PullRequestReopen
         value.clone()
     }
 }
-#[doc = "PullRequestReopenedPullRequestActiveLockReason"]
+#[doc = "`PullRequestReopenedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70495,7 +70495,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReopenedPullRequestBase"]
+#[doc = "`PullRequestReopenedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70547,7 +70547,7 @@ impl ::std::convert::From<&PullRequestReopenedPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestReopenedPullRequestHead"]
+#[doc = "`PullRequestReopenedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70599,7 +70599,7 @@ impl ::std::convert::From<&PullRequestReopenedPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestReopenedPullRequestLinks"]
+#[doc = "`PullRequestReopenedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70666,7 +70666,7 @@ impl ::std::convert::From<&PullRequestReopenedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReopenedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestReopenedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70704,7 +70704,7 @@ impl ::std::convert::From<Team> for PullRequestReopenedPullRequestRequestedRevie
         Self::Team(value)
     }
 }
-#[doc = "PullRequestReopenedPullRequestState"]
+#[doc = "`PullRequestReopenedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70776,7 +70776,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReopenedPullR
         value.parse()
     }
 }
-#[doc = "PullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71054,7 +71054,7 @@ impl ::std::convert::From<&PullRequestReviewComment> for PullRequestReviewCommen
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreated"]
+#[doc = "`PullRequestReviewCommentCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71418,7 +71418,7 @@ impl ::std::convert::From<&PullRequestReviewCommentCreated> for PullRequestRevie
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedAction"]
+#[doc = "`PullRequestReviewCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71490,7 +71490,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequest"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71852,7 +71852,7 @@ impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequest>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestActiveLockReason"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71943,7 +71943,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestBase"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71995,7 +71995,7 @@ impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestHead"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72047,7 +72047,7 @@ impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestLinks"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72114,7 +72114,7 @@ impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72158,7 +72158,7 @@ impl ::std::convert::From<Team>
         Self::Team(value)
     }
 }
-#[doc = "PullRequestReviewCommentCreatedPullRequestState"]
+#[doc = "`PullRequestReviewCommentCreatedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72239,7 +72239,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentDeleted"]
+#[doc = "`PullRequestReviewCommentDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72603,7 +72603,7 @@ impl ::std::convert::From<&PullRequestReviewCommentDeleted> for PullRequestRevie
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedAction"]
+#[doc = "`PullRequestReviewCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72675,7 +72675,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequest"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73037,7 +73037,7 @@ impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequest>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestActiveLockReason"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73128,7 +73128,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestBase"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73180,7 +73180,7 @@ impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestHead"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73232,7 +73232,7 @@ impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestLinks"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73299,7 +73299,7 @@ impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73343,7 +73343,7 @@ impl ::std::convert::From<Team>
         Self::Team(value)
     }
 }
-#[doc = "PullRequestReviewCommentDeletedPullRequestState"]
+#[doc = "`PullRequestReviewCommentDeletedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73424,7 +73424,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentEdited"]
+#[doc = "`PullRequestReviewCommentEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73810,7 +73810,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEdited> for PullRequestReview
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedAction"]
+#[doc = "`PullRequestReviewCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73929,7 +73929,7 @@ impl ::std::default::Default for PullRequestReviewCommentEditedChanges {
         }
     }
 }
-#[doc = "PullRequestReviewCommentEditedChangesBody"]
+#[doc = "`PullRequestReviewCommentEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73962,7 +73962,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedChangesBody>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequest"]
+#[doc = "`PullRequestReviewCommentEditedPullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74324,7 +74324,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequest>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestActiveLockReason"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74415,7 +74415,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestBase"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74467,7 +74467,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestBase>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestHead"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74519,7 +74519,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestHead>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestLinks"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74586,7 +74586,7 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestRequestedReviewersItem"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74630,7 +74630,7 @@ impl ::std::convert::From<Team>
         Self::Team(value)
     }
 }
-#[doc = "PullRequestReviewCommentEditedPullRequestState"]
+#[doc = "`PullRequestReviewCommentEditedPullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74711,7 +74711,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewCommentEvent"]
+#[doc = "`PullRequestReviewCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74758,7 +74758,7 @@ impl ::std::convert::From<PullRequestReviewCommentEdited> for PullRequestReviewC
         Self::Edited(value)
     }
 }
-#[doc = "PullRequestReviewCommentLinks"]
+#[doc = "`PullRequestReviewCommentLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74955,7 +74955,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
         value.parse()
     }
 }
-#[doc = "PullRequestReviewDismissed"]
+#[doc = "`PullRequestReviewDismissed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75094,7 +75094,7 @@ impl ::std::convert::From<&PullRequestReviewDismissed> for PullRequestReviewDism
         value.clone()
     }
 }
-#[doc = "PullRequestReviewDismissedAction"]
+#[doc = "`PullRequestReviewDismissedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75275,7 +75275,7 @@ impl ::std::convert::From<&PullRequestReviewDismissedReview> for PullRequestRevi
         value.clone()
     }
 }
-#[doc = "PullRequestReviewDismissedReviewLinks"]
+#[doc = "`PullRequestReviewDismissedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75311,7 +75311,7 @@ impl ::std::convert::From<&PullRequestReviewDismissedReviewLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewDismissedReviewState"]
+#[doc = "`PullRequestReviewDismissedReviewState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75383,7 +75383,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewDismiss
         value.parse()
     }
 }
-#[doc = "PullRequestReviewEdited"]
+#[doc = "`PullRequestReviewEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75540,7 +75540,7 @@ impl ::std::convert::From<&PullRequestReviewEdited> for PullRequestReviewEdited 
         value.clone()
     }
 }
-#[doc = "PullRequestReviewEditedAction"]
+#[doc = "`PullRequestReviewEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75612,7 +75612,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewEditedA
         value.parse()
     }
 }
-#[doc = "PullRequestReviewEditedChanges"]
+#[doc = "`PullRequestReviewEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75656,7 +75656,7 @@ impl ::std::default::Default for PullRequestReviewEditedChanges {
         }
     }
 }
-#[doc = "PullRequestReviewEditedChangesBody"]
+#[doc = "`PullRequestReviewEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75795,7 +75795,7 @@ impl ::std::convert::From<&PullRequestReviewEditedReview> for PullRequestReviewE
         value.clone()
     }
 }
-#[doc = "PullRequestReviewEditedReviewLinks"]
+#[doc = "`PullRequestReviewEditedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75831,7 +75831,7 @@ impl ::std::convert::From<&PullRequestReviewEditedReviewLinks>
         value.clone()
     }
 }
-#[doc = "PullRequestReviewEvent"]
+#[doc = "`PullRequestReviewEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75878,7 +75878,7 @@ impl ::std::convert::From<PullRequestReviewSubmitted> for PullRequestReviewEvent
         Self::Submitted(value)
     }
 }
-#[doc = "PullRequestReviewRequestRemoved"]
+#[doc = "`PullRequestReviewRequestRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76010,7 +76010,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestRemoved {
         value.clone()
     }
 }
-#[doc = "PullRequestReviewRequestRemovedVariant0Action"]
+#[doc = "`PullRequestReviewRequestRemovedVariant0Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76086,7 +76086,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewRequestRemovedVariant1Action"]
+#[doc = "`PullRequestReviewRequestRemovedVariant1Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76162,7 +76162,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "PullRequestReviewRequested"]
+#[doc = "`PullRequestReviewRequested`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76294,7 +76294,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequested {
         value.clone()
     }
 }
-#[doc = "PullRequestReviewRequestedVariant0Action"]
+#[doc = "`PullRequestReviewRequestedVariant0Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76366,7 +76366,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewRequest
         value.parse()
     }
 }
-#[doc = "PullRequestReviewRequestedVariant1Action"]
+#[doc = "`PullRequestReviewRequestedVariant1Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76438,7 +76438,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewRequest
         value.parse()
     }
 }
-#[doc = "PullRequestReviewSubmitted"]
+#[doc = "`PullRequestReviewSubmitted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76574,7 +76574,7 @@ impl ::std::convert::From<&PullRequestReviewSubmitted> for PullRequestReviewSubm
         value.clone()
     }
 }
-#[doc = "PullRequestReviewSubmittedAction"]
+#[doc = "`PullRequestReviewSubmittedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76752,7 +76752,7 @@ impl ::std::convert::From<&PullRequestReviewSubmittedReview> for PullRequestRevi
         value.clone()
     }
 }
-#[doc = "PullRequestReviewSubmittedReviewLinks"]
+#[doc = "`PullRequestReviewSubmittedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76866,7 +76866,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestState {
         value.parse()
     }
 }
-#[doc = "PullRequestSynchronize"]
+#[doc = "`PullRequestSynchronize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76942,7 +76942,7 @@ impl ::std::convert::From<&PullRequestSynchronize> for PullRequestSynchronize {
         value.clone()
     }
 }
-#[doc = "PullRequestSynchronizeAction"]
+#[doc = "`PullRequestSynchronizeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77014,7 +77014,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestSynchronizeAc
         value.parse()
     }
 }
-#[doc = "PullRequestUnassigned"]
+#[doc = "`PullRequestUnassigned`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77085,7 +77085,7 @@ impl ::std::convert::From<&PullRequestUnassigned> for PullRequestUnassigned {
         value.clone()
     }
 }
-#[doc = "PullRequestUnassignedAction"]
+#[doc = "`PullRequestUnassignedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77157,7 +77157,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnassignedAct
         value.parse()
     }
 }
-#[doc = "PullRequestUnlabeled"]
+#[doc = "`PullRequestUnlabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77228,7 +77228,7 @@ impl ::std::convert::From<&PullRequestUnlabeled> for PullRequestUnlabeled {
         value.clone()
     }
 }
-#[doc = "PullRequestUnlabeledAction"]
+#[doc = "`PullRequestUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77300,7 +77300,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnlabeledActi
         value.parse()
     }
 }
-#[doc = "PullRequestUnlocked"]
+#[doc = "`PullRequestUnlocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77366,7 +77366,7 @@ impl ::std::convert::From<&PullRequestUnlocked> for PullRequestUnlocked {
         value.clone()
     }
 }
-#[doc = "PullRequestUnlockedAction"]
+#[doc = "`PullRequestUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77438,7 +77438,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnlockedActio
         value.parse()
     }
 }
-#[doc = "PushEvent"]
+#[doc = "`PushEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77888,7 +77888,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseAssetState {
         value.parse()
     }
 }
-#[doc = "ReleaseCreated"]
+#[doc = "`ReleaseCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77947,7 +77947,7 @@ impl ::std::convert::From<&ReleaseCreated> for ReleaseCreated {
         value.clone()
     }
 }
-#[doc = "ReleaseCreatedAction"]
+#[doc = "`ReleaseCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78019,7 +78019,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseCreatedAction {
         value.parse()
     }
 }
-#[doc = "ReleaseDeleted"]
+#[doc = "`ReleaseDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78078,7 +78078,7 @@ impl ::std::convert::From<&ReleaseDeleted> for ReleaseDeleted {
         value.clone()
     }
 }
-#[doc = "ReleaseDeletedAction"]
+#[doc = "`ReleaseDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78150,7 +78150,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseDeletedAction {
         value.parse()
     }
 }
-#[doc = "ReleaseEdited"]
+#[doc = "`ReleaseEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78243,7 +78243,7 @@ impl ::std::convert::From<&ReleaseEdited> for ReleaseEdited {
         value.clone()
     }
 }
-#[doc = "ReleaseEditedAction"]
+#[doc = "`ReleaseEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78315,7 +78315,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseEditedAction {
         value.parse()
     }
 }
-#[doc = "ReleaseEditedChanges"]
+#[doc = "`ReleaseEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78375,7 +78375,7 @@ impl ::std::default::Default for ReleaseEditedChanges {
         }
     }
 }
-#[doc = "ReleaseEditedChangesBody"]
+#[doc = "`ReleaseEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78406,7 +78406,7 @@ impl ::std::convert::From<&ReleaseEditedChangesBody> for ReleaseEditedChangesBod
         value.clone()
     }
 }
-#[doc = "ReleaseEditedChangesName"]
+#[doc = "`ReleaseEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78437,7 +78437,7 @@ impl ::std::convert::From<&ReleaseEditedChangesName> for ReleaseEditedChangesNam
         value.clone()
     }
 }
-#[doc = "ReleaseEvent"]
+#[doc = "`ReleaseEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78520,7 +78520,7 @@ impl ::std::convert::From<ReleaseUnpublished> for ReleaseEvent {
         Self::Unpublished(value)
     }
 }
-#[doc = "ReleasePrereleased"]
+#[doc = "`ReleasePrereleased`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78599,7 +78599,7 @@ impl ::std::convert::From<&ReleasePrereleased> for ReleasePrereleased {
         value.clone()
     }
 }
-#[doc = "ReleasePrereleasedAction"]
+#[doc = "`ReleasePrereleasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78671,7 +78671,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleasePrereleasedAction
         value.parse()
     }
 }
-#[doc = "ReleasePrereleasedRelease"]
+#[doc = "`ReleasePrereleasedRelease`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78731,7 +78731,7 @@ impl ::std::convert::From<&ReleasePrereleasedRelease> for ReleasePrereleasedRele
         value.clone()
     }
 }
-#[doc = "ReleasePublished"]
+#[doc = "`ReleasePublished`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78807,7 +78807,7 @@ impl ::std::convert::From<&ReleasePublished> for ReleasePublished {
         value.clone()
     }
 }
-#[doc = "ReleasePublishedAction"]
+#[doc = "`ReleasePublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78879,7 +78879,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleasePublishedAction {
         value.parse()
     }
 }
-#[doc = "ReleasePublishedRelease"]
+#[doc = "`ReleasePublishedRelease`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78937,7 +78937,7 @@ impl ::std::convert::From<&ReleasePublishedRelease> for ReleasePublishedRelease 
         value.clone()
     }
 }
-#[doc = "ReleaseReleased"]
+#[doc = "`ReleaseReleased`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78996,7 +78996,7 @@ impl ::std::convert::From<&ReleaseReleased> for ReleaseReleased {
         value.clone()
     }
 }
-#[doc = "ReleaseReleasedAction"]
+#[doc = "`ReleaseReleasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79068,7 +79068,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseReleasedAction {
         value.parse()
     }
 }
-#[doc = "ReleaseUnpublished"]
+#[doc = "`ReleaseUnpublished`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79143,7 +79143,7 @@ impl ::std::convert::From<&ReleaseUnpublished> for ReleaseUnpublished {
         value.clone()
     }
 }
-#[doc = "ReleaseUnpublishedAction"]
+#[doc = "`ReleaseUnpublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79215,7 +79215,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseUnpublishedAction
         value.parse()
     }
 }
-#[doc = "ReleaseUnpublishedRelease"]
+#[doc = "`ReleaseUnpublishedRelease`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79272,7 +79272,7 @@ impl ::std::convert::From<&ReleaseUnpublishedRelease> for ReleaseUnpublishedRele
         value.clone()
     }
 }
-#[doc = "RepoRef"]
+#[doc = "`RepoRef`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79907,7 +79907,7 @@ impl ::std::convert::From<&Repository> for Repository {
         value.clone()
     }
 }
-#[doc = "RepositoryArchived"]
+#[doc = "`RepositoryArchived`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79982,7 +79982,7 @@ impl ::std::convert::From<&RepositoryArchived> for RepositoryArchived {
         value.clone()
     }
 }
-#[doc = "RepositoryArchivedAction"]
+#[doc = "`RepositoryArchivedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80054,7 +80054,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryArchivedAction
         value.parse()
     }
 }
-#[doc = "RepositoryArchivedRepository"]
+#[doc = "`RepositoryArchivedRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80205,7 +80205,7 @@ impl ::std::convert::From<&RepositoryArchivedRepository> for RepositoryArchivedR
         value.clone()
     }
 }
-#[doc = "RepositoryArchivedRepositoryCreatedAt"]
+#[doc = "`RepositoryArchivedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80288,7 +80288,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryArchivedRepositoryPermissions"]
+#[doc = "`RepositoryArchivedRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80339,7 +80339,7 @@ impl ::std::convert::From<&RepositoryArchivedRepositoryPermissions>
         value.clone()
     }
 }
-#[doc = "RepositoryArchivedRepositoryPushedAt"]
+#[doc = "`RepositoryArchivedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80384,7 +80384,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryCreated"]
+#[doc = "`RepositoryCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80438,7 +80438,7 @@ impl ::std::convert::From<&RepositoryCreated> for RepositoryCreated {
         value.clone()
     }
 }
-#[doc = "RepositoryCreatedAction"]
+#[doc = "`RepositoryCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80510,7 +80510,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAction 
         value.parse()
     }
 }
-#[doc = "RepositoryCreatedAt"]
+#[doc = "`RepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80591,7 +80591,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>> for RepositoryC
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryDeleted"]
+#[doc = "`RepositoryDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80645,7 +80645,7 @@ impl ::std::convert::From<&RepositoryDeleted> for RepositoryDeleted {
         value.clone()
     }
 }
-#[doc = "RepositoryDeletedAction"]
+#[doc = "`RepositoryDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80717,7 +80717,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryDeletedAction 
         value.parse()
     }
 }
-#[doc = "RepositoryDispatchEvent"]
+#[doc = "`RepositoryDispatchEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80755,7 +80755,7 @@ impl ::std::convert::From<RepositoryDispatchOnDemandTest> for RepositoryDispatch
         Self(value)
     }
 }
-#[doc = "RepositoryDispatchOnDemandTest"]
+#[doc = "`RepositoryDispatchOnDemandTest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80820,7 +80820,7 @@ impl ::std::convert::From<&RepositoryDispatchOnDemandTest> for RepositoryDispatc
         value.clone()
     }
 }
-#[doc = "RepositoryDispatchOnDemandTestAction"]
+#[doc = "`RepositoryDispatchOnDemandTestAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80892,7 +80892,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryDispatchOnDema
         value.parse()
     }
 }
-#[doc = "RepositoryEdited"]
+#[doc = "`RepositoryEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80996,7 +80996,7 @@ impl ::std::convert::From<&RepositoryEdited> for RepositoryEdited {
         value.clone()
     }
 }
-#[doc = "RepositoryEditedAction"]
+#[doc = "`RepositoryEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81068,7 +81068,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryEditedAction {
         value.parse()
     }
 }
-#[doc = "RepositoryEditedChanges"]
+#[doc = "`RepositoryEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81147,7 +81147,7 @@ impl ::std::default::Default for RepositoryEditedChanges {
         }
     }
 }
-#[doc = "RepositoryEditedChangesDefaultBranch"]
+#[doc = "`RepositoryEditedChangesDefaultBranch`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81178,7 +81178,7 @@ impl ::std::convert::From<&RepositoryEditedChangesDefaultBranch>
         value.clone()
     }
 }
-#[doc = "RepositoryEditedChangesDescription"]
+#[doc = "`RepositoryEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81212,7 +81212,7 @@ impl ::std::convert::From<&RepositoryEditedChangesDescription>
         value.clone()
     }
 }
-#[doc = "RepositoryEditedChangesHomepage"]
+#[doc = "`RepositoryEditedChangesHomepage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81244,7 +81244,7 @@ impl ::std::convert::From<&RepositoryEditedChangesHomepage> for RepositoryEdited
         value.clone()
     }
 }
-#[doc = "RepositoryEvent"]
+#[doc = "`RepositoryEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81345,7 +81345,7 @@ impl ::std::convert::From<RepositoryUnarchived> for RepositoryEvent {
         Self::Unarchived(value)
     }
 }
-#[doc = "RepositoryImportEvent"]
+#[doc = "`RepositoryImportEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81401,7 +81401,7 @@ impl ::std::convert::From<&RepositoryImportEvent> for RepositoryImportEvent {
         value.clone()
     }
 }
-#[doc = "RepositoryImportEventStatus"]
+#[doc = "`RepositoryImportEventStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81483,7 +81483,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryImportEventSta
         value.parse()
     }
 }
-#[doc = "RepositoryLite"]
+#[doc = "`RepositoryLite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81786,7 +81786,7 @@ impl ::std::convert::From<&RepositoryLite> for RepositoryLite {
         value.clone()
     }
 }
-#[doc = "RepositoryPermissions"]
+#[doc = "`RepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81835,7 +81835,7 @@ impl ::std::convert::From<&RepositoryPermissions> for RepositoryPermissions {
         value.clone()
     }
 }
-#[doc = "RepositoryPrivatized"]
+#[doc = "`RepositoryPrivatized`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81909,7 +81909,7 @@ impl ::std::convert::From<&RepositoryPrivatized> for RepositoryPrivatized {
         value.clone()
     }
 }
-#[doc = "RepositoryPrivatizedAction"]
+#[doc = "`RepositoryPrivatizedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81981,7 +81981,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPrivatizedActi
         value.parse()
     }
 }
-#[doc = "RepositoryPrivatizedRepository"]
+#[doc = "`RepositoryPrivatizedRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82131,7 +82131,7 @@ impl ::std::convert::From<&RepositoryPrivatizedRepository> for RepositoryPrivati
         value.clone()
     }
 }
-#[doc = "RepositoryPrivatizedRepositoryCreatedAt"]
+#[doc = "`RepositoryPrivatizedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82214,7 +82214,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryPrivatizedRepositoryPermissions"]
+#[doc = "`RepositoryPrivatizedRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82265,7 +82265,7 @@ impl ::std::convert::From<&RepositoryPrivatizedRepositoryPermissions>
         value.clone()
     }
 }
-#[doc = "RepositoryPrivatizedRepositoryPushedAt"]
+#[doc = "`RepositoryPrivatizedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82310,7 +82310,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryPublicized"]
+#[doc = "`RepositoryPublicized`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82384,7 +82384,7 @@ impl ::std::convert::From<&RepositoryPublicized> for RepositoryPublicized {
         value.clone()
     }
 }
-#[doc = "RepositoryPublicizedAction"]
+#[doc = "`RepositoryPublicizedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82456,7 +82456,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPublicizedActi
         value.parse()
     }
 }
-#[doc = "RepositoryPublicizedRepository"]
+#[doc = "`RepositoryPublicizedRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82606,7 +82606,7 @@ impl ::std::convert::From<&RepositoryPublicizedRepository> for RepositoryPublici
         value.clone()
     }
 }
-#[doc = "RepositoryPublicizedRepositoryCreatedAt"]
+#[doc = "`RepositoryPublicizedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82689,7 +82689,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryPublicizedRepositoryPermissions"]
+#[doc = "`RepositoryPublicizedRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82740,7 +82740,7 @@ impl ::std::convert::From<&RepositoryPublicizedRepositoryPermissions>
         value.clone()
     }
 }
-#[doc = "RepositoryPublicizedRepositoryPushedAt"]
+#[doc = "`RepositoryPublicizedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82785,7 +82785,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryPushedAt"]
+#[doc = "`RepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82828,7 +82828,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>> for RepositoryP
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryRenamed"]
+#[doc = "`RepositoryRenamed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82914,7 +82914,7 @@ impl ::std::convert::From<&RepositoryRenamed> for RepositoryRenamed {
         value.clone()
     }
 }
-#[doc = "RepositoryRenamedAction"]
+#[doc = "`RepositoryRenamedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82986,7 +82986,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryRenamedAction 
         value.parse()
     }
 }
-#[doc = "RepositoryRenamedChanges"]
+#[doc = "`RepositoryRenamedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83033,7 +83033,7 @@ impl ::std::convert::From<&RepositoryRenamedChanges> for RepositoryRenamedChange
         value.clone()
     }
 }
-#[doc = "RepositoryRenamedChangesRepository"]
+#[doc = "`RepositoryRenamedChangesRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83073,7 +83073,7 @@ impl ::std::convert::From<&RepositoryRenamedChangesRepository>
         value.clone()
     }
 }
-#[doc = "RepositoryRenamedChangesRepositoryName"]
+#[doc = "`RepositoryRenamedChangesRepositoryName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83104,7 +83104,7 @@ impl ::std::convert::From<&RepositoryRenamedChangesRepositoryName>
         value.clone()
     }
 }
-#[doc = "RepositoryTransferred"]
+#[doc = "`RepositoryTransferred`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83187,7 +83187,7 @@ impl ::std::convert::From<&RepositoryTransferred> for RepositoryTransferred {
         value.clone()
     }
 }
-#[doc = "RepositoryTransferredAction"]
+#[doc = "`RepositoryTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83259,7 +83259,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryTransferredAct
         value.parse()
     }
 }
-#[doc = "RepositoryTransferredChanges"]
+#[doc = "`RepositoryTransferredChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83303,7 +83303,7 @@ impl ::std::convert::From<&RepositoryTransferredChanges> for RepositoryTransferr
         value.clone()
     }
 }
-#[doc = "RepositoryTransferredChangesOwner"]
+#[doc = "`RepositoryTransferredChangesOwner`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83340,7 +83340,7 @@ impl ::std::convert::From<&RepositoryTransferredChangesOwner>
         value.clone()
     }
 }
-#[doc = "RepositoryTransferredChangesOwnerFrom"]
+#[doc = "`RepositoryTransferredChangesOwnerFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83376,7 +83376,7 @@ impl ::std::default::Default for RepositoryTransferredChangesOwnerFrom {
         }
     }
 }
-#[doc = "RepositoryUnarchived"]
+#[doc = "`RepositoryUnarchived`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83451,7 +83451,7 @@ impl ::std::convert::From<&RepositoryUnarchived> for RepositoryUnarchived {
         value.clone()
     }
 }
-#[doc = "RepositoryUnarchivedAction"]
+#[doc = "`RepositoryUnarchivedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83523,7 +83523,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryUnarchivedActi
         value.parse()
     }
 }
-#[doc = "RepositoryUnarchivedRepository"]
+#[doc = "`RepositoryUnarchivedRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83674,7 +83674,7 @@ impl ::std::convert::From<&RepositoryUnarchivedRepository> for RepositoryUnarchi
         value.clone()
     }
 }
-#[doc = "RepositoryUnarchivedRepositoryCreatedAt"]
+#[doc = "`RepositoryUnarchivedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83757,7 +83757,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryUnarchivedRepositoryPermissions"]
+#[doc = "`RepositoryUnarchivedRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83808,7 +83808,7 @@ impl ::std::convert::From<&RepositoryUnarchivedRepositoryPermissions>
         value.clone()
     }
 }
-#[doc = "RepositoryUnarchivedRepositoryPushedAt"]
+#[doc = "`RepositoryUnarchivedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83853,7 +83853,7 @@ impl ::std::convert::From<chrono::DateTime<chrono::offset::Utc>>
         Self::Variant1(value)
     }
 }
-#[doc = "RepositoryVulnerabilityAlertCreate"]
+#[doc = "`RepositoryVulnerabilityAlertCreate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83958,7 +83958,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertCreate>
         value.clone()
     }
 }
-#[doc = "RepositoryVulnerabilityAlertCreateAction"]
+#[doc = "`RepositoryVulnerabilityAlertCreateAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84118,7 +84118,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertCreateAlert>
         value.clone()
     }
 }
-#[doc = "RepositoryVulnerabilityAlertDismiss"]
+#[doc = "`RepositoryVulnerabilityAlertDismiss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84226,7 +84226,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertDismiss>
         value.clone()
     }
 }
-#[doc = "RepositoryVulnerabilityAlertDismissAction"]
+#[doc = "`RepositoryVulnerabilityAlertDismissAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84386,7 +84386,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertDismissAlert>
         value.clone()
     }
 }
-#[doc = "RepositoryVulnerabilityAlertEvent"]
+#[doc = "`RepositoryVulnerabilityAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84439,7 +84439,7 @@ impl ::std::convert::From<RepositoryVulnerabilityAlertResolve>
         Self::Resolve(value)
     }
 }
-#[doc = "RepositoryVulnerabilityAlertResolve"]
+#[doc = "`RepositoryVulnerabilityAlertResolve`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84544,7 +84544,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertResolve>
         value.clone()
     }
 }
-#[doc = "RepositoryVulnerabilityAlertResolveAction"]
+#[doc = "`RepositoryVulnerabilityAlertResolveAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84704,7 +84704,7 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertResolveAlert>
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertCreated"]
+#[doc = "`SecretScanningAlertCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84784,7 +84784,7 @@ impl ::std::convert::From<&SecretScanningAlertCreated> for SecretScanningAlertCr
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertCreatedAction"]
+#[doc = "`SecretScanningAlertCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84906,7 +84906,7 @@ impl ::std::convert::From<&SecretScanningAlertCreatedAlert> for SecretScanningAl
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertEvent"]
+#[doc = "`SecretScanningAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -84953,7 +84953,7 @@ impl ::std::convert::From<SecretScanningAlertResolved> for SecretScanningAlertEv
         Self::Resolved(value)
     }
 }
-#[doc = "SecretScanningAlertReopened"]
+#[doc = "`SecretScanningAlertReopened`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85038,7 +85038,7 @@ impl ::std::convert::From<&SecretScanningAlertReopened> for SecretScanningAlertR
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertReopenedAction"]
+#[doc = "`SecretScanningAlertReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85160,7 +85160,7 @@ impl ::std::convert::From<&SecretScanningAlertReopenedAlert> for SecretScanningA
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertResolved"]
+#[doc = "`SecretScanningAlertResolved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85251,7 +85251,7 @@ impl ::std::convert::From<&SecretScanningAlertResolved> for SecretScanningAlertR
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertResolvedAction"]
+#[doc = "`SecretScanningAlertResolvedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85379,7 +85379,7 @@ impl ::std::convert::From<&SecretScanningAlertResolvedAlert> for SecretScanningA
         value.clone()
     }
 }
-#[doc = "SecretScanningAlertResolvedAlertResolution"]
+#[doc = "`SecretScanningAlertResolvedAlertResolution`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85468,7 +85468,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SecretScanningAlertResol
         value.parse()
     }
 }
-#[doc = "SecurityAdvisoryEvent"]
+#[doc = "`SecurityAdvisoryEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85524,7 +85524,7 @@ impl ::std::convert::From<SecurityAdvisoryWithdrawn> for SecurityAdvisoryEvent {
         Self::Withdrawn(value)
     }
 }
-#[doc = "SecurityAdvisoryPerformed"]
+#[doc = "`SecurityAdvisoryPerformed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -85730,7 +85730,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformed> for SecurityAdvisoryPerfor
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedAction"]
+#[doc = "`SecurityAdvisoryPerformedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86003,7 +86003,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisory>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryCvss"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86042,7 +86042,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryCvss>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryCwesItem"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86078,7 +86078,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryCwesItem>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86115,7 +86115,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersI
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86147,7 +86147,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryReferencesIt
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86220,7 +86220,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86255,7 +86255,7 @@ impl
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage"]
+#[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86291,7 +86291,7 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublished"]
+#[doc = "`SecurityAdvisoryPublished`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86497,7 +86497,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublished> for SecurityAdvisoryPublis
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedAction"]
+#[doc = "`SecurityAdvisoryPublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86770,7 +86770,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisory>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryCvss"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86809,7 +86809,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryCvss>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryCwesItem"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86845,7 +86845,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryCwesItem>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86882,7 +86882,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersI
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86914,7 +86914,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryReferencesIt
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86987,7 +86987,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87022,7 +87022,7 @@ impl
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage"]
+#[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87058,7 +87058,7 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdated"]
+#[doc = "`SecurityAdvisoryUpdated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87264,7 +87264,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdated> for SecurityAdvisoryUpdated 
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedAction"]
+#[doc = "`SecurityAdvisoryUpdatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87537,7 +87537,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisory>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryCvss"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87576,7 +87576,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryCvss>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87612,7 +87612,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87649,7 +87649,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersIte
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87681,7 +87681,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87754,7 +87754,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitie
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87789,7 +87789,7 @@ impl
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage"]
+#[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87825,7 +87825,7 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitie
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawn"]
+#[doc = "`SecurityAdvisoryWithdrawn`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88028,7 +88028,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawn> for SecurityAdvisoryWithdr
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnAction"]
+#[doc = "`SecurityAdvisoryWithdrawnAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88298,7 +88298,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisory>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryCvss"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88337,7 +88337,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCvss>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88373,7 +88373,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem>
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88410,7 +88410,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersI
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88442,7 +88442,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesIt
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88515,7 +88515,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88550,7 +88550,7 @@ impl
         value.clone()
     }
 }
-#[doc = "SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage"]
+#[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88586,7 +88586,7 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilit
         value.clone()
     }
 }
-#[doc = "SimplePullRequest"]
+#[doc = "`SimplePullRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88946,7 +88946,7 @@ impl ::std::convert::From<&SimplePullRequest> for SimplePullRequest {
         value.clone()
     }
 }
-#[doc = "SimplePullRequestActiveLockReason"]
+#[doc = "`SimplePullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89033,7 +89033,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SimplePullRequestActiveL
         value.parse()
     }
 }
-#[doc = "SimplePullRequestBase"]
+#[doc = "`SimplePullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89083,7 +89083,7 @@ impl ::std::convert::From<&SimplePullRequestBase> for SimplePullRequestBase {
         value.clone()
     }
 }
-#[doc = "SimplePullRequestHead"]
+#[doc = "`SimplePullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89133,7 +89133,7 @@ impl ::std::convert::From<&SimplePullRequestHead> for SimplePullRequestHead {
         value.clone()
     }
 }
-#[doc = "SimplePullRequestLinks"]
+#[doc = "`SimplePullRequestLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89198,7 +89198,7 @@ impl ::std::convert::From<&SimplePullRequestLinks> for SimplePullRequestLinks {
         value.clone()
     }
 }
-#[doc = "SimplePullRequestRequestedReviewersItem"]
+#[doc = "`SimplePullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89236,7 +89236,7 @@ impl ::std::convert::From<Team> for SimplePullRequestRequestedReviewersItem {
         Self::Team(value)
     }
 }
-#[doc = "SimplePullRequestState"]
+#[doc = "`SimplePullRequestState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89313,7 +89313,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SimplePullRequestState {
         value.parse()
     }
 }
-#[doc = "SponsorshipCancelled"]
+#[doc = "`SponsorshipCancelled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89386,7 +89386,7 @@ impl ::std::convert::From<&SponsorshipCancelled> for SponsorshipCancelled {
         value.clone()
     }
 }
-#[doc = "SponsorshipCancelledAction"]
+#[doc = "`SponsorshipCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89458,7 +89458,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipCancelledActi
         value.parse()
     }
 }
-#[doc = "SponsorshipCancelledSponsorship"]
+#[doc = "`SponsorshipCancelledSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89512,7 +89512,7 @@ impl ::std::convert::From<&SponsorshipCancelledSponsorship> for SponsorshipCance
         value.clone()
     }
 }
-#[doc = "SponsorshipCreated"]
+#[doc = "`SponsorshipCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89585,7 +89585,7 @@ impl ::std::convert::From<&SponsorshipCreated> for SponsorshipCreated {
         value.clone()
     }
 }
-#[doc = "SponsorshipCreatedAction"]
+#[doc = "`SponsorshipCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89657,7 +89657,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipCreatedAction
         value.parse()
     }
 }
-#[doc = "SponsorshipCreatedSponsorship"]
+#[doc = "`SponsorshipCreatedSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89711,7 +89711,7 @@ impl ::std::convert::From<&SponsorshipCreatedSponsorship> for SponsorshipCreated
         value.clone()
     }
 }
-#[doc = "SponsorshipEdited"]
+#[doc = "`SponsorshipEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89805,7 +89805,7 @@ impl ::std::convert::From<&SponsorshipEdited> for SponsorshipEdited {
         value.clone()
     }
 }
-#[doc = "SponsorshipEditedAction"]
+#[doc = "`SponsorshipEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89877,7 +89877,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipEditedAction 
         value.parse()
     }
 }
-#[doc = "SponsorshipEditedChanges"]
+#[doc = "`SponsorshipEditedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89921,7 +89921,7 @@ impl ::std::default::Default for SponsorshipEditedChanges {
         }
     }
 }
-#[doc = "SponsorshipEditedChangesPrivacyLevel"]
+#[doc = "`SponsorshipEditedChangesPrivacyLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89954,7 +89954,7 @@ impl ::std::convert::From<&SponsorshipEditedChangesPrivacyLevel>
         value.clone()
     }
 }
-#[doc = "SponsorshipEditedSponsorship"]
+#[doc = "`SponsorshipEditedSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90008,7 +90008,7 @@ impl ::std::convert::From<&SponsorshipEditedSponsorship> for SponsorshipEditedSp
         value.clone()
     }
 }
-#[doc = "SponsorshipEvent"]
+#[doc = "`SponsorshipEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90082,7 +90082,7 @@ impl ::std::convert::From<SponsorshipTierChanged> for SponsorshipEvent {
         Self::TierChanged(value)
     }
 }
-#[doc = "SponsorshipPendingCancellation"]
+#[doc = "`SponsorshipPendingCancellation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90162,7 +90162,7 @@ impl ::std::convert::From<&SponsorshipPendingCancellation> for SponsorshipPendin
         value.clone()
     }
 }
-#[doc = "SponsorshipPendingCancellationAction"]
+#[doc = "`SponsorshipPendingCancellationAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90234,7 +90234,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipPendingCancel
         value.parse()
     }
 }
-#[doc = "SponsorshipPendingCancellationSponsorship"]
+#[doc = "`SponsorshipPendingCancellationSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90290,7 +90290,7 @@ impl ::std::convert::From<&SponsorshipPendingCancellationSponsorship>
         value.clone()
     }
 }
-#[doc = "SponsorshipPendingTierChange"]
+#[doc = "`SponsorshipPendingTierChange`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90393,7 +90393,7 @@ impl ::std::convert::From<&SponsorshipPendingTierChange> for SponsorshipPendingT
         value.clone()
     }
 }
-#[doc = "SponsorshipPendingTierChangeAction"]
+#[doc = "`SponsorshipPendingTierChangeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90465,7 +90465,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipPendingTierCh
         value.parse()
     }
 }
-#[doc = "SponsorshipPendingTierChangeChanges"]
+#[doc = "`SponsorshipPendingTierChangeChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90505,7 +90505,7 @@ impl ::std::convert::From<&SponsorshipPendingTierChangeChanges>
         value.clone()
     }
 }
-#[doc = "SponsorshipPendingTierChangeChangesTier"]
+#[doc = "`SponsorshipPendingTierChangeChangesTier`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90536,7 +90536,7 @@ impl ::std::convert::From<&SponsorshipPendingTierChangeChangesTier>
         value.clone()
     }
 }
-#[doc = "SponsorshipPendingTierChangeSponsorship"]
+#[doc = "`SponsorshipPendingTierChangeSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90659,7 +90659,7 @@ impl ::std::convert::From<&SponsorshipTier> for SponsorshipTier {
         value.clone()
     }
 }
-#[doc = "SponsorshipTierChanged"]
+#[doc = "`SponsorshipTierChanged`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90755,7 +90755,7 @@ impl ::std::convert::From<&SponsorshipTierChanged> for SponsorshipTierChanged {
         value.clone()
     }
 }
-#[doc = "SponsorshipTierChangedAction"]
+#[doc = "`SponsorshipTierChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90827,7 +90827,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipTierChangedAc
         value.parse()
     }
 }
-#[doc = "SponsorshipTierChangedChanges"]
+#[doc = "`SponsorshipTierChangedChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90865,7 +90865,7 @@ impl ::std::convert::From<&SponsorshipTierChangedChanges> for SponsorshipTierCha
         value.clone()
     }
 }
-#[doc = "SponsorshipTierChangedChangesTier"]
+#[doc = "`SponsorshipTierChangedChangesTier`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90896,7 +90896,7 @@ impl ::std::convert::From<&SponsorshipTierChangedChangesTier>
         value.clone()
     }
 }
-#[doc = "SponsorshipTierChangedSponsorship"]
+#[doc = "`SponsorshipTierChangedSponsorship`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90952,7 +90952,7 @@ impl ::std::convert::From<&SponsorshipTierChangedSponsorship>
         value.clone()
     }
 }
-#[doc = "StarCreated"]
+#[doc = "`StarCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91013,7 +91013,7 @@ impl ::std::convert::From<&StarCreated> for StarCreated {
         value.clone()
     }
 }
-#[doc = "StarCreatedAction"]
+#[doc = "`StarCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91085,7 +91085,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StarCreatedAction {
         value.parse()
     }
 }
-#[doc = "StarDeleted"]
+#[doc = "`StarDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91146,7 +91146,7 @@ impl ::std::convert::From<&StarDeleted> for StarDeleted {
         value.clone()
     }
 }
-#[doc = "StarDeletedAction"]
+#[doc = "`StarDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91218,7 +91218,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StarDeletedAction {
         value.parse()
     }
 }
-#[doc = "StarEvent"]
+#[doc = "`StarEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91256,7 +91256,7 @@ impl ::std::convert::From<StarDeleted> for StarEvent {
         Self::Deleted(value)
     }
 }
-#[doc = "StatusEvent"]
+#[doc = "`StatusEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91626,7 +91626,7 @@ impl ::std::convert::From<&StatusEvent> for StatusEvent {
         value.clone()
     }
 }
-#[doc = "StatusEventBranchesItem"]
+#[doc = "`StatusEventBranchesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91679,7 +91679,7 @@ impl ::std::convert::From<&StatusEventBranchesItem> for StatusEventBranchesItem 
         value.clone()
     }
 }
-#[doc = "StatusEventBranchesItemCommit"]
+#[doc = "`StatusEventBranchesItemCommit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91714,7 +91714,7 @@ impl ::std::convert::From<&StatusEventBranchesItemCommit> for StatusEventBranche
         value.clone()
     }
 }
-#[doc = "StatusEventCommit"]
+#[doc = "`StatusEventCommit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91944,7 +91944,7 @@ impl ::std::convert::From<&StatusEventCommit> for StatusEventCommit {
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommit"]
+#[doc = "`StatusEventCommitCommit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92092,7 +92092,7 @@ impl ::std::convert::From<&StatusEventCommitCommit> for StatusEventCommitCommit 
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommitAuthor"]
+#[doc = "`StatusEventCommitCommitAuthor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92134,7 +92134,7 @@ impl ::std::convert::From<&StatusEventCommitCommitAuthor> for StatusEventCommitC
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommitCommitter"]
+#[doc = "`StatusEventCommitCommitCommitter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92176,7 +92176,7 @@ impl ::std::convert::From<&StatusEventCommitCommitCommitter> for StatusEventComm
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommitTree"]
+#[doc = "`StatusEventCommitCommitTree`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92211,7 +92211,7 @@ impl ::std::convert::From<&StatusEventCommitCommitTree> for StatusEventCommitCom
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommitVerification"]
+#[doc = "`StatusEventCommitCommitVerification`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92278,7 +92278,7 @@ impl ::std::convert::From<&StatusEventCommitCommitVerification>
         value.clone()
     }
 }
-#[doc = "StatusEventCommitCommitVerificationReason"]
+#[doc = "`StatusEventCommitCommitVerificationReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92410,7 +92410,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StatusEventCommitCommitV
         value.parse()
     }
 }
-#[doc = "StatusEventCommitParentsItem"]
+#[doc = "`StatusEventCommitParentsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92717,7 +92717,7 @@ impl ::std::convert::From<&Team> for Team {
         value.clone()
     }
 }
-#[doc = "TeamAddEvent"]
+#[doc = "`TeamAddEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92768,7 +92768,7 @@ impl ::std::convert::From<&TeamAddEvent> for TeamAddEvent {
         value.clone()
     }
 }
-#[doc = "TeamAddedToRepository"]
+#[doc = "`TeamAddedToRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92827,7 +92827,7 @@ impl ::std::convert::From<&TeamAddedToRepository> for TeamAddedToRepository {
         value.clone()
     }
 }
-#[doc = "TeamAddedToRepositoryAction"]
+#[doc = "`TeamAddedToRepositoryAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92899,7 +92899,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamAddedToRepositoryAct
         value.parse()
     }
 }
-#[doc = "TeamCreated"]
+#[doc = "`TeamCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92958,7 +92958,7 @@ impl ::std::convert::From<&TeamCreated> for TeamCreated {
         value.clone()
     }
 }
-#[doc = "TeamCreatedAction"]
+#[doc = "`TeamCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93030,7 +93030,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamCreatedAction {
         value.parse()
     }
 }
-#[doc = "TeamDeleted"]
+#[doc = "`TeamDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93089,7 +93089,7 @@ impl ::std::convert::From<&TeamDeleted> for TeamDeleted {
         value.clone()
     }
 }
-#[doc = "TeamDeletedAction"]
+#[doc = "`TeamDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93161,7 +93161,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamDeletedAction {
         value.parse()
     }
 }
-#[doc = "TeamEdited"]
+#[doc = "`TeamEdited`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93304,7 +93304,7 @@ impl ::std::convert::From<&TeamEdited> for TeamEdited {
         value.clone()
     }
 }
-#[doc = "TeamEditedAction"]
+#[doc = "`TeamEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93492,7 +93492,7 @@ impl ::std::default::Default for TeamEditedChanges {
         }
     }
 }
-#[doc = "TeamEditedChangesDescription"]
+#[doc = "`TeamEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93523,7 +93523,7 @@ impl ::std::convert::From<&TeamEditedChangesDescription> for TeamEditedChangesDe
         value.clone()
     }
 }
-#[doc = "TeamEditedChangesName"]
+#[doc = "`TeamEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93554,7 +93554,7 @@ impl ::std::convert::From<&TeamEditedChangesName> for TeamEditedChangesName {
         value.clone()
     }
 }
-#[doc = "TeamEditedChangesPrivacy"]
+#[doc = "`TeamEditedChangesPrivacy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93585,7 +93585,7 @@ impl ::std::convert::From<&TeamEditedChangesPrivacy> for TeamEditedChangesPrivac
         value.clone()
     }
 }
-#[doc = "TeamEditedChangesRepository"]
+#[doc = "`TeamEditedChangesRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93638,7 +93638,7 @@ impl ::std::convert::From<&TeamEditedChangesRepository> for TeamEditedChangesRep
         value.clone()
     }
 }
-#[doc = "TeamEditedChangesRepositoryPermissions"]
+#[doc = "`TeamEditedChangesRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93684,7 +93684,7 @@ impl ::std::convert::From<&TeamEditedChangesRepositoryPermissions>
         value.clone()
     }
 }
-#[doc = "TeamEditedChangesRepositoryPermissionsFrom"]
+#[doc = "`TeamEditedChangesRepositoryPermissionsFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93738,7 +93738,7 @@ impl ::std::default::Default for TeamEditedChangesRepositoryPermissionsFrom {
         }
     }
 }
-#[doc = "TeamEvent"]
+#[doc = "`TeamEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93803,7 +93803,7 @@ impl ::std::convert::From<TeamRemovedFromRepository> for TeamEvent {
         Self::RemovedFromRepository(value)
     }
 }
-#[doc = "TeamParent"]
+#[doc = "`TeamParent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93904,7 +93904,7 @@ impl ::std::convert::From<&TeamParent> for TeamParent {
         value.clone()
     }
 }
-#[doc = "TeamParentPrivacy"]
+#[doc = "`TeamParentPrivacy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93986,7 +93986,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamParentPrivacy {
         value.parse()
     }
 }
-#[doc = "TeamPrivacy"]
+#[doc = "`TeamPrivacy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94068,7 +94068,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamPrivacy {
         value.parse()
     }
 }
-#[doc = "TeamRemovedFromRepository"]
+#[doc = "`TeamRemovedFromRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94127,7 +94127,7 @@ impl ::std::convert::From<&TeamRemovedFromRepository> for TeamRemovedFromReposit
         value.clone()
     }
 }
-#[doc = "TeamRemovedFromRepositoryAction"]
+#[doc = "`TeamRemovedFromRepositoryAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94199,7 +94199,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamRemovedFromRepositor
         value.parse()
     }
 }
-#[doc = "User"]
+#[doc = "`User`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94346,7 +94346,7 @@ impl ::std::convert::From<&User> for User {
         value.clone()
     }
 }
-#[doc = "UserType"]
+#[doc = "`UserType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94425,7 +94425,7 @@ impl ::std::convert::TryFrom<::std::string::String> for UserType {
         value.parse()
     }
 }
-#[doc = "WatchEvent"]
+#[doc = "`WatchEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94463,7 +94463,7 @@ impl ::std::convert::From<WatchStarted> for WatchEvent {
         Self(value)
     }
 }
-#[doc = "WatchStarted"]
+#[doc = "`WatchStarted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94517,7 +94517,7 @@ impl ::std::convert::From<&WatchStarted> for WatchStarted {
         value.clone()
     }
 }
-#[doc = "WatchStartedAction"]
+#[doc = "`WatchStartedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94589,7 +94589,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WatchStartedAction {
         value.parse()
     }
 }
-#[doc = "WebhookEvents"]
+#[doc = "`WebhookEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94687,7 +94687,7 @@ impl ::std::convert::From<[::std::string::String; 1usize]> for WebhookEvents {
         Self::Variant1(value)
     }
 }
-#[doc = "WebhookEventsVariant0Item"]
+#[doc = "`WebhookEventsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94989,7 +94989,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WebhookEventsVariant0Ite
         value.parse()
     }
 }
-#[doc = "Workflow"]
+#[doc = "`Workflow`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95068,7 +95068,7 @@ impl ::std::convert::From<&Workflow> for Workflow {
         value.clone()
     }
 }
-#[doc = "WorkflowDispatchEvent"]
+#[doc = "`WorkflowDispatchEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95139,7 +95139,7 @@ impl ::std::convert::From<&WorkflowDispatchEvent> for WorkflowDispatchEvent {
         value.clone()
     }
 }
-#[doc = "WorkflowJob"]
+#[doc = "`WorkflowJob`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95267,7 +95267,7 @@ impl ::std::convert::From<&WorkflowJob> for WorkflowJob {
         value.clone()
     }
 }
-#[doc = "WorkflowJobCompleted"]
+#[doc = "`WorkflowJobCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95346,7 +95346,7 @@ impl ::std::convert::From<&WorkflowJobCompleted> for WorkflowJobCompleted {
         value.clone()
     }
 }
-#[doc = "WorkflowJobCompletedAction"]
+#[doc = "`WorkflowJobCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95418,7 +95418,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedActi
         value.parse()
     }
 }
-#[doc = "WorkflowJobCompletedWorkflowJob"]
+#[doc = "`WorkflowJobCompletedWorkflowJob`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95472,7 +95472,7 @@ impl ::std::convert::From<&WorkflowJobCompletedWorkflowJob> for WorkflowJobCompl
         value.clone()
     }
 }
-#[doc = "WorkflowJobCompletedWorkflowJobConclusion"]
+#[doc = "`WorkflowJobCompletedWorkflowJobConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95549,7 +95549,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedWork
         value.parse()
     }
 }
-#[doc = "WorkflowJobCompletedWorkflowJobStatus"]
+#[doc = "`WorkflowJobCompletedWorkflowJobStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95631,7 +95631,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedWork
         value.parse()
     }
 }
-#[doc = "WorkflowJobConclusion"]
+#[doc = "`WorkflowJobConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95708,7 +95708,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobConclusion {
         value.parse()
     }
 }
-#[doc = "WorkflowJobEvent"]
+#[doc = "`WorkflowJobEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95755,7 +95755,7 @@ impl ::std::convert::From<WorkflowJobStarted> for WorkflowJobEvent {
         Self::Started(value)
     }
 }
-#[doc = "WorkflowJobQueued"]
+#[doc = "`WorkflowJobQueued`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95893,7 +95893,7 @@ impl ::std::convert::From<&WorkflowJobQueued> for WorkflowJobQueued {
         value.clone()
     }
 }
-#[doc = "WorkflowJobQueuedAction"]
+#[doc = "`WorkflowJobQueuedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95965,7 +95965,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobQueuedAction 
         value.parse()
     }
 }
-#[doc = "WorkflowJobQueuedWorkflowJob"]
+#[doc = "`WorkflowJobQueuedWorkflowJob`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96078,7 +96078,7 @@ impl ::std::convert::From<&WorkflowJobQueuedWorkflowJob> for WorkflowJobQueuedWo
         value.clone()
     }
 }
-#[doc = "WorkflowJobQueuedWorkflowJobStatus"]
+#[doc = "`WorkflowJobQueuedWorkflowJobStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96150,7 +96150,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobQueuedWorkflo
         value.parse()
     }
 }
-#[doc = "WorkflowJobStarted"]
+#[doc = "`WorkflowJobStarted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96238,7 +96238,7 @@ impl ::std::convert::From<&WorkflowJobStarted> for WorkflowJobStarted {
         value.clone()
     }
 }
-#[doc = "WorkflowJobStartedAction"]
+#[doc = "`WorkflowJobStartedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96310,7 +96310,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobStartedAction
         value.parse()
     }
 }
-#[doc = "WorkflowJobStartedWorkflowJob"]
+#[doc = "`WorkflowJobStartedWorkflowJob`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96373,7 +96373,7 @@ impl ::std::convert::From<&WorkflowJobStartedWorkflowJob> for WorkflowJobStarted
         value.clone()
     }
 }
-#[doc = "WorkflowJobStartedWorkflowJobConclusion"]
+#[doc = "`WorkflowJobStartedWorkflowJobConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96426,7 +96426,7 @@ impl<'de> ::serde::Deserialize<'de> for WorkflowJobStartedWorkflowJobConclusion 
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "WorkflowJobStartedWorkflowJobStatus"]
+#[doc = "`WorkflowJobStartedWorkflowJobStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96508,7 +96508,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobStartedWorkfl
         value.parse()
     }
 }
-#[doc = "WorkflowJobStatus"]
+#[doc = "`WorkflowJobStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96590,7 +96590,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobStatus {
         value.parse()
     }
 }
-#[doc = "WorkflowRun"]
+#[doc = "`WorkflowRun`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96844,7 +96844,7 @@ impl ::std::convert::From<&WorkflowRun> for WorkflowRun {
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompleted"]
+#[doc = "`WorkflowRunCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96933,7 +96933,7 @@ impl ::std::convert::From<&WorkflowRunCompleted> for WorkflowRunCompleted {
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompletedAction"]
+#[doc = "`WorkflowRunCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97005,7 +97005,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunCompletedActi
         value.parse()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRun"]
+#[doc = "`WorkflowRunCompletedWorkflowRun`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97076,7 +97076,7 @@ impl ::std::convert::From<&WorkflowRunCompletedWorkflowRun> for WorkflowRunCompl
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRunConclusion"]
+#[doc = "`WorkflowRunCompletedWorkflowRunConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97178,7 +97178,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunCompletedWork
         value.parse()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRunPullRequestsItem"]
+#[doc = "`WorkflowRunCompletedWorkflowRunPullRequestsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97264,7 +97264,7 @@ impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItem>
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRunPullRequestsItemBase"]
+#[doc = "`WorkflowRunCompletedWorkflowRunPullRequestsItemBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97306,7 +97306,7 @@ impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItemBase>
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRunPullRequestsItemHead"]
+#[doc = "`WorkflowRunCompletedWorkflowRunPullRequestsItemHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97348,7 +97348,7 @@ impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItemHead>
         value.clone()
     }
 }
-#[doc = "WorkflowRunCompletedWorkflowRunStatus"]
+#[doc = "`WorkflowRunCompletedWorkflowRunStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97435,7 +97435,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunCompletedWork
         value.parse()
     }
 }
-#[doc = "WorkflowRunConclusion"]
+#[doc = "`WorkflowRunConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97537,7 +97537,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunConclusion {
         value.parse()
     }
 }
-#[doc = "WorkflowRunEvent"]
+#[doc = "`WorkflowRunEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97575,7 +97575,7 @@ impl ::std::convert::From<WorkflowRunRequested> for WorkflowRunEvent {
         Self::Requested(value)
     }
 }
-#[doc = "WorkflowRunPullRequestsItem"]
+#[doc = "`WorkflowRunPullRequestsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97659,7 +97659,7 @@ impl ::std::convert::From<&WorkflowRunPullRequestsItem> for WorkflowRunPullReque
         value.clone()
     }
 }
-#[doc = "WorkflowRunPullRequestsItemBase"]
+#[doc = "`WorkflowRunPullRequestsItemBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97699,7 +97699,7 @@ impl ::std::convert::From<&WorkflowRunPullRequestsItemBase> for WorkflowRunPullR
         value.clone()
     }
 }
-#[doc = "WorkflowRunPullRequestsItemHead"]
+#[doc = "`WorkflowRunPullRequestsItemHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97739,7 +97739,7 @@ impl ::std::convert::From<&WorkflowRunPullRequestsItemHead> for WorkflowRunPullR
         value.clone()
     }
 }
-#[doc = "WorkflowRunRequested"]
+#[doc = "`WorkflowRunRequested`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97803,7 +97803,7 @@ impl ::std::convert::From<&WorkflowRunRequested> for WorkflowRunRequested {
         value.clone()
     }
 }
-#[doc = "WorkflowRunRequestedAction"]
+#[doc = "`WorkflowRunRequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97875,7 +97875,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunRequestedActi
         value.parse()
     }
 }
-#[doc = "WorkflowRunStatus"]
+#[doc = "`WorkflowRunStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97962,7 +97962,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunStatus {
         value.parse()
     }
 }
-#[doc = "WorkflowStep"]
+#[doc = "`WorkflowStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98003,7 +98003,7 @@ impl ::std::convert::From<WorkflowStepCompleted> for WorkflowStep {
         Self::Completed(value)
     }
 }
-#[doc = "WorkflowStepCompleted"]
+#[doc = "`WorkflowStepCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98067,7 +98067,7 @@ impl ::std::convert::From<&WorkflowStepCompleted> for WorkflowStepCompleted {
         value.clone()
     }
 }
-#[doc = "WorkflowStepCompletedConclusion"]
+#[doc = "`WorkflowStepCompletedConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98149,7 +98149,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowStepCompletedCon
         value.parse()
     }
 }
-#[doc = "WorkflowStepCompletedStatus"]
+#[doc = "`WorkflowStepCompletedStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98221,7 +98221,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowStepCompletedSta
         value.parse()
     }
 }
-#[doc = "WorkflowStepInProgress"]
+#[doc = "`WorkflowStepInProgress`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98280,7 +98280,7 @@ impl ::std::convert::From<&WorkflowStepInProgress> for WorkflowStepInProgress {
         value.clone()
     }
 }
-#[doc = "WorkflowStepInProgressStatus"]
+#[doc = "`WorkflowStepInProgressStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -24,7 +24,7 @@ pub mod error {
         }
     }
 }
-#[doc = "AggregateTransform"]
+#[doc = "`AggregateTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -230,7 +230,7 @@ impl ::std::convert::From<&AggregateTransform> for AggregateTransform {
         value.clone()
     }
 }
-#[doc = "AggregateTransformAs"]
+#[doc = "`AggregateTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -283,7 +283,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformAsVariant0Item"]
+#[doc = "`AggregateTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -320,7 +320,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformCross"]
+#[doc = "`AggregateTransformCross`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -358,7 +358,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformCross {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformDrop"]
+#[doc = "`AggregateTransformDrop`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -402,7 +402,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformDrop {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformFields"]
+#[doc = "`AggregateTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -458,7 +458,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformFieldsVariant0Item"]
+#[doc = "`AggregateTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -509,7 +509,7 @@ impl ::std::convert::From<Expr> for AggregateTransformFieldsVariant0Item {
         Self::Variant2(value)
     }
 }
-#[doc = "AggregateTransformGroupby"]
+#[doc = "`AggregateTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -562,7 +562,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformGroupbyVariant0Item"]
+#[doc = "`AggregateTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -609,7 +609,7 @@ impl ::std::convert::From<Expr> for AggregateTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "AggregateTransformKey"]
+#[doc = "`AggregateTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -656,7 +656,7 @@ impl ::std::convert::From<Expr> for AggregateTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "AggregateTransformOps"]
+#[doc = "`AggregateTransformOps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -731,7 +731,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformOps {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformOpsVariant0Item"]
+#[doc = "`AggregateTransformOpsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -796,7 +796,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformOpsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "AggregateTransformOpsVariant0ItemVariant0"]
+#[doc = "`AggregateTransformOpsVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -982,7 +982,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformOpsVar
         value.parse()
     }
 }
-#[doc = "AggregateTransformType"]
+#[doc = "`AggregateTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1053,7 +1053,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformType {
         value.parse()
     }
 }
-#[doc = "AlignValue"]
+#[doc = "`AlignValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1259,7 +1259,7 @@ impl ::std::convert::From<AlignValueVariant1> for AlignValue {
         Self::Variant1(value)
     }
 }
-#[doc = "AlignValueVariant0Item"]
+#[doc = "`AlignValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1387,7 +1387,7 @@ impl ::std::convert::From<AlignValueVariant0ItemVariant2> for AlignValueVariant0
         Self::Variant2(value)
     }
 }
-#[doc = "AlignValueVariant0ItemVariant0"]
+#[doc = "`AlignValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1523,7 +1523,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "AlignValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`AlignValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1608,7 +1608,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "AlignValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`AlignValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1692,7 +1692,7 @@ impl ::std::convert::From<bool> for AlignValueVariant0ItemVariant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "AlignValueVariant0ItemVariant1"]
+#[doc = "`AlignValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1810,7 +1810,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "AlignValueVariant0ItemVariant2"]
+#[doc = "`AlignValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1928,7 +1928,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "AlignValueVariant1"]
+#[doc = "`AlignValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2045,7 +2045,7 @@ impl ::std::convert::From<AlignValueVariant1Variant2> for AlignValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "AlignValueVariant1Variant0"]
+#[doc = "`AlignValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2170,7 +2170,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "AlignValueVariant1Variant0Variant1Value"]
+#[doc = "`AlignValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2251,7 +2251,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Varian
         value.parse()
     }
 }
-#[doc = "AlignValueVariant1Variant0Variant3Range"]
+#[doc = "`AlignValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2331,7 +2331,7 @@ impl ::std::convert::From<bool> for AlignValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "AlignValueVariant1Variant1"]
+#[doc = "`AlignValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2446,7 +2446,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "AlignValueVariant1Variant2"]
+#[doc = "`AlignValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2561,7 +2561,7 @@ impl ::std::convert::From<&Self> for AlignValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "AnchorValue"]
+#[doc = "`AnchorValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2767,7 +2767,7 @@ impl ::std::convert::From<AnchorValueVariant1> for AnchorValue {
         Self::Variant1(value)
     }
 }
-#[doc = "AnchorValueVariant0Item"]
+#[doc = "`AnchorValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -2895,7 +2895,7 @@ impl ::std::convert::From<AnchorValueVariant0ItemVariant2> for AnchorValueVarian
         Self::Variant2(value)
     }
 }
-#[doc = "AnchorValueVariant0ItemVariant0"]
+#[doc = "`AnchorValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3031,7 +3031,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "AnchorValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`AnchorValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3116,7 +3116,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "AnchorValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`AnchorValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3200,7 +3200,7 @@ impl ::std::convert::From<bool> for AnchorValueVariant0ItemVariant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "AnchorValueVariant0ItemVariant1"]
+#[doc = "`AnchorValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3318,7 +3318,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "AnchorValueVariant0ItemVariant2"]
+#[doc = "`AnchorValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3436,7 +3436,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "AnchorValueVariant1"]
+#[doc = "`AnchorValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3553,7 +3553,7 @@ impl ::std::convert::From<AnchorValueVariant1Variant2> for AnchorValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "AnchorValueVariant1Variant0"]
+#[doc = "`AnchorValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3678,7 +3678,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "AnchorValueVariant1Variant0Variant1Value"]
+#[doc = "`AnchorValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3759,7 +3759,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Varia
         value.parse()
     }
 }
-#[doc = "AnchorValueVariant1Variant0Variant3Range"]
+#[doc = "`AnchorValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3839,7 +3839,7 @@ impl ::std::convert::From<bool> for AnchorValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "AnchorValueVariant1Variant1"]
+#[doc = "`AnchorValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -3954,7 +3954,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "AnchorValueVariant1Variant2"]
+#[doc = "`AnchorValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4069,7 +4069,7 @@ impl ::std::convert::From<&Self> for AnchorValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "AnyValue"]
+#[doc = "`AnyValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4263,7 +4263,7 @@ impl ::std::convert::From<AnyValueVariant1> for AnyValue {
         Self::Variant1(value)
     }
 }
-#[doc = "AnyValueVariant0Item"]
+#[doc = "`AnyValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4385,7 +4385,7 @@ impl ::std::convert::From<AnyValueVariant0ItemVariant2> for AnyValueVariant0Item
         Self::Variant2(value)
     }
 }
-#[doc = "AnyValueVariant0ItemVariant0"]
+#[doc = "`AnyValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4515,7 +4515,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "AnyValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`AnyValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4595,7 +4595,7 @@ impl ::std::convert::From<bool> for AnyValueVariant0ItemVariant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "AnyValueVariant0ItemVariant1"]
+#[doc = "`AnyValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4707,7 +4707,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "AnyValueVariant0ItemVariant2"]
+#[doc = "`AnyValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4819,7 +4819,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "AnyValueVariant1"]
+#[doc = "`AnyValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4930,7 +4930,7 @@ impl ::std::convert::From<AnyValueVariant1Variant2> for AnyValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "AnyValueVariant1Variant0"]
+#[doc = "`AnyValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5049,7 +5049,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "AnyValueVariant1Variant0Variant3Range"]
+#[doc = "`AnyValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5129,7 +5129,7 @@ impl ::std::convert::From<bool> for AnyValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "AnyValueVariant1Variant1"]
+#[doc = "`AnyValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5238,7 +5238,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "AnyValueVariant1Variant2"]
+#[doc = "`AnyValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5347,7 +5347,7 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "ArrayOrSignal"]
+#[doc = "`ArrayOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5385,7 +5385,7 @@ impl ::std::convert::From<SignalRef> for ArrayOrSignal {
         Self::Variant1(value)
     }
 }
-#[doc = "ArrayValue"]
+#[doc = "`ArrayValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5583,7 +5583,7 @@ impl ::std::convert::From<ArrayValueVariant1> for ArrayValue {
         Self::Variant1(value)
     }
 }
-#[doc = "ArrayValueVariant0Item"]
+#[doc = "`ArrayValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5707,7 +5707,7 @@ impl ::std::convert::From<ArrayValueVariant0ItemVariant2> for ArrayValueVariant0
         Self::Variant2(value)
     }
 }
-#[doc = "ArrayValueVariant0ItemVariant0"]
+#[doc = "`ArrayValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5839,7 +5839,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "ArrayValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`ArrayValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -5923,7 +5923,7 @@ impl ::std::convert::From<bool> for ArrayValueVariant0ItemVariant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "ArrayValueVariant0ItemVariant1"]
+#[doc = "`ArrayValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6037,7 +6037,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "ArrayValueVariant0ItemVariant2"]
+#[doc = "`ArrayValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6151,7 +6151,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "ArrayValueVariant1"]
+#[doc = "`ArrayValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6264,7 +6264,7 @@ impl ::std::convert::From<ArrayValueVariant1Variant2> for ArrayValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "ArrayValueVariant1Variant0"]
+#[doc = "`ArrayValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6385,7 +6385,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "ArrayValueVariant1Variant0Variant3Range"]
+#[doc = "`ArrayValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6465,7 +6465,7 @@ impl ::std::convert::From<bool> for ArrayValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "ArrayValueVariant1Variant1"]
+#[doc = "`ArrayValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6576,7 +6576,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "ArrayValueVariant1Variant2"]
+#[doc = "`ArrayValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6687,7 +6687,7 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "Autosize"]
+#[doc = "`Autosize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6768,7 +6768,7 @@ impl ::std::convert::From<SignalRef> for Autosize {
         Self::Variant2(value)
     }
 }
-#[doc = "AutosizeVariant0"]
+#[doc = "`AutosizeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6860,7 +6860,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AutosizeVariant0 {
         value.parse()
     }
 }
-#[doc = "AutosizeVariant1Contains"]
+#[doc = "`AutosizeVariant1Contains`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -6936,7 +6936,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AutosizeVariant1Contains
         value.parse()
     }
 }
-#[doc = "AutosizeVariant1Type"]
+#[doc = "`AutosizeVariant1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -7033,7 +7033,7 @@ impl ::std::default::Default for AutosizeVariant1Type {
         AutosizeVariant1Type::Pad
     }
 }
-#[doc = "Axis"]
+#[doc = "`Axis`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8295,7 +8295,7 @@ impl ::std::convert::From<&Axis> for Axis {
         value.clone()
     }
 }
-#[doc = "AxisBandPosition"]
+#[doc = "`AxisBandPosition`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8333,7 +8333,7 @@ impl ::std::convert::From<NumberValue> for AxisBandPosition {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisDomainCap"]
+#[doc = "`AxisDomainCap`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8366,7 +8366,7 @@ impl ::std::convert::From<StringValue> for AxisDomainCap {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisDomainColor"]
+#[doc = "`AxisDomainColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8403,7 +8403,7 @@ impl ::std::convert::From<ColorValue> for AxisDomainColor {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisDomainDash"]
+#[doc = "`AxisDomainDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8444,7 +8444,7 @@ impl ::std::convert::From<ArrayValue> for AxisDomainDash {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisDomainDashOffset"]
+#[doc = "`AxisDomainDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8482,7 +8482,7 @@ impl ::std::convert::From<NumberValue> for AxisDomainDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisDomainOpacity"]
+#[doc = "`AxisDomainOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8520,7 +8520,7 @@ impl ::std::convert::From<NumberValue> for AxisDomainOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisDomainWidth"]
+#[doc = "`AxisDomainWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8558,7 +8558,7 @@ impl ::std::convert::From<NumberValue> for AxisDomainWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisEncode"]
+#[doc = "`AxisEncode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8622,7 +8622,7 @@ impl ::std::default::Default for AxisEncode {
         }
     }
 }
-#[doc = "AxisFormat"]
+#[doc = "`AxisFormat`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8713,7 +8713,7 @@ impl ::std::convert::From<SignalRef> for AxisFormat {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisFormatType"]
+#[doc = "`AxisFormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8755,7 +8755,7 @@ impl ::std::convert::From<SignalRef> for AxisFormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisFormatTypeVariant0"]
+#[doc = "`AxisFormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8836,7 +8836,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisFormatTypeVariant0 {
         value.parse()
     }
 }
-#[doc = "AxisGridCap"]
+#[doc = "`AxisGridCap`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8869,7 +8869,7 @@ impl ::std::convert::From<StringValue> for AxisGridCap {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisGridColor"]
+#[doc = "`AxisGridColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8906,7 +8906,7 @@ impl ::std::convert::From<ColorValue> for AxisGridColor {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisGridDash"]
+#[doc = "`AxisGridDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8947,7 +8947,7 @@ impl ::std::convert::From<ArrayValue> for AxisGridDash {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisGridDashOffset"]
+#[doc = "`AxisGridDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -8985,7 +8985,7 @@ impl ::std::convert::From<NumberValue> for AxisGridDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisGridOpacity"]
+#[doc = "`AxisGridOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9023,7 +9023,7 @@ impl ::std::convert::From<NumberValue> for AxisGridOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisGridWidth"]
+#[doc = "`AxisGridWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9061,7 +9061,7 @@ impl ::std::convert::From<NumberValue> for AxisGridWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelAlign"]
+#[doc = "`AxisLabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9103,7 +9103,7 @@ impl ::std::convert::From<AlignValue> for AxisLabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelAlignVariant0"]
+#[doc = "`AxisLabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9184,7 +9184,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisLabelAlignVariant0 {
         value.parse()
     }
 }
-#[doc = "AxisLabelAngle"]
+#[doc = "`AxisLabelAngle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9222,7 +9222,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelAngle {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelBaseline"]
+#[doc = "`AxisLabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9267,7 +9267,7 @@ impl ::std::convert::From<BaselineValue> for AxisLabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelBaselineVariant0"]
+#[doc = "`AxisLabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9363,7 +9363,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisLabelBaselineVariant
         value.parse()
     }
 }
-#[doc = "AxisLabelBound"]
+#[doc = "`AxisLabelBound`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9410,7 +9410,7 @@ impl ::std::convert::From<SignalRef> for AxisLabelBound {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisLabelColor"]
+#[doc = "`AxisLabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9447,7 +9447,7 @@ impl ::std::convert::From<ColorValue> for AxisLabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisLabelFlush"]
+#[doc = "`AxisLabelFlush`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9494,7 +9494,7 @@ impl ::std::convert::From<SignalRef> for AxisLabelFlush {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisLabelFont"]
+#[doc = "`AxisLabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9527,7 +9527,7 @@ impl ::std::convert::From<StringValue> for AxisLabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelFontSize"]
+#[doc = "`AxisLabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9565,7 +9565,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelFontStyle"]
+#[doc = "`AxisLabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9598,7 +9598,7 @@ impl ::std::convert::From<StringValue> for AxisLabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelFontWeight"]
+#[doc = "`AxisLabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9660,7 +9660,7 @@ impl ::std::convert::From<FontWeightValue> for AxisLabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelLimit"]
+#[doc = "`AxisLabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9698,7 +9698,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelLineHeight"]
+#[doc = "`AxisLabelLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9736,7 +9736,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelOffset"]
+#[doc = "`AxisLabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9774,7 +9774,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelOpacity"]
+#[doc = "`AxisLabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9812,7 +9812,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisLabelPadding"]
+#[doc = "`AxisLabelPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9850,7 +9850,7 @@ impl ::std::convert::From<NumberValue> for AxisLabelPadding {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisMaxExtent"]
+#[doc = "`AxisMaxExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9888,7 +9888,7 @@ impl ::std::convert::From<NumberValue> for AxisMaxExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisMinExtent"]
+#[doc = "`AxisMinExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9926,7 +9926,7 @@ impl ::std::convert::From<NumberValue> for AxisMinExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisOffset"]
+#[doc = "`AxisOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -9964,7 +9964,7 @@ impl ::std::convert::From<NumberValue> for AxisOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisOrient"]
+#[doc = "`AxisOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10007,7 +10007,7 @@ impl ::std::convert::From<SignalRef> for AxisOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisOrientVariant0"]
+#[doc = "`AxisOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10093,7 +10093,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisOrientVariant0 {
         value.parse()
     }
 }
-#[doc = "AxisPosition"]
+#[doc = "`AxisPosition`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10131,7 +10131,7 @@ impl ::std::convert::From<NumberValue> for AxisPosition {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickCap"]
+#[doc = "`AxisTickCap`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10164,7 +10164,7 @@ impl ::std::convert::From<StringValue> for AxisTickCap {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickColor"]
+#[doc = "`AxisTickColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10201,7 +10201,7 @@ impl ::std::convert::From<ColorValue> for AxisTickColor {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisTickDash"]
+#[doc = "`AxisTickDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10242,7 +10242,7 @@ impl ::std::convert::From<ArrayValue> for AxisTickDash {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickDashOffset"]
+#[doc = "`AxisTickDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10280,7 +10280,7 @@ impl ::std::convert::From<NumberValue> for AxisTickDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickOffset"]
+#[doc = "`AxisTickOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10318,7 +10318,7 @@ impl ::std::convert::From<NumberValue> for AxisTickOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickOpacity"]
+#[doc = "`AxisTickOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10356,7 +10356,7 @@ impl ::std::convert::From<NumberValue> for AxisTickOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickRound"]
+#[doc = "`AxisTickRound`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10394,7 +10394,7 @@ impl ::std::convert::From<BooleanValue> for AxisTickRound {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickSize"]
+#[doc = "`AxisTickSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10432,7 +10432,7 @@ impl ::std::convert::From<NumberValue> for AxisTickSize {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTickWidth"]
+#[doc = "`AxisTickWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10470,7 +10470,7 @@ impl ::std::convert::From<NumberValue> for AxisTickWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleAlign"]
+#[doc = "`AxisTitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10512,7 +10512,7 @@ impl ::std::convert::From<AlignValue> for AxisTitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleAlignVariant0"]
+#[doc = "`AxisTitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10593,7 +10593,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisTitleAlignVariant0 {
         value.parse()
     }
 }
-#[doc = "AxisTitleAnchor"]
+#[doc = "`AxisTitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10636,7 +10636,7 @@ impl ::std::convert::From<AnchorValue> for AxisTitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleAnchorVariant0"]
+#[doc = "`AxisTitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10718,7 +10718,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisTitleAnchorVariant0 
         value.parse()
     }
 }
-#[doc = "AxisTitleAngle"]
+#[doc = "`AxisTitleAngle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10756,7 +10756,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleAngle {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleBaseline"]
+#[doc = "`AxisTitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10801,7 +10801,7 @@ impl ::std::convert::From<BaselineValue> for AxisTitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleBaselineVariant0"]
+#[doc = "`AxisTitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10897,7 +10897,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisTitleBaselineVariant
         value.parse()
     }
 }
-#[doc = "AxisTitleColor"]
+#[doc = "`AxisTitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10934,7 +10934,7 @@ impl ::std::convert::From<ColorValue> for AxisTitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "AxisTitleFont"]
+#[doc = "`AxisTitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -10967,7 +10967,7 @@ impl ::std::convert::From<StringValue> for AxisTitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleFontSize"]
+#[doc = "`AxisTitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11005,7 +11005,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleFontStyle"]
+#[doc = "`AxisTitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11038,7 +11038,7 @@ impl ::std::convert::From<StringValue> for AxisTitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleFontWeight"]
+#[doc = "`AxisTitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11100,7 +11100,7 @@ impl ::std::convert::From<FontWeightValue> for AxisTitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleLimit"]
+#[doc = "`AxisTitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11138,7 +11138,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleLineHeight"]
+#[doc = "`AxisTitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11176,7 +11176,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleOpacity"]
+#[doc = "`AxisTitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11214,7 +11214,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitlePadding"]
+#[doc = "`AxisTitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11252,7 +11252,7 @@ impl ::std::convert::From<NumberValue> for AxisTitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleX"]
+#[doc = "`AxisTitleX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11290,7 +11290,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleX {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTitleY"]
+#[doc = "`AxisTitleY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11328,7 +11328,7 @@ impl ::std::convert::From<NumberValue> for AxisTitleY {
         Self::Variant1(value)
     }
 }
-#[doc = "AxisTranslate"]
+#[doc = "`AxisTranslate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11366,7 +11366,7 @@ impl ::std::convert::From<NumberValue> for AxisTranslate {
         Self::Variant1(value)
     }
 }
-#[doc = "Background"]
+#[doc = "`Background`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11400,7 +11400,7 @@ impl ::std::convert::From<StringOrSignal> for Background {
         Self(value)
     }
 }
-#[doc = "BaseColorValue"]
+#[doc = "`BaseColorValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11609,7 +11609,7 @@ impl ::std::convert::From<BaseColorValueVariant0> for BaseColorValue {
         Self::Variant0(value)
     }
 }
-#[doc = "BaseColorValueVariant0"]
+#[doc = "`BaseColorValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11729,7 +11729,7 @@ impl ::std::convert::From<BaseColorValueVariant0Variant2> for BaseColorValueVari
         Self::Variant2(value)
     }
 }
-#[doc = "BaseColorValueVariant0Variant0"]
+#[doc = "`BaseColorValueVariant0Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11857,7 +11857,7 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0 {
         value.clone()
     }
 }
-#[doc = "BaseColorValueVariant0Variant0Variant3Range"]
+#[doc = "`BaseColorValueVariant0Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -11941,7 +11941,7 @@ impl ::std::convert::From<bool> for BaseColorValueVariant0Variant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "BaseColorValueVariant0Variant1"]
+#[doc = "`BaseColorValueVariant0Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12059,7 +12059,7 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant1 {
         value.clone()
     }
 }
-#[doc = "BaseColorValueVariant0Variant2"]
+#[doc = "`BaseColorValueVariant0Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12177,7 +12177,7 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant2 {
         value.clone()
     }
 }
-#[doc = "BaseColorValueVariant4Color"]
+#[doc = "`BaseColorValueVariant4Color`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12233,7 +12233,7 @@ impl ::std::convert::From<ColorHcl> for BaseColorValueVariant4Color {
         Self::Hcl(value)
     }
 }
-#[doc = "BaselineValue"]
+#[doc = "`BaselineValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12441,7 +12441,7 @@ impl ::std::convert::From<BaselineValueVariant1> for BaselineValue {
         Self::Variant1(value)
     }
 }
-#[doc = "BaselineValueVariant0Item"]
+#[doc = "`BaselineValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12570,7 +12570,7 @@ impl ::std::convert::From<BaselineValueVariant0ItemVariant2> for BaselineValueVa
         Self::Variant2(value)
     }
 }
-#[doc = "BaselineValueVariant0ItemVariant0"]
+#[doc = "`BaselineValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12707,7 +12707,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "BaselineValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`BaselineValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12797,7 +12797,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BaselineValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`BaselineValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -12881,7 +12881,7 @@ impl ::std::convert::From<bool> for BaselineValueVariant0ItemVariant0Variant3Ran
         Self::Variant1(value)
     }
 }
-#[doc = "BaselineValueVariant0ItemVariant1"]
+#[doc = "`BaselineValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13000,7 +13000,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "BaselineValueVariant0ItemVariant2"]
+#[doc = "`BaselineValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13119,7 +13119,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "BaselineValueVariant1"]
+#[doc = "`BaselineValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13237,7 +13237,7 @@ impl ::std::convert::From<BaselineValueVariant1Variant2> for BaselineValueVarian
         Self::Variant2(value)
     }
 }
-#[doc = "BaselineValueVariant1Variant0"]
+#[doc = "`BaselineValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13363,7 +13363,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "BaselineValueVariant1Variant0Variant1Value"]
+#[doc = "`BaselineValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13451,7 +13451,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Var
         value.parse()
     }
 }
-#[doc = "BaselineValueVariant1Variant0Variant3Range"]
+#[doc = "`BaselineValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13533,7 +13533,7 @@ impl ::std::convert::From<bool> for BaselineValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "BaselineValueVariant1Variant1"]
+#[doc = "`BaselineValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13649,7 +13649,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "BaselineValueVariant1Variant2"]
+#[doc = "`BaselineValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -13765,7 +13765,7 @@ impl ::std::convert::From<&Self> for BaselineValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "BinTransform"]
+#[doc = "`BinTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14029,7 +14029,7 @@ impl ::std::convert::From<&BinTransform> for BinTransform {
         value.clone()
     }
 }
-#[doc = "BinTransformAnchor"]
+#[doc = "`BinTransformAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14067,7 +14067,7 @@ impl ::std::convert::From<SignalRef> for BinTransformAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformAs"]
+#[doc = "`BinTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14129,7 +14129,7 @@ impl ::std::convert::From<SignalRef> for BinTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformAsVariant0Item"]
+#[doc = "`BinTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14162,7 +14162,7 @@ impl ::std::convert::From<SignalRef> for BinTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformBase"]
+#[doc = "`BinTransformBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14206,7 +14206,7 @@ impl ::std::convert::From<SignalRef> for BinTransformBase {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformDivide"]
+#[doc = "`BinTransformDivide`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14266,7 +14266,7 @@ impl ::std::convert::From<SignalRef> for BinTransformDivide {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformDivideVariant0Item"]
+#[doc = "`BinTransformDivideVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14304,7 +14304,7 @@ impl ::std::convert::From<SignalRef> for BinTransformDivideVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformExtent"]
+#[doc = "`BinTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14354,7 +14354,7 @@ impl ::std::convert::From<SignalRef> for BinTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformExtentVariant0Item"]
+#[doc = "`BinTransformExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14392,7 +14392,7 @@ impl ::std::convert::From<SignalRef> for BinTransformExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformField"]
+#[doc = "`BinTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14439,7 +14439,7 @@ impl ::std::convert::From<Expr> for BinTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "BinTransformInterval"]
+#[doc = "`BinTransformInterval`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14483,7 +14483,7 @@ impl ::std::convert::From<SignalRef> for BinTransformInterval {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformMaxbins"]
+#[doc = "`BinTransformMaxbins`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14527,7 +14527,7 @@ impl ::std::convert::From<SignalRef> for BinTransformMaxbins {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformMinstep"]
+#[doc = "`BinTransformMinstep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14565,7 +14565,7 @@ impl ::std::convert::From<SignalRef> for BinTransformMinstep {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformName"]
+#[doc = "`BinTransformName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14598,7 +14598,7 @@ impl ::std::convert::From<SignalRef> for BinTransformName {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformNice"]
+#[doc = "`BinTransformNice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14642,7 +14642,7 @@ impl ::std::convert::From<SignalRef> for BinTransformNice {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformSpan"]
+#[doc = "`BinTransformSpan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14680,7 +14680,7 @@ impl ::std::convert::From<SignalRef> for BinTransformSpan {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformStep"]
+#[doc = "`BinTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14718,7 +14718,7 @@ impl ::std::convert::From<SignalRef> for BinTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformSteps"]
+#[doc = "`BinTransformSteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14766,7 +14766,7 @@ impl ::std::convert::From<SignalRef> for BinTransformSteps {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformStepsVariant0Item"]
+#[doc = "`BinTransformStepsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14804,7 +14804,7 @@ impl ::std::convert::From<SignalRef> for BinTransformStepsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "BinTransformType"]
+#[doc = "`BinTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14875,7 +14875,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BinTransformType {
         value.parse()
     }
 }
-#[doc = "Bind"]
+#[doc = "`Bind`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15082,7 +15082,7 @@ impl ::std::convert::From<&Self> for Bind {
         value.clone()
     }
 }
-#[doc = "BindVariant0Input"]
+#[doc = "`BindVariant0Input`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15153,7 +15153,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BindVariant0Input {
         value.parse()
     }
 }
-#[doc = "BindVariant1Input"]
+#[doc = "`BindVariant1Input`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15229,7 +15229,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BindVariant1Input {
         value.parse()
     }
 }
-#[doc = "BindVariant2Input"]
+#[doc = "`BindVariant2Input`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15300,7 +15300,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BindVariant2Input {
         value.parse()
     }
 }
-#[doc = "BindVariant3Input"]
+#[doc = "`BindVariant3Input`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15364,7 +15364,7 @@ impl<'de> ::serde::Deserialize<'de> for BindVariant3Input {
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "BlendValue"]
+#[doc = "`BlendValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15596,7 +15596,7 @@ impl ::std::convert::From<BlendValueVariant1> for BlendValue {
         Self::Variant1(value)
     }
 }
-#[doc = "BlendValueVariant0Item"]
+#[doc = "`BlendValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15737,7 +15737,7 @@ impl ::std::convert::From<BlendValueVariant0ItemVariant2> for BlendValueVariant0
         Self::Variant2(value)
     }
 }
-#[doc = "BlendValueVariant0ItemVariant0"]
+#[doc = "`BlendValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -15886,7 +15886,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "BlendValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`BlendValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16032,7 +16032,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "BlendValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`BlendValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16116,7 +16116,7 @@ impl ::std::convert::From<bool> for BlendValueVariant0ItemVariant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "BlendValueVariant0ItemVariant1"]
+#[doc = "`BlendValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16247,7 +16247,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "BlendValueVariant0ItemVariant2"]
+#[doc = "`BlendValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16378,7 +16378,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "BlendValueVariant1"]
+#[doc = "`BlendValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16508,7 +16508,7 @@ impl ::std::convert::From<BlendValueVariant1Variant2> for BlendValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "BlendValueVariant1Variant0"]
+#[doc = "`BlendValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16646,7 +16646,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "BlendValueVariant1Variant0Variant1Value"]
+#[doc = "`BlendValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16788,7 +16788,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Varian
         value.parse()
     }
 }
-#[doc = "BlendValueVariant1Variant0Variant3Range"]
+#[doc = "`BlendValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16868,7 +16868,7 @@ impl ::std::convert::From<bool> for BlendValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "BlendValueVariant1Variant1"]
+#[doc = "`BlendValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -16996,7 +16996,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "BlendValueVariant1Variant2"]
+#[doc = "`BlendValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17124,7 +17124,7 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "BooleanOrSignal"]
+#[doc = "`BooleanOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17162,7 +17162,7 @@ impl ::std::convert::From<SignalRef> for BooleanOrSignal {
         Self::Variant1(value)
     }
 }
-#[doc = "BooleanValue"]
+#[doc = "`BooleanValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17360,7 +17360,7 @@ impl ::std::convert::From<BooleanValueVariant1> for BooleanValue {
         Self::Variant1(value)
     }
 }
-#[doc = "BooleanValueVariant0Item"]
+#[doc = "`BooleanValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17484,7 +17484,7 @@ impl ::std::convert::From<BooleanValueVariant0ItemVariant2> for BooleanValueVari
         Self::Variant2(value)
     }
 }
-#[doc = "BooleanValueVariant0ItemVariant0"]
+#[doc = "`BooleanValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17616,7 +17616,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "BooleanValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`BooleanValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17700,7 +17700,7 @@ impl ::std::convert::From<bool> for BooleanValueVariant0ItemVariant0Variant3Rang
         Self::Variant1(value)
     }
 }
-#[doc = "BooleanValueVariant0ItemVariant1"]
+#[doc = "`BooleanValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17814,7 +17814,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "BooleanValueVariant0ItemVariant2"]
+#[doc = "`BooleanValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -17928,7 +17928,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "BooleanValueVariant1"]
+#[doc = "`BooleanValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18041,7 +18041,7 @@ impl ::std::convert::From<BooleanValueVariant1Variant2> for BooleanValueVariant1
         Self::Variant2(value)
     }
 }
-#[doc = "BooleanValueVariant1Variant0"]
+#[doc = "`BooleanValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18162,7 +18162,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "BooleanValueVariant1Variant0Variant3Range"]
+#[doc = "`BooleanValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18242,7 +18242,7 @@ impl ::std::convert::From<bool> for BooleanValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "BooleanValueVariant1Variant1"]
+#[doc = "`BooleanValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18353,7 +18353,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "BooleanValueVariant1Variant2"]
+#[doc = "`BooleanValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18464,7 +18464,7 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "CollectTransform"]
+#[doc = "`CollectTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18506,7 +18506,7 @@ impl ::std::convert::From<&CollectTransform> for CollectTransform {
         value.clone()
     }
 }
-#[doc = "CollectTransformType"]
+#[doc = "`CollectTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18577,7 +18577,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CollectTransformType {
         value.parse()
     }
 }
-#[doc = "ColorHcl"]
+#[doc = "`ColorHcl`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18614,7 +18614,7 @@ impl ::std::convert::From<&ColorHcl> for ColorHcl {
         value.clone()
     }
 }
-#[doc = "ColorHsl"]
+#[doc = "`ColorHsl`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18651,7 +18651,7 @@ impl ::std::convert::From<&ColorHsl> for ColorHsl {
         value.clone()
     }
 }
-#[doc = "ColorLab"]
+#[doc = "`ColorLab`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18688,7 +18688,7 @@ impl ::std::convert::From<&ColorLab> for ColorLab {
         value.clone()
     }
 }
-#[doc = "ColorRgb"]
+#[doc = "`ColorRgb`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18725,7 +18725,7 @@ impl ::std::convert::From<&ColorRgb> for ColorRgb {
         value.clone()
     }
 }
-#[doc = "Compare"]
+#[doc = "`Compare`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18801,7 +18801,7 @@ impl ::std::convert::From<&Self> for Compare {
         value.clone()
     }
 }
-#[doc = "CompareVariant0Field"]
+#[doc = "`CompareVariant0Field`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18839,7 +18839,7 @@ impl ::std::convert::From<Expr> for CompareVariant0Field {
         Self::Expr(value)
     }
 }
-#[doc = "CompareVariant1FieldItem"]
+#[doc = "`CompareVariant1FieldItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -18877,7 +18877,7 @@ impl ::std::convert::From<Expr> for CompareVariant1FieldItem {
         Self::Expr(value)
     }
 }
-#[doc = "ContourTransform"]
+#[doc = "`ContourTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19092,7 +19092,7 @@ impl ::std::convert::From<&ContourTransform> for ContourTransform {
         value.clone()
     }
 }
-#[doc = "ContourTransformBandwidth"]
+#[doc = "`ContourTransformBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19130,7 +19130,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformBandwidth {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformCellSize"]
+#[doc = "`ContourTransformCellSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19168,7 +19168,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformCellSize {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformCount"]
+#[doc = "`ContourTransformCount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19206,7 +19206,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformCount {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformNice"]
+#[doc = "`ContourTransformNice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19244,7 +19244,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformNice {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformSize"]
+#[doc = "`ContourTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19294,7 +19294,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformSizeVariant0Item"]
+#[doc = "`ContourTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19332,7 +19332,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformSmooth"]
+#[doc = "`ContourTransformSmooth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19376,7 +19376,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformSmooth {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformThresholds"]
+#[doc = "`ContourTransformThresholds`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19426,7 +19426,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformThresholds {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformThresholdsVariant0Item"]
+#[doc = "`ContourTransformThresholdsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19464,7 +19464,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformThresholdsVariant0Item 
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformType"]
+#[doc = "`ContourTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19535,7 +19535,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ContourTransformType {
         value.parse()
     }
 }
-#[doc = "ContourTransformValues"]
+#[doc = "`ContourTransformValues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19585,7 +19585,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformValues {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformValuesVariant0Item"]
+#[doc = "`ContourTransformValuesVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19623,7 +19623,7 @@ impl ::std::convert::From<SignalRef> for ContourTransformValuesVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ContourTransformWeight"]
+#[doc = "`ContourTransformWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19670,7 +19670,7 @@ impl ::std::convert::From<Expr> for ContourTransformWeight {
         Self::Expr(value)
     }
 }
-#[doc = "ContourTransformX"]
+#[doc = "`ContourTransformX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19717,7 +19717,7 @@ impl ::std::convert::From<Expr> for ContourTransformX {
         Self::Expr(value)
     }
 }
-#[doc = "ContourTransformY"]
+#[doc = "`ContourTransformY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19764,7 +19764,7 @@ impl ::std::convert::From<Expr> for ContourTransformY {
         Self::Expr(value)
     }
 }
-#[doc = "CountpatternTransform"]
+#[doc = "`CountpatternTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19886,7 +19886,7 @@ impl ::std::convert::From<&CountpatternTransform> for CountpatternTransform {
         value.clone()
     }
 }
-#[doc = "CountpatternTransformAs"]
+#[doc = "`CountpatternTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19950,7 +19950,7 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "CountpatternTransformAsVariant0Item"]
+#[doc = "`CountpatternTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19983,7 +19983,7 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "CountpatternTransformCase"]
+#[doc = "`CountpatternTransformCase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20031,7 +20031,7 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformCase {
         Self::Variant1(value)
     }
 }
-#[doc = "CountpatternTransformCaseVariant0"]
+#[doc = "`CountpatternTransformCaseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20112,7 +20112,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CountpatternTransformCas
         value.parse()
     }
 }
-#[doc = "CountpatternTransformField"]
+#[doc = "`CountpatternTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20159,7 +20159,7 @@ impl ::std::convert::From<Expr> for CountpatternTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "CountpatternTransformPattern"]
+#[doc = "`CountpatternTransformPattern`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20198,7 +20198,7 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformPattern {
         Self::Variant1(value)
     }
 }
-#[doc = "CountpatternTransformStopwords"]
+#[doc = "`CountpatternTransformStopwords`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20231,7 +20231,7 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformStopwords {
         Self::Variant1(value)
     }
 }
-#[doc = "CountpatternTransformType"]
+#[doc = "`CountpatternTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20302,7 +20302,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CountpatternTransformTyp
         value.parse()
     }
 }
-#[doc = "CrossTransform"]
+#[doc = "`CrossTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20372,7 +20372,7 @@ impl ::std::convert::From<&CrossTransform> for CrossTransform {
         value.clone()
     }
 }
-#[doc = "CrossTransformAs"]
+#[doc = "`CrossTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20434,7 +20434,7 @@ impl ::std::convert::From<SignalRef> for CrossTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "CrossTransformAsVariant0Item"]
+#[doc = "`CrossTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20467,7 +20467,7 @@ impl ::std::convert::From<SignalRef> for CrossTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "CrossTransformType"]
+#[doc = "`CrossTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20538,7 +20538,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CrossTransformType {
         value.parse()
     }
 }
-#[doc = "CrossfilterTransform"]
+#[doc = "`CrossfilterTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20613,7 +20613,7 @@ impl ::std::convert::From<&CrossfilterTransform> for CrossfilterTransform {
         value.clone()
     }
 }
-#[doc = "CrossfilterTransformFields"]
+#[doc = "`CrossfilterTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20666,7 +20666,7 @@ impl ::std::convert::From<SignalRef> for CrossfilterTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "CrossfilterTransformFieldsVariant0Item"]
+#[doc = "`CrossfilterTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20713,7 +20713,7 @@ impl ::std::convert::From<Expr> for CrossfilterTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "CrossfilterTransformQuery"]
+#[doc = "`CrossfilterTransformQuery`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20752,7 +20752,7 @@ impl ::std::convert::From<SignalRef> for CrossfilterTransformQuery {
         Self::Variant1(value)
     }
 }
-#[doc = "CrossfilterTransformType"]
+#[doc = "`CrossfilterTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20823,7 +20823,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CrossfilterTransformType
         value.parse()
     }
 }
-#[doc = "Data"]
+#[doc = "`Data`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21524,7 +21524,7 @@ impl ::std::convert::From<&Self> for Data {
         value.clone()
     }
 }
-#[doc = "DataVariant1Source"]
+#[doc = "`DataVariant1Source`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21561,7 +21561,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for DataVarian
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2Format"]
+#[doc = "`DataVariant2Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21873,7 +21873,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2Format {
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0"]
+#[doc = "`DataVariant2FormatVariant0Subtype0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -21945,7 +21945,7 @@ impl ::std::default::Default for DataVariant2FormatVariant0Subtype0 {
         }
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0Parse"]
+#[doc = "`DataVariant2FormatVariant0Subtype0Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22029,7 +22029,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype0Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0ParseVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype0ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22104,7 +22104,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0ParseVariant1Value"]
+#[doc = "`DataVariant2FormatVariant0Subtype0ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22198,7 +22198,7 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22290,7 +22290,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22379,7 +22379,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1"]
+#[doc = "`DataVariant2FormatVariant0Subtype1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22467,7 +22467,7 @@ impl ::std::default::Default for DataVariant2FormatVariant0Subtype1 {
         }
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1Parse"]
+#[doc = "`DataVariant2FormatVariant0Subtype1Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22551,7 +22551,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype1Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1ParseVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype1ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22626,7 +22626,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1ParseVariant1Value"]
+#[doc = "`DataVariant2FormatVariant0Subtype1ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22720,7 +22720,7 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22812,7 +22812,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22901,7 +22901,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype1Type"]
+#[doc = "`DataVariant2FormatVariant0Subtype1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -22972,7 +22972,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant2FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2"]
+#[doc = "`DataVariant2FormatVariant0Subtype2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23048,7 +23048,7 @@ impl ::std::convert::From<&DataVariant2FormatVariant0Subtype2>
         value.clone()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2Parse"]
+#[doc = "`DataVariant2FormatVariant0Subtype2Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23132,7 +23132,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype2Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2ParseVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype2ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23207,7 +23207,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2ParseVariant1Value"]
+#[doc = "`DataVariant2FormatVariant0Subtype2ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23301,7 +23301,7 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23393,7 +23393,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23482,7 +23482,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype2Type"]
+#[doc = "`DataVariant2FormatVariant0Subtype2Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23558,7 +23558,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant2FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3"]
+#[doc = "`DataVariant2FormatVariant0Subtype3`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23638,7 +23638,7 @@ impl ::std::convert::From<&DataVariant2FormatVariant0Subtype3>
         value.clone()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3Parse"]
+#[doc = "`DataVariant2FormatVariant0Subtype3Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23722,7 +23722,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype3Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3ParseVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype3ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23797,7 +23797,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3ParseVariant1Value"]
+#[doc = "`DataVariant2FormatVariant0Subtype3ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23891,7 +23891,7 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -23983,7 +23983,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24072,7 +24072,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype3Type"]
+#[doc = "`DataVariant2FormatVariant0Subtype3Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24143,7 +24143,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant2FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype4"]
+#[doc = "`DataVariant2FormatVariant0Subtype4`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24228,7 +24228,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4 {
         value.clone()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype4Variant0Type"]
+#[doc = "`DataVariant2FormatVariant0Subtype4Variant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24303,7 +24303,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype4Variant1Filter"]
+#[doc = "`DataVariant2FormatVariant0Subtype4Variant1Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24384,7 +24384,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant2FormatVariant0Subtype4Variant1Type"]
+#[doc = "`DataVariant2FormatVariant0Subtype4Variant1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24459,7 +24459,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3Format"]
+#[doc = "`DataVariant3Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24771,7 +24771,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3Format {
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0"]
+#[doc = "`DataVariant3FormatVariant0Subtype0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24843,7 +24843,7 @@ impl ::std::default::Default for DataVariant3FormatVariant0Subtype0 {
         }
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0Parse"]
+#[doc = "`DataVariant3FormatVariant0Subtype0Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -24927,7 +24927,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype0Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0ParseVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype0ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25002,7 +25002,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0ParseVariant1Value"]
+#[doc = "`DataVariant3FormatVariant0Subtype0ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25096,7 +25096,7 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25188,7 +25188,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25277,7 +25277,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1"]
+#[doc = "`DataVariant3FormatVariant0Subtype1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25365,7 +25365,7 @@ impl ::std::default::Default for DataVariant3FormatVariant0Subtype1 {
         }
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1Parse"]
+#[doc = "`DataVariant3FormatVariant0Subtype1Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25449,7 +25449,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype1Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1ParseVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype1ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25524,7 +25524,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1ParseVariant1Value"]
+#[doc = "`DataVariant3FormatVariant0Subtype1ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25618,7 +25618,7 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25710,7 +25710,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25799,7 +25799,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype1Type"]
+#[doc = "`DataVariant3FormatVariant0Subtype1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25870,7 +25870,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant3FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2"]
+#[doc = "`DataVariant3FormatVariant0Subtype2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -25946,7 +25946,7 @@ impl ::std::convert::From<&DataVariant3FormatVariant0Subtype2>
         value.clone()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2Parse"]
+#[doc = "`DataVariant3FormatVariant0Subtype2Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26030,7 +26030,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype2Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2ParseVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype2ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26105,7 +26105,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2ParseVariant1Value"]
+#[doc = "`DataVariant3FormatVariant0Subtype2ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26199,7 +26199,7 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26291,7 +26291,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26380,7 +26380,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype2Type"]
+#[doc = "`DataVariant3FormatVariant0Subtype2Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26456,7 +26456,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant3FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3"]
+#[doc = "`DataVariant3FormatVariant0Subtype3`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26536,7 +26536,7 @@ impl ::std::convert::From<&DataVariant3FormatVariant0Subtype3>
         value.clone()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3Parse"]
+#[doc = "`DataVariant3FormatVariant0Subtype3Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26620,7 +26620,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype3Parse
         Self::Variant2(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3ParseVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype3ParseVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26695,7 +26695,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3ParseVariant1Value"]
+#[doc = "`DataVariant3FormatVariant0Subtype3ParseVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26789,7 +26789,7 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVa
         Self::Variant1(value)
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0"]
+#[doc = "`DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26881,7 +26881,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1"]
+#[doc = "`DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -26970,7 +26970,7 @@ impl<'de> ::serde::Deserialize<'de>
             })
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype3Type"]
+#[doc = "`DataVariant3FormatVariant0Subtype3Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27041,7 +27041,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant3FormatVarian
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype4"]
+#[doc = "`DataVariant3FormatVariant0Subtype4`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27126,7 +27126,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4 {
         value.clone()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype4Variant0Type"]
+#[doc = "`DataVariant3FormatVariant0Subtype4Variant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27201,7 +27201,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype4Variant1Filter"]
+#[doc = "`DataVariant3FormatVariant0Subtype4Variant1Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27282,7 +27282,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3FormatVariant0Subtype4Variant1Type"]
+#[doc = "`DataVariant3FormatVariant0Subtype4Variant1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27357,7 +27357,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DataVariant3Values"]
+#[doc = "`DataVariant3Values`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27393,7 +27393,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3Values {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransform"]
+#[doc = "`DensityTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27728,7 +27728,7 @@ impl ::std::convert::From<&DensityTransform> for DensityTransform {
         value.clone()
     }
 }
-#[doc = "DensityTransformAs"]
+#[doc = "`DensityTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27788,7 +27788,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformAsVariant0Item"]
+#[doc = "`DensityTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27821,7 +27821,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistribution"]
+#[doc = "`DensityTransformDistribution`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28068,7 +28068,7 @@ impl ::std::convert::From<&Self> for DensityTransformDistribution {
         value.clone()
     }
 }
-#[doc = "DensityTransformDistributionBandwidth"]
+#[doc = "`DensityTransformDistributionBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28106,7 +28106,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionBandwidth {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionDistributions"]
+#[doc = "`DensityTransformDistributionDistributions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28147,7 +28147,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionDistributio
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionField"]
+#[doc = "`DensityTransformDistributionField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28194,7 +28194,7 @@ impl ::std::convert::From<Expr> for DensityTransformDistributionField {
         Self::Expr(value)
     }
 }
-#[doc = "DensityTransformDistributionMax"]
+#[doc = "`DensityTransformDistributionMax`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28238,7 +28238,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMax {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionMean"]
+#[doc = "`DensityTransformDistributionMean`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28276,7 +28276,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMean {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionMin"]
+#[doc = "`DensityTransformDistributionMin`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28314,7 +28314,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMin {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionStdev"]
+#[doc = "`DensityTransformDistributionStdev`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28358,7 +28358,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionStdev {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionWeights"]
+#[doc = "`DensityTransformDistributionWeights`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28408,7 +28408,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeights {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformDistributionWeightsVariant0Item"]
+#[doc = "`DensityTransformDistributionWeightsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28446,7 +28446,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeightsVari
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformExtent"]
+#[doc = "`DensityTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28496,7 +28496,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformExtentVariant0Item"]
+#[doc = "`DensityTransformExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28534,7 +28534,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformMaxsteps"]
+#[doc = "`DensityTransformMaxsteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28578,7 +28578,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformMaxsteps {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformMethod"]
+#[doc = "`DensityTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28617,7 +28617,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformMinsteps"]
+#[doc = "`DensityTransformMinsteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28661,7 +28661,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformMinsteps {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformSteps"]
+#[doc = "`DensityTransformSteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28699,7 +28699,7 @@ impl ::std::convert::From<SignalRef> for DensityTransformSteps {
         Self::Variant1(value)
     }
 }
-#[doc = "DensityTransformType"]
+#[doc = "`DensityTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28770,7 +28770,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DensityTransformType {
         value.parse()
     }
 }
-#[doc = "DirectionValue"]
+#[doc = "`DirectionValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28974,7 +28974,7 @@ impl ::std::convert::From<DirectionValueVariant1> for DirectionValue {
         Self::Variant1(value)
     }
 }
-#[doc = "DirectionValueVariant0Item"]
+#[doc = "`DirectionValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29101,7 +29101,7 @@ impl ::std::convert::From<DirectionValueVariant0ItemVariant2> for DirectionValue
         Self::Variant2(value)
     }
 }
-#[doc = "DirectionValueVariant0ItemVariant0"]
+#[doc = "`DirectionValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29236,7 +29236,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "DirectionValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`DirectionValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29316,7 +29316,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DirectionValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`DirectionValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29400,7 +29400,7 @@ impl ::std::convert::From<bool> for DirectionValueVariant0ItemVariant0Variant3Ra
         Self::Variant1(value)
     }
 }
-#[doc = "DirectionValueVariant0ItemVariant1"]
+#[doc = "`DirectionValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29517,7 +29517,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "DirectionValueVariant0ItemVariant2"]
+#[doc = "`DirectionValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29634,7 +29634,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "DirectionValueVariant1"]
+#[doc = "`DirectionValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29750,7 +29750,7 @@ impl ::std::convert::From<DirectionValueVariant1Variant2> for DirectionValueVari
         Self::Variant2(value)
     }
 }
-#[doc = "DirectionValueVariant1Variant0"]
+#[doc = "`DirectionValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29874,7 +29874,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "DirectionValueVariant1Variant0Variant1Value"]
+#[doc = "`DirectionValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -29954,7 +29954,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "DirectionValueVariant1Variant0Variant3Range"]
+#[doc = "`DirectionValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30038,7 +30038,7 @@ impl ::std::convert::From<bool> for DirectionValueVariant1Variant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "DirectionValueVariant1Variant1"]
+#[doc = "`DirectionValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30152,7 +30152,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "DirectionValueVariant1Variant2"]
+#[doc = "`DirectionValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30266,7 +30266,7 @@ impl ::std::convert::From<&Self> for DirectionValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "DotbinTransform"]
+#[doc = "`DotbinTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30380,7 +30380,7 @@ impl ::std::convert::From<&DotbinTransform> for DotbinTransform {
         value.clone()
     }
 }
-#[doc = "DotbinTransformAs"]
+#[doc = "`DotbinTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30419,7 +30419,7 @@ impl ::std::convert::From<SignalRef> for DotbinTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "DotbinTransformField"]
+#[doc = "`DotbinTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30466,7 +30466,7 @@ impl ::std::convert::From<Expr> for DotbinTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "DotbinTransformGroupby"]
+#[doc = "`DotbinTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30519,7 +30519,7 @@ impl ::std::convert::From<SignalRef> for DotbinTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "DotbinTransformGroupbyVariant0Item"]
+#[doc = "`DotbinTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30566,7 +30566,7 @@ impl ::std::convert::From<Expr> for DotbinTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "DotbinTransformSmooth"]
+#[doc = "`DotbinTransformSmooth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30604,7 +30604,7 @@ impl ::std::convert::From<SignalRef> for DotbinTransformSmooth {
         Self::Variant1(value)
     }
 }
-#[doc = "DotbinTransformStep"]
+#[doc = "`DotbinTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30642,7 +30642,7 @@ impl ::std::convert::From<SignalRef> for DotbinTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "DotbinTransformType"]
+#[doc = "`DotbinTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30713,7 +30713,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DotbinTransformType {
         value.parse()
     }
 }
-#[doc = "Element"]
+#[doc = "`Element`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30768,7 +30768,7 @@ impl ::std::fmt::Display for Element {
         self.0.fmt(f)
     }
 }
-#[doc = "Encode"]
+#[doc = "`Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30808,7 +30808,7 @@ impl ::std::convert::From<::std::collections::HashMap<EncodeKey, EncodeEntry>> f
         Self(value)
     }
 }
-#[doc = "EncodeEntry"]
+#[doc = "`EncodeEntry`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31365,7 +31365,7 @@ impl ::std::default::Default for EncodeEntry {
         }
     }
 }
-#[doc = "EncodeKey"]
+#[doc = "`EncodeKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31438,7 +31438,7 @@ impl<'de> ::serde::Deserialize<'de> for EncodeKey {
             })
     }
 }
-#[doc = "Everything"]
+#[doc = "`Everything`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31564,7 +31564,7 @@ impl ::std::default::Default for Everything {
         }
     }
 }
-#[doc = "EverythingMarksItem"]
+#[doc = "`EverythingMarksItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31602,7 +31602,7 @@ impl ::std::convert::From<MarkVisual> for EverythingMarksItem {
         Self::Visual(value)
     }
 }
-#[doc = "Expr"]
+#[doc = "`Expr`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31638,7 +31638,7 @@ impl ::std::convert::From<&Expr> for Expr {
         value.clone()
     }
 }
-#[doc = "ExprString"]
+#[doc = "`ExprString`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31693,7 +31693,7 @@ impl ::std::fmt::Display for ExprString {
         self.0.fmt(f)
     }
 }
-#[doc = "ExtentTransform"]
+#[doc = "`ExtentTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31745,7 +31745,7 @@ impl ::std::convert::From<&ExtentTransform> for ExtentTransform {
         value.clone()
     }
 }
-#[doc = "ExtentTransformField"]
+#[doc = "`ExtentTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31792,7 +31792,7 @@ impl ::std::convert::From<Expr> for ExtentTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "ExtentTransformType"]
+#[doc = "`ExtentTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31863,7 +31863,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ExtentTransformType {
         value.parse()
     }
 }
-#[doc = "Facet"]
+#[doc = "`Facet`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -31975,7 +31975,7 @@ impl ::std::convert::From<&Facet> for Facet {
         value.clone()
     }
 }
-#[doc = "FacetFacet"]
+#[doc = "`FacetFacet`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32084,7 +32084,7 @@ impl ::std::convert::From<&Self> for FacetFacet {
         value.clone()
     }
 }
-#[doc = "FacetFacetVariant1Aggregate"]
+#[doc = "`FacetFacetVariant1Aggregate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32149,7 +32149,7 @@ impl ::std::default::Default for FacetFacetVariant1Aggregate {
         }
     }
 }
-#[doc = "FacetFacetVariant1Groupby"]
+#[doc = "`FacetFacetVariant1Groupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32185,7 +32185,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for FacetFacet
         Self::Variant1(value)
     }
 }
-#[doc = "Field"]
+#[doc = "`Field`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32273,7 +32273,7 @@ impl ::std::convert::From<SignalRef> for Field {
         Self::Variant1(value)
     }
 }
-#[doc = "FilterTransform"]
+#[doc = "`FilterTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32315,7 +32315,7 @@ impl ::std::convert::From<&FilterTransform> for FilterTransform {
         value.clone()
     }
 }
-#[doc = "FilterTransformType"]
+#[doc = "`FilterTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32386,7 +32386,7 @@ impl ::std::convert::TryFrom<::std::string::String> for FilterTransformType {
         value.parse()
     }
 }
-#[doc = "FlattenTransform"]
+#[doc = "`FlattenTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32486,7 +32486,7 @@ impl ::std::convert::From<&FlattenTransform> for FlattenTransform {
         value.clone()
     }
 }
-#[doc = "FlattenTransformAs"]
+#[doc = "`FlattenTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32534,7 +32534,7 @@ impl ::std::convert::From<SignalRef> for FlattenTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "FlattenTransformAsVariant0Item"]
+#[doc = "`FlattenTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32567,7 +32567,7 @@ impl ::std::convert::From<SignalRef> for FlattenTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "FlattenTransformFields"]
+#[doc = "`FlattenTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32620,7 +32620,7 @@ impl ::std::convert::From<SignalRef> for FlattenTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "FlattenTransformFieldsVariant0Item"]
+#[doc = "`FlattenTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32667,7 +32667,7 @@ impl ::std::convert::From<Expr> for FlattenTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "FlattenTransformIndex"]
+#[doc = "`FlattenTransformIndex`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32700,7 +32700,7 @@ impl ::std::convert::From<SignalRef> for FlattenTransformIndex {
         Self::Variant1(value)
     }
 }
-#[doc = "FlattenTransformType"]
+#[doc = "`FlattenTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32771,7 +32771,7 @@ impl ::std::convert::TryFrom<::std::string::String> for FlattenTransformType {
         value.parse()
     }
 }
-#[doc = "FoldTransform"]
+#[doc = "`FoldTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32861,7 +32861,7 @@ impl ::std::convert::From<&FoldTransform> for FoldTransform {
         value.clone()
     }
 }
-#[doc = "FoldTransformAs"]
+#[doc = "`FoldTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32923,7 +32923,7 @@ impl ::std::convert::From<SignalRef> for FoldTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "FoldTransformAsVariant0Item"]
+#[doc = "`FoldTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32956,7 +32956,7 @@ impl ::std::convert::From<SignalRef> for FoldTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "FoldTransformFields"]
+#[doc = "`FoldTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33009,7 +33009,7 @@ impl ::std::convert::From<SignalRef> for FoldTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "FoldTransformFieldsVariant0Item"]
+#[doc = "`FoldTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33056,7 +33056,7 @@ impl ::std::convert::From<Expr> for FoldTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "FoldTransformType"]
+#[doc = "`FoldTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33127,7 +33127,7 @@ impl ::std::convert::TryFrom<::std::string::String> for FoldTransformType {
         value.parse()
     }
 }
-#[doc = "FontWeightValue"]
+#[doc = "`FontWeightValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33373,7 +33373,7 @@ impl ::std::convert::From<FontWeightValueVariant1> for FontWeightValue {
         Self::Variant1(value)
     }
 }
-#[doc = "FontWeightValueVariant0Item"]
+#[doc = "`FontWeightValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33521,7 +33521,7 @@ impl ::std::convert::From<FontWeightValueVariant0ItemVariant2> for FontWeightVal
         Self::Variant2(value)
     }
 }
-#[doc = "FontWeightValueVariant0ItemVariant0"]
+#[doc = "`FontWeightValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33677,7 +33677,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "FontWeightValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`FontWeightValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33761,7 +33761,7 @@ impl ::std::convert::From<bool> for FontWeightValueVariant0ItemVariant0Variant3R
         Self::Variant1(value)
     }
 }
-#[doc = "FontWeightValueVariant0ItemVariant1"]
+#[doc = "`FontWeightValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33899,7 +33899,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "FontWeightValueVariant0ItemVariant2"]
+#[doc = "`FontWeightValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34037,7 +34037,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "FontWeightValueVariant1"]
+#[doc = "`FontWeightValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34174,7 +34174,7 @@ impl ::std::convert::From<FontWeightValueVariant1Variant2> for FontWeightValueVa
         Self::Variant2(value)
     }
 }
-#[doc = "FontWeightValueVariant1Variant0"]
+#[doc = "`FontWeightValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34319,7 +34319,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "FontWeightValueVariant1Variant0Variant3Range"]
+#[doc = "`FontWeightValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34403,7 +34403,7 @@ impl ::std::convert::From<bool> for FontWeightValueVariant1Variant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "FontWeightValueVariant1Variant1"]
+#[doc = "`FontWeightValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34538,7 +34538,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "FontWeightValueVariant1Variant2"]
+#[doc = "`FontWeightValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -34673,7 +34673,7 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "ForceTransform"]
+#[doc = "`ForceTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35139,7 +35139,7 @@ impl ::std::convert::From<&ForceTransform> for ForceTransform {
         value.clone()
     }
 }
-#[doc = "ForceTransformAlpha"]
+#[doc = "`ForceTransformAlpha`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35183,7 +35183,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlpha {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformAlphaMin"]
+#[doc = "`ForceTransformAlphaMin`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35227,7 +35227,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlphaMin {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformAlphaTarget"]
+#[doc = "`ForceTransformAlphaTarget`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35265,7 +35265,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlphaTarget {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformAs"]
+#[doc = "`ForceTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35329,7 +35329,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformAsVariant0Item"]
+#[doc = "`ForceTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35362,7 +35362,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItem"]
+#[doc = "`ForceTransformForcesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35736,7 +35736,7 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItem {
         value.clone()
     }
 }
-#[doc = "ForceTransformForcesItemDistance"]
+#[doc = "`ForceTransformForcesItemDistance`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35798,7 +35798,7 @@ impl ::std::convert::From<ParamField> for ForceTransformForcesItemDistance {
         Self::Variant3(value)
     }
 }
-#[doc = "ForceTransformForcesItemDistanceMax"]
+#[doc = "`ForceTransformForcesItemDistanceMax`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35836,7 +35836,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMax {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemDistanceMin"]
+#[doc = "`ForceTransformForcesItemDistanceMin`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35880,7 +35880,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMin {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemId"]
+#[doc = "`ForceTransformForcesItemId`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35927,7 +35927,7 @@ impl ::std::convert::From<Expr> for ForceTransformForcesItemId {
         Self::Expr(value)
     }
 }
-#[doc = "ForceTransformForcesItemIterations"]
+#[doc = "`ForceTransformForcesItemIterations`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35971,7 +35971,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemIterations {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemRadius"]
+#[doc = "`ForceTransformForcesItemRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36027,7 +36027,7 @@ impl ::std::convert::From<ParamField> for ForceTransformForcesItemRadius {
         Self::Variant3(value)
     }
 }
-#[doc = "ForceTransformForcesItemStrength"]
+#[doc = "`ForceTransformForcesItemStrength`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36071,7 +36071,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemStrength {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemTheta"]
+#[doc = "`ForceTransformForcesItemTheta`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36115,7 +36115,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemTheta {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemX"]
+#[doc = "`ForceTransformForcesItemX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36153,7 +36153,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemX {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformForcesItemY"]
+#[doc = "`ForceTransformForcesItemY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36191,7 +36191,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemY {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformIterations"]
+#[doc = "`ForceTransformIterations`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36235,7 +36235,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformIterations {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformRestart"]
+#[doc = "`ForceTransformRestart`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36273,7 +36273,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformRestart {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformStatic"]
+#[doc = "`ForceTransformStatic`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36311,7 +36311,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformStatic {
         Self::Variant1(value)
     }
 }
-#[doc = "ForceTransformType"]
+#[doc = "`ForceTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36382,7 +36382,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ForceTransformType {
         value.parse()
     }
 }
-#[doc = "ForceTransformVelocityDecay"]
+#[doc = "`ForceTransformVelocityDecay`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36426,7 +36426,7 @@ impl ::std::convert::From<SignalRef> for ForceTransformVelocityDecay {
         Self::Variant1(value)
     }
 }
-#[doc = "FormulaTransform"]
+#[doc = "`FormulaTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36493,7 +36493,7 @@ impl ::std::convert::From<&FormulaTransform> for FormulaTransform {
         value.clone()
     }
 }
-#[doc = "FormulaTransformAs"]
+#[doc = "`FormulaTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36526,7 +36526,7 @@ impl ::std::convert::From<SignalRef> for FormulaTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "FormulaTransformInitonly"]
+#[doc = "`FormulaTransformInitonly`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36564,7 +36564,7 @@ impl ::std::convert::From<SignalRef> for FormulaTransformInitonly {
         Self::Variant1(value)
     }
 }
-#[doc = "FormulaTransformType"]
+#[doc = "`FormulaTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36635,7 +36635,7 @@ impl ::std::convert::TryFrom<::std::string::String> for FormulaTransformType {
         value.parse()
     }
 }
-#[doc = "From"]
+#[doc = "`From`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36669,7 +36669,7 @@ impl ::std::default::Default for From {
         }
     }
 }
-#[doc = "GeojsonTransform"]
+#[doc = "`GeojsonTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36748,7 +36748,7 @@ impl ::std::convert::From<&GeojsonTransform> for GeojsonTransform {
         value.clone()
     }
 }
-#[doc = "GeojsonTransformFields"]
+#[doc = "`GeojsonTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36801,7 +36801,7 @@ impl ::std::convert::From<SignalRef> for GeojsonTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "GeojsonTransformFieldsVariant0Item"]
+#[doc = "`GeojsonTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36848,7 +36848,7 @@ impl ::std::convert::From<Expr> for GeojsonTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "GeojsonTransformGeojson"]
+#[doc = "`GeojsonTransformGeojson`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36895,7 +36895,7 @@ impl ::std::convert::From<Expr> for GeojsonTransformGeojson {
         Self::Expr(value)
     }
 }
-#[doc = "GeojsonTransformType"]
+#[doc = "`GeojsonTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36966,7 +36966,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GeojsonTransformType {
         value.parse()
     }
 }
-#[doc = "GeopathTransform"]
+#[doc = "`GeopathTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37058,7 +37058,7 @@ impl ::std::convert::From<&GeopathTransform> for GeopathTransform {
         value.clone()
     }
 }
-#[doc = "GeopathTransformAs"]
+#[doc = "`GeopathTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37097,7 +37097,7 @@ impl ::std::convert::From<SignalRef> for GeopathTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "GeopathTransformField"]
+#[doc = "`GeopathTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37144,7 +37144,7 @@ impl ::std::convert::From<Expr> for GeopathTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "GeopathTransformPointRadius"]
+#[doc = "`GeopathTransformPointRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37200,7 +37200,7 @@ impl ::std::convert::From<ParamField> for GeopathTransformPointRadius {
         Self::Variant3(value)
     }
 }
-#[doc = "GeopathTransformType"]
+#[doc = "`GeopathTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37271,7 +37271,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GeopathTransformType {
         value.parse()
     }
 }
-#[doc = "GeopointTransform"]
+#[doc = "`GeopointTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37368,7 +37368,7 @@ impl ::std::convert::From<&GeopointTransform> for GeopointTransform {
         value.clone()
     }
 }
-#[doc = "GeopointTransformAs"]
+#[doc = "`GeopointTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37430,7 +37430,7 @@ impl ::std::convert::From<SignalRef> for GeopointTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "GeopointTransformAsVariant0Item"]
+#[doc = "`GeopointTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37463,7 +37463,7 @@ impl ::std::convert::From<SignalRef> for GeopointTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "GeopointTransformFields"]
+#[doc = "`GeopointTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37518,7 +37518,7 @@ impl ::std::convert::From<SignalRef> for GeopointTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "GeopointTransformFieldsVariant0Item"]
+#[doc = "`GeopointTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37565,7 +37565,7 @@ impl ::std::convert::From<Expr> for GeopointTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "GeopointTransformType"]
+#[doc = "`GeopointTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37636,7 +37636,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GeopointTransformType {
         value.parse()
     }
 }
-#[doc = "GeoshapeTransform"]
+#[doc = "`GeoshapeTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37729,7 +37729,7 @@ impl ::std::convert::From<&GeoshapeTransform> for GeoshapeTransform {
         value.clone()
     }
 }
-#[doc = "GeoshapeTransformAs"]
+#[doc = "`GeoshapeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37768,7 +37768,7 @@ impl ::std::convert::From<SignalRef> for GeoshapeTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "GeoshapeTransformField"]
+#[doc = "`GeoshapeTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37823,7 +37823,7 @@ impl ::std::convert::From<Expr> for GeoshapeTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "GeoshapeTransformPointRadius"]
+#[doc = "`GeoshapeTransformPointRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37879,7 +37879,7 @@ impl ::std::convert::From<ParamField> for GeoshapeTransformPointRadius {
         Self::Variant3(value)
     }
 }
-#[doc = "GeoshapeTransformType"]
+#[doc = "`GeoshapeTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37950,7 +37950,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GeoshapeTransformType {
         value.parse()
     }
 }
-#[doc = "GradientStops"]
+#[doc = "`GradientStops`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38000,7 +38000,7 @@ impl ::std::convert::From<::std::vec::Vec<GradientStopsItem>> for GradientStops 
         Self(value)
     }
 }
-#[doc = "GradientStopsItem"]
+#[doc = "`GradientStopsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38034,7 +38034,7 @@ impl ::std::convert::From<&GradientStopsItem> for GradientStopsItem {
         value.clone()
     }
 }
-#[doc = "GraticuleTransform"]
+#[doc = "`GraticuleTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38223,7 +38223,7 @@ impl ::std::convert::From<&GraticuleTransform> for GraticuleTransform {
         value.clone()
     }
 }
-#[doc = "GraticuleTransformExtent"]
+#[doc = "`GraticuleTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38264,7 +38264,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformExtentMajor"]
+#[doc = "`GraticuleTransformExtentMajor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38305,7 +38305,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMajor {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformExtentMinor"]
+#[doc = "`GraticuleTransformExtentMinor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38346,7 +38346,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMinor {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformPrecision"]
+#[doc = "`GraticuleTransformPrecision`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38390,7 +38390,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformPrecision {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStep"]
+#[doc = "`GraticuleTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38440,7 +38440,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStepMajor"]
+#[doc = "`GraticuleTransformStepMajor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38504,7 +38504,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajor {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStepMajorVariant0Item"]
+#[doc = "`GraticuleTransformStepMajorVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38542,7 +38542,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajorVariant0Item
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStepMinor"]
+#[doc = "`GraticuleTransformStepMinor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38606,7 +38606,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinor {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStepMinorVariant0Item"]
+#[doc = "`GraticuleTransformStepMinorVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38644,7 +38644,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinorVariant0Item
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformStepVariant0Item"]
+#[doc = "`GraticuleTransformStepVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38682,7 +38682,7 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "GraticuleTransformType"]
+#[doc = "`GraticuleTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38753,7 +38753,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GraticuleTransformType {
         value.parse()
     }
 }
-#[doc = "GuideEncode"]
+#[doc = "`GuideEncode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38805,7 +38805,7 @@ impl ::std::default::Default for GuideEncode {
         }
     }
 }
-#[doc = "HeatmapTransform"]
+#[doc = "`HeatmapTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38922,7 +38922,7 @@ impl ::std::convert::From<&HeatmapTransform> for HeatmapTransform {
         value.clone()
     }
 }
-#[doc = "HeatmapTransformAs"]
+#[doc = "`HeatmapTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38961,7 +38961,7 @@ impl ::std::convert::From<SignalRef> for HeatmapTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "HeatmapTransformColor"]
+#[doc = "`HeatmapTransformColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39012,7 +39012,7 @@ impl ::std::convert::From<ParamField> for HeatmapTransformColor {
         Self::Variant3(value)
     }
 }
-#[doc = "HeatmapTransformField"]
+#[doc = "`HeatmapTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39059,7 +39059,7 @@ impl ::std::convert::From<Expr> for HeatmapTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "HeatmapTransformOpacity"]
+#[doc = "`HeatmapTransformOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39115,7 +39115,7 @@ impl ::std::convert::From<ParamField> for HeatmapTransformOpacity {
         Self::Variant3(value)
     }
 }
-#[doc = "HeatmapTransformResolve"]
+#[doc = "`HeatmapTransformResolve`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39162,7 +39162,7 @@ impl ::std::convert::From<SignalRef> for HeatmapTransformResolve {
         Self::Variant1(value)
     }
 }
-#[doc = "HeatmapTransformResolveVariant0"]
+#[doc = "`HeatmapTransformResolveVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39238,7 +39238,7 @@ impl ::std::convert::TryFrom<::std::string::String> for HeatmapTransformResolveV
         value.parse()
     }
 }
-#[doc = "HeatmapTransformType"]
+#[doc = "`HeatmapTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39309,7 +39309,7 @@ impl ::std::convert::TryFrom<::std::string::String> for HeatmapTransformType {
         value.parse()
     }
 }
-#[doc = "IdentifierTransform"]
+#[doc = "`IdentifierTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39359,7 +39359,7 @@ impl ::std::convert::From<&IdentifierTransform> for IdentifierTransform {
         value.clone()
     }
 }
-#[doc = "IdentifierTransformAs"]
+#[doc = "`IdentifierTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39392,7 +39392,7 @@ impl ::std::convert::From<SignalRef> for IdentifierTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "IdentifierTransformType"]
+#[doc = "`IdentifierTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39463,7 +39463,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IdentifierTransformType 
         value.parse()
     }
 }
-#[doc = "ImputeTransform"]
+#[doc = "`ImputeTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39590,7 +39590,7 @@ impl ::std::convert::From<&ImputeTransform> for ImputeTransform {
         value.clone()
     }
 }
-#[doc = "ImputeTransformField"]
+#[doc = "`ImputeTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39637,7 +39637,7 @@ impl ::std::convert::From<Expr> for ImputeTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "ImputeTransformGroupby"]
+#[doc = "`ImputeTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39690,7 +39690,7 @@ impl ::std::convert::From<SignalRef> for ImputeTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "ImputeTransformGroupbyVariant0Item"]
+#[doc = "`ImputeTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39737,7 +39737,7 @@ impl ::std::convert::From<Expr> for ImputeTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "ImputeTransformKey"]
+#[doc = "`ImputeTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39784,7 +39784,7 @@ impl ::std::convert::From<Expr> for ImputeTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "ImputeTransformKeyvals"]
+#[doc = "`ImputeTransformKeyvals`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39823,7 +39823,7 @@ impl ::std::convert::From<SignalRef> for ImputeTransformKeyvals {
         Self::Variant1(value)
     }
 }
-#[doc = "ImputeTransformMethod"]
+#[doc = "`ImputeTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39873,7 +39873,7 @@ impl ::std::convert::From<SignalRef> for ImputeTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "ImputeTransformMethodVariant0"]
+#[doc = "`ImputeTransformMethodVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39964,7 +39964,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ImputeTransformMethodVar
         value.parse()
     }
 }
-#[doc = "ImputeTransformType"]
+#[doc = "`ImputeTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40035,7 +40035,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ImputeTransformType {
         value.parse()
     }
 }
-#[doc = "IsocontourTransform"]
+#[doc = "`IsocontourTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40237,7 +40237,7 @@ impl ::std::convert::From<&IsocontourTransform> for IsocontourTransform {
         value.clone()
     }
 }
-#[doc = "IsocontourTransformAs"]
+#[doc = "`IsocontourTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40280,7 +40280,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformField"]
+#[doc = "`IsocontourTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40327,7 +40327,7 @@ impl ::std::convert::From<Expr> for IsocontourTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "IsocontourTransformLevels"]
+#[doc = "`IsocontourTransformLevels`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40365,7 +40365,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformLevels {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformNice"]
+#[doc = "`IsocontourTransformNice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40403,7 +40403,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformNice {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformResolve"]
+#[doc = "`IsocontourTransformResolve`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40450,7 +40450,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformResolve {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformResolveVariant0"]
+#[doc = "`IsocontourTransformResolveVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40526,7 +40526,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformResol
         value.parse()
     }
 }
-#[doc = "IsocontourTransformScale"]
+#[doc = "`IsocontourTransformScale`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40582,7 +40582,7 @@ impl ::std::convert::From<ParamField> for IsocontourTransformScale {
         Self::Variant3(value)
     }
 }
-#[doc = "IsocontourTransformSmooth"]
+#[doc = "`IsocontourTransformSmooth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40626,7 +40626,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformSmooth {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformThresholds"]
+#[doc = "`IsocontourTransformThresholds`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40676,7 +40676,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformThresholds {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformThresholdsVariant0Item"]
+#[doc = "`IsocontourTransformThresholdsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40714,7 +40714,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformThresholdsVariant0It
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformTranslate"]
+#[doc = "`IsocontourTransformTranslate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40770,7 +40770,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformTranslate {
         Self::Variant1(value)
     }
 }
-#[doc = "IsocontourTransformTranslateVariant0Item"]
+#[doc = "`IsocontourTransformTranslateVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40826,7 +40826,7 @@ impl ::std::convert::From<ParamField> for IsocontourTransformTranslateVariant0It
         Self::Variant3(value)
     }
 }
-#[doc = "IsocontourTransformType"]
+#[doc = "`IsocontourTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40897,7 +40897,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformType 
         value.parse()
     }
 }
-#[doc = "IsocontourTransformZero"]
+#[doc = "`IsocontourTransformZero`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40941,7 +40941,7 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformZero {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransform"]
+#[doc = "`JoinaggregateTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41122,7 +41122,7 @@ impl ::std::convert::From<&JoinaggregateTransform> for JoinaggregateTransform {
         value.clone()
     }
 }
-#[doc = "JoinaggregateTransformAs"]
+#[doc = "`JoinaggregateTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41175,7 +41175,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformAsVariant0Item"]
+#[doc = "`JoinaggregateTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41212,7 +41212,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformFields"]
+#[doc = "`JoinaggregateTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41268,7 +41268,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformFieldsVariant0Item"]
+#[doc = "`JoinaggregateTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41319,7 +41319,7 @@ impl ::std::convert::From<Expr> for JoinaggregateTransformFieldsVariant0Item {
         Self::Variant2(value)
     }
 }
-#[doc = "JoinaggregateTransformGroupby"]
+#[doc = "`JoinaggregateTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41372,7 +41372,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformGroupbyVariant0Item"]
+#[doc = "`JoinaggregateTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41419,7 +41419,7 @@ impl ::std::convert::From<Expr> for JoinaggregateTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "JoinaggregateTransformKey"]
+#[doc = "`JoinaggregateTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41466,7 +41466,7 @@ impl ::std::convert::From<Expr> for JoinaggregateTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "JoinaggregateTransformOps"]
+#[doc = "`JoinaggregateTransformOps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41541,7 +41541,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformOps {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformOpsVariant0Item"]
+#[doc = "`JoinaggregateTransformOpsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41606,7 +41606,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformOpsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "JoinaggregateTransformOpsVariant0ItemVariant0"]
+#[doc = "`JoinaggregateTransformOpsVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41796,7 +41796,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "JoinaggregateTransformType"]
+#[doc = "`JoinaggregateTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41867,7 +41867,7 @@ impl ::std::convert::TryFrom<::std::string::String> for JoinaggregateTransformTy
         value.parse()
     }
 }
-#[doc = "Kde2dTransform"]
+#[doc = "`Kde2dTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42063,7 +42063,7 @@ impl ::std::convert::From<&Kde2dTransform> for Kde2dTransform {
         value.clone()
     }
 }
-#[doc = "Kde2dTransformAs"]
+#[doc = "`Kde2dTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42102,7 +42102,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformBandwidth"]
+#[doc = "`Kde2dTransformBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42154,7 +42154,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidth {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformBandwidthVariant0Item"]
+#[doc = "`Kde2dTransformBandwidthVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42192,7 +42192,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidthVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformCellSize"]
+#[doc = "`Kde2dTransformCellSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42230,7 +42230,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformCellSize {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformCounts"]
+#[doc = "`Kde2dTransformCounts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42268,7 +42268,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformCounts {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformGroupby"]
+#[doc = "`Kde2dTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42321,7 +42321,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformGroupbyVariant0Item"]
+#[doc = "`Kde2dTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42368,7 +42368,7 @@ impl ::std::convert::From<Expr> for Kde2dTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "Kde2dTransformSize"]
+#[doc = "`Kde2dTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42418,7 +42418,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformSizeVariant0Item"]
+#[doc = "`Kde2dTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42456,7 +42456,7 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "Kde2dTransformType"]
+#[doc = "`Kde2dTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42527,7 +42527,7 @@ impl ::std::convert::TryFrom<::std::string::String> for Kde2dTransformType {
         value.parse()
     }
 }
-#[doc = "Kde2dTransformWeight"]
+#[doc = "`Kde2dTransformWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42574,7 +42574,7 @@ impl ::std::convert::From<Expr> for Kde2dTransformWeight {
         Self::Expr(value)
     }
 }
-#[doc = "Kde2dTransformX"]
+#[doc = "`Kde2dTransformX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42621,7 +42621,7 @@ impl ::std::convert::From<Expr> for Kde2dTransformX {
         Self::Expr(value)
     }
 }
-#[doc = "Kde2dTransformY"]
+#[doc = "`Kde2dTransformY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42668,7 +42668,7 @@ impl ::std::convert::From<Expr> for Kde2dTransformY {
         Self::Expr(value)
     }
 }
-#[doc = "KdeTransform"]
+#[doc = "`KdeTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42885,7 +42885,7 @@ impl ::std::convert::From<&KdeTransform> for KdeTransform {
         value.clone()
     }
 }
-#[doc = "KdeTransformAs"]
+#[doc = "`KdeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42945,7 +42945,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformAsVariant0Item"]
+#[doc = "`KdeTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42978,7 +42978,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformBandwidth"]
+#[doc = "`KdeTransformBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43016,7 +43016,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformBandwidth {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformCounts"]
+#[doc = "`KdeTransformCounts`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43054,7 +43054,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformCounts {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformCumulative"]
+#[doc = "`KdeTransformCumulative`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43092,7 +43092,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformCumulative {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformExtent"]
+#[doc = "`KdeTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43142,7 +43142,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformExtentVariant0Item"]
+#[doc = "`KdeTransformExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43180,7 +43180,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformField"]
+#[doc = "`KdeTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43227,7 +43227,7 @@ impl ::std::convert::From<Expr> for KdeTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "KdeTransformGroupby"]
+#[doc = "`KdeTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43280,7 +43280,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformGroupbyVariant0Item"]
+#[doc = "`KdeTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43327,7 +43327,7 @@ impl ::std::convert::From<Expr> for KdeTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "KdeTransformMaxsteps"]
+#[doc = "`KdeTransformMaxsteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43371,7 +43371,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformMaxsteps {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformMinsteps"]
+#[doc = "`KdeTransformMinsteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43415,7 +43415,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformMinsteps {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformResolve"]
+#[doc = "`KdeTransformResolve`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43462,7 +43462,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformResolve {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformResolveVariant0"]
+#[doc = "`KdeTransformResolveVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43538,7 +43538,7 @@ impl ::std::convert::TryFrom<::std::string::String> for KdeTransformResolveVaria
         value.parse()
     }
 }
-#[doc = "KdeTransformSteps"]
+#[doc = "`KdeTransformSteps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43576,7 +43576,7 @@ impl ::std::convert::From<SignalRef> for KdeTransformSteps {
         Self::Variant1(value)
     }
 }
-#[doc = "KdeTransformType"]
+#[doc = "`KdeTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43647,7 +43647,7 @@ impl ::std::convert::TryFrom<::std::string::String> for KdeTransformType {
         value.parse()
     }
 }
-#[doc = "LabelOverlap"]
+#[doc = "`LabelOverlap`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43697,7 +43697,7 @@ impl ::std::convert::From<SignalRef> for LabelOverlap {
         Self::Variant2(value)
     }
 }
-#[doc = "LabelOverlapVariant1"]
+#[doc = "`LabelOverlapVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43773,7 +43773,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelOverlapVariant1 {
         value.parse()
     }
 }
-#[doc = "LabelTransform"]
+#[doc = "`LabelTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44022,7 +44022,7 @@ impl ::std::convert::From<&LabelTransform> for LabelTransform {
         value.clone()
     }
 }
-#[doc = "LabelTransformAnchor"]
+#[doc = "`LabelTransformAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44096,7 +44096,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformAnchorVariant0Item"]
+#[doc = "`LabelTransformAnchorVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44129,7 +44129,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAnchorVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformAs"]
+#[doc = "`LabelTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44197,7 +44197,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformAsVariant0Item"]
+#[doc = "`LabelTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44230,7 +44230,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformAvoidBaseMark"]
+#[doc = "`LabelTransformAvoidBaseMark`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44274,7 +44274,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAvoidBaseMark {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformAvoidMarks"]
+#[doc = "`LabelTransformAvoidMarks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44315,7 +44315,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformAvoidMarks {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformLineAnchor"]
+#[doc = "`LabelTransformLineAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44354,7 +44354,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformLineAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformMarkIndex"]
+#[doc = "`LabelTransformMarkIndex`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44392,7 +44392,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformMarkIndex {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformMethod"]
+#[doc = "`LabelTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44431,7 +44431,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformOffset"]
+#[doc = "`LabelTransformOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44489,7 +44489,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformOffsetVariant0Item"]
+#[doc = "`LabelTransformOffsetVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44527,7 +44527,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformOffsetVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformPadding"]
+#[doc = "`LabelTransformPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44569,7 +44569,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformPadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformSize"]
+#[doc = "`LabelTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44619,7 +44619,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformSizeVariant0Item"]
+#[doc = "`LabelTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44657,7 +44657,7 @@ impl ::std::convert::From<SignalRef> for LabelTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LabelTransformType"]
+#[doc = "`LabelTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44728,7 +44728,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelTransformType {
         value.parse()
     }
 }
-#[doc = "Layout"]
+#[doc = "`Layout`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45062,7 +45062,7 @@ impl ::std::convert::From<SignalRef> for Layout {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0Align"]
+#[doc = "`LayoutVariant0Align`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45142,7 +45142,7 @@ impl ::std::convert::From<LayoutVariant0AlignVariant0> for LayoutVariant0Align {
         Self::Variant0(value)
     }
 }
-#[doc = "LayoutVariant0AlignVariant0"]
+#[doc = "`LayoutVariant0AlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45184,7 +45184,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant0 {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0AlignVariant0Variant0"]
+#[doc = "`LayoutVariant0AlignVariant0Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45265,7 +45265,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "LayoutVariant0AlignVariant1Column"]
+#[doc = "`LayoutVariant0AlignVariant1Column`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45309,7 +45309,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Column {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0AlignVariant1ColumnVariant0"]
+#[doc = "`LayoutVariant0AlignVariant1ColumnVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45390,7 +45390,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "LayoutVariant0AlignVariant1Row"]
+#[doc = "`LayoutVariant0AlignVariant1Row`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45434,7 +45434,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Row {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0AlignVariant1RowVariant0"]
+#[doc = "`LayoutVariant0AlignVariant1RowVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45515,7 +45515,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "LayoutVariant0Bounds"]
+#[doc = "`LayoutVariant0Bounds`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45556,7 +45556,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Bounds {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0BoundsVariant0"]
+#[doc = "`LayoutVariant0BoundsVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45632,7 +45632,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0BoundsVari
         value.parse()
     }
 }
-#[doc = "LayoutVariant0Center"]
+#[doc = "`LayoutVariant0Center`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45688,7 +45688,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Center {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0FooterBand"]
+#[doc = "`LayoutVariant0FooterBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45739,7 +45739,7 @@ impl ::std::convert::From<NumberOrSignal> for LayoutVariant0FooterBand {
         Self::Variant0(value)
     }
 }
-#[doc = "LayoutVariant0HeaderBand"]
+#[doc = "`LayoutVariant0HeaderBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45790,7 +45790,7 @@ impl ::std::convert::From<NumberOrSignal> for LayoutVariant0HeaderBand {
         Self::Variant0(value)
     }
 }
-#[doc = "LayoutVariant0Offset"]
+#[doc = "`LayoutVariant0Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45890,7 +45890,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0Padding"]
+#[doc = "`LayoutVariant0Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45946,7 +45946,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0TitleAnchor"]
+#[doc = "`LayoutVariant0TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46023,7 +46023,7 @@ impl ::std::convert::From<LayoutVariant0TitleAnchorVariant0> for LayoutVariant0T
         Self::Variant0(value)
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant0"]
+#[doc = "`LayoutVariant0TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46066,7 +46066,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant0 {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant0Variant0"]
+#[doc = "`LayoutVariant0TitleAnchorVariant0Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46142,7 +46142,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0TitleAncho
         value.parse()
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant1Column"]
+#[doc = "`LayoutVariant0TitleAnchorVariant1Column`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46185,7 +46185,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Column
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant1ColumnVariant0"]
+#[doc = "`LayoutVariant0TitleAnchorVariant1ColumnVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46265,7 +46265,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant1Row"]
+#[doc = "`LayoutVariant0TitleAnchorVariant1Row`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46308,7 +46308,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Row {
         Self::Variant1(value)
     }
 }
-#[doc = "LayoutVariant0TitleAnchorVariant1RowVariant0"]
+#[doc = "`LayoutVariant0TitleAnchorVariant1RowVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46388,7 +46388,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "LayoutVariant0TitleBand"]
+#[doc = "`LayoutVariant0TitleBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46439,7 +46439,7 @@ impl ::std::convert::From<NumberOrSignal> for LayoutVariant0TitleBand {
         Self::Variant0(value)
     }
 }
-#[doc = "Legend"]
+#[doc = "`Legend`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49652,7 +49652,7 @@ impl ::std::convert::From<&Self> for Legend {
         value.clone()
     }
 }
-#[doc = "LegendVariant0CornerRadius"]
+#[doc = "`LegendVariant0CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49690,7 +49690,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0Direction"]
+#[doc = "`LegendVariant0Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49766,7 +49766,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant0Encode"]
+#[doc = "`LegendVariant0Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49830,7 +49830,7 @@ impl ::std::default::Default for LegendVariant0Encode {
         }
     }
 }
-#[doc = "LegendVariant0FillColor"]
+#[doc = "`LegendVariant0FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49867,7 +49867,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0Format"]
+#[doc = "`LegendVariant0Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -49958,7 +49958,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant0Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0FormatType"]
+#[doc = "`LegendVariant0FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50000,7 +50000,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant0FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0FormatTypeVariant0"]
+#[doc = "`LegendVariant0FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50081,7 +50081,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant0GradientOpacity"]
+#[doc = "`LegendVariant0GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50119,7 +50119,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0GradientStrokeColor"]
+#[doc = "`LegendVariant0GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50156,7 +50156,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0GradientStrokeWidth"]
+#[doc = "`LegendVariant0GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50194,7 +50194,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0GridAlign"]
+#[doc = "`LegendVariant0GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50236,7 +50236,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant0GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0GridAlignVariant0"]
+#[doc = "`LegendVariant0GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50317,7 +50317,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant0LabelAlign"]
+#[doc = "`LegendVariant0LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50359,7 +50359,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant0LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelAlignVariant0"]
+#[doc = "`LegendVariant0LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50440,7 +50440,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant0LabelBaseline"]
+#[doc = "`LegendVariant0LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50485,7 +50485,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant0LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelBaselineVariant0"]
+#[doc = "`LegendVariant0LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50581,7 +50581,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant0LabelColor"]
+#[doc = "`LegendVariant0LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50618,7 +50618,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0LabelFont"]
+#[doc = "`LegendVariant0LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50651,7 +50651,7 @@ impl ::std::convert::From<StringValue> for LegendVariant0LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelFontSize"]
+#[doc = "`LegendVariant0LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50689,7 +50689,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelFontStyle"]
+#[doc = "`LegendVariant0LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50722,7 +50722,7 @@ impl ::std::convert::From<StringValue> for LegendVariant0LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelFontWeight"]
+#[doc = "`LegendVariant0LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50784,7 +50784,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant0LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelLimit"]
+#[doc = "`LegendVariant0LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50822,7 +50822,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelOffset"]
+#[doc = "`LegendVariant0LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50860,7 +50860,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LabelOpacity"]
+#[doc = "`LegendVariant0LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50898,7 +50898,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LegendX"]
+#[doc = "`LegendVariant0LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50936,7 +50936,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0LegendY"]
+#[doc = "`LegendVariant0LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -50974,7 +50974,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0Offset"]
+#[doc = "`LegendVariant0Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51012,7 +51012,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0Orient"]
+#[doc = "`LegendVariant0Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51061,7 +51061,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant0Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0OrientVariant0"]
+#[doc = "`LegendVariant0OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51173,7 +51173,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant0Padding"]
+#[doc = "`LegendVariant0Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51211,7 +51211,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0StrokeColor"]
+#[doc = "`LegendVariant0StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51248,7 +51248,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0SymbolDash"]
+#[doc = "`LegendVariant0SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51289,7 +51289,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant0SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolDashOffset"]
+#[doc = "`LegendVariant0SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51327,7 +51327,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolFillColor"]
+#[doc = "`LegendVariant0SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51364,7 +51364,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0SymbolOffset"]
+#[doc = "`LegendVariant0SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51402,7 +51402,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolOpacity"]
+#[doc = "`LegendVariant0SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51440,7 +51440,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolSize"]
+#[doc = "`LegendVariant0SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51478,7 +51478,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolStrokeColor"]
+#[doc = "`LegendVariant0SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51515,7 +51515,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0SymbolStrokeWidth"]
+#[doc = "`LegendVariant0SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51553,7 +51553,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0SymbolType"]
+#[doc = "`LegendVariant0SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51586,7 +51586,7 @@ impl ::std::convert::From<StringValue> for LegendVariant0SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleAlign"]
+#[doc = "`LegendVariant0TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51628,7 +51628,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant0TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleAlignVariant0"]
+#[doc = "`LegendVariant0TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51709,7 +51709,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant0TitleAnchor"]
+#[doc = "`LegendVariant0TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51754,7 +51754,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant0TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleAnchorVariant0"]
+#[doc = "`LegendVariant0TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51836,7 +51836,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant0TitleBaseline"]
+#[doc = "`LegendVariant0TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51881,7 +51881,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant0TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleBaselineVariant0"]
+#[doc = "`LegendVariant0TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -51977,7 +51977,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant0TitleColor"]
+#[doc = "`LegendVariant0TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52014,7 +52014,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant0TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant0TitleFont"]
+#[doc = "`LegendVariant0TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52047,7 +52047,7 @@ impl ::std::convert::From<StringValue> for LegendVariant0TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleFontSize"]
+#[doc = "`LegendVariant0TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52085,7 +52085,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleFontStyle"]
+#[doc = "`LegendVariant0TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52118,7 +52118,7 @@ impl ::std::convert::From<StringValue> for LegendVariant0TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleFontWeight"]
+#[doc = "`LegendVariant0TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52180,7 +52180,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant0TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleLimit"]
+#[doc = "`LegendVariant0TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52218,7 +52218,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleLineHeight"]
+#[doc = "`LegendVariant0TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52256,7 +52256,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleOpacity"]
+#[doc = "`LegendVariant0TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52294,7 +52294,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleOrient"]
+#[doc = "`LegendVariant0TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52337,7 +52337,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant0TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0TitleOrientVariant0"]
+#[doc = "`LegendVariant0TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52423,7 +52423,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant0TitlePadding"]
+#[doc = "`LegendVariant0TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52461,7 +52461,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant0Type"]
+#[doc = "`LegendVariant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52537,7 +52537,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant1CornerRadius"]
+#[doc = "`LegendVariant1CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52575,7 +52575,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1Direction"]
+#[doc = "`LegendVariant1Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52651,7 +52651,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant1Encode"]
+#[doc = "`LegendVariant1Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52715,7 +52715,7 @@ impl ::std::default::Default for LegendVariant1Encode {
         }
     }
 }
-#[doc = "LegendVariant1FillColor"]
+#[doc = "`LegendVariant1FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52752,7 +52752,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1Format"]
+#[doc = "`LegendVariant1Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52843,7 +52843,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant1Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1FormatType"]
+#[doc = "`LegendVariant1FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52885,7 +52885,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant1FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1FormatTypeVariant0"]
+#[doc = "`LegendVariant1FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52966,7 +52966,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant1GradientOpacity"]
+#[doc = "`LegendVariant1GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53004,7 +53004,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1GradientStrokeColor"]
+#[doc = "`LegendVariant1GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53041,7 +53041,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1GradientStrokeWidth"]
+#[doc = "`LegendVariant1GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53079,7 +53079,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1GridAlign"]
+#[doc = "`LegendVariant1GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53121,7 +53121,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant1GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1GridAlignVariant0"]
+#[doc = "`LegendVariant1GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53202,7 +53202,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant1LabelAlign"]
+#[doc = "`LegendVariant1LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53244,7 +53244,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant1LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelAlignVariant0"]
+#[doc = "`LegendVariant1LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53325,7 +53325,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant1LabelBaseline"]
+#[doc = "`LegendVariant1LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53370,7 +53370,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant1LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelBaselineVariant0"]
+#[doc = "`LegendVariant1LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53466,7 +53466,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant1LabelColor"]
+#[doc = "`LegendVariant1LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53503,7 +53503,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1LabelFont"]
+#[doc = "`LegendVariant1LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53536,7 +53536,7 @@ impl ::std::convert::From<StringValue> for LegendVariant1LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelFontSize"]
+#[doc = "`LegendVariant1LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53574,7 +53574,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelFontStyle"]
+#[doc = "`LegendVariant1LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53607,7 +53607,7 @@ impl ::std::convert::From<StringValue> for LegendVariant1LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelFontWeight"]
+#[doc = "`LegendVariant1LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53669,7 +53669,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant1LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelLimit"]
+#[doc = "`LegendVariant1LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53707,7 +53707,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelOffset"]
+#[doc = "`LegendVariant1LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53745,7 +53745,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LabelOpacity"]
+#[doc = "`LegendVariant1LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53783,7 +53783,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LegendX"]
+#[doc = "`LegendVariant1LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53821,7 +53821,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1LegendY"]
+#[doc = "`LegendVariant1LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53859,7 +53859,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1Offset"]
+#[doc = "`LegendVariant1Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53897,7 +53897,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1Orient"]
+#[doc = "`LegendVariant1Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -53946,7 +53946,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant1Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1OrientVariant0"]
+#[doc = "`LegendVariant1OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54058,7 +54058,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant1Padding"]
+#[doc = "`LegendVariant1Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54096,7 +54096,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1StrokeColor"]
+#[doc = "`LegendVariant1StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54133,7 +54133,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1SymbolDash"]
+#[doc = "`LegendVariant1SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54174,7 +54174,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant1SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolDashOffset"]
+#[doc = "`LegendVariant1SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54212,7 +54212,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolFillColor"]
+#[doc = "`LegendVariant1SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54249,7 +54249,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1SymbolOffset"]
+#[doc = "`LegendVariant1SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54287,7 +54287,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolOpacity"]
+#[doc = "`LegendVariant1SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54325,7 +54325,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolSize"]
+#[doc = "`LegendVariant1SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54363,7 +54363,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolStrokeColor"]
+#[doc = "`LegendVariant1SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54400,7 +54400,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1SymbolStrokeWidth"]
+#[doc = "`LegendVariant1SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54438,7 +54438,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1SymbolType"]
+#[doc = "`LegendVariant1SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54471,7 +54471,7 @@ impl ::std::convert::From<StringValue> for LegendVariant1SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleAlign"]
+#[doc = "`LegendVariant1TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54513,7 +54513,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant1TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleAlignVariant0"]
+#[doc = "`LegendVariant1TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54594,7 +54594,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant1TitleAnchor"]
+#[doc = "`LegendVariant1TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54639,7 +54639,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant1TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleAnchorVariant0"]
+#[doc = "`LegendVariant1TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54721,7 +54721,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant1TitleBaseline"]
+#[doc = "`LegendVariant1TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54766,7 +54766,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant1TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleBaselineVariant0"]
+#[doc = "`LegendVariant1TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54862,7 +54862,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant1TitleColor"]
+#[doc = "`LegendVariant1TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54899,7 +54899,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant1TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant1TitleFont"]
+#[doc = "`LegendVariant1TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54932,7 +54932,7 @@ impl ::std::convert::From<StringValue> for LegendVariant1TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleFontSize"]
+#[doc = "`LegendVariant1TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -54970,7 +54970,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleFontStyle"]
+#[doc = "`LegendVariant1TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55003,7 +55003,7 @@ impl ::std::convert::From<StringValue> for LegendVariant1TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleFontWeight"]
+#[doc = "`LegendVariant1TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55065,7 +55065,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant1TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleLimit"]
+#[doc = "`LegendVariant1TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55103,7 +55103,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleLineHeight"]
+#[doc = "`LegendVariant1TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55141,7 +55141,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleOpacity"]
+#[doc = "`LegendVariant1TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55179,7 +55179,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleOrient"]
+#[doc = "`LegendVariant1TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55222,7 +55222,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant1TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1TitleOrientVariant0"]
+#[doc = "`LegendVariant1TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55308,7 +55308,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant1TitlePadding"]
+#[doc = "`LegendVariant1TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55346,7 +55346,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant1Type"]
+#[doc = "`LegendVariant1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55422,7 +55422,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant2CornerRadius"]
+#[doc = "`LegendVariant2CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55460,7 +55460,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2Direction"]
+#[doc = "`LegendVariant2Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55536,7 +55536,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant2Encode"]
+#[doc = "`LegendVariant2Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55600,7 +55600,7 @@ impl ::std::default::Default for LegendVariant2Encode {
         }
     }
 }
-#[doc = "LegendVariant2FillColor"]
+#[doc = "`LegendVariant2FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55637,7 +55637,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2Format"]
+#[doc = "`LegendVariant2Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55728,7 +55728,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant2Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2FormatType"]
+#[doc = "`LegendVariant2FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55770,7 +55770,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant2FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2FormatTypeVariant0"]
+#[doc = "`LegendVariant2FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55851,7 +55851,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant2GradientOpacity"]
+#[doc = "`LegendVariant2GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55889,7 +55889,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2GradientStrokeColor"]
+#[doc = "`LegendVariant2GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55926,7 +55926,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2GradientStrokeWidth"]
+#[doc = "`LegendVariant2GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -55964,7 +55964,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2GridAlign"]
+#[doc = "`LegendVariant2GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56006,7 +56006,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant2GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2GridAlignVariant0"]
+#[doc = "`LegendVariant2GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56087,7 +56087,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant2LabelAlign"]
+#[doc = "`LegendVariant2LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56129,7 +56129,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant2LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelAlignVariant0"]
+#[doc = "`LegendVariant2LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56210,7 +56210,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant2LabelBaseline"]
+#[doc = "`LegendVariant2LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56255,7 +56255,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant2LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelBaselineVariant0"]
+#[doc = "`LegendVariant2LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56351,7 +56351,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant2LabelColor"]
+#[doc = "`LegendVariant2LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56388,7 +56388,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2LabelFont"]
+#[doc = "`LegendVariant2LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56421,7 +56421,7 @@ impl ::std::convert::From<StringValue> for LegendVariant2LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelFontSize"]
+#[doc = "`LegendVariant2LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56459,7 +56459,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelFontStyle"]
+#[doc = "`LegendVariant2LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56492,7 +56492,7 @@ impl ::std::convert::From<StringValue> for LegendVariant2LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelFontWeight"]
+#[doc = "`LegendVariant2LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56554,7 +56554,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant2LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelLimit"]
+#[doc = "`LegendVariant2LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56592,7 +56592,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelOffset"]
+#[doc = "`LegendVariant2LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56630,7 +56630,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LabelOpacity"]
+#[doc = "`LegendVariant2LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56668,7 +56668,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LegendX"]
+#[doc = "`LegendVariant2LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56706,7 +56706,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2LegendY"]
+#[doc = "`LegendVariant2LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56744,7 +56744,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2Offset"]
+#[doc = "`LegendVariant2Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56782,7 +56782,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2Orient"]
+#[doc = "`LegendVariant2Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56831,7 +56831,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant2Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2OrientVariant0"]
+#[doc = "`LegendVariant2OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56943,7 +56943,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant2Padding"]
+#[doc = "`LegendVariant2Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -56981,7 +56981,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2StrokeColor"]
+#[doc = "`LegendVariant2StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57018,7 +57018,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2SymbolDash"]
+#[doc = "`LegendVariant2SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57059,7 +57059,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant2SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolDashOffset"]
+#[doc = "`LegendVariant2SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57097,7 +57097,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolFillColor"]
+#[doc = "`LegendVariant2SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57134,7 +57134,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2SymbolOffset"]
+#[doc = "`LegendVariant2SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57172,7 +57172,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolOpacity"]
+#[doc = "`LegendVariant2SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57210,7 +57210,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolSize"]
+#[doc = "`LegendVariant2SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57248,7 +57248,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolStrokeColor"]
+#[doc = "`LegendVariant2SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57285,7 +57285,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2SymbolStrokeWidth"]
+#[doc = "`LegendVariant2SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57323,7 +57323,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2SymbolType"]
+#[doc = "`LegendVariant2SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57356,7 +57356,7 @@ impl ::std::convert::From<StringValue> for LegendVariant2SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleAlign"]
+#[doc = "`LegendVariant2TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57398,7 +57398,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant2TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleAlignVariant0"]
+#[doc = "`LegendVariant2TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57479,7 +57479,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant2TitleAnchor"]
+#[doc = "`LegendVariant2TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57524,7 +57524,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant2TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleAnchorVariant0"]
+#[doc = "`LegendVariant2TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57606,7 +57606,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant2TitleBaseline"]
+#[doc = "`LegendVariant2TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57651,7 +57651,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant2TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleBaselineVariant0"]
+#[doc = "`LegendVariant2TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57747,7 +57747,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant2TitleColor"]
+#[doc = "`LegendVariant2TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57784,7 +57784,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant2TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant2TitleFont"]
+#[doc = "`LegendVariant2TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57817,7 +57817,7 @@ impl ::std::convert::From<StringValue> for LegendVariant2TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleFontSize"]
+#[doc = "`LegendVariant2TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57855,7 +57855,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleFontStyle"]
+#[doc = "`LegendVariant2TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57888,7 +57888,7 @@ impl ::std::convert::From<StringValue> for LegendVariant2TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleFontWeight"]
+#[doc = "`LegendVariant2TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57950,7 +57950,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant2TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleLimit"]
+#[doc = "`LegendVariant2TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57988,7 +57988,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleLineHeight"]
+#[doc = "`LegendVariant2TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58026,7 +58026,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleOpacity"]
+#[doc = "`LegendVariant2TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58064,7 +58064,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleOrient"]
+#[doc = "`LegendVariant2TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58107,7 +58107,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant2TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2TitleOrientVariant0"]
+#[doc = "`LegendVariant2TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58193,7 +58193,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant2TitlePadding"]
+#[doc = "`LegendVariant2TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58231,7 +58231,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant2Type"]
+#[doc = "`LegendVariant2Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58307,7 +58307,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant3CornerRadius"]
+#[doc = "`LegendVariant3CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58345,7 +58345,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3Direction"]
+#[doc = "`LegendVariant3Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58421,7 +58421,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant3Encode"]
+#[doc = "`LegendVariant3Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58485,7 +58485,7 @@ impl ::std::default::Default for LegendVariant3Encode {
         }
     }
 }
-#[doc = "LegendVariant3FillColor"]
+#[doc = "`LegendVariant3FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58522,7 +58522,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3Format"]
+#[doc = "`LegendVariant3Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58613,7 +58613,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant3Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3FormatType"]
+#[doc = "`LegendVariant3FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58655,7 +58655,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant3FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3FormatTypeVariant0"]
+#[doc = "`LegendVariant3FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58736,7 +58736,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant3GradientOpacity"]
+#[doc = "`LegendVariant3GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58774,7 +58774,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3GradientStrokeColor"]
+#[doc = "`LegendVariant3GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58811,7 +58811,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3GradientStrokeWidth"]
+#[doc = "`LegendVariant3GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58849,7 +58849,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3GridAlign"]
+#[doc = "`LegendVariant3GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58891,7 +58891,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant3GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3GridAlignVariant0"]
+#[doc = "`LegendVariant3GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -58972,7 +58972,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant3LabelAlign"]
+#[doc = "`LegendVariant3LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59014,7 +59014,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant3LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelAlignVariant0"]
+#[doc = "`LegendVariant3LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59095,7 +59095,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant3LabelBaseline"]
+#[doc = "`LegendVariant3LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59140,7 +59140,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant3LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelBaselineVariant0"]
+#[doc = "`LegendVariant3LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59236,7 +59236,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant3LabelColor"]
+#[doc = "`LegendVariant3LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59273,7 +59273,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3LabelFont"]
+#[doc = "`LegendVariant3LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59306,7 +59306,7 @@ impl ::std::convert::From<StringValue> for LegendVariant3LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelFontSize"]
+#[doc = "`LegendVariant3LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59344,7 +59344,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelFontStyle"]
+#[doc = "`LegendVariant3LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59377,7 +59377,7 @@ impl ::std::convert::From<StringValue> for LegendVariant3LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelFontWeight"]
+#[doc = "`LegendVariant3LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59439,7 +59439,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant3LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelLimit"]
+#[doc = "`LegendVariant3LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59477,7 +59477,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelOffset"]
+#[doc = "`LegendVariant3LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59515,7 +59515,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LabelOpacity"]
+#[doc = "`LegendVariant3LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59553,7 +59553,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LegendX"]
+#[doc = "`LegendVariant3LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59591,7 +59591,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3LegendY"]
+#[doc = "`LegendVariant3LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59629,7 +59629,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3Offset"]
+#[doc = "`LegendVariant3Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59667,7 +59667,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3Orient"]
+#[doc = "`LegendVariant3Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59716,7 +59716,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant3Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3OrientVariant0"]
+#[doc = "`LegendVariant3OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59828,7 +59828,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant3Padding"]
+#[doc = "`LegendVariant3Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59866,7 +59866,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3StrokeColor"]
+#[doc = "`LegendVariant3StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59903,7 +59903,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3SymbolDash"]
+#[doc = "`LegendVariant3SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59944,7 +59944,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant3SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolDashOffset"]
+#[doc = "`LegendVariant3SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -59982,7 +59982,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolFillColor"]
+#[doc = "`LegendVariant3SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60019,7 +60019,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3SymbolOffset"]
+#[doc = "`LegendVariant3SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60057,7 +60057,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolOpacity"]
+#[doc = "`LegendVariant3SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60095,7 +60095,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolSize"]
+#[doc = "`LegendVariant3SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60133,7 +60133,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolStrokeColor"]
+#[doc = "`LegendVariant3SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60170,7 +60170,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3SymbolStrokeWidth"]
+#[doc = "`LegendVariant3SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60208,7 +60208,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3SymbolType"]
+#[doc = "`LegendVariant3SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60241,7 +60241,7 @@ impl ::std::convert::From<StringValue> for LegendVariant3SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleAlign"]
+#[doc = "`LegendVariant3TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60283,7 +60283,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant3TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleAlignVariant0"]
+#[doc = "`LegendVariant3TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60364,7 +60364,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant3TitleAnchor"]
+#[doc = "`LegendVariant3TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60409,7 +60409,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant3TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleAnchorVariant0"]
+#[doc = "`LegendVariant3TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60491,7 +60491,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant3TitleBaseline"]
+#[doc = "`LegendVariant3TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60536,7 +60536,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant3TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleBaselineVariant0"]
+#[doc = "`LegendVariant3TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60632,7 +60632,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant3TitleColor"]
+#[doc = "`LegendVariant3TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60669,7 +60669,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant3TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant3TitleFont"]
+#[doc = "`LegendVariant3TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60702,7 +60702,7 @@ impl ::std::convert::From<StringValue> for LegendVariant3TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleFontSize"]
+#[doc = "`LegendVariant3TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60740,7 +60740,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleFontStyle"]
+#[doc = "`LegendVariant3TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60773,7 +60773,7 @@ impl ::std::convert::From<StringValue> for LegendVariant3TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleFontWeight"]
+#[doc = "`LegendVariant3TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60835,7 +60835,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant3TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleLimit"]
+#[doc = "`LegendVariant3TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60873,7 +60873,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleLineHeight"]
+#[doc = "`LegendVariant3TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60911,7 +60911,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleOpacity"]
+#[doc = "`LegendVariant3TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60949,7 +60949,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleOrient"]
+#[doc = "`LegendVariant3TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -60992,7 +60992,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant3TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3TitleOrientVariant0"]
+#[doc = "`LegendVariant3TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61078,7 +61078,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant3TitlePadding"]
+#[doc = "`LegendVariant3TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61116,7 +61116,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant3Type"]
+#[doc = "`LegendVariant3Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61192,7 +61192,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant4CornerRadius"]
+#[doc = "`LegendVariant4CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61230,7 +61230,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4Direction"]
+#[doc = "`LegendVariant4Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61306,7 +61306,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant4Encode"]
+#[doc = "`LegendVariant4Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61370,7 +61370,7 @@ impl ::std::default::Default for LegendVariant4Encode {
         }
     }
 }
-#[doc = "LegendVariant4FillColor"]
+#[doc = "`LegendVariant4FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61407,7 +61407,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4Format"]
+#[doc = "`LegendVariant4Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61498,7 +61498,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant4Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4FormatType"]
+#[doc = "`LegendVariant4FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61540,7 +61540,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant4FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4FormatTypeVariant0"]
+#[doc = "`LegendVariant4FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61621,7 +61621,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant4GradientOpacity"]
+#[doc = "`LegendVariant4GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61659,7 +61659,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4GradientStrokeColor"]
+#[doc = "`LegendVariant4GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61696,7 +61696,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4GradientStrokeWidth"]
+#[doc = "`LegendVariant4GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61734,7 +61734,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4GridAlign"]
+#[doc = "`LegendVariant4GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61776,7 +61776,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant4GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4GridAlignVariant0"]
+#[doc = "`LegendVariant4GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61857,7 +61857,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant4LabelAlign"]
+#[doc = "`LegendVariant4LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61899,7 +61899,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant4LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelAlignVariant0"]
+#[doc = "`LegendVariant4LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61980,7 +61980,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant4LabelBaseline"]
+#[doc = "`LegendVariant4LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62025,7 +62025,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant4LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelBaselineVariant0"]
+#[doc = "`LegendVariant4LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62121,7 +62121,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant4LabelColor"]
+#[doc = "`LegendVariant4LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62158,7 +62158,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4LabelFont"]
+#[doc = "`LegendVariant4LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62191,7 +62191,7 @@ impl ::std::convert::From<StringValue> for LegendVariant4LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelFontSize"]
+#[doc = "`LegendVariant4LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62229,7 +62229,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelFontStyle"]
+#[doc = "`LegendVariant4LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62262,7 +62262,7 @@ impl ::std::convert::From<StringValue> for LegendVariant4LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelFontWeight"]
+#[doc = "`LegendVariant4LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62324,7 +62324,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant4LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelLimit"]
+#[doc = "`LegendVariant4LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62362,7 +62362,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelOffset"]
+#[doc = "`LegendVariant4LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62400,7 +62400,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LabelOpacity"]
+#[doc = "`LegendVariant4LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62438,7 +62438,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LegendX"]
+#[doc = "`LegendVariant4LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62476,7 +62476,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4LegendY"]
+#[doc = "`LegendVariant4LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62514,7 +62514,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4Offset"]
+#[doc = "`LegendVariant4Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62552,7 +62552,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4Orient"]
+#[doc = "`LegendVariant4Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62601,7 +62601,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant4Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4OrientVariant0"]
+#[doc = "`LegendVariant4OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62713,7 +62713,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant4Padding"]
+#[doc = "`LegendVariant4Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62751,7 +62751,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4StrokeColor"]
+#[doc = "`LegendVariant4StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62788,7 +62788,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4SymbolDash"]
+#[doc = "`LegendVariant4SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62829,7 +62829,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant4SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolDashOffset"]
+#[doc = "`LegendVariant4SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62867,7 +62867,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolFillColor"]
+#[doc = "`LegendVariant4SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62904,7 +62904,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4SymbolOffset"]
+#[doc = "`LegendVariant4SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62942,7 +62942,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolOpacity"]
+#[doc = "`LegendVariant4SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -62980,7 +62980,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolSize"]
+#[doc = "`LegendVariant4SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63018,7 +63018,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolStrokeColor"]
+#[doc = "`LegendVariant4SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63055,7 +63055,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4SymbolStrokeWidth"]
+#[doc = "`LegendVariant4SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63093,7 +63093,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4SymbolType"]
+#[doc = "`LegendVariant4SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63126,7 +63126,7 @@ impl ::std::convert::From<StringValue> for LegendVariant4SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleAlign"]
+#[doc = "`LegendVariant4TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63168,7 +63168,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant4TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleAlignVariant0"]
+#[doc = "`LegendVariant4TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63249,7 +63249,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant4TitleAnchor"]
+#[doc = "`LegendVariant4TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63294,7 +63294,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant4TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleAnchorVariant0"]
+#[doc = "`LegendVariant4TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63376,7 +63376,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant4TitleBaseline"]
+#[doc = "`LegendVariant4TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63421,7 +63421,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant4TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleBaselineVariant0"]
+#[doc = "`LegendVariant4TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63517,7 +63517,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant4TitleColor"]
+#[doc = "`LegendVariant4TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63554,7 +63554,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant4TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant4TitleFont"]
+#[doc = "`LegendVariant4TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63587,7 +63587,7 @@ impl ::std::convert::From<StringValue> for LegendVariant4TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleFontSize"]
+#[doc = "`LegendVariant4TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63625,7 +63625,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleFontStyle"]
+#[doc = "`LegendVariant4TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63658,7 +63658,7 @@ impl ::std::convert::From<StringValue> for LegendVariant4TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleFontWeight"]
+#[doc = "`LegendVariant4TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63720,7 +63720,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant4TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleLimit"]
+#[doc = "`LegendVariant4TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63758,7 +63758,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleLineHeight"]
+#[doc = "`LegendVariant4TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63796,7 +63796,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleOpacity"]
+#[doc = "`LegendVariant4TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63834,7 +63834,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleOrient"]
+#[doc = "`LegendVariant4TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63877,7 +63877,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant4TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4TitleOrientVariant0"]
+#[doc = "`LegendVariant4TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -63963,7 +63963,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant4TitlePadding"]
+#[doc = "`LegendVariant4TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64001,7 +64001,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant4Type"]
+#[doc = "`LegendVariant4Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64077,7 +64077,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant5CornerRadius"]
+#[doc = "`LegendVariant5CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64115,7 +64115,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5Direction"]
+#[doc = "`LegendVariant5Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64191,7 +64191,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant5Encode"]
+#[doc = "`LegendVariant5Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64255,7 +64255,7 @@ impl ::std::default::Default for LegendVariant5Encode {
         }
     }
 }
-#[doc = "LegendVariant5FillColor"]
+#[doc = "`LegendVariant5FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64292,7 +64292,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5Format"]
+#[doc = "`LegendVariant5Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64383,7 +64383,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant5Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5FormatType"]
+#[doc = "`LegendVariant5FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64425,7 +64425,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant5FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5FormatTypeVariant0"]
+#[doc = "`LegendVariant5FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64506,7 +64506,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant5GradientOpacity"]
+#[doc = "`LegendVariant5GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64544,7 +64544,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5GradientStrokeColor"]
+#[doc = "`LegendVariant5GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64581,7 +64581,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5GradientStrokeWidth"]
+#[doc = "`LegendVariant5GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64619,7 +64619,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5GridAlign"]
+#[doc = "`LegendVariant5GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64661,7 +64661,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant5GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5GridAlignVariant0"]
+#[doc = "`LegendVariant5GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64742,7 +64742,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant5LabelAlign"]
+#[doc = "`LegendVariant5LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64784,7 +64784,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant5LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelAlignVariant0"]
+#[doc = "`LegendVariant5LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64865,7 +64865,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant5LabelBaseline"]
+#[doc = "`LegendVariant5LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64910,7 +64910,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant5LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelBaselineVariant0"]
+#[doc = "`LegendVariant5LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65006,7 +65006,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant5LabelColor"]
+#[doc = "`LegendVariant5LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65043,7 +65043,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5LabelFont"]
+#[doc = "`LegendVariant5LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65076,7 +65076,7 @@ impl ::std::convert::From<StringValue> for LegendVariant5LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelFontSize"]
+#[doc = "`LegendVariant5LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65114,7 +65114,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelFontStyle"]
+#[doc = "`LegendVariant5LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65147,7 +65147,7 @@ impl ::std::convert::From<StringValue> for LegendVariant5LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelFontWeight"]
+#[doc = "`LegendVariant5LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65209,7 +65209,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant5LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelLimit"]
+#[doc = "`LegendVariant5LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65247,7 +65247,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelOffset"]
+#[doc = "`LegendVariant5LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65285,7 +65285,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LabelOpacity"]
+#[doc = "`LegendVariant5LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65323,7 +65323,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LegendX"]
+#[doc = "`LegendVariant5LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65361,7 +65361,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5LegendY"]
+#[doc = "`LegendVariant5LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65399,7 +65399,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5Offset"]
+#[doc = "`LegendVariant5Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65437,7 +65437,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5Orient"]
+#[doc = "`LegendVariant5Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65486,7 +65486,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant5Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5OrientVariant0"]
+#[doc = "`LegendVariant5OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65598,7 +65598,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant5Padding"]
+#[doc = "`LegendVariant5Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65636,7 +65636,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5StrokeColor"]
+#[doc = "`LegendVariant5StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65673,7 +65673,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5SymbolDash"]
+#[doc = "`LegendVariant5SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65714,7 +65714,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant5SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolDashOffset"]
+#[doc = "`LegendVariant5SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65752,7 +65752,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolFillColor"]
+#[doc = "`LegendVariant5SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65789,7 +65789,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5SymbolOffset"]
+#[doc = "`LegendVariant5SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65827,7 +65827,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolOpacity"]
+#[doc = "`LegendVariant5SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65865,7 +65865,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolSize"]
+#[doc = "`LegendVariant5SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65903,7 +65903,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolStrokeColor"]
+#[doc = "`LegendVariant5SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65940,7 +65940,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5SymbolStrokeWidth"]
+#[doc = "`LegendVariant5SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65978,7 +65978,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5SymbolType"]
+#[doc = "`LegendVariant5SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66011,7 +66011,7 @@ impl ::std::convert::From<StringValue> for LegendVariant5SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleAlign"]
+#[doc = "`LegendVariant5TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66053,7 +66053,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant5TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleAlignVariant0"]
+#[doc = "`LegendVariant5TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66134,7 +66134,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant5TitleAnchor"]
+#[doc = "`LegendVariant5TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66179,7 +66179,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant5TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleAnchorVariant0"]
+#[doc = "`LegendVariant5TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66261,7 +66261,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant5TitleBaseline"]
+#[doc = "`LegendVariant5TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66306,7 +66306,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant5TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleBaselineVariant0"]
+#[doc = "`LegendVariant5TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66402,7 +66402,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant5TitleColor"]
+#[doc = "`LegendVariant5TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66439,7 +66439,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant5TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant5TitleFont"]
+#[doc = "`LegendVariant5TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66472,7 +66472,7 @@ impl ::std::convert::From<StringValue> for LegendVariant5TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleFontSize"]
+#[doc = "`LegendVariant5TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66510,7 +66510,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleFontStyle"]
+#[doc = "`LegendVariant5TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66543,7 +66543,7 @@ impl ::std::convert::From<StringValue> for LegendVariant5TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleFontWeight"]
+#[doc = "`LegendVariant5TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66605,7 +66605,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant5TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleLimit"]
+#[doc = "`LegendVariant5TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66643,7 +66643,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleLineHeight"]
+#[doc = "`LegendVariant5TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66681,7 +66681,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleOpacity"]
+#[doc = "`LegendVariant5TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66719,7 +66719,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleOrient"]
+#[doc = "`LegendVariant5TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66762,7 +66762,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant5TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5TitleOrientVariant0"]
+#[doc = "`LegendVariant5TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66848,7 +66848,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant5TitlePadding"]
+#[doc = "`LegendVariant5TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66886,7 +66886,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant5Type"]
+#[doc = "`LegendVariant5Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -66962,7 +66962,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5Type {
         value.parse()
     }
 }
-#[doc = "LegendVariant6CornerRadius"]
+#[doc = "`LegendVariant6CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67000,7 +67000,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6CornerRadius {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6Direction"]
+#[doc = "`LegendVariant6Direction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67076,7 +67076,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6Direction 
         value.parse()
     }
 }
-#[doc = "LegendVariant6Encode"]
+#[doc = "`LegendVariant6Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67140,7 +67140,7 @@ impl ::std::default::Default for LegendVariant6Encode {
         }
     }
 }
-#[doc = "LegendVariant6FillColor"]
+#[doc = "`LegendVariant6FillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67177,7 +67177,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6FillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6Format"]
+#[doc = "`LegendVariant6Format`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67268,7 +67268,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant6Format {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6FormatType"]
+#[doc = "`LegendVariant6FormatType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67310,7 +67310,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant6FormatType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6FormatTypeVariant0"]
+#[doc = "`LegendVariant6FormatTypeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67391,7 +67391,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6FormatType
         value.parse()
     }
 }
-#[doc = "LegendVariant6GradientOpacity"]
+#[doc = "`LegendVariant6GradientOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67429,7 +67429,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6GradientOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6GradientStrokeColor"]
+#[doc = "`LegendVariant6GradientStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67466,7 +67466,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6GradientStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6GradientStrokeWidth"]
+#[doc = "`LegendVariant6GradientStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67504,7 +67504,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6GradientStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6GridAlign"]
+#[doc = "`LegendVariant6GridAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67546,7 +67546,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant6GridAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6GridAlignVariant0"]
+#[doc = "`LegendVariant6GridAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67627,7 +67627,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6GridAlignV
         value.parse()
     }
 }
-#[doc = "LegendVariant6LabelAlign"]
+#[doc = "`LegendVariant6LabelAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67669,7 +67669,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant6LabelAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelAlignVariant0"]
+#[doc = "`LegendVariant6LabelAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67750,7 +67750,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6LabelAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant6LabelBaseline"]
+#[doc = "`LegendVariant6LabelBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67795,7 +67795,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant6LabelBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelBaselineVariant0"]
+#[doc = "`LegendVariant6LabelBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67891,7 +67891,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6LabelBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant6LabelColor"]
+#[doc = "`LegendVariant6LabelColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67928,7 +67928,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6LabelColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6LabelFont"]
+#[doc = "`LegendVariant6LabelFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67961,7 +67961,7 @@ impl ::std::convert::From<StringValue> for LegendVariant6LabelFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelFontSize"]
+#[doc = "`LegendVariant6LabelFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67999,7 +67999,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelFontStyle"]
+#[doc = "`LegendVariant6LabelFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68032,7 +68032,7 @@ impl ::std::convert::From<StringValue> for LegendVariant6LabelFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelFontWeight"]
+#[doc = "`LegendVariant6LabelFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68094,7 +68094,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant6LabelFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelLimit"]
+#[doc = "`LegendVariant6LabelLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68132,7 +68132,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelOffset"]
+#[doc = "`LegendVariant6LabelOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68170,7 +68170,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LabelOpacity"]
+#[doc = "`LegendVariant6LabelOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68208,7 +68208,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LegendX"]
+#[doc = "`LegendVariant6LegendX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68246,7 +68246,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LegendX {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6LegendY"]
+#[doc = "`LegendVariant6LegendY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68284,7 +68284,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LegendY {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6Offset"]
+#[doc = "`LegendVariant6Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68322,7 +68322,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6Orient"]
+#[doc = "`LegendVariant6Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68371,7 +68371,7 @@ impl ::std::convert::From<SignalRef> for LegendVariant6Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6OrientVariant0"]
+#[doc = "`LegendVariant6OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68483,7 +68483,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6OrientVari
         value.parse()
     }
 }
-#[doc = "LegendVariant6Padding"]
+#[doc = "`LegendVariant6Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68521,7 +68521,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6Padding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6StrokeColor"]
+#[doc = "`LegendVariant6StrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68558,7 +68558,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6StrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6SymbolDash"]
+#[doc = "`LegendVariant6SymbolDash`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68599,7 +68599,7 @@ impl ::std::convert::From<ArrayValue> for LegendVariant6SymbolDash {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolDashOffset"]
+#[doc = "`LegendVariant6SymbolDashOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68637,7 +68637,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolDashOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolFillColor"]
+#[doc = "`LegendVariant6SymbolFillColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68674,7 +68674,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6SymbolFillColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6SymbolOffset"]
+#[doc = "`LegendVariant6SymbolOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68712,7 +68712,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolOpacity"]
+#[doc = "`LegendVariant6SymbolOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68750,7 +68750,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolSize"]
+#[doc = "`LegendVariant6SymbolSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68788,7 +68788,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolStrokeColor"]
+#[doc = "`LegendVariant6SymbolStrokeColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68825,7 +68825,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6SymbolStrokeColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6SymbolStrokeWidth"]
+#[doc = "`LegendVariant6SymbolStrokeWidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68863,7 +68863,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolStrokeWidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6SymbolType"]
+#[doc = "`LegendVariant6SymbolType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68896,7 +68896,7 @@ impl ::std::convert::From<StringValue> for LegendVariant6SymbolType {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleAlign"]
+#[doc = "`LegendVariant6TitleAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68938,7 +68938,7 @@ impl ::std::convert::From<AlignValue> for LegendVariant6TitleAlign {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleAlignVariant0"]
+#[doc = "`LegendVariant6TitleAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69019,7 +69019,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleAlign
         value.parse()
     }
 }
-#[doc = "LegendVariant6TitleAnchor"]
+#[doc = "`LegendVariant6TitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69064,7 +69064,7 @@ impl ::std::convert::From<AnchorValue> for LegendVariant6TitleAnchor {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleAnchorVariant0"]
+#[doc = "`LegendVariant6TitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69146,7 +69146,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleAncho
         value.parse()
     }
 }
-#[doc = "LegendVariant6TitleBaseline"]
+#[doc = "`LegendVariant6TitleBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69191,7 +69191,7 @@ impl ::std::convert::From<BaselineValue> for LegendVariant6TitleBaseline {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleBaselineVariant0"]
+#[doc = "`LegendVariant6TitleBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69287,7 +69287,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleBasel
         value.parse()
     }
 }
-#[doc = "LegendVariant6TitleColor"]
+#[doc = "`LegendVariant6TitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69324,7 +69324,7 @@ impl ::std::convert::From<ColorValue> for LegendVariant6TitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "LegendVariant6TitleFont"]
+#[doc = "`LegendVariant6TitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69357,7 +69357,7 @@ impl ::std::convert::From<StringValue> for LegendVariant6TitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleFontSize"]
+#[doc = "`LegendVariant6TitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69395,7 +69395,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleFontStyle"]
+#[doc = "`LegendVariant6TitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69428,7 +69428,7 @@ impl ::std::convert::From<StringValue> for LegendVariant6TitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleFontWeight"]
+#[doc = "`LegendVariant6TitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69490,7 +69490,7 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant6TitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleLimit"]
+#[doc = "`LegendVariant6TitleLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69528,7 +69528,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleLineHeight"]
+#[doc = "`LegendVariant6TitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69566,7 +69566,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleOpacity"]
+#[doc = "`LegendVariant6TitleOpacity`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69604,7 +69604,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleOpacity {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleOrient"]
+#[doc = "`LegendVariant6TitleOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69647,7 +69647,7 @@ impl ::std::convert::From<OrientValue> for LegendVariant6TitleOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6TitleOrientVariant0"]
+#[doc = "`LegendVariant6TitleOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69733,7 +69733,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleOrien
         value.parse()
     }
 }
-#[doc = "LegendVariant6TitlePadding"]
+#[doc = "`LegendVariant6TitlePadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69771,7 +69771,7 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitlePadding {
         Self::Variant1(value)
     }
 }
-#[doc = "LegendVariant6Type"]
+#[doc = "`LegendVariant6Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69847,7 +69847,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6Type {
         value.parse()
     }
 }
-#[doc = "LinearGradient"]
+#[doc = "`LinearGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69908,7 +69908,7 @@ impl ::std::convert::From<&LinearGradient> for LinearGradient {
         value.clone()
     }
 }
-#[doc = "LinearGradientGradient"]
+#[doc = "`LinearGradientGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69979,7 +69979,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LinearGradientGradient {
         value.parse()
     }
 }
-#[doc = "LinkpathTransform"]
+#[doc = "`LinkpathTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70134,7 +70134,7 @@ impl ::std::convert::From<&LinkpathTransform> for LinkpathTransform {
         value.clone()
     }
 }
-#[doc = "LinkpathTransformAs"]
+#[doc = "`LinkpathTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70173,7 +70173,7 @@ impl ::std::convert::From<SignalRef> for LinkpathTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "LinkpathTransformOrient"]
+#[doc = "`LinkpathTransformOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70221,7 +70221,7 @@ impl ::std::convert::From<SignalRef> for LinkpathTransformOrient {
         Self::Variant1(value)
     }
 }
-#[doc = "LinkpathTransformOrientVariant0"]
+#[doc = "`LinkpathTransformOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70302,7 +70302,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LinkpathTransformOrientV
         value.parse()
     }
 }
-#[doc = "LinkpathTransformShape"]
+#[doc = "`LinkpathTransformShape`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70352,7 +70352,7 @@ impl ::std::convert::From<SignalRef> for LinkpathTransformShape {
         Self::Variant1(value)
     }
 }
-#[doc = "LinkpathTransformShapeVariant0"]
+#[doc = "`LinkpathTransformShapeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70443,7 +70443,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LinkpathTransformShapeVa
         value.parse()
     }
 }
-#[doc = "LinkpathTransformSourceX"]
+#[doc = "`LinkpathTransformSourceX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70498,7 +70498,7 @@ impl ::std::convert::From<Expr> for LinkpathTransformSourceX {
         Self::Expr(value)
     }
 }
-#[doc = "LinkpathTransformSourceY"]
+#[doc = "`LinkpathTransformSourceY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70553,7 +70553,7 @@ impl ::std::convert::From<Expr> for LinkpathTransformSourceY {
         Self::Expr(value)
     }
 }
-#[doc = "LinkpathTransformTargetX"]
+#[doc = "`LinkpathTransformTargetX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70608,7 +70608,7 @@ impl ::std::convert::From<Expr> for LinkpathTransformTargetX {
         Self::Expr(value)
     }
 }
-#[doc = "LinkpathTransformTargetY"]
+#[doc = "`LinkpathTransformTargetY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70663,7 +70663,7 @@ impl ::std::convert::From<Expr> for LinkpathTransformTargetY {
         Self::Expr(value)
     }
 }
-#[doc = "LinkpathTransformType"]
+#[doc = "`LinkpathTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70734,7 +70734,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LinkpathTransformType {
         value.parse()
     }
 }
-#[doc = "Listener"]
+#[doc = "`Listener`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70784,7 +70784,7 @@ impl ::std::convert::From<Stream> for Listener {
         Self::Variant2(value)
     }
 }
-#[doc = "LoessTransform"]
+#[doc = "`LoessTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70915,7 +70915,7 @@ impl ::std::convert::From<&LoessTransform> for LoessTransform {
         value.clone()
     }
 }
-#[doc = "LoessTransformAs"]
+#[doc = "`LoessTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70963,7 +70963,7 @@ impl ::std::convert::From<SignalRef> for LoessTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "LoessTransformAsVariant0Item"]
+#[doc = "`LoessTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70996,7 +70996,7 @@ impl ::std::convert::From<SignalRef> for LoessTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LoessTransformBandwidth"]
+#[doc = "`LoessTransformBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71040,7 +71040,7 @@ impl ::std::convert::From<SignalRef> for LoessTransformBandwidth {
         Self::Variant1(value)
     }
 }
-#[doc = "LoessTransformGroupby"]
+#[doc = "`LoessTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71093,7 +71093,7 @@ impl ::std::convert::From<SignalRef> for LoessTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "LoessTransformGroupbyVariant0Item"]
+#[doc = "`LoessTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71140,7 +71140,7 @@ impl ::std::convert::From<Expr> for LoessTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "LoessTransformType"]
+#[doc = "`LoessTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71211,7 +71211,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LoessTransformType {
         value.parse()
     }
 }
-#[doc = "LoessTransformX"]
+#[doc = "`LoessTransformX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71258,7 +71258,7 @@ impl ::std::convert::From<Expr> for LoessTransformX {
         Self::Expr(value)
     }
 }
-#[doc = "LoessTransformY"]
+#[doc = "`LoessTransformY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71305,7 +71305,7 @@ impl ::std::convert::From<Expr> for LoessTransformY {
         Self::Expr(value)
     }
 }
-#[doc = "LookupTransform"]
+#[doc = "`LookupTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71441,7 +71441,7 @@ impl ::std::convert::From<&LookupTransform> for LookupTransform {
         value.clone()
     }
 }
-#[doc = "LookupTransformAs"]
+#[doc = "`LookupTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71489,7 +71489,7 @@ impl ::std::convert::From<SignalRef> for LookupTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "LookupTransformAsVariant0Item"]
+#[doc = "`LookupTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71522,7 +71522,7 @@ impl ::std::convert::From<SignalRef> for LookupTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "LookupTransformFields"]
+#[doc = "`LookupTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71575,7 +71575,7 @@ impl ::std::convert::From<SignalRef> for LookupTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "LookupTransformFieldsVariant0Item"]
+#[doc = "`LookupTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71622,7 +71622,7 @@ impl ::std::convert::From<Expr> for LookupTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "LookupTransformKey"]
+#[doc = "`LookupTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71669,7 +71669,7 @@ impl ::std::convert::From<Expr> for LookupTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "LookupTransformType"]
+#[doc = "`LookupTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71740,7 +71740,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LookupTransformType {
         value.parse()
     }
 }
-#[doc = "LookupTransformValues"]
+#[doc = "`LookupTransformValues`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71793,7 +71793,7 @@ impl ::std::convert::From<SignalRef> for LookupTransformValues {
         Self::Variant1(value)
     }
 }
-#[doc = "LookupTransformValuesVariant0Item"]
+#[doc = "`LookupTransformValuesVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71840,7 +71840,7 @@ impl ::std::convert::From<Expr> for LookupTransformValuesVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "Mark"]
+#[doc = "`Mark`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71931,7 +71931,7 @@ impl ::std::convert::From<&Mark> for Mark {
         value.clone()
     }
 }
-#[doc = "MarkGroup"]
+#[doc = "`MarkGroup`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72027,7 +72027,7 @@ impl ::std::convert::From<&MarkGroup> for MarkGroup {
         value.clone()
     }
 }
-#[doc = "MarkGroupFrom"]
+#[doc = "`MarkGroupFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72065,7 +72065,7 @@ impl ::std::convert::From<Facet> for MarkGroupFrom {
         Self::Facet(value)
     }
 }
-#[doc = "MarkGroupMarksItem"]
+#[doc = "`MarkGroupMarksItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72103,7 +72103,7 @@ impl ::std::convert::From<MarkVisual> for MarkGroupMarksItem {
         Self::Visual(value)
     }
 }
-#[doc = "MarkGroupType"]
+#[doc = "`MarkGroupType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72175,7 +72175,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MarkGroupType {
         value.parse()
     }
 }
-#[doc = "MarkVisual"]
+#[doc = "`MarkVisual`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72240,7 +72240,7 @@ impl ::std::convert::From<&MarkVisual> for MarkVisual {
         value.clone()
     }
 }
-#[doc = "Markclip"]
+#[doc = "`Markclip`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72295,7 +72295,7 @@ impl ::std::convert::From<BooleanOrSignal> for Markclip {
         Self::Variant0(value)
     }
 }
-#[doc = "Marktype"]
+#[doc = "`Marktype`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72350,7 +72350,7 @@ impl ::std::fmt::Display for Marktype {
         self.0.fmt(f)
     }
 }
-#[doc = "NestTransform"]
+#[doc = "`NestTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72424,7 +72424,7 @@ impl ::std::convert::From<&NestTransform> for NestTransform {
         value.clone()
     }
 }
-#[doc = "NestTransformGenerate"]
+#[doc = "`NestTransformGenerate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72462,7 +72462,7 @@ impl ::std::convert::From<SignalRef> for NestTransformGenerate {
         Self::Variant1(value)
     }
 }
-#[doc = "NestTransformKeys"]
+#[doc = "`NestTransformKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72513,7 +72513,7 @@ impl ::std::convert::From<SignalRef> for NestTransformKeys {
         Self::Variant1(value)
     }
 }
-#[doc = "NestTransformKeysVariant0Item"]
+#[doc = "`NestTransformKeysVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72560,7 +72560,7 @@ impl ::std::convert::From<Expr> for NestTransformKeysVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "NestTransformType"]
+#[doc = "`NestTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72631,7 +72631,7 @@ impl ::std::convert::TryFrom<::std::string::String> for NestTransformType {
         value.parse()
     }
 }
-#[doc = "NumberModifiers"]
+#[doc = "`NumberModifiers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72728,7 +72728,7 @@ impl ::std::default::Default for NumberModifiers {
         }
     }
 }
-#[doc = "NumberModifiersBand"]
+#[doc = "`NumberModifiersBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72808,7 +72808,7 @@ impl ::std::convert::From<bool> for NumberModifiersBand {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberModifiersExponent"]
+#[doc = "`NumberModifiersExponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72846,7 +72846,7 @@ impl ::std::convert::From<NumberValue> for NumberModifiersExponent {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberModifiersMult"]
+#[doc = "`NumberModifiersMult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72884,7 +72884,7 @@ impl ::std::convert::From<NumberValue> for NumberModifiersMult {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberModifiersOffset"]
+#[doc = "`NumberModifiersOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72922,7 +72922,7 @@ impl ::std::convert::From<NumberValue> for NumberModifiersOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberOrSignal"]
+#[doc = "`NumberOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72960,7 +72960,7 @@ impl ::std::convert::From<SignalRef> for NumberOrSignal {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValue"]
+#[doc = "`NumberValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73158,7 +73158,7 @@ impl ::std::convert::From<NumberValueVariant1> for NumberValue {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0Item"]
+#[doc = "`NumberValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73290,7 +73290,7 @@ impl ::std::convert::From<NumberValueVariant0ItemVariant2> for NumberValueVarian
         Self::Variant2(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0"]
+#[doc = "`NumberValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73517,7 +73517,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant0Band"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant0Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73601,7 +73601,7 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant0Band 
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant0Exponent"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant0Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73639,7 +73639,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant0Mult"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant0Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73677,7 +73677,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant0Offset"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant0Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73715,7 +73715,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant1Band"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant1Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73799,7 +73799,7 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant1Band 
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant1Exponent"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant1Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73837,7 +73837,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant1Mult"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant1Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73875,7 +73875,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant1Offset"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant1Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73913,7 +73913,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant2Band"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant2Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -73997,7 +73997,7 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant2Band 
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant2Exponent"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant2Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74035,7 +74035,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant2Mult"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant2Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74073,7 +74073,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant2Offset"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant2Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74111,7 +74111,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant3Band"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant3Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74195,7 +74195,7 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant3Band 
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant3Exponent"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74233,7 +74233,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant3Mult"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant3Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74271,7 +74271,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant3Offset"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant3Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74309,7 +74309,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`NumberValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74393,7 +74393,7 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant1"]
+#[doc = "`NumberValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74554,7 +74554,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant0ItemVariant2"]
+#[doc = "`NumberValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74715,7 +74715,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant0ItemVariant3Exponent"]
+#[doc = "`NumberValueVariant0ItemVariant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74753,7 +74753,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant3Expone
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant3Mult"]
+#[doc = "`NumberValueVariant0ItemVariant3Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74791,7 +74791,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant3Mult {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant0ItemVariant3Offset"]
+#[doc = "`NumberValueVariant0ItemVariant3Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74829,7 +74829,7 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant3Offset
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1"]
+#[doc = "`NumberValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -74952,7 +74952,7 @@ impl ::std::convert::From<NumberValueVariant1Variant2> for NumberValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0"]
+#[doc = "`NumberValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75168,7 +75168,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant0Band"]
+#[doc = "`NumberValueVariant1Variant0Variant0Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75248,7 +75248,7 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant0Band {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant0Exponent"]
+#[doc = "`NumberValueVariant1Variant0Variant0Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75288,7 +75288,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant0Mult"]
+#[doc = "`NumberValueVariant1Variant0Variant0Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75328,7 +75328,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant0Offset"]
+#[doc = "`NumberValueVariant1Variant0Variant0Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75368,7 +75368,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant1Band"]
+#[doc = "`NumberValueVariant1Variant0Variant1Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75448,7 +75448,7 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant1Band {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant1Exponent"]
+#[doc = "`NumberValueVariant1Variant0Variant1Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75488,7 +75488,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant1Mult"]
+#[doc = "`NumberValueVariant1Variant0Variant1Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75528,7 +75528,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant1Offset"]
+#[doc = "`NumberValueVariant1Variant0Variant1Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75568,7 +75568,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant2Band"]
+#[doc = "`NumberValueVariant1Variant0Variant2Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75648,7 +75648,7 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant2Band {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant2Exponent"]
+#[doc = "`NumberValueVariant1Variant0Variant2Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75688,7 +75688,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant2Mult"]
+#[doc = "`NumberValueVariant1Variant0Variant2Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75728,7 +75728,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant2Offset"]
+#[doc = "`NumberValueVariant1Variant0Variant2Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75768,7 +75768,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant3Band"]
+#[doc = "`NumberValueVariant1Variant0Variant3Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75848,7 +75848,7 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant3Band {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant3Exponent"]
+#[doc = "`NumberValueVariant1Variant0Variant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75888,7 +75888,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant3Mult"]
+#[doc = "`NumberValueVariant1Variant0Variant3Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75928,7 +75928,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant3Offset"]
+#[doc = "`NumberValueVariant1Variant0Variant3Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75968,7 +75968,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant0Variant3Range"]
+#[doc = "`NumberValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76048,7 +76048,7 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant1"]
+#[doc = "`NumberValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76206,7 +76206,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant1Variant2"]
+#[doc = "`NumberValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76364,7 +76364,7 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "NumberValueVariant1Variant3Exponent"]
+#[doc = "`NumberValueVariant1Variant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76402,7 +76402,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>> for NumberValueVariant
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant3Mult"]
+#[doc = "`NumberValueVariant1Variant3Mult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76440,7 +76440,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>> for NumberValueVariant
         Self::Variant1(value)
     }
 }
-#[doc = "NumberValueVariant1Variant3Offset"]
+#[doc = "`NumberValueVariant1Variant3Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76478,7 +76478,7 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>> for NumberValueVariant
         Self::Variant1(value)
     }
 }
-#[doc = "OnEvents"]
+#[doc = "`OnEvents`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76589,7 +76589,7 @@ impl ::std::convert::From<::std::vec::Vec<OnEventsItem>> for OnEvents {
         Self(value)
     }
 }
-#[doc = "OnEventsItem"]
+#[doc = "`OnEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76694,7 +76694,7 @@ impl ::std::convert::From<&Self> for OnEventsItem {
         value.clone()
     }
 }
-#[doc = "OnEventsItemVariant0Events"]
+#[doc = "`OnEventsItemVariant0Events`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76745,7 +76745,7 @@ impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant0Eve
         Self::Variant2(value)
     }
 }
-#[doc = "OnEventsItemVariant1Events"]
+#[doc = "`OnEventsItemVariant1Events`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76796,7 +76796,7 @@ impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant1Eve
         Self::Variant2(value)
     }
 }
-#[doc = "OnEventsItemVariant1Update"]
+#[doc = "`OnEventsItemVariant1Update`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76853,7 +76853,7 @@ impl ::std::convert::From<SignalRef> for OnEventsItemVariant1Update {
         Self::Variant2(value)
     }
 }
-#[doc = "OnMarkTrigger"]
+#[doc = "`OnMarkTrigger`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76905,7 +76905,7 @@ impl ::std::convert::From<::std::vec::Vec<OnMarkTriggerItem>> for OnMarkTrigger 
         Self(value)
     }
 }
-#[doc = "OnMarkTriggerItem"]
+#[doc = "`OnMarkTriggerItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -76944,7 +76944,7 @@ impl ::std::convert::From<&OnMarkTriggerItem> for OnMarkTriggerItem {
         value.clone()
     }
 }
-#[doc = "OnTrigger"]
+#[doc = "`OnTrigger`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77012,7 +77012,7 @@ impl ::std::convert::From<::std::vec::Vec<OnTriggerItem>> for OnTrigger {
         Self(value)
     }
 }
-#[doc = "OnTriggerItem"]
+#[doc = "`OnTriggerItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77073,7 +77073,7 @@ impl ::std::convert::From<&OnTriggerItem> for OnTriggerItem {
         value.clone()
     }
 }
-#[doc = "OnTriggerItemRemove"]
+#[doc = "`OnTriggerItemRemove`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77153,7 +77153,7 @@ impl ::std::convert::From<ExprString> for OnTriggerItemRemove {
         Self::Variant1(value)
     }
 }
-#[doc = "OrientValue"]
+#[doc = "`OrientValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77361,7 +77361,7 @@ impl ::std::convert::From<OrientValueVariant1> for OrientValue {
         Self::Variant1(value)
     }
 }
-#[doc = "OrientValueVariant0Item"]
+#[doc = "`OrientValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77490,7 +77490,7 @@ impl ::std::convert::From<OrientValueVariant0ItemVariant2> for OrientValueVarian
         Self::Variant2(value)
     }
 }
-#[doc = "OrientValueVariant0ItemVariant0"]
+#[doc = "`OrientValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77627,7 +77627,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "OrientValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`OrientValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77717,7 +77717,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "OrientValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`OrientValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77801,7 +77801,7 @@ impl ::std::convert::From<bool> for OrientValueVariant0ItemVariant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "OrientValueVariant0ItemVariant1"]
+#[doc = "`OrientValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -77920,7 +77920,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "OrientValueVariant0ItemVariant2"]
+#[doc = "`OrientValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78039,7 +78039,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "OrientValueVariant1"]
+#[doc = "`OrientValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78157,7 +78157,7 @@ impl ::std::convert::From<OrientValueVariant1Variant2> for OrientValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "OrientValueVariant1Variant0"]
+#[doc = "`OrientValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78283,7 +78283,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "OrientValueVariant1Variant0Variant1Value"]
+#[doc = "`OrientValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78369,7 +78369,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Varia
         value.parse()
     }
 }
-#[doc = "OrientValueVariant1Variant0Variant3Range"]
+#[doc = "`OrientValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78449,7 +78449,7 @@ impl ::std::convert::From<bool> for OrientValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "OrientValueVariant1Variant1"]
+#[doc = "`OrientValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78565,7 +78565,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "OrientValueVariant1Variant2"]
+#[doc = "`OrientValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78681,7 +78681,7 @@ impl ::std::convert::From<&Self> for OrientValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "PackTransform"]
+#[doc = "`PackTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78820,7 +78820,7 @@ impl ::std::convert::From<&PackTransform> for PackTransform {
         value.clone()
     }
 }
-#[doc = "PackTransformAs"]
+#[doc = "`PackTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78888,7 +78888,7 @@ impl ::std::convert::From<SignalRef> for PackTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "PackTransformAsVariant0Item"]
+#[doc = "`PackTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78921,7 +78921,7 @@ impl ::std::convert::From<SignalRef> for PackTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "PackTransformField"]
+#[doc = "`PackTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78968,7 +78968,7 @@ impl ::std::convert::From<Expr> for PackTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "PackTransformPadding"]
+#[doc = "`PackTransformPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79006,7 +79006,7 @@ impl ::std::convert::From<SignalRef> for PackTransformPadding {
         Self::Variant1(value)
     }
 }
-#[doc = "PackTransformRadius"]
+#[doc = "`PackTransformRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79053,7 +79053,7 @@ impl ::std::convert::From<Expr> for PackTransformRadius {
         Self::Expr(value)
     }
 }
-#[doc = "PackTransformSize"]
+#[doc = "`PackTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79103,7 +79103,7 @@ impl ::std::convert::From<SignalRef> for PackTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "PackTransformSizeVariant0Item"]
+#[doc = "`PackTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79141,7 +79141,7 @@ impl ::std::convert::From<SignalRef> for PackTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "PackTransformType"]
+#[doc = "`PackTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79212,7 +79212,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PackTransformType {
         value.parse()
     }
 }
-#[doc = "Padding"]
+#[doc = "`Padding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79278,7 +79278,7 @@ impl ::std::convert::From<SignalRef> for Padding {
         Self::Variant2(value)
     }
 }
-#[doc = "ParamField"]
+#[doc = "`ParamField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79316,7 +79316,7 @@ impl ::std::convert::From<&ParamField> for ParamField {
         value.clone()
     }
 }
-#[doc = "PartitionTransform"]
+#[doc = "`PartitionTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79453,7 +79453,7 @@ impl ::std::convert::From<&PartitionTransform> for PartitionTransform {
         value.clone()
     }
 }
-#[doc = "PartitionTransformAs"]
+#[doc = "`PartitionTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79523,7 +79523,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformAsVariant0Item"]
+#[doc = "`PartitionTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79556,7 +79556,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformField"]
+#[doc = "`PartitionTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79603,7 +79603,7 @@ impl ::std::convert::From<Expr> for PartitionTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "PartitionTransformPadding"]
+#[doc = "`PartitionTransformPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79641,7 +79641,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformPadding {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformRound"]
+#[doc = "`PartitionTransformRound`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79679,7 +79679,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformRound {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformSize"]
+#[doc = "`PartitionTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79729,7 +79729,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformSizeVariant0Item"]
+#[doc = "`PartitionTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79767,7 +79767,7 @@ impl ::std::convert::From<SignalRef> for PartitionTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "PartitionTransformType"]
+#[doc = "`PartitionTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79838,7 +79838,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PartitionTransformType {
         value.parse()
     }
 }
-#[doc = "PieTransform"]
+#[doc = "`PieTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79959,7 +79959,7 @@ impl ::std::convert::From<&PieTransform> for PieTransform {
         value.clone()
     }
 }
-#[doc = "PieTransformAs"]
+#[doc = "`PieTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80021,7 +80021,7 @@ impl ::std::convert::From<SignalRef> for PieTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "PieTransformAsVariant0Item"]
+#[doc = "`PieTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80054,7 +80054,7 @@ impl ::std::convert::From<SignalRef> for PieTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "PieTransformEndAngle"]
+#[doc = "`PieTransformEndAngle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80098,7 +80098,7 @@ impl ::std::convert::From<SignalRef> for PieTransformEndAngle {
         Self::Variant1(value)
     }
 }
-#[doc = "PieTransformField"]
+#[doc = "`PieTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80145,7 +80145,7 @@ impl ::std::convert::From<Expr> for PieTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "PieTransformSort"]
+#[doc = "`PieTransformSort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80183,7 +80183,7 @@ impl ::std::convert::From<SignalRef> for PieTransformSort {
         Self::Variant1(value)
     }
 }
-#[doc = "PieTransformStartAngle"]
+#[doc = "`PieTransformStartAngle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80221,7 +80221,7 @@ impl ::std::convert::From<SignalRef> for PieTransformStartAngle {
         Self::Variant1(value)
     }
 }
-#[doc = "PieTransformType"]
+#[doc = "`PieTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80292,7 +80292,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PieTransformType {
         value.parse()
     }
 }
-#[doc = "PivotTransform"]
+#[doc = "`PivotTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80449,7 +80449,7 @@ impl ::std::convert::From<&PivotTransform> for PivotTransform {
         value.clone()
     }
 }
-#[doc = "PivotTransformField"]
+#[doc = "`PivotTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80496,7 +80496,7 @@ impl ::std::convert::From<Expr> for PivotTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "PivotTransformGroupby"]
+#[doc = "`PivotTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80549,7 +80549,7 @@ impl ::std::convert::From<SignalRef> for PivotTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "PivotTransformGroupbyVariant0Item"]
+#[doc = "`PivotTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80596,7 +80596,7 @@ impl ::std::convert::From<Expr> for PivotTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "PivotTransformKey"]
+#[doc = "`PivotTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80643,7 +80643,7 @@ impl ::std::convert::From<Expr> for PivotTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "PivotTransformLimit"]
+#[doc = "`PivotTransformLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80681,7 +80681,7 @@ impl ::std::convert::From<SignalRef> for PivotTransformLimit {
         Self::Variant1(value)
     }
 }
-#[doc = "PivotTransformOp"]
+#[doc = "`PivotTransformOp`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80750,7 +80750,7 @@ impl ::std::convert::From<SignalRef> for PivotTransformOp {
         Self::Variant1(value)
     }
 }
-#[doc = "PivotTransformOpVariant0"]
+#[doc = "`PivotTransformOpVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80936,7 +80936,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PivotTransformOpVariant0
         value.parse()
     }
 }
-#[doc = "PivotTransformType"]
+#[doc = "`PivotTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81007,7 +81007,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PivotTransformType {
         value.parse()
     }
 }
-#[doc = "PivotTransformValue"]
+#[doc = "`PivotTransformValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81054,7 +81054,7 @@ impl ::std::convert::From<Expr> for PivotTransformValue {
         Self::Expr(value)
     }
 }
-#[doc = "ProjectTransform"]
+#[doc = "`ProjectTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81145,7 +81145,7 @@ impl ::std::convert::From<&ProjectTransform> for ProjectTransform {
         value.clone()
     }
 }
-#[doc = "ProjectTransformAs"]
+#[doc = "`ProjectTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81196,7 +81196,7 @@ impl ::std::convert::From<SignalRef> for ProjectTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectTransformAsVariant0Item"]
+#[doc = "`ProjectTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81233,7 +81233,7 @@ impl ::std::convert::From<SignalRef> for ProjectTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectTransformFields"]
+#[doc = "`ProjectTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81286,7 +81286,7 @@ impl ::std::convert::From<SignalRef> for ProjectTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectTransformFieldsVariant0Item"]
+#[doc = "`ProjectTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81333,7 +81333,7 @@ impl ::std::convert::From<Expr> for ProjectTransformFieldsVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "ProjectTransformType"]
+#[doc = "`ProjectTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81404,7 +81404,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectTransformType {
         value.parse()
     }
 }
-#[doc = "Projection"]
+#[doc = "`Projection`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81628,7 +81628,7 @@ impl ::std::convert::From<&Projection> for Projection {
         value.clone()
     }
 }
-#[doc = "ProjectionCenter"]
+#[doc = "`ProjectionCenter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81671,7 +81671,7 @@ impl ::std::convert::From<SignalRef> for ProjectionCenter {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionClipExtent"]
+#[doc = "`ProjectionClipExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81726,7 +81726,7 @@ impl ::std::convert::From<SignalRef> for ProjectionClipExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionClipExtentVariant0Item"]
+#[doc = "`ProjectionClipExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81769,7 +81769,7 @@ impl ::std::convert::From<SignalRef> for ProjectionClipExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionExtent"]
+#[doc = "`ProjectionExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81824,7 +81824,7 @@ impl ::std::convert::From<SignalRef> for ProjectionExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionExtentVariant0Item"]
+#[doc = "`ProjectionExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81867,7 +81867,7 @@ impl ::std::convert::From<SignalRef> for ProjectionExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionFit"]
+#[doc = "`ProjectionFit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81907,7 +81907,7 @@ impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ProjectionFi
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionParallels"]
+#[doc = "`ProjectionParallels`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81950,7 +81950,7 @@ impl ::std::convert::From<SignalRef> for ProjectionParallels {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionRotate"]
+#[doc = "`ProjectionRotate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81993,7 +81993,7 @@ impl ::std::convert::From<SignalRef> for ProjectionRotate {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionSize"]
+#[doc = "`ProjectionSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82036,7 +82036,7 @@ impl ::std::convert::From<SignalRef> for ProjectionSize {
         Self::Variant1(value)
     }
 }
-#[doc = "ProjectionTranslate"]
+#[doc = "`ProjectionTranslate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82079,7 +82079,7 @@ impl ::std::convert::From<SignalRef> for ProjectionTranslate {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransform"]
+#[doc = "`QuantileTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82217,7 +82217,7 @@ impl ::std::convert::From<&QuantileTransform> for QuantileTransform {
         value.clone()
     }
 }
-#[doc = "QuantileTransformAs"]
+#[doc = "`QuantileTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82279,7 +82279,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformAsVariant0Item"]
+#[doc = "`QuantileTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82312,7 +82312,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformField"]
+#[doc = "`QuantileTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82359,7 +82359,7 @@ impl ::std::convert::From<Expr> for QuantileTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "QuantileTransformGroupby"]
+#[doc = "`QuantileTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82412,7 +82412,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformGroupbyVariant0Item"]
+#[doc = "`QuantileTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82459,7 +82459,7 @@ impl ::std::convert::From<Expr> for QuantileTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "QuantileTransformProbs"]
+#[doc = "`QuantileTransformProbs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82509,7 +82509,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformProbs {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformProbsVariant0Item"]
+#[doc = "`QuantileTransformProbsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82547,7 +82547,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformProbsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformStep"]
+#[doc = "`QuantileTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82591,7 +82591,7 @@ impl ::std::convert::From<SignalRef> for QuantileTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "QuantileTransformType"]
+#[doc = "`QuantileTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82662,7 +82662,7 @@ impl ::std::convert::TryFrom<::std::string::String> for QuantileTransformType {
         value.parse()
     }
 }
-#[doc = "RadialGradient"]
+#[doc = "`RadialGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82733,7 +82733,7 @@ impl ::std::convert::From<&RadialGradient> for RadialGradient {
         value.clone()
     }
 }
-#[doc = "RadialGradientGradient"]
+#[doc = "`RadialGradientGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82804,7 +82804,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RadialGradientGradient {
         value.parse()
     }
 }
-#[doc = "RegressionTransform"]
+#[doc = "`RegressionTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82984,7 +82984,7 @@ impl ::std::convert::From<&RegressionTransform> for RegressionTransform {
         value.clone()
     }
 }
-#[doc = "RegressionTransformAs"]
+#[doc = "`RegressionTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83034,7 +83034,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformAsVariant0Item"]
+#[doc = "`RegressionTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83067,7 +83067,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformExtent"]
+#[doc = "`RegressionTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83119,7 +83119,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformExtentVariant0Item"]
+#[doc = "`RegressionTransformExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83157,7 +83157,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformGroupby"]
+#[doc = "`RegressionTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83210,7 +83210,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformGroupbyVariant0Item"]
+#[doc = "`RegressionTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83257,7 +83257,7 @@ impl ::std::convert::From<Expr> for RegressionTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "RegressionTransformMethod"]
+#[doc = "`RegressionTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83296,7 +83296,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformOrder"]
+#[doc = "`RegressionTransformOrder`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83340,7 +83340,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformOrder {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformParams"]
+#[doc = "`RegressionTransformParams`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83378,7 +83378,7 @@ impl ::std::convert::From<SignalRef> for RegressionTransformParams {
         Self::Variant1(value)
     }
 }
-#[doc = "RegressionTransformType"]
+#[doc = "`RegressionTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83449,7 +83449,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RegressionTransformType 
         value.parse()
     }
 }
-#[doc = "RegressionTransformX"]
+#[doc = "`RegressionTransformX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83496,7 +83496,7 @@ impl ::std::convert::From<Expr> for RegressionTransformX {
         Self::Expr(value)
     }
 }
-#[doc = "RegressionTransformY"]
+#[doc = "`RegressionTransformY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83543,7 +83543,7 @@ impl ::std::convert::From<Expr> for RegressionTransformY {
         Self::Expr(value)
     }
 }
-#[doc = "ResolvefilterTransform"]
+#[doc = "`ResolvefilterTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83595,7 +83595,7 @@ impl ::std::convert::From<&ResolvefilterTransform> for ResolvefilterTransform {
         value.clone()
     }
 }
-#[doc = "ResolvefilterTransformIgnore"]
+#[doc = "`ResolvefilterTransformIgnore`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83633,7 +83633,7 @@ impl ::std::convert::From<SignalRef> for ResolvefilterTransformIgnore {
         Self::Variant1(value)
     }
 }
-#[doc = "ResolvefilterTransformType"]
+#[doc = "`ResolvefilterTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83704,7 +83704,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ResolvefilterTransformTy
         value.parse()
     }
 }
-#[doc = "Rule"]
+#[doc = "`Rule`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83736,7 +83736,7 @@ impl ::std::default::Default for Rule {
         }
     }
 }
-#[doc = "SampleTransform"]
+#[doc = "`SampleTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83786,7 +83786,7 @@ impl ::std::convert::From<&SampleTransform> for SampleTransform {
         value.clone()
     }
 }
-#[doc = "SampleTransformSize"]
+#[doc = "`SampleTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83830,7 +83830,7 @@ impl ::std::convert::From<SignalRef> for SampleTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "SampleTransformType"]
+#[doc = "`SampleTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83901,7 +83901,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SampleTransformType {
         value.parse()
     }
 }
-#[doc = "Scale"]
+#[doc = "`Scale`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86924,7 +86924,7 @@ impl ::std::convert::From<&Self> for Scale {
         value.clone()
     }
 }
-#[doc = "ScaleBins"]
+#[doc = "`ScaleBins`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -86990,7 +86990,7 @@ impl ::std::convert::From<SignalRef> for ScaleBins {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleData"]
+#[doc = "`ScaleData`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87225,7 +87225,7 @@ impl ::std::convert::From<&Self> for ScaleData {
         value.clone()
     }
 }
-#[doc = "ScaleDataVariant0Sort"]
+#[doc = "`ScaleDataVariant0Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87277,7 +87277,7 @@ impl ::std::convert::From<bool> for ScaleDataVariant0Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleDataVariant1Sort"]
+#[doc = "`ScaleDataVariant1Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87355,7 +87355,7 @@ impl ::std::convert::From<bool> for ScaleDataVariant1Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleDataVariant1SortVariant1Op"]
+#[doc = "`ScaleDataVariant1SortVariant1Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87426,7 +87426,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant1SortVar
         value.parse()
     }
 }
-#[doc = "ScaleDataVariant1SortVariant2Op"]
+#[doc = "`ScaleDataVariant1SortVariant2Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87507,7 +87507,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant1SortVar
         value.parse()
     }
 }
-#[doc = "ScaleDataVariant2FieldsItem"]
+#[doc = "`ScaleDataVariant2FieldsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87580,7 +87580,7 @@ impl ::std::convert::From<SignalRef> for ScaleDataVariant2FieldsItem {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleDataVariant2FieldsItemVariant1Item"]
+#[doc = "`ScaleDataVariant2FieldsItemVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87667,7 +87667,7 @@ impl ::std::convert::From<bool> for ScaleDataVariant2FieldsItemVariant1Item {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleDataVariant2Sort"]
+#[doc = "`ScaleDataVariant2Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87745,7 +87745,7 @@ impl ::std::convert::From<bool> for ScaleDataVariant2Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleDataVariant2SortVariant1Op"]
+#[doc = "`ScaleDataVariant2SortVariant1Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87816,7 +87816,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant2SortVar
         value.parse()
     }
 }
-#[doc = "ScaleDataVariant2SortVariant2Op"]
+#[doc = "`ScaleDataVariant2SortVariant2Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87897,7 +87897,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant2SortVar
         value.parse()
     }
 }
-#[doc = "ScaleField"]
+#[doc = "`ScaleField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87931,7 +87931,7 @@ impl ::std::convert::From<StringOrSignal> for ScaleField {
         Self(value)
     }
 }
-#[doc = "ScaleInterpolate"]
+#[doc = "`ScaleInterpolate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87985,7 +87985,7 @@ impl ::std::convert::From<SignalRef> for ScaleInterpolate {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant0Domain"]
+#[doc = "`ScaleVariant0Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88059,7 +88059,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant0Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant0DomainRaw"]
+#[doc = "`ScaleVariant0DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88101,7 +88101,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant0DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant0DomainVariant0Item"]
+#[doc = "`ScaleVariant0DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88168,7 +88168,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant0Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant0Type"]
+#[doc = "`ScaleVariant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88239,7 +88239,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant0Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant10Domain"]
+#[doc = "`ScaleVariant10Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88313,7 +88313,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant10DomainRaw"]
+#[doc = "`ScaleVariant10DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88355,7 +88355,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant10DomainVariant0Item"]
+#[doc = "`ScaleVariant10DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88422,7 +88422,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10Dom
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant10Nice"]
+#[doc = "`ScaleVariant10Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88469,7 +88469,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10Nice {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant10Range"]
+#[doc = "`ScaleVariant10Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88609,7 +88609,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant10RangeVariant0"]
+#[doc = "`ScaleVariant10RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88715,7 +88715,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant10RangeVaria
         value.parse()
     }
 }
-#[doc = "ScaleVariant10RangeVariant1Item"]
+#[doc = "`ScaleVariant10RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88782,7 +88782,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10Ran
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant10RangeVariant2Extent"]
+#[doc = "`ScaleVariant10RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88825,7 +88825,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant10RangeVariant2Scheme"]
+#[doc = "`ScaleVariant10RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88879,7 +88879,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant10RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant10RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88912,7 +88912,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2SchemeVarian
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant10Type"]
+#[doc = "`ScaleVariant10Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88983,7 +88983,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant10Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant11Domain"]
+#[doc = "`ScaleVariant11Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89057,7 +89057,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant11DomainRaw"]
+#[doc = "`ScaleVariant11DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89099,7 +89099,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant11DomainVariant0Item"]
+#[doc = "`ScaleVariant11DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89166,7 +89166,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11Dom
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant11Nice"]
+#[doc = "`ScaleVariant11Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89213,7 +89213,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11Nice {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant11Range"]
+#[doc = "`ScaleVariant11Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89353,7 +89353,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant11RangeVariant0"]
+#[doc = "`ScaleVariant11RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89459,7 +89459,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant11RangeVaria
         value.parse()
     }
 }
-#[doc = "ScaleVariant11RangeVariant1Item"]
+#[doc = "`ScaleVariant11RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89526,7 +89526,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11Ran
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant11RangeVariant2Extent"]
+#[doc = "`ScaleVariant11RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89569,7 +89569,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant11RangeVariant2Scheme"]
+#[doc = "`ScaleVariant11RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89623,7 +89623,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant11RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant11RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89656,7 +89656,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2SchemeVarian
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant11Type"]
+#[doc = "`ScaleVariant11Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89727,7 +89727,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant11Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant1Domain"]
+#[doc = "`ScaleVariant1Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89801,7 +89801,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant1DomainRaw"]
+#[doc = "`ScaleVariant1DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89843,7 +89843,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant1DomainVariant0Item"]
+#[doc = "`ScaleVariant1DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89910,7 +89910,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant1Range"]
+#[doc = "`ScaleVariant1Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90256,7 +90256,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1Range {
         Self::Variant4(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant0"]
+#[doc = "`ScaleVariant1RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90362,7 +90362,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant1RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant1RangeVariant1Item"]
+#[doc = "`ScaleVariant1RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90429,7 +90429,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant2Extent"]
+#[doc = "`ScaleVariant1RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90472,7 +90472,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant2Scheme"]
+#[doc = "`ScaleVariant1RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90526,7 +90526,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant1RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90559,7 +90559,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3"]
+#[doc = "`ScaleVariant1RangeVariant3`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90794,7 +90794,7 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3 {
         value.clone()
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant0Sort"]
+#[doc = "`ScaleVariant1RangeVariant3Variant0Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90846,7 +90846,7 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant1Sort"]
+#[doc = "`ScaleVariant1RangeVariant3Variant1Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90924,7 +90924,7 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant1Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant1SortVariant1Op"]
+#[doc = "`ScaleVariant1RangeVariant3Variant1SortVariant1Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90999,7 +90999,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant1SortVariant2Op"]
+#[doc = "`ScaleVariant1RangeVariant3Variant1SortVariant2Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91084,7 +91084,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant2FieldsItem"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2FieldsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91159,7 +91159,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant3Variant2Field
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91250,7 +91250,7 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItem
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant2Sort"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91328,7 +91328,7 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2Sort {
         Self::Variant0(value)
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant2SortVariant1Op"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2SortVariant1Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91403,7 +91403,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "ScaleVariant1RangeVariant3Variant2SortVariant2Op"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2SortVariant2Op`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91488,7 +91488,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "ScaleVariant1Type"]
+#[doc = "`ScaleVariant1Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91559,7 +91559,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant1Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant2Domain"]
+#[doc = "`ScaleVariant2Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91633,7 +91633,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant2Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant2DomainRaw"]
+#[doc = "`ScaleVariant2DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91675,7 +91675,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant2DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant2DomainVariant0Item"]
+#[doc = "`ScaleVariant2DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91742,7 +91742,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant2Range"]
+#[doc = "`ScaleVariant2Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91836,7 +91836,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant2Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant2RangeVariant0"]
+#[doc = "`ScaleVariant2RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91942,7 +91942,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant2RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant2RangeVariant1Item"]
+#[doc = "`ScaleVariant2RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92009,7 +92009,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant2Type"]
+#[doc = "`ScaleVariant2Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92080,7 +92080,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant2Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant3Domain"]
+#[doc = "`ScaleVariant3Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92154,7 +92154,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant3Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant3DomainRaw"]
+#[doc = "`ScaleVariant3DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92196,7 +92196,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant3DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant3DomainVariant0Item"]
+#[doc = "`ScaleVariant3DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92263,7 +92263,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant3Range"]
+#[doc = "`ScaleVariant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92357,7 +92357,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant3Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant3RangeVariant0"]
+#[doc = "`ScaleVariant3RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92463,7 +92463,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant3RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant3RangeVariant1Item"]
+#[doc = "`ScaleVariant3RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92530,7 +92530,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant3Type"]
+#[doc = "`ScaleVariant3Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92601,7 +92601,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant3Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant4Domain"]
+#[doc = "`ScaleVariant4Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92675,7 +92675,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant4DomainRaw"]
+#[doc = "`ScaleVariant4DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92717,7 +92717,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant4DomainVariant0Item"]
+#[doc = "`ScaleVariant4DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92784,7 +92784,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant4Nice"]
+#[doc = "`ScaleVariant4Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92831,7 +92831,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4Nice {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant4Range"]
+#[doc = "`ScaleVariant4Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92969,7 +92969,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant4RangeVariant0"]
+#[doc = "`ScaleVariant4RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93075,7 +93075,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant4RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant4RangeVariant1Item"]
+#[doc = "`ScaleVariant4RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93142,7 +93142,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant4RangeVariant2Extent"]
+#[doc = "`ScaleVariant4RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93185,7 +93185,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant4RangeVariant2Scheme"]
+#[doc = "`ScaleVariant4RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93239,7 +93239,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant4RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant4RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93272,7 +93272,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant4Type"]
+#[doc = "`ScaleVariant4Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93348,7 +93348,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant4Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant5Domain"]
+#[doc = "`ScaleVariant5Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93422,7 +93422,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant5DomainRaw"]
+#[doc = "`ScaleVariant5DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93464,7 +93464,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant5DomainVariant0Item"]
+#[doc = "`ScaleVariant5DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93531,7 +93531,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant5Range"]
+#[doc = "`ScaleVariant5Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93669,7 +93669,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant5RangeVariant0"]
+#[doc = "`ScaleVariant5RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93775,7 +93775,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant5RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant5RangeVariant1Item"]
+#[doc = "`ScaleVariant5RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93842,7 +93842,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant5RangeVariant2Extent"]
+#[doc = "`ScaleVariant5RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93885,7 +93885,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant5RangeVariant2Scheme"]
+#[doc = "`ScaleVariant5RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93939,7 +93939,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant5RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant5RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93972,7 +93972,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant5Type"]
+#[doc = "`ScaleVariant5Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94043,7 +94043,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant5Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant6Domain"]
+#[doc = "`ScaleVariant6Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94117,7 +94117,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant6DomainRaw"]
+#[doc = "`ScaleVariant6DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94159,7 +94159,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant6DomainVariant0Item"]
+#[doc = "`ScaleVariant6DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94226,7 +94226,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant6Range"]
+#[doc = "`ScaleVariant6Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94364,7 +94364,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant6RangeVariant0"]
+#[doc = "`ScaleVariant6RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94470,7 +94470,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant6RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant6RangeVariant1Item"]
+#[doc = "`ScaleVariant6RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94537,7 +94537,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant6RangeVariant2Extent"]
+#[doc = "`ScaleVariant6RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94580,7 +94580,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant6RangeVariant2Scheme"]
+#[doc = "`ScaleVariant6RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94634,7 +94634,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant6RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant6RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94667,7 +94667,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant6Type"]
+#[doc = "`ScaleVariant6Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94738,7 +94738,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant6Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant7Domain"]
+#[doc = "`ScaleVariant7Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94812,7 +94812,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant7DomainRaw"]
+#[doc = "`ScaleVariant7DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94854,7 +94854,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant7DomainVariant0Item"]
+#[doc = "`ScaleVariant7DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94921,7 +94921,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant7Nice"]
+#[doc = "`ScaleVariant7Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95004,7 +95004,7 @@ impl ::std::convert::From<ScaleVariant7NiceVariant1> for ScaleVariant7Nice {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant7NiceVariant1"]
+#[doc = "`ScaleVariant7NiceVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95110,7 +95110,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7NiceVariant
         value.parse()
     }
 }
-#[doc = "ScaleVariant7NiceVariant2Interval"]
+#[doc = "`ScaleVariant7NiceVariant2Interval`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95159,7 +95159,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7NiceVariant2Interval {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant7NiceVariant2IntervalVariant0"]
+#[doc = "`ScaleVariant7NiceVariant2IntervalVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95265,7 +95265,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7NiceVariant
         value.parse()
     }
 }
-#[doc = "ScaleVariant7Range"]
+#[doc = "`ScaleVariant7Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95403,7 +95403,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant7RangeVariant0"]
+#[doc = "`ScaleVariant7RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95509,7 +95509,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant7RangeVariant1Item"]
+#[doc = "`ScaleVariant7RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95576,7 +95576,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant7RangeVariant2Extent"]
+#[doc = "`ScaleVariant7RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95619,7 +95619,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant7RangeVariant2Scheme"]
+#[doc = "`ScaleVariant7RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95673,7 +95673,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant7RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant7RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95706,7 +95706,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant7Type"]
+#[doc = "`ScaleVariant7Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95782,7 +95782,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant8Domain"]
+#[doc = "`ScaleVariant8Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95856,7 +95856,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant8DomainRaw"]
+#[doc = "`ScaleVariant8DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95898,7 +95898,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant8DomainVariant0Item"]
+#[doc = "`ScaleVariant8DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95965,7 +95965,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant8Nice"]
+#[doc = "`ScaleVariant8Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96012,7 +96012,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8Nice {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant8Range"]
+#[doc = "`ScaleVariant8Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96150,7 +96150,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant8RangeVariant0"]
+#[doc = "`ScaleVariant8RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96256,7 +96256,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant8RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant8RangeVariant1Item"]
+#[doc = "`ScaleVariant8RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96323,7 +96323,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant8RangeVariant2Extent"]
+#[doc = "`ScaleVariant8RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96366,7 +96366,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant8RangeVariant2Scheme"]
+#[doc = "`ScaleVariant8RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96420,7 +96420,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant8RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant8RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96453,7 +96453,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant8Type"]
+#[doc = "`ScaleVariant8Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96534,7 +96534,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant8Type {
         value.parse()
     }
 }
-#[doc = "ScaleVariant9Domain"]
+#[doc = "`ScaleVariant9Domain`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96608,7 +96608,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9Domain {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant9DomainRaw"]
+#[doc = "`ScaleVariant9DomainRaw`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96650,7 +96650,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9DomainRaw {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant9DomainVariant0Item"]
+#[doc = "`ScaleVariant9DomainVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96717,7 +96717,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9Doma
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant9Nice"]
+#[doc = "`ScaleVariant9Nice`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96764,7 +96764,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9Nice {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant9Range"]
+#[doc = "`ScaleVariant9Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96902,7 +96902,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9Range {
         Self::Variant3(value)
     }
 }
-#[doc = "ScaleVariant9RangeVariant0"]
+#[doc = "`ScaleVariant9RangeVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97008,7 +97008,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant9RangeVarian
         value.parse()
     }
 }
-#[doc = "ScaleVariant9RangeVariant1Item"]
+#[doc = "`ScaleVariant9RangeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97075,7 +97075,7 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9Rang
         Self::Variant5(value)
     }
 }
-#[doc = "ScaleVariant9RangeVariant2Extent"]
+#[doc = "`ScaleVariant9RangeVariant2Extent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97118,7 +97118,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Extent {
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant9RangeVariant2Scheme"]
+#[doc = "`ScaleVariant9RangeVariant2Scheme`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97172,7 +97172,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Scheme {
         Self::Variant2(value)
     }
 }
-#[doc = "ScaleVariant9RangeVariant2SchemeVariant1Item"]
+#[doc = "`ScaleVariant9RangeVariant2SchemeVariant1Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97205,7 +97205,7 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2SchemeVariant
         Self::Variant1(value)
     }
 }
-#[doc = "ScaleVariant9Type"]
+#[doc = "`ScaleVariant9Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97276,7 +97276,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant9Type {
         value.parse()
     }
 }
-#[doc = "Scope"]
+#[doc = "`Scope`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97396,7 +97396,7 @@ impl ::std::default::Default for Scope {
         }
     }
 }
-#[doc = "ScopeMarksItem"]
+#[doc = "`ScopeMarksItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97434,7 +97434,7 @@ impl ::std::convert::From<MarkVisual> for ScopeMarksItem {
         Self::Visual(value)
     }
 }
-#[doc = "Selector"]
+#[doc = "`Selector`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97489,7 +97489,7 @@ impl ::std::fmt::Display for Selector {
         self.0.fmt(f)
     }
 }
-#[doc = "SequenceTransform"]
+#[doc = "`SequenceTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97576,7 +97576,7 @@ impl ::std::convert::From<&SequenceTransform> for SequenceTransform {
         value.clone()
     }
 }
-#[doc = "SequenceTransformAs"]
+#[doc = "`SequenceTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97615,7 +97615,7 @@ impl ::std::convert::From<SignalRef> for SequenceTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "SequenceTransformStart"]
+#[doc = "`SequenceTransformStart`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97653,7 +97653,7 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStart {
         Self::Variant1(value)
     }
 }
-#[doc = "SequenceTransformStep"]
+#[doc = "`SequenceTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97697,7 +97697,7 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "SequenceTransformStop"]
+#[doc = "`SequenceTransformStop`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97735,7 +97735,7 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStop {
         Self::Variant1(value)
     }
 }
-#[doc = "SequenceTransformType"]
+#[doc = "`SequenceTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97806,7 +97806,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SequenceTransformType {
         value.parse()
     }
 }
-#[doc = "Signal"]
+#[doc = "`Signal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97940,7 +97940,7 @@ impl ::std::convert::From<&Self> for Signal {
         value.clone()
     }
 }
-#[doc = "SignalName"]
+#[doc = "`SignalName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98005,7 +98005,7 @@ impl<'de> ::serde::Deserialize<'de> for SignalName {
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "SignalRef"]
+#[doc = "`SignalRef`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98032,7 +98032,7 @@ impl ::std::convert::From<&SignalRef> for SignalRef {
         value.clone()
     }
 }
-#[doc = "SignalVariant0Push"]
+#[doc = "`SignalVariant0Push`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98103,7 +98103,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SignalVariant0Push {
         value.parse()
     }
 }
-#[doc = "SortOrder"]
+#[doc = "`SortOrder`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98144,7 +98144,7 @@ impl ::std::convert::From<SignalRef> for SortOrder {
         Self::Variant1(value)
     }
 }
-#[doc = "SortOrderVariant0"]
+#[doc = "`SortOrderVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98220,7 +98220,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SortOrderVariant0 {
         value.parse()
     }
 }
-#[doc = "StackTransform"]
+#[doc = "`StackTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98347,7 +98347,7 @@ impl ::std::convert::From<&StackTransform> for StackTransform {
         value.clone()
     }
 }
-#[doc = "StackTransformAs"]
+#[doc = "`StackTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98409,7 +98409,7 @@ impl ::std::convert::From<SignalRef> for StackTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "StackTransformAsVariant0Item"]
+#[doc = "`StackTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98442,7 +98442,7 @@ impl ::std::convert::From<SignalRef> for StackTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "StackTransformField"]
+#[doc = "`StackTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98489,7 +98489,7 @@ impl ::std::convert::From<Expr> for StackTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "StackTransformGroupby"]
+#[doc = "`StackTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98542,7 +98542,7 @@ impl ::std::convert::From<SignalRef> for StackTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "StackTransformGroupbyVariant0Item"]
+#[doc = "`StackTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98589,7 +98589,7 @@ impl ::std::convert::From<Expr> for StackTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "StackTransformOffset"]
+#[doc = "`StackTransformOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98637,7 +98637,7 @@ impl ::std::convert::From<SignalRef> for StackTransformOffset {
         Self::Variant1(value)
     }
 }
-#[doc = "StackTransformOffsetVariant0"]
+#[doc = "`StackTransformOffsetVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98718,7 +98718,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StackTransformOffsetVari
         value.parse()
     }
 }
-#[doc = "StackTransformType"]
+#[doc = "`StackTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98789,7 +98789,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StackTransformType {
         value.parse()
     }
 }
-#[doc = "StratifyTransform"]
+#[doc = "`StratifyTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98857,7 +98857,7 @@ impl ::std::convert::From<&StratifyTransform> for StratifyTransform {
         value.clone()
     }
 }
-#[doc = "StratifyTransformKey"]
+#[doc = "`StratifyTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98904,7 +98904,7 @@ impl ::std::convert::From<Expr> for StratifyTransformKey {
         Self::Expr(value)
     }
 }
-#[doc = "StratifyTransformParentKey"]
+#[doc = "`StratifyTransformParentKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98951,7 +98951,7 @@ impl ::std::convert::From<Expr> for StratifyTransformParentKey {
         Self::Expr(value)
     }
 }
-#[doc = "StratifyTransformType"]
+#[doc = "`StratifyTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99022,7 +99022,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StratifyTransformType {
         value.parse()
     }
 }
-#[doc = "Stream"]
+#[doc = "`Stream`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99182,7 +99182,7 @@ impl ::std::convert::From<&Self> for Stream {
         value.clone()
     }
 }
-#[doc = "StreamVariant0Filter"]
+#[doc = "`StreamVariant0Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99224,7 +99224,7 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant0Filter 
         Self::Variant1(value)
     }
 }
-#[doc = "StreamVariant1Filter"]
+#[doc = "`StreamVariant1Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99266,7 +99266,7 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant1Filter 
         Self::Variant1(value)
     }
 }
-#[doc = "StreamVariant2Filter"]
+#[doc = "`StreamVariant2Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99308,7 +99308,7 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant2Filter 
         Self::Variant1(value)
     }
 }
-#[doc = "StringModifiers"]
+#[doc = "`StringModifiers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99340,7 +99340,7 @@ impl ::std::default::Default for StringModifiers {
         }
     }
 }
-#[doc = "StringOrSignal"]
+#[doc = "`StringOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99373,7 +99373,7 @@ impl ::std::convert::From<SignalRef> for StringOrSignal {
         Self::Variant1(value)
     }
 }
-#[doc = "StringValue"]
+#[doc = "`StringValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99571,7 +99571,7 @@ impl ::std::convert::From<StringValueVariant1> for StringValue {
         Self::Variant1(value)
     }
 }
-#[doc = "StringValueVariant0Item"]
+#[doc = "`StringValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99695,7 +99695,7 @@ impl ::std::convert::From<StringValueVariant0ItemVariant2> for StringValueVarian
         Self::Variant2(value)
     }
 }
-#[doc = "StringValueVariant0ItemVariant0"]
+#[doc = "`StringValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99827,7 +99827,7 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "StringValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`StringValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -99911,7 +99911,7 @@ impl ::std::convert::From<bool> for StringValueVariant0ItemVariant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "StringValueVariant0ItemVariant1"]
+#[doc = "`StringValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100025,7 +100025,7 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "StringValueVariant0ItemVariant2"]
+#[doc = "`StringValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100139,7 +100139,7 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "StringValueVariant1"]
+#[doc = "`StringValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100252,7 +100252,7 @@ impl ::std::convert::From<StringValueVariant1Variant2> for StringValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "StringValueVariant1Variant0"]
+#[doc = "`StringValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100373,7 +100373,7 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "StringValueVariant1Variant0Variant3Range"]
+#[doc = "`StringValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100453,7 +100453,7 @@ impl ::std::convert::From<bool> for StringValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "StringValueVariant1Variant1"]
+#[doc = "`StringValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100564,7 +100564,7 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "StringValueVariant1Variant2"]
+#[doc = "`StringValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100675,7 +100675,7 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValue"]
+#[doc = "`StrokeCapValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -100881,7 +100881,7 @@ impl ::std::convert::From<StrokeCapValueVariant1> for StrokeCapValue {
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeCapValueVariant0Item"]
+#[doc = "`StrokeCapValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101009,7 +101009,7 @@ impl ::std::convert::From<StrokeCapValueVariant0ItemVariant2> for StrokeCapValue
         Self::Variant2(value)
     }
 }
-#[doc = "StrokeCapValueVariant0ItemVariant0"]
+#[doc = "`StrokeCapValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101145,7 +101145,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`StrokeCapValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101230,7 +101230,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "StrokeCapValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`StrokeCapValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101314,7 +101314,7 @@ impl ::std::convert::From<bool> for StrokeCapValueVariant0ItemVariant0Variant3Ra
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeCapValueVariant0ItemVariant1"]
+#[doc = "`StrokeCapValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101432,7 +101432,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValueVariant0ItemVariant2"]
+#[doc = "`StrokeCapValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101550,7 +101550,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValueVariant1"]
+#[doc = "`StrokeCapValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101667,7 +101667,7 @@ impl ::std::convert::From<StrokeCapValueVariant1Variant2> for StrokeCapValueVari
         Self::Variant2(value)
     }
 }
-#[doc = "StrokeCapValueVariant1Variant0"]
+#[doc = "`StrokeCapValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101792,7 +101792,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValueVariant1Variant0Variant1Value"]
+#[doc = "`StrokeCapValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101877,7 +101877,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "StrokeCapValueVariant1Variant0Variant3Range"]
+#[doc = "`StrokeCapValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -101961,7 +101961,7 @@ impl ::std::convert::From<bool> for StrokeCapValueVariant1Variant0Variant3Range 
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeCapValueVariant1Variant1"]
+#[doc = "`StrokeCapValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102076,7 +102076,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "StrokeCapValueVariant1Variant2"]
+#[doc = "`StrokeCapValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102191,7 +102191,7 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValue"]
+#[doc = "`StrokeJoinValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102397,7 +102397,7 @@ impl ::std::convert::From<StrokeJoinValueVariant1> for StrokeJoinValue {
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeJoinValueVariant0Item"]
+#[doc = "`StrokeJoinValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102525,7 +102525,7 @@ impl ::std::convert::From<StrokeJoinValueVariant0ItemVariant2> for StrokeJoinVal
         Self::Variant2(value)
     }
 }
-#[doc = "StrokeJoinValueVariant0ItemVariant0"]
+#[doc = "`StrokeJoinValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102661,7 +102661,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`StrokeJoinValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102746,7 +102746,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "StrokeJoinValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`StrokeJoinValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102830,7 +102830,7 @@ impl ::std::convert::From<bool> for StrokeJoinValueVariant0ItemVariant0Variant3R
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeJoinValueVariant0ItemVariant1"]
+#[doc = "`StrokeJoinValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -102948,7 +102948,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValueVariant0ItemVariant2"]
+#[doc = "`StrokeJoinValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103066,7 +103066,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValueVariant1"]
+#[doc = "`StrokeJoinValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103183,7 +103183,7 @@ impl ::std::convert::From<StrokeJoinValueVariant1Variant2> for StrokeJoinValueVa
         Self::Variant2(value)
     }
 }
-#[doc = "StrokeJoinValueVariant1Variant0"]
+#[doc = "`StrokeJoinValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103308,7 +103308,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValueVariant1Variant0Variant1Value"]
+#[doc = "`StrokeJoinValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103393,7 +103393,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "StrokeJoinValueVariant1Variant0Variant3Range"]
+#[doc = "`StrokeJoinValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103477,7 +103477,7 @@ impl ::std::convert::From<bool> for StrokeJoinValueVariant1Variant0Variant3Range
         Self::Variant1(value)
     }
 }
-#[doc = "StrokeJoinValueVariant1Variant1"]
+#[doc = "`StrokeJoinValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103592,7 +103592,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "StrokeJoinValueVariant1Variant2"]
+#[doc = "`StrokeJoinValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103707,7 +103707,7 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "Style"]
+#[doc = "`Style`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103743,7 +103743,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for Style {
         Self::Variant1(value)
     }
 }
-#[doc = "TextOrSignal"]
+#[doc = "`TextOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103791,7 +103791,7 @@ impl ::std::convert::From<SignalRef> for TextOrSignal {
         Self::Variant1(value)
     }
 }
-#[doc = "TextOrSignalVariant0"]
+#[doc = "`TextOrSignalVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -103827,7 +103827,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for TextOrSign
         Self::Variant1(value)
     }
 }
-#[doc = "TextValue"]
+#[doc = "`TextValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104045,7 +104045,7 @@ impl ::std::convert::From<TextValueVariant1> for TextValue {
         Self::Variant1(value)
     }
 }
-#[doc = "TextValueVariant0Item"]
+#[doc = "`TextValueVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104179,7 +104179,7 @@ impl ::std::convert::From<TextValueVariant0ItemVariant2> for TextValueVariant0It
         Self::Variant2(value)
     }
 }
-#[doc = "TextValueVariant0ItemVariant0"]
+#[doc = "`TextValueVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104321,7 +104321,7 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0 {
         value.clone()
     }
 }
-#[doc = "TextValueVariant0ItemVariant0Variant1Value"]
+#[doc = "`TextValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104359,7 +104359,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
         Self::Variant1(value)
     }
 }
-#[doc = "TextValueVariant0ItemVariant0Variant3Range"]
+#[doc = "`TextValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104441,7 +104441,7 @@ impl ::std::convert::From<bool> for TextValueVariant0ItemVariant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "TextValueVariant0ItemVariant1"]
+#[doc = "`TextValueVariant0ItemVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104565,7 +104565,7 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant1 {
         value.clone()
     }
 }
-#[doc = "TextValueVariant0ItemVariant2"]
+#[doc = "`TextValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104689,7 +104689,7 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant2 {
         value.clone()
     }
 }
-#[doc = "TextValueVariant1"]
+#[doc = "`TextValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104812,7 +104812,7 @@ impl ::std::convert::From<TextValueVariant1Variant2> for TextValueVariant1 {
         Self::Variant2(value)
     }
 }
-#[doc = "TextValueVariant1Variant0"]
+#[doc = "`TextValueVariant1Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104943,7 +104943,7 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant0 {
         value.clone()
     }
 }
-#[doc = "TextValueVariant1Variant0Variant1Value"]
+#[doc = "`TextValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -104981,7 +104981,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
         Self::Variant1(value)
     }
 }
-#[doc = "TextValueVariant1Variant0Variant3Range"]
+#[doc = "`TextValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105061,7 +105061,7 @@ impl ::std::convert::From<bool> for TextValueVariant1Variant0Variant3Range {
         Self::Variant1(value)
     }
 }
-#[doc = "TextValueVariant1Variant1"]
+#[doc = "`TextValueVariant1Variant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105182,7 +105182,7 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant1 {
         value.clone()
     }
 }
-#[doc = "TextValueVariant1Variant2"]
+#[doc = "`TextValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105303,7 +105303,7 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant2 {
         value.clone()
     }
 }
-#[doc = "TickBand"]
+#[doc = "`TickBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105344,7 +105344,7 @@ impl ::std::convert::From<SignalRef> for TickBand {
         Self::Variant1(value)
     }
 }
-#[doc = "TickBandVariant0"]
+#[doc = "`TickBandVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105420,7 +105420,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TickBandVariant0 {
         value.parse()
     }
 }
-#[doc = "TickCount"]
+#[doc = "`TickCount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105512,7 +105512,7 @@ impl ::std::convert::From<SignalRef> for TickCount {
         Self::Variant3(value)
     }
 }
-#[doc = "TickCountVariant1"]
+#[doc = "`TickCountVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105618,7 +105618,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TickCountVariant1 {
         value.parse()
     }
 }
-#[doc = "TickCountVariant2Interval"]
+#[doc = "`TickCountVariant2Interval`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105665,7 +105665,7 @@ impl ::std::convert::From<SignalRef> for TickCountVariant2Interval {
         Self::Variant1(value)
     }
 }
-#[doc = "TickCountVariant2IntervalVariant0"]
+#[doc = "`TickCountVariant2IntervalVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105771,7 +105771,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TickCountVariant2Interva
         value.parse()
     }
 }
-#[doc = "TimeunitTransform"]
+#[doc = "`TimeunitTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105962,7 +105962,7 @@ impl ::std::convert::From<&TimeunitTransform> for TimeunitTransform {
         value.clone()
     }
 }
-#[doc = "TimeunitTransformAs"]
+#[doc = "`TimeunitTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106024,7 +106024,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformAsVariant0Item"]
+#[doc = "`TimeunitTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106057,7 +106057,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformExtent"]
+#[doc = "`TimeunitTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106107,7 +106107,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformExtentVariant0Item"]
+#[doc = "`TimeunitTransformExtentVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106145,7 +106145,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformExtentVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformField"]
+#[doc = "`TimeunitTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106192,7 +106192,7 @@ impl ::std::convert::From<Expr> for TimeunitTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "TimeunitTransformInterval"]
+#[doc = "`TimeunitTransformInterval`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106236,7 +106236,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformInterval {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformMaxbins"]
+#[doc = "`TimeunitTransformMaxbins`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106280,7 +106280,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformMaxbins {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformStep"]
+#[doc = "`TimeunitTransformStep`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106324,7 +106324,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformStep {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformTimezone"]
+#[doc = "`TimeunitTransformTimezone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106371,7 +106371,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformTimezone {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformTimezoneVariant0"]
+#[doc = "`TimeunitTransformTimezoneVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106447,7 +106447,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformTimezon
         value.parse()
     }
 }
-#[doc = "TimeunitTransformType"]
+#[doc = "`TimeunitTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106518,7 +106518,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformType {
         value.parse()
     }
 }
-#[doc = "TimeunitTransformUnits"]
+#[doc = "`TimeunitTransformUnits`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106580,7 +106580,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformUnits {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformUnitsVariant0Item"]
+#[doc = "`TimeunitTransformUnitsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106632,7 +106632,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformUnitsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TimeunitTransformUnitsVariant0ItemVariant0"]
+#[doc = "`TimeunitTransformUnitsVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106755,7 +106755,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformUnitsVa
         value.parse()
     }
 }
-#[doc = "Title"]
+#[doc = "`Title`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107245,7 +107245,7 @@ impl ::std::convert::From<&Self> for Title {
         value.clone()
     }
 }
-#[doc = "TitleVariant1Align"]
+#[doc = "`TitleVariant1Align`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107287,7 +107287,7 @@ impl ::std::convert::From<AlignValue> for TitleVariant1Align {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1AlignVariant0"]
+#[doc = "`TitleVariant1AlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107368,7 +107368,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AlignVarian
         value.parse()
     }
 }
-#[doc = "TitleVariant1Anchor"]
+#[doc = "`TitleVariant1Anchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107413,7 +107413,7 @@ impl ::std::convert::From<AnchorValue> for TitleVariant1Anchor {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1AnchorVariant0"]
+#[doc = "`TitleVariant1AnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107495,7 +107495,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AnchorVaria
         value.parse()
     }
 }
-#[doc = "TitleVariant1Angle"]
+#[doc = "`TitleVariant1Angle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107533,7 +107533,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Angle {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Baseline"]
+#[doc = "`TitleVariant1Baseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107578,7 +107578,7 @@ impl ::std::convert::From<BaselineValue> for TitleVariant1Baseline {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1BaselineVariant0"]
+#[doc = "`TitleVariant1BaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107674,7 +107674,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1BaselineVar
         value.parse()
     }
 }
-#[doc = "TitleVariant1Color"]
+#[doc = "`TitleVariant1Color`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107711,7 +107711,7 @@ impl ::std::convert::From<ColorValue> for TitleVariant1Color {
         Self::Variant2(value)
     }
 }
-#[doc = "TitleVariant1Dx"]
+#[doc = "`TitleVariant1Dx`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107749,7 +107749,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Dx {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Dy"]
+#[doc = "`TitleVariant1Dy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107787,7 +107787,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Dy {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Encode"]
+#[doc = "`TitleVariant1Encode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107852,7 +107852,7 @@ impl ::std::default::Default for TitleVariant1Encode {
         }
     }
 }
-#[doc = "TitleVariant1EncodeSubtype0Key"]
+#[doc = "`TitleVariant1EncodeSubtype0Key`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107929,7 +107929,7 @@ impl<'de> ::serde::Deserialize<'de> for TitleVariant1EncodeSubtype0Key {
             })
     }
 }
-#[doc = "TitleVariant1EncodeSubtype1"]
+#[doc = "`TitleVariant1EncodeSubtype1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107975,7 +107975,7 @@ impl ::std::default::Default for TitleVariant1EncodeSubtype1 {
         }
     }
 }
-#[doc = "TitleVariant1Font"]
+#[doc = "`TitleVariant1Font`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108008,7 +108008,7 @@ impl ::std::convert::From<StringValue> for TitleVariant1Font {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1FontSize"]
+#[doc = "`TitleVariant1FontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108046,7 +108046,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1FontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1FontStyle"]
+#[doc = "`TitleVariant1FontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108079,7 +108079,7 @@ impl ::std::convert::From<StringValue> for TitleVariant1FontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1FontWeight"]
+#[doc = "`TitleVariant1FontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108141,7 +108141,7 @@ impl ::std::convert::From<FontWeightValue> for TitleVariant1FontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Frame"]
+#[doc = "`TitleVariant1Frame`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108182,7 +108182,7 @@ impl ::std::convert::From<StringValue> for TitleVariant1Frame {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1FrameVariant0"]
+#[doc = "`TitleVariant1FrameVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108258,7 +108258,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1FrameVarian
         value.parse()
     }
 }
-#[doc = "TitleVariant1Limit"]
+#[doc = "`TitleVariant1Limit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108296,7 +108296,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Limit {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1LineHeight"]
+#[doc = "`TitleVariant1LineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108334,7 +108334,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1LineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Offset"]
+#[doc = "`TitleVariant1Offset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108372,7 +108372,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Offset {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1Orient"]
+#[doc = "`TitleVariant1Orient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108417,7 +108417,7 @@ impl ::std::convert::From<SignalRef> for TitleVariant1Orient {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1OrientVariant0"]
+#[doc = "`TitleVariant1OrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108509,7 +108509,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1OrientVaria
         value.parse()
     }
 }
-#[doc = "TitleVariant1SubtitleColor"]
+#[doc = "`TitleVariant1SubtitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108546,7 +108546,7 @@ impl ::std::convert::From<ColorValue> for TitleVariant1SubtitleColor {
         Self::Variant2(value)
     }
 }
-#[doc = "TitleVariant1SubtitleFont"]
+#[doc = "`TitleVariant1SubtitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108579,7 +108579,7 @@ impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFont {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1SubtitleFontSize"]
+#[doc = "`TitleVariant1SubtitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108617,7 +108617,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1SubtitleFontSize {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1SubtitleFontStyle"]
+#[doc = "`TitleVariant1SubtitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108650,7 +108650,7 @@ impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFontStyle {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1SubtitleFontWeight"]
+#[doc = "`TitleVariant1SubtitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108712,7 +108712,7 @@ impl ::std::convert::From<FontWeightValue> for TitleVariant1SubtitleFontWeight {
         Self::Variant1(value)
     }
 }
-#[doc = "TitleVariant1SubtitleLineHeight"]
+#[doc = "`TitleVariant1SubtitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108750,7 +108750,7 @@ impl ::std::convert::From<NumberValue> for TitleVariant1SubtitleLineHeight {
         Self::Variant1(value)
     }
 }
-#[doc = "Transform"]
+#[doc = "`Transform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109229,7 +109229,7 @@ impl ::std::convert::From<WordcloudTransform> for Transform {
         Self::WordcloudTransform(value)
     }
 }
-#[doc = "TransformMark"]
+#[doc = "`TransformMark`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109519,7 +109519,7 @@ impl ::std::convert::From<WordcloudTransform> for TransformMark {
         Self::WordcloudTransform(value)
     }
 }
-#[doc = "TreeTransform"]
+#[doc = "`TreeTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109687,7 +109687,7 @@ impl ::std::convert::From<&TreeTransform> for TreeTransform {
         value.clone()
     }
 }
-#[doc = "TreeTransformAs"]
+#[doc = "`TreeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109753,7 +109753,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformAsVariant0Item"]
+#[doc = "`TreeTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109786,7 +109786,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformField"]
+#[doc = "`TreeTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109833,7 +109833,7 @@ impl ::std::convert::From<Expr> for TreeTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "TreeTransformMethod"]
+#[doc = "`TreeTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109880,7 +109880,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformMethodVariant0"]
+#[doc = "`TreeTransformMethodVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109956,7 +109956,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreeTransformMethodVaria
         value.parse()
     }
 }
-#[doc = "TreeTransformNodeSize"]
+#[doc = "`TreeTransformNodeSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110006,7 +110006,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSize {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformNodeSizeVariant0Item"]
+#[doc = "`TreeTransformNodeSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110044,7 +110044,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformSeparation"]
+#[doc = "`TreeTransformSeparation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110088,7 +110088,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformSeparation {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformSize"]
+#[doc = "`TreeTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110138,7 +110138,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformSizeVariant0Item"]
+#[doc = "`TreeTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110176,7 +110176,7 @@ impl ::std::convert::From<SignalRef> for TreeTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TreeTransformType"]
+#[doc = "`TreeTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110247,7 +110247,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreeTransformType {
         value.parse()
     }
 }
-#[doc = "TreelinksTransform"]
+#[doc = "`TreelinksTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110284,7 +110284,7 @@ impl ::std::convert::From<&TreelinksTransform> for TreelinksTransform {
         value.clone()
     }
 }
-#[doc = "TreelinksTransformType"]
+#[doc = "`TreelinksTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110355,7 +110355,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreelinksTransformType {
         value.parse()
     }
 }
-#[doc = "TreemapTransform"]
+#[doc = "`TreemapTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110621,7 +110621,7 @@ impl ::std::convert::From<&TreemapTransform> for TreemapTransform {
         value.clone()
     }
 }
-#[doc = "TreemapTransformAs"]
+#[doc = "`TreemapTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110691,7 +110691,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformAsVariant0Item"]
+#[doc = "`TreemapTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110724,7 +110724,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformField"]
+#[doc = "`TreemapTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110771,7 +110771,7 @@ impl ::std::convert::From<Expr> for TreemapTransformField {
         Self::Expr(value)
     }
 }
-#[doc = "TreemapTransformMethod"]
+#[doc = "`TreemapTransformMethod`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110822,7 +110822,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformMethod {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformMethodVariant0"]
+#[doc = "`TreemapTransformMethodVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110918,7 +110918,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreemapTransformMethodVa
         value.parse()
     }
 }
-#[doc = "TreemapTransformPadding"]
+#[doc = "`TreemapTransformPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110956,7 +110956,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPadding {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingBottom"]
+#[doc = "`TreemapTransformPaddingBottom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110994,7 +110994,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingBottom {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingInner"]
+#[doc = "`TreemapTransformPaddingInner`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111032,7 +111032,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingInner {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingLeft"]
+#[doc = "`TreemapTransformPaddingLeft`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111070,7 +111070,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingLeft {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingOuter"]
+#[doc = "`TreemapTransformPaddingOuter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111108,7 +111108,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingOuter {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingRight"]
+#[doc = "`TreemapTransformPaddingRight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111146,7 +111146,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingRight {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformPaddingTop"]
+#[doc = "`TreemapTransformPaddingTop`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111184,7 +111184,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingTop {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformRatio"]
+#[doc = "`TreemapTransformRatio`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111228,7 +111228,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformRatio {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformRound"]
+#[doc = "`TreemapTransformRound`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111266,7 +111266,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformRound {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformSize"]
+#[doc = "`TreemapTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111316,7 +111316,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformSizeVariant0Item"]
+#[doc = "`TreemapTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111354,7 +111354,7 @@ impl ::std::convert::From<SignalRef> for TreemapTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "TreemapTransformType"]
+#[doc = "`TreemapTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111425,7 +111425,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreemapTransformType {
         value.parse()
     }
 }
-#[doc = "VoronoiTransform"]
+#[doc = "`VoronoiTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111554,7 +111554,7 @@ impl ::std::convert::From<&VoronoiTransform> for VoronoiTransform {
         value.clone()
     }
 }
-#[doc = "VoronoiTransformAs"]
+#[doc = "`VoronoiTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111593,7 +111593,7 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "VoronoiTransformExtent"]
+#[doc = "`VoronoiTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111652,7 +111652,7 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformExtent {
         Self::Variant1(value)
     }
 }
-#[doc = "VoronoiTransformSize"]
+#[doc = "`VoronoiTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111702,7 +111702,7 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "VoronoiTransformSizeVariant0Item"]
+#[doc = "`VoronoiTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111740,7 +111740,7 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "VoronoiTransformType"]
+#[doc = "`VoronoiTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111811,7 +111811,7 @@ impl ::std::convert::TryFrom<::std::string::String> for VoronoiTransformType {
         value.parse()
     }
 }
-#[doc = "VoronoiTransformX"]
+#[doc = "`VoronoiTransformX`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111858,7 +111858,7 @@ impl ::std::convert::From<Expr> for VoronoiTransformX {
         Self::Expr(value)
     }
 }
-#[doc = "VoronoiTransformY"]
+#[doc = "`VoronoiTransformY`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111905,7 +111905,7 @@ impl ::std::convert::From<Expr> for VoronoiTransformY {
         Self::Expr(value)
     }
 }
-#[doc = "WindowTransform"]
+#[doc = "`WindowTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112161,7 +112161,7 @@ impl ::std::convert::From<&WindowTransform> for WindowTransform {
         value.clone()
     }
 }
-#[doc = "WindowTransformAs"]
+#[doc = "`WindowTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112212,7 +112212,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformAsVariant0Item"]
+#[doc = "`WindowTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112249,7 +112249,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformFields"]
+#[doc = "`WindowTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112305,7 +112305,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformFields {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformFieldsVariant0Item"]
+#[doc = "`WindowTransformFieldsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112356,7 +112356,7 @@ impl ::std::convert::From<Expr> for WindowTransformFieldsVariant0Item {
         Self::Variant2(value)
     }
 }
-#[doc = "WindowTransformFrame"]
+#[doc = "`WindowTransformFrame`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112421,7 +112421,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformFrame {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformFrameVariant0Item"]
+#[doc = "`WindowTransformFrameVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112463,7 +112463,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformFrameVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformGroupby"]
+#[doc = "`WindowTransformGroupby`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112516,7 +112516,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformGroupby {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformGroupbyVariant0Item"]
+#[doc = "`WindowTransformGroupbyVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112563,7 +112563,7 @@ impl ::std::convert::From<Expr> for WindowTransformGroupbyVariant0Item {
         Self::Expr(value)
     }
 }
-#[doc = "WindowTransformIgnorePeers"]
+#[doc = "`WindowTransformIgnorePeers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112601,7 +112601,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformIgnorePeers {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformOps"]
+#[doc = "`WindowTransformOps`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112687,7 +112687,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformOps {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformOpsVariant0Item"]
+#[doc = "`WindowTransformOpsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112765,7 +112765,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformOpsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformOpsVariant0ItemVariant0"]
+#[doc = "`WindowTransformOpsVariant0ItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113016,7 +113016,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WindowTransformOpsVarian
         value.parse()
     }
 }
-#[doc = "WindowTransformParams"]
+#[doc = "`WindowTransformParams`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113069,7 +113069,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformParams {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformParamsVariant0Item"]
+#[doc = "`WindowTransformParamsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113111,7 +113111,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformParamsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WindowTransformType"]
+#[doc = "`WindowTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113182,7 +113182,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WindowTransformType {
         value.parse()
     }
 }
-#[doc = "WordcloudTransform"]
+#[doc = "`WordcloudTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113456,7 +113456,7 @@ impl ::std::convert::From<&WordcloudTransform> for WordcloudTransform {
         value.clone()
     }
 }
-#[doc = "WordcloudTransformAs"]
+#[doc = "`WordcloudTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113528,7 +113528,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformAs {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformAsVariant0Item"]
+#[doc = "`WordcloudTransformAsVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113561,7 +113561,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformAsVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformFont"]
+#[doc = "`WordcloudTransformFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113618,7 +113618,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFont {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformFontSize"]
+#[doc = "`WordcloudTransformFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113680,7 +113680,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontSize {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformFontSizeRange"]
+#[doc = "`WordcloudTransformFontSizeRange`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113746,7 +113746,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRange {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformFontSizeRangeVariant0Item"]
+#[doc = "`WordcloudTransformFontSizeRangeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113784,7 +113784,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRangeVariant0
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformFontStyle"]
+#[doc = "`WordcloudTransformFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113841,7 +113841,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontStyle {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformFontWeight"]
+#[doc = "`WordcloudTransformFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113898,7 +113898,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontWeight {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformPadding"]
+#[doc = "`WordcloudTransformPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113954,7 +113954,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformPadding {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformRotate"]
+#[doc = "`WordcloudTransformRotate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -114010,7 +114010,7 @@ impl ::std::convert::From<ParamField> for WordcloudTransformRotate {
         Self::Variant3(value)
     }
 }
-#[doc = "WordcloudTransformSize"]
+#[doc = "`WordcloudTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -114060,7 +114060,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSize {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformSizeVariant0Item"]
+#[doc = "`WordcloudTransformSizeVariant0Item`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -114098,7 +114098,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSizeVariant0Item {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformSpiral"]
+#[doc = "`WordcloudTransformSpiral`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -114131,7 +114131,7 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSpiral {
         Self::Variant1(value)
     }
 }
-#[doc = "WordcloudTransformText"]
+#[doc = "`WordcloudTransformText`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -114178,7 +114178,7 @@ impl ::std::convert::From<Expr> for WordcloudTransformText {
         Self::Expr(value)
     }
 }
-#[doc = "WordcloudTransformType"]
+#[doc = "`WordcloudTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "ArraySansItems"]
+#[doc = "`ArraySansItems`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61,7 +61,7 @@ impl ::std::convert::From<Vec<::serde_json::Value>> for ArraySansItems {
         Self(value)
     }
 }
-#[doc = "LessSimpleTwoTuple"]
+#[doc = "`LessSimpleTwoTuple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108,7 +108,7 @@ impl ::std::convert::From<(::std::string::String, ::std::string::String)> for Le
         Self(value)
     }
 }
-#[doc = "SimpleTwoArray"]
+#[doc = "`SimpleTwoArray`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -147,7 +147,7 @@ impl ::std::convert::From<[::std::string::String; 2usize]> for SimpleTwoArray {
         Self(value)
     }
 }
-#[doc = "SimpleTwoTuple"]
+#[doc = "`SimpleTwoTuple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -191,7 +191,7 @@ impl ::std::convert::From<(::std::string::String, ::std::string::String)> for Si
         Self(value)
     }
 }
-#[doc = "UnsimpleTwoTuple"]
+#[doc = "`UnsimpleTwoTuple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -235,7 +235,7 @@ impl ::std::convert::From<(::std::string::String, ::std::string::String)> for Un
         Self(value)
     }
 }
-#[doc = "YoloTwoArray"]
+#[doc = "`YoloTwoArray`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "TestType"]
+#[doc = "`TestType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -75,7 +75,7 @@ impl TestType {
         Default::default()
     }
 }
-#[doc = "TestTypeWhereNot"]
+#[doc = "`TestTypeWhereNot`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -131,7 +131,7 @@ impl<'de> ::serde::Deserialize<'de> for TestTypeWhereNot {
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "TestTypeWhyNot"]
+#[doc = "`TestTypeWhyNot`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "LetterBox"]
+#[doc = "`LetterBox`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -69,7 +69,7 @@ impl LetterBox {
         Default::default()
     }
 }
-#[doc = "LetterBoxLetter"]
+#[doc = "`LetterBoxLetter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "IdOrName"]
+#[doc = "`IdOrName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -116,7 +116,7 @@ impl ::std::convert::From<Name> for IdOrName {
         Self::Name(value)
     }
 }
-#[doc = "IdOrNameRedundant"]
+#[doc = "`IdOrNameRedundant`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -199,7 +199,7 @@ impl ::std::convert::From<Name> for IdOrNameRedundant {
         Self::Variant1(value)
     }
 }
-#[doc = "IdOrYolo"]
+#[doc = "`IdOrYolo`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -291,7 +291,7 @@ impl ::std::convert::From<IdOrYoloYolo> for IdOrYolo {
         Self::Yolo(value)
     }
 }
-#[doc = "IdOrYoloYolo"]
+#[doc = "`IdOrYoloYolo`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "DeadSimple"]
+#[doc = "`DeadSimple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65,7 +65,7 @@ impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json:
         Self(value)
     }
 }
-#[doc = "Eh"]
+#[doc = "`Eh`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -121,7 +121,7 @@ impl ::std::fmt::Display for Eh {
         self.0.fmt(f)
     }
 }
-#[doc = "MapWithDateKeys"]
+#[doc = "`MapWithDateKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -166,7 +166,7 @@ impl ::std::convert::From<::std::collections::HashMap<chrono::naive::NaiveDate, 
         Self(value)
     }
 }
-#[doc = "MapWithDateTimeKeys"]
+#[doc = "`MapWithDateTimeKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -215,7 +215,7 @@ impl ::std::convert::From<::std::collections::HashMap<chrono::DateTime<chrono::o
         Self(value)
     }
 }
-#[doc = "MapWithKeys"]
+#[doc = "`MapWithKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -255,7 +255,7 @@ impl ::std::convert::From<::std::collections::HashMap<Eh, Value>> for MapWithKey
         Self(value)
     }
 }
-#[doc = "Value"]
+#[doc = "`Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/maps_custom.rs
+++ b/typify/tests/schemas/maps_custom.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "DeadSimple"]
+#[doc = "`DeadSimple`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -65,7 +65,7 @@ impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json:
         Self(value)
     }
 }
-#[doc = "Eh"]
+#[doc = "`Eh`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -121,7 +121,7 @@ impl ::std::fmt::Display for Eh {
         self.0.fmt(f)
     }
 }
-#[doc = "MapWithDateKeys"]
+#[doc = "`MapWithDateKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -166,7 +166,7 @@ impl ::std::convert::From<std::collections::BTreeMap<chrono::naive::NaiveDate, V
         Self(value)
     }
 }
-#[doc = "MapWithDateTimeKeys"]
+#[doc = "`MapWithDateTimeKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -215,7 +215,7 @@ impl ::std::convert::From<std::collections::BTreeMap<chrono::DateTime<chrono::of
         Self(value)
     }
 }
-#[doc = "MapWithKeys"]
+#[doc = "`MapWithKeys`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -255,7 +255,7 @@ impl ::std::convert::From<std::collections::BTreeMap<Eh, Value>> for MapWithKeys
         Self(value)
     }
 }
-#[doc = "Value"]
+#[doc = "`Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "BarProp"]
+#[doc = "`BarProp`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -61,7 +61,7 @@ impl BarProp {
         Default::default()
     }
 }
-#[doc = "ButNotThat"]
+#[doc = "`ButNotThat`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -149,7 +149,7 @@ impl CommentedTypeMerged {
         Default::default()
     }
 }
-#[doc = "HereAndThere"]
+#[doc = "`HereAndThere`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -207,7 +207,7 @@ impl ::std::convert::From<&Self> for HereAndThere {
         value.clone()
     }
 }
-#[doc = "JsonResponseBase"]
+#[doc = "`JsonResponseBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -244,7 +244,7 @@ impl JsonResponseBase {
         Default::default()
     }
 }
-#[doc = "JsonSuccess"]
+#[doc = "`JsonSuccess`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -327,7 +327,7 @@ impl JsonSuccessBase {
         Default::default()
     }
 }
-#[doc = "JsonSuccessBaseResult"]
+#[doc = "`JsonSuccessBaseResult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -399,7 +399,7 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessBaseResult {
         value.parse()
     }
 }
-#[doc = "JsonSuccessResult"]
+#[doc = "`JsonSuccessResult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -471,7 +471,7 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessResult {
         value.parse()
     }
 }
-#[doc = "MergeEmpty"]
+#[doc = "`MergeEmpty`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -531,7 +531,7 @@ impl MergeEmpty {
         Default::default()
     }
 }
-#[doc = "NarrowNumber"]
+#[doc = "`NarrowNumber`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -601,7 +601,7 @@ impl ::std::fmt::Display for NarrowNumber {
         self.0.fmt(f)
     }
 }
-#[doc = "OrderDependentMerge"]
+#[doc = "`OrderDependentMerge`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -641,7 +641,7 @@ impl OrderDependentMerge {
         Default::default()
     }
 }
-#[doc = "Pickingone"]
+#[doc = "`Pickingone`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -681,7 +681,7 @@ impl Pickingone {
         Default::default()
     }
 }
-#[doc = "PickingoneInstallation"]
+#[doc = "`PickingoneInstallation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -725,7 +725,7 @@ impl PickingoneInstallation {
         Default::default()
     }
 }
-#[doc = "PickingoneSuspendedBy"]
+#[doc = "`PickingoneSuspendedBy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -777,7 +777,7 @@ impl PickingoneSuspendedBy {
         Default::default()
     }
 }
-#[doc = "PickingoneUser"]
+#[doc = "`PickingoneUser`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -817,7 +817,7 @@ impl PickingoneUser {
         Default::default()
     }
 }
-#[doc = "TrimFat"]
+#[doc = "`TrimFat`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -863,7 +863,7 @@ impl TrimFat {
         Default::default()
     }
 }
-#[doc = "Unresolvable"]
+#[doc = "`Unresolvable`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -931,7 +931,7 @@ impl ::std::convert::From<&Self> for Unresolvable {
         value.clone()
     }
 }
-#[doc = "Unsatisfiable1"]
+#[doc = "`Unsatisfiable1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -973,7 +973,7 @@ impl ::std::convert::From<&Self> for Unsatisfiable1 {
         value.clone()
     }
 }
-#[doc = "Unsatisfiable2"]
+#[doc = "`Unsatisfiable2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1031,7 +1031,7 @@ impl ::std::convert::From<&Self> for Unsatisfiable2 {
         value.clone()
     }
 }
-#[doc = "Unsatisfiable3"]
+#[doc = "`Unsatisfiable3`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1076,7 +1076,7 @@ impl ::std::convert::From<&Self> for Unsatisfiable3 {
         value.clone()
     }
 }
-#[doc = "Unsatisfiable3A"]
+#[doc = "`Unsatisfiable3A`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1117,7 +1117,7 @@ impl Unsatisfiable3A {
         Default::default()
     }
 }
-#[doc = "Unsatisfiable3B"]
+#[doc = "`Unsatisfiable3B`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1189,7 +1189,7 @@ impl ::std::convert::TryFrom<::std::string::String> for Unsatisfiable3B {
         value.parse()
     }
 }
-#[doc = "Unsatisfiable3C"]
+#[doc = "`Unsatisfiable3C`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1261,7 +1261,7 @@ impl ::std::convert::TryFrom<::std::string::String> for Unsatisfiable3C {
         value.parse()
     }
 }
-#[doc = "WeirdEnum"]
+#[doc = "`WeirdEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "IntOrStr"]
+#[doc = "`IntOrStr`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96,7 +96,7 @@ impl ::std::convert::From<i64> for IntOrStr {
         Self::Integer(value)
     }
 }
-#[doc = "OneOfSeveral"]
+#[doc = "`OneOfSeveral`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -150,7 +150,7 @@ impl ::std::convert::From<i64> for OneOfSeveral {
         Self::Integer(value)
     }
 }
-#[doc = "ReallyJustNull"]
+#[doc = "`ReallyJustNull`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -190,7 +190,7 @@ impl ::std::convert::From<()> for ReallyJustNull {
         Self(value)
     }
 }
-#[doc = "SeriouslyAnything"]
+#[doc = "`SeriouslyAnything`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -232,7 +232,7 @@ impl ::std::convert::From<::serde_json::Value> for SeriouslyAnything {
         Self(value)
     }
 }
-#[doc = "YesNoMaybe"]
+#[doc = "`YesNoMaybe`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "ArrayBs"]
+#[doc = "`ArrayBs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70,7 +70,7 @@ impl ::std::convert::From<::std::vec::Vec<bool>> for ArrayBs {
         Self(value)
     }
 }
-#[doc = "IntegerBs"]
+#[doc = "`IntegerBs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -141,7 +141,7 @@ impl ::std::fmt::Display for IntegerBs {
         self.0.fmt(f)
     }
 }
-#[doc = "ObjectBs"]
+#[doc = "`ObjectBs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "TestGrammarForPatternProperties"]
+#[doc = "`TestGrammarForPatternProperties`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -67,7 +67,7 @@ impl TestGrammarForPatternProperties {
         Default::default()
     }
 }
-#[doc = "TestGrammarForPatternPropertiesRulesKey"]
+#[doc = "`TestGrammarForPatternPropertiesRulesKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Node"]
+#[doc = "`Node`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Box"]
+#[doc = "`Box`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -57,7 +57,7 @@ impl Box {
         Default::default()
     }
 }
-#[doc = "Copy"]
+#[doc = "`Copy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89,7 +89,7 @@ impl Copy {
         Default::default()
     }
 }
-#[doc = "DoubleOptionCollision"]
+#[doc = "`DoubleOptionCollision`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -137,7 +137,7 @@ impl DoubleOptionCollision {
         Default::default()
     }
 }
-#[doc = "DoubleOptionCollisionOption"]
+#[doc = "`DoubleOptionCollisionOption`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -177,7 +177,7 @@ impl DoubleOptionCollisionOption {
         Default::default()
     }
 }
-#[doc = "Drop"]
+#[doc = "`Drop`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -209,7 +209,7 @@ impl Drop {
         Default::default()
     }
 }
-#[doc = "FlattenedKeywords"]
+#[doc = "`FlattenedKeywords`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -246,7 +246,7 @@ impl FlattenedKeywords {
         Default::default()
     }
 }
-#[doc = "KeywordFieldsEnum"]
+#[doc = "`KeywordFieldsEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -314,7 +314,7 @@ impl ::std::convert::From<[::std::string::String; 2usize]> for KeywordFieldsEnum
         Self::Variant1(value)
     }
 }
-#[doc = "MapOfKeywords"]
+#[doc = "`MapOfKeywords`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -366,7 +366,7 @@ impl MapOfKeywords {
         Default::default()
     }
 }
-#[doc = "MapOfKeywordsKeywordMapValue"]
+#[doc = "`MapOfKeywordsKeywordMapValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -503,7 +503,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MapOfKeywordsKeywordMapV
         value.parse()
     }
 }
-#[doc = "NestedTypeCollisions"]
+#[doc = "`NestedTypeCollisions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -557,7 +557,7 @@ impl NestedTypeCollisions {
         Default::default()
     }
 }
-#[doc = "NestedTypeCollisionsOptionType"]
+#[doc = "`NestedTypeCollisionsOptionType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -598,7 +598,7 @@ impl NestedTypeCollisionsOptionType {
         Default::default()
     }
 }
-#[doc = "Option"]
+#[doc = "`Option`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -630,7 +630,7 @@ impl Option {
         Default::default()
     }
 }
-#[doc = "Pin"]
+#[doc = "`Pin`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -662,7 +662,7 @@ impl Pin {
         Default::default()
     }
 }
-#[doc = "RustKeywordMonster"]
+#[doc = "`RustKeywordMonster`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -989,7 +989,7 @@ impl RustKeywordMonster {
         Default::default()
     }
 }
-#[doc = "Send"]
+#[doc = "`Send`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1021,7 +1021,7 @@ impl Send {
         Default::default()
     }
 }
-#[doc = "Std"]
+#[doc = "`Std`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1139,7 +1139,7 @@ impl Std {
         Default::default()
     }
 }
-#[doc = "StdBoxed"]
+#[doc = "`StdBoxed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1171,7 +1171,7 @@ impl StdBoxed {
         Default::default()
     }
 }
-#[doc = "StdConvert"]
+#[doc = "`StdConvert`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1203,7 +1203,7 @@ impl StdConvert {
         Default::default()
     }
 }
-#[doc = "StdFmt"]
+#[doc = "`StdFmt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1235,7 +1235,7 @@ impl StdFmt {
         Default::default()
     }
 }
-#[doc = "StdOption"]
+#[doc = "`StdOption`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1267,7 +1267,7 @@ impl StdOption {
         Default::default()
     }
 }
-#[doc = "StdResult"]
+#[doc = "`StdResult`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1299,7 +1299,7 @@ impl StdResult {
         Default::default()
     }
 }
-#[doc = "StdStr"]
+#[doc = "`StdStr`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1331,7 +1331,7 @@ impl StdStr {
         Default::default()
     }
 }
-#[doc = "StdString"]
+#[doc = "`StdString`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1363,7 +1363,7 @@ impl StdString {
         Default::default()
     }
 }
-#[doc = "String"]
+#[doc = "`String`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1395,7 +1395,7 @@ impl String {
         Default::default()
     }
 }
-#[doc = "StringEnum"]
+#[doc = "`StringEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1477,7 +1477,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StringEnum {
         value.parse()
     }
 }
-#[doc = "StringNewtype"]
+#[doc = "`StringNewtype`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1554,7 +1554,7 @@ impl<'de> ::serde::Deserialize<'de> for StringNewtype {
             })
     }
 }
-#[doc = "Sync"]
+#[doc = "`Sync`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1586,7 +1586,7 @@ impl Sync {
         Default::default()
     }
 }
-#[doc = "TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords"]
+#[doc = "`TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1605,7 +1605,7 @@ impl :: std :: ops :: Deref for TestSchemaWithVariousDefinitionsTypeNamesAndProp
 impl :: std :: convert :: From < TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords > for :: serde_json :: Value { fn from (value : TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords) -> Self { value . 0 } }
 impl :: std :: convert :: From < & TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords > for TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords { fn from (value : & TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords) -> Self { value . clone () } }
 impl :: std :: convert :: From < :: serde_json :: Value > for TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords { fn from (value : :: serde_json :: Value) -> Self { Self (value) } }
-#[doc = "TypeWithOptionField"]
+#[doc = "`TypeWithOptionField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1645,7 +1645,7 @@ impl TypeWithOptionField {
         Default::default()
     }
 }
-#[doc = "Vec"]
+#[doc = "`Vec`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "AnythingWorks"]
+#[doc = "`AnythingWorks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -52,7 +52,7 @@ impl AnythingWorks {
         Default::default()
     }
 }
-#[doc = "FloatsArentTerribleImTold"]
+#[doc = "`FloatsArentTerribleImTold`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90,7 +90,7 @@ impl FloatsArentTerribleImTold {
         Default::default()
     }
 }
-#[doc = "JustOne"]
+#[doc = "`JustOne`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "TestEnum"]
+#[doc = "`TestEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "TestType"]
+#[doc = "`TestType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72,7 +72,7 @@ impl TestType {
         Default::default()
     }
 }
-#[doc = "TypeThatHasMoreDerives"]
+#[doc = "`TypeThatHasMoreDerives`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "Doodad"]
+#[doc = "`Doodad`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64,7 +64,7 @@ impl Doodad {
         Default::default()
     }
 }
-#[doc = "MrDefaultNumbers"]
+#[doc = "`MrDefaultNumbers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113,7 +113,7 @@ impl MrDefaultNumbers {
         Default::default()
     }
 }
-#[doc = "OuterThing"]
+#[doc = "`OuterThing`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -163,7 +163,7 @@ impl OuterThing {
         Default::default()
     }
 }
-#[doc = "TestBed"]
+#[doc = "`TestBed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -222,7 +222,7 @@ impl TestBed {
         Default::default()
     }
 }
-#[doc = "ThingWithDefaults"]
+#[doc = "`ThingWithDefaults`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "PatternString"]
+#[doc = "`PatternString`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98,7 +98,7 @@ impl<'de> ::serde::Deserialize<'de> for PatternString {
             })
     }
 }
-#[doc = "Sub10Primes"]
+#[doc = "`Sub10Primes`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "TestType"]
+#[doc = "`TestType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -64,7 +64,7 @@ impl TestType {
         Default::default()
     }
 }
-#[doc = "TestTypeValue"]
+#[doc = "`TestTypeValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "AlternativeEnum"]
+#[doc = "`AlternativeEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110,7 +110,7 @@ impl ::std::default::Default for AlternativeEnum {
         AlternativeEnum::Choice2
     }
 }
-#[doc = "CommentedVariants"]
+#[doc = "`CommentedVariants`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -204,7 +204,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CommentedVariants {
         value.parse()
     }
 }
-#[doc = "DiskAttachment"]
+#[doc = "`DiskAttachment`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -247,7 +247,7 @@ impl DiskAttachment {
         Default::default()
     }
 }
-#[doc = "DiskAttachmentState"]
+#[doc = "`DiskAttachmentState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -332,7 +332,7 @@ impl ::std::default::Default for DiskAttachmentState {
         DiskAttachmentState::Detached
     }
 }
-#[doc = "EmptyObject"]
+#[doc = "`EmptyObject`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -372,7 +372,7 @@ impl EmptyObject {
         Default::default()
     }
 }
-#[doc = "EmptyObjectProp"]
+#[doc = "`EmptyObjectProp`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -432,7 +432,7 @@ impl<'de> ::serde::Deserialize<'de> for EmptyObjectProp {
         .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = "EnumAndConstant"]
+#[doc = "`EnumAndConstant`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -526,7 +526,7 @@ impl ::std::convert::From<&Self> for EnumAndConstant {
         value.clone()
     }
 }
-#[doc = "IpNet"]
+#[doc = "`IpNet`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -617,7 +617,7 @@ impl ::std::convert::From<Ipv6Net> for IpNet {
         Self::V6(value)
     }
 }
-#[doc = "Ipv4Net"]
+#[doc = "`Ipv4Net`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -672,7 +672,7 @@ impl ::std::fmt::Display for Ipv4Net {
         self.0.fmt(f)
     }
 }
-#[doc = "Ipv6Net"]
+#[doc = "`Ipv6Net`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -727,7 +727,7 @@ impl ::std::fmt::Display for Ipv6Net {
         self.0.fmt(f)
     }
 }
-#[doc = "JankNames"]
+#[doc = "`JankNames`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -785,7 +785,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, i64
         Self::Variant2(value)
     }
 }
-#[doc = "Never"]
+#[doc = "`Never`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -812,7 +812,7 @@ impl ::std::convert::From<&Self> for Never {
         value.clone()
     }
 }
-#[doc = "NeverEver"]
+#[doc = "`NeverEver`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -839,7 +839,7 @@ impl ::std::convert::From<&Self> for NeverEver {
         value.clone()
     }
 }
-#[doc = "NullStringEnumWithUnknownFormat"]
+#[doc = "`NullStringEnumWithUnknownFormat`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -888,7 +888,7 @@ impl ::std::convert::From<::std::option::Option<NullStringEnumWithUnknownFormatI
         Self(value)
     }
 }
-#[doc = "NullStringEnumWithUnknownFormatInner"]
+#[doc = "`NullStringEnumWithUnknownFormatInner`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -971,7 +971,7 @@ impl ::std::convert::TryFrom<::std::string::String> for NullStringEnumWithUnknow
         value.parse()
     }
 }
-#[doc = "OneOfTypes"]
+#[doc = "`OneOfTypes`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1020,7 +1020,7 @@ impl ::std::convert::From<i64> for OneOfTypes {
         Self::Bar(value)
     }
 }
-#[doc = "ReferenceDef"]
+#[doc = "`ReferenceDef`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1134,7 +1134,7 @@ impl
         Self::Variant1(value)
     }
 }
-#[doc = "ReferencesVariant1Value"]
+#[doc = "`ReferencesVariant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1214,7 +1214,7 @@ impl ::std::convert::From<ReferenceDef> for ReferencesVariant1Value {
         Self::ReferenceDef(value)
     }
 }
-#[doc = "ShouldBeExclusive"]
+#[doc = "`ShouldBeExclusive`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1255,7 +1255,7 @@ impl ::std::convert::From<&Self> for ShouldBeExclusive {
         value.clone()
     }
 }
-#[doc = "StringVersion"]
+#[doc = "`StringVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -25,7 +25,7 @@ pub mod error {
         }
     }
 }
-#[doc = "AllTheThings"]
+#[doc = "`AllTheThings`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -68,7 +68,7 @@ impl AllTheThings {
         Default::default()
     }
 }
-#[doc = "Marker"]
+#[doc = "`Marker`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]


### PR DESCRIPTION
Missing backticks trigger the pedantic `doc_markdown` lint in clippy.

---

This complements #757 and resolves all remaining `doc_markdown` lints. Submitting separately due to the large number of changes. The only non-trivial change is in `typify-impl/src/type_entry.rs`.