### PR TITLE
Try harder to disambiguate enum variant identifiers

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -7,7 +7,7 @@ use crate::type_entry::{
     EnumTagType, TypeEntry, TypeEntryDetails, TypeEntryEnum, TypeEntryNewtype, TypeEntryStruct,
     Variant, VariantDetails,
 };
-use crate::util::{all_mutually_exclusive, recase, ref_key, Case, StringValidator};
+use crate::util::{all_mutually_exclusive, ref_key, StringValidator};
 use log::{debug, info};
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
@@ -918,14 +918,12 @@ impl TypeSpace {
                     has_null = true;
                     None
                 }
-                serde_json::Value::String(value) if validator.is_valid(value) => {
-                    let (name, rename) = recase(value, Case::Pascal);
-                    Some(Ok(Variant {
-                        name,
-                        rename,
-                        description: None,
-                        details: VariantDetails::Simple,
-                    }))
+                serde_json::Value::String(variant_name) if validator.is_valid(variant_name) => {
+                    Some(Ok(Variant::new(
+                        variant_name.clone(),
+                        None,
+                        VariantDetails::Simple,
+                    )))
                 }
 
                 // Ignore enum variants whose strings don't match the given

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::collections::BTreeSet;
 

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -384,7 +384,7 @@ pub(crate) fn validate_default_for_external_enum(
     if let Some(simple_name) = default.as_str() {
         let variant = variants
             .iter()
-            .find(|variant| simple_name == variant.rename.as_ref().unwrap_or(&variant.name))?;
+            .find(|variant| simple_name == &variant.raw_name)?;
         matches!(&variant.details, VariantDetails::Simple).then(|| ())?;
 
         Some(DefaultKind::Specific)
@@ -396,9 +396,7 @@ pub(crate) fn validate_default_for_external_enum(
 
         let (name, value) = map.iter().next()?;
 
-        let variant = variants
-            .iter()
-            .find(|variant| name == variant.rename.as_ref().unwrap_or(&variant.name))?;
+        let variant = variants.iter().find(|variant| name == &variant.raw_name)?;
 
         match &variant.details {
             VariantDetails::Simple => None,
@@ -419,9 +417,7 @@ pub(crate) fn validate_default_for_internal_enum(
 ) -> Option<DefaultKind> {
     let map = default.as_object()?;
     let name = map.get(tag).and_then(serde_json::Value::as_str)?;
-    let variant = variants
-        .iter()
-        .find(|variant| name == variant.rename.as_ref().unwrap_or(&variant.name))?;
+    let variant = variants.iter().find(|variant| name == &variant.raw_name)?;
 
     match &variant.details {
         VariantDetails::Simple => Some(DefaultKind::Specific),
@@ -462,7 +458,7 @@ pub(crate) fn validate_default_for_adjacent_enum(
 
     let variant = variants
         .iter()
-        .find(|variant| tag_value == variant.rename.as_ref().unwrap_or(&variant.name))?;
+        .find(|variant| tag_value == &variant.raw_name)?;
 
     match (&variant.details, content_value) {
         (VariantDetails::Simple, None) => Some(DefaultKind::Specific),

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -384,7 +384,7 @@ pub(crate) fn validate_default_for_external_enum(
     if let Some(simple_name) = default.as_str() {
         let variant = variants
             .iter()
-            .find(|variant| simple_name == &variant.raw_name)?;
+            .find(|variant| simple_name == variant.raw_name)?;
         matches!(&variant.details, VariantDetails::Simple).then(|| ())?;
 
         Some(DefaultKind::Specific)
@@ -417,7 +417,7 @@ pub(crate) fn validate_default_for_internal_enum(
 ) -> Option<DefaultKind> {
     let map = default.as_object()?;
     let name = map.get(tag).and_then(serde_json::Value::as_str)?;
-    let variant = variants.iter().find(|variant| name == &variant.raw_name)?;
+    let variant = variants.iter().find(|variant| name == variant.raw_name)?;
 
     match &variant.details {
         VariantDetails::Simple => Some(DefaultKind::Specific),
@@ -458,7 +458,7 @@ pub(crate) fn validate_default_for_adjacent_enum(
 
     let variant = variants
         .iter()
-        .find(|variant| tag_value == &variant.raw_name)?;
+        .find(|variant| tag_value == variant.raw_name)?;
 
     match (&variant.details, content_value) {
         (VariantDetails::Simple, None) => Some(DefaultKind::Specific),

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::collections::BTreeMap;
 

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     util::{
         constant_string_value, get_object, get_type_name, metadata_description,
-        metadata_title_and_description, recase, schema_is_named, Case,
+        metadata_title_and_description, schema_is_named,
     },
     Name, Result, TypeSpace,
 };
@@ -211,15 +211,11 @@ impl TypeSpace {
                 ProtoVariant::Simple {
                     name: variant_name,
                     description,
-                } => {
-                    let (name, rename) = recase(variant_name, Case::Pascal);
-                    Some(Variant {
-                        name,
-                        rename,
-                        description,
-                        details: VariantDetails::Simple,
-                    })
-                }
+                } => Some(Variant::new(
+                    variant_name.to_string(),
+                    description,
+                    VariantDetails::Simple,
+                )),
 
                 ProtoVariant::Typed {
                     name: variant_name,
@@ -233,13 +229,7 @@ impl TypeSpace {
                         .ok()?;
                     deny_unknown_fields |= deny;
 
-                    let (name, rename) = recase(variant_name, Case::Pascal);
-                    Some(Variant {
-                        name,
-                        rename,
-                        description,
-                        details,
-                    })
+                    Some(Variant::new(variant_name.to_string(), description, details))
                 }
             })
             .collect::<Option<Vec<_>>>()?;
@@ -409,23 +399,19 @@ impl TypeSpace {
         if validation.properties.len() == 1 {
             let (tag_name, schema) = validation.properties.iter().next().unwrap();
             let variant_name = constant_string_value(schema).unwrap();
-            let (name, rename) = recase(variant_name, Case::Pascal);
 
             // The lone property must be our tag.
             assert_eq!(tag_name, tag);
             assert_eq!(validation.required.len(), 1);
 
-            let variant = Variant {
-                name,
-                rename,
-                description: None,
-                details: VariantDetails::Simple,
-            };
-            Ok(variant)
+            Ok(Variant::new(
+                variant_name.to_string(),
+                None,
+                VariantDetails::Simple,
+            ))
         } else {
             let tag_schema = validation.properties.get(tag).unwrap();
             let variant_name = constant_string_value(tag_schema).unwrap();
-            let (name, rename) = recase(variant_name, Case::Pascal);
 
             // Make a new object validation that omits the tag.
             let mut new_validation = validation.clone();
@@ -434,13 +420,11 @@ impl TypeSpace {
 
             let (properties, _) =
                 self.struct_members(enum_type_name.into_option(), &new_validation)?;
-            let variant = Variant {
-                name,
-                rename,
-                description: metadata_title_and_description(metadata),
-                details: VariantDetails::Struct(properties),
-            };
-            Ok(variant)
+            Ok(Variant::new(
+                variant_name.to_string(),
+                metadata_title_and_description(metadata),
+                VariantDetails::Struct(properties),
+            ))
         }
     }
 
@@ -543,23 +527,16 @@ impl TypeSpace {
         if validation.properties.len() == 1 {
             let (tag_name, schema) = validation.properties.iter().next().unwrap();
             let variant_name = constant_string_value(schema).unwrap();
-            let (name, rename) = recase(variant_name, Case::Pascal);
 
             // The lone property must be our tag.
             assert_eq!(tag_name, tag);
             assert_eq!(validation.required.len(), 1);
 
-            let variant = Variant {
-                name,
-                rename,
-                description: None,
-                details: VariantDetails::Simple,
-            };
+            let variant = Variant::new(variant_name.to_string(), None, VariantDetails::Simple);
             Ok((variant, false))
         } else {
             let tag_schema = validation.properties.get(tag).unwrap();
             let variant_name = constant_string_value(tag_schema).unwrap();
-            let (name, rename) = recase(variant_name, Case::Pascal);
 
             let sub_type_name = match enum_type_name {
                 // If the type name is known (required) we append the name of
@@ -582,12 +559,11 @@ impl TypeSpace {
             let content_schema = validation.properties.get(content).unwrap();
             let (details, deny) = self.external_variant(sub_type_name, content_schema)?;
 
-            let variant = Variant {
-                name,
-                rename,
-                description: metadata_title_and_description(metadata),
+            let variant = Variant::new(
+                variant_name.to_string(),
+                metadata_title_and_description(metadata),
                 details,
-            };
+            );
             Ok((variant, deny))
         }
     }
@@ -692,14 +668,9 @@ impl TypeSpace {
 
         let variants = variant_details
             .into_iter()
-            .map(|(details, name)| {
-                assert!(!name.is_empty());
-                Variant {
-                    name,
-                    rename: None,
-                    description: None,
-                    details,
-                }
+            .map(|(details, variant_name)| {
+                assert!(!variant_name.is_empty());
+                Variant::new(variant_name, None, details)
             })
             .collect();
 
@@ -738,18 +709,20 @@ pub(crate) fn output_variant(
     output: &mut OutputSpace,
     type_name: &str,
 ) -> TokenStream {
-    let name = format_ident!("{}", variant.name);
+    let ident_name = variant.ident_name.as_ref().unwrap();
+    let variant_name = format_ident!("{}", ident_name);
     let doc = variant.description.as_ref().map(|s| {
         quote! { #[doc = #s] }
     });
-    let serde = variant.rename.as_ref().map(|s| {
+    let serde = (&variant.raw_name != ident_name).then(|| {
+        let s = &variant.raw_name;
         quote! { #[serde(rename = #s)] }
     });
     match &variant.details {
         VariantDetails::Simple => quote! {
             #doc
             #serde
-            #name,
+            #variant_name,
         },
         VariantDetails::Item(type_id) => {
             let item_type_ident = type_space
@@ -761,7 +734,7 @@ pub(crate) fn output_variant(
             quote! {
                 #doc
                 #serde
-                #name(#item_type_ident),
+                #variant_name(#item_type_ident),
             }
         }
 
@@ -778,7 +751,7 @@ pub(crate) fn output_variant(
                 quote! {
                     #doc
                     #serde
-                    #name(#(#types),*),
+                    #variant_name(#(#types),*),
                 }
             } else {
                 // A tuple variant with a single element requires special
@@ -788,7 +761,7 @@ pub(crate) fn output_variant(
                 quote! {
                     #doc
                     #serde
-                    #name((#(#types,)*)),
+                    #variant_name((#(#types,)*)),
                 }
             }
         }
@@ -799,7 +772,7 @@ pub(crate) fn output_variant(
 
                 let prop_type_entry = type_space.id_to_entry.get(&prop.type_id).unwrap();
                 let (prop_serde, _) = generate_serde_attr(
-                    &format!("{}{}", type_name, &variant.name),
+                    &format!("{}{}", type_name, variant.ident_name.as_ref().unwrap()),
                     &prop.name,
                     &prop.rename,
                     &prop.state,
@@ -820,7 +793,7 @@ pub(crate) fn output_variant(
             quote! {
                 #doc
                 #serde
-                #name {
+                #variant_name {
                     #(#prop_streams)*
                 },
             }
@@ -1210,7 +1183,7 @@ mod tests {
         {
             let variant_names = variants
                 .iter()
-                .map(|variant| variant.name.clone())
+                .map(|variant| variant.ident_name.as_ref().unwrap().clone())
                 .collect::<HashSet<_>>();
             assert_eq!(variant_names.len(), variants.len());
             assert_eq!(tag_type, &EnumTagType::Untagged);
@@ -1328,7 +1301,10 @@ mod tests {
                     match &variant.details {
                         VariantDetails::Item(item) => {
                             let variant_type = type_space.id_to_entry.get(item).unwrap();
-                            assert!(variant_type.name().unwrap().ends_with(&variant.name));
+                            assert!(variant_type
+                                .name()
+                                .unwrap()
+                                .ends_with(variant.ident_name.as_ref().unwrap()));
                         }
                         _ => panic!("{:#?}", type_entry),
                     }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! typify backend implementation.
 

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -1138,7 +1138,7 @@ impl<'a> TypeEnum<'a> {
                 ),
             };
             TypeEnumVariantInfo {
-                name: variant.name.as_str(),
+                name: variant.ident_name.as_ref().unwrap(),
                 description: variant.description.as_deref(),
                 details,
             }
@@ -1325,7 +1325,7 @@ mod tests {
                 }
                 let var_names = variants
                     .iter()
-                    .map(|variant| variant.name.clone())
+                    .map(|variant| variant.ident_name.as_ref().unwrap().clone())
                     .collect::<HashSet<_>>();
                 assert_eq!(
                     var_names,
@@ -1371,7 +1371,7 @@ mod tests {
                 let variants = variants
                     .iter()
                     .map(|v| match v.details {
-                        VariantDetails::Simple => v.name.clone(),
+                        VariantDetails::Simple => v.ident_name.as_ref().unwrap().clone(),
                         _ => panic!("unexpected variant type"),
                     })
                     .collect::<HashSet<_>>();

--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -850,11 +850,13 @@ impl StringValidator {
 
 #[cfg(test)]
 mod tests {
+    use heck::ToPascalCase;
     use schemars::{
         gen::{SchemaGenerator, SchemaSettings},
         schema::StringValidation,
         schema_for, JsonSchema,
     };
+    use unicode_ident::is_xid_continue;
 
     use crate::{
         util::{sanitize, schemas_mutually_exclusive, Case},
@@ -1025,5 +1027,24 @@ mod tests {
         assert!(ach.is_valid("Shadrach"));
         assert!(ach.is_valid("Meshach"));
         assert!(!ach.is_valid("Abednego"));
+    }
+
+    #[test]
+    fn test_recase_dots() {
+        let x = sanitize("2.5G", Case::Pascal);
+        println!("{:#?}", x);
+        let x = sanitize("25G", Case::Pascal);
+        println!("{:#?}", x);
+        let x = sanitize("2,5,g", Case::Pascal);
+        println!("{:#?}", x);
+
+        println!();
+        println!(
+            "{}",
+            "2.5G"
+                .replace(|c| !is_xid_continue(c), "x")
+                .to_pascal_case()
+        );
+        panic!();
     }
 }

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{collections::BTreeMap, str::FromStr};
 

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -237,7 +237,7 @@ fn value_for_internal_enum(
     let ser_name = map.get(tag).and_then(serde_json::Value::as_str)?;
     let variant = variants
         .iter()
-        .find(|variant| ser_name == &variant.raw_name)?;
+        .find(|variant| ser_name == variant.raw_name)?;
     let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
     let type_ident = format_ident!("{}", type_name);
 
@@ -283,7 +283,7 @@ fn value_for_adjacent_enum(
 
     let variant = variants
         .iter()
-        .find(|variant| tag_value == &variant.raw_name)?;
+        .find(|variant| tag_value == variant.raw_name)?;
     let type_ident = format_ident!("{}", type_name);
     let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
     match (&variant.details, content_value) {

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -189,10 +189,10 @@ fn value_for_external_enum(
     if let Some(simple_name) = value.as_str() {
         let variant = variants
             .iter()
-            .find(|variant| simple_name == variant.rename.as_ref().unwrap_or(&variant.name))?;
+            .find(|variant| simple_name == variant.raw_name)?;
         matches!(&variant.details, VariantDetails::Simple).then(|| ())?;
 
-        let var_ident = format_ident!("{}", &variant.name);
+        let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
         let type_ident = format_ident!("{}", type_name);
         Some(quote! { #scope #type_ident::#var_ident })
     } else {
@@ -203,11 +203,9 @@ fn value_for_external_enum(
 
         let (name, var_value) = map.iter().next()?;
 
-        let variant = variants
-            .iter()
-            .find(|variant| name == variant.rename.as_ref().unwrap_or(&variant.name))?;
+        let variant = variants.iter().find(|variant| name == &variant.raw_name)?;
 
-        let var_ident = format_ident!("{}", &variant.name);
+        let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
         let type_ident = format_ident!("{}", type_name);
         match &variant.details {
             VariantDetails::Simple => None,
@@ -239,8 +237,8 @@ fn value_for_internal_enum(
     let ser_name = map.get(tag).and_then(serde_json::Value::as_str)?;
     let variant = variants
         .iter()
-        .find(|variant| ser_name == variant.rename.as_ref().unwrap_or(&variant.name))?;
-    let var_ident = format_ident!("{}", &variant.name);
+        .find(|variant| ser_name == &variant.raw_name)?;
+    let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
     let type_ident = format_ident!("{}", type_name);
 
     match &variant.details {
@@ -285,9 +283,9 @@ fn value_for_adjacent_enum(
 
     let variant = variants
         .iter()
-        .find(|variant| tag_value == variant.rename.as_ref().unwrap_or(&variant.name))?;
+        .find(|variant| tag_value == &variant.raw_name)?;
     let type_ident = format_ident!("{}", type_name);
-    let var_ident = format_ident!("{}", &variant.name);
+    let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
     match (&variant.details, content_value) {
         (VariantDetails::Simple, None) => Some(quote! { #scope #type_ident::#var_ident}),
         (VariantDetails::Tuple(types), Some(content_value)) => {
@@ -311,7 +309,7 @@ fn value_for_untagged_enum(
 ) -> Option<TokenStream> {
     let type_ident = format_ident!("{}", type_name);
     variants.iter().find_map(|variant| {
-        let var_ident = format_ident!("{}", &variant.name);
+        let var_ident = format_ident!("{}", &variant.ident_name.as_ref().unwrap());
         match &variant.details {
             VariantDetails::Simple => {
                 value.as_null()?;

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -849,7 +849,7 @@ pub enum AggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "__count__")]
-    Count,
+    XXcountXx,
     #[serde(rename = "missing")]
     Missing,
     #[serde(rename = "valid")]
@@ -903,7 +903,7 @@ impl ::std::fmt::Display for AggregateTransformOpsVariant0ItemVariant0 {
         match *self {
             Self::Values => write!(f, "values"),
             Self::Count => write!(f, "count"),
-            Self::Count => write!(f, "__count__"),
+            Self::XXcountXx => write!(f, "__count__"),
             Self::Missing => write!(f, "missing"),
             Self::Valid => write!(f, "valid"),
             Self::Sum => write!(f, "sum"),
@@ -934,7 +934,7 @@ impl ::std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
-            "__count__" => Ok(Self::Count),
+            "__count__" => Ok(Self::XXcountXx),
             "missing" => Ok(Self::Missing),
             "valid" => Ok(Self::Valid),
             "sum" => Ok(Self::Sum),
@@ -41659,7 +41659,7 @@ pub enum JoinaggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "__count__")]
-    Count,
+    XXcountXx,
     #[serde(rename = "missing")]
     Missing,
     #[serde(rename = "valid")]
@@ -41713,7 +41713,7 @@ impl ::std::fmt::Display for JoinaggregateTransformOpsVariant0ItemVariant0 {
         match *self {
             Self::Values => write!(f, "values"),
             Self::Count => write!(f, "count"),
-            Self::Count => write!(f, "__count__"),
+            Self::XXcountXx => write!(f, "__count__"),
             Self::Missing => write!(f, "missing"),
             Self::Valid => write!(f, "valid"),
             Self::Sum => write!(f, "sum"),
@@ -41744,7 +41744,7 @@ impl ::std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
-            "__count__" => Ok(Self::Count),
+            "__count__" => Ok(Self::XXcountXx),
             "missing" => Ok(Self::Missing),
             "valid" => Ok(Self::Valid),
             "sum" => Ok(Self::Sum),
@@ -80803,7 +80803,7 @@ pub enum PivotTransformOpVariant0 {
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "__count__")]
-    Count,
+    XXcountXx,
     #[serde(rename = "missing")]
     Missing,
     #[serde(rename = "valid")]
@@ -80857,7 +80857,7 @@ impl ::std::fmt::Display for PivotTransformOpVariant0 {
         match *self {
             Self::Values => write!(f, "values"),
             Self::Count => write!(f, "count"),
-            Self::Count => write!(f, "__count__"),
+            Self::XXcountXx => write!(f, "__count__"),
             Self::Missing => write!(f, "missing"),
             Self::Valid => write!(f, "valid"),
             Self::Sum => write!(f, "sum"),
@@ -80888,7 +80888,7 @@ impl ::std::str::FromStr for PivotTransformOpVariant0 {
         match value {
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
-            "__count__" => Ok(Self::Count),
+            "__count__" => Ok(Self::XXcountXx),
             "missing" => Ok(Self::Missing),
             "valid" => Ok(Self::Valid),
             "sum" => Ok(Self::Sum),
@@ -112827,15 +112827,15 @@ impl ::std::convert::From<SignalRef> for WindowTransformOpsVariant0Item {
 )]
 pub enum WindowTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "row_number")]
-    RowNumber,
+    RowXnumber,
     #[serde(rename = "rank")]
     Rank,
     #[serde(rename = "dense_rank")]
-    DenseRank,
+    DenseXrank,
     #[serde(rename = "percent_rank")]
-    PercentRank,
+    PercentXrank,
     #[serde(rename = "cume_dist")]
-    CumeDist,
+    CumeXdist,
     #[serde(rename = "ntile")]
     Ntile,
     #[serde(rename = "lag")]
@@ -112843,21 +112843,21 @@ pub enum WindowTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "lead")]
     Lead,
     #[serde(rename = "first_value")]
-    FirstValue,
+    FirstXvalue,
     #[serde(rename = "last_value")]
-    LastValue,
+    LastXvalue,
     #[serde(rename = "nth_value")]
-    NthValue,
+    NthXvalue,
     #[serde(rename = "prev_value")]
-    PrevValue,
+    PrevXvalue,
     #[serde(rename = "next_value")]
-    NextValue,
+    NextXvalue,
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
     Count,
     #[serde(rename = "__count__")]
-    Count,
+    XXcountXx,
     #[serde(rename = "missing")]
     Missing,
     #[serde(rename = "valid")]
@@ -112909,22 +112909,22 @@ impl ::std::convert::From<&Self> for WindowTransformOpsVariant0ItemVariant0 {
 impl ::std::fmt::Display for WindowTransformOpsVariant0ItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RowNumber => write!(f, "row_number"),
+            Self::RowXnumber => write!(f, "row_number"),
             Self::Rank => write!(f, "rank"),
-            Self::DenseRank => write!(f, "dense_rank"),
-            Self::PercentRank => write!(f, "percent_rank"),
-            Self::CumeDist => write!(f, "cume_dist"),
+            Self::DenseXrank => write!(f, "dense_rank"),
+            Self::PercentXrank => write!(f, "percent_rank"),
+            Self::CumeXdist => write!(f, "cume_dist"),
             Self::Ntile => write!(f, "ntile"),
             Self::Lag => write!(f, "lag"),
             Self::Lead => write!(f, "lead"),
-            Self::FirstValue => write!(f, "first_value"),
-            Self::LastValue => write!(f, "last_value"),
-            Self::NthValue => write!(f, "nth_value"),
-            Self::PrevValue => write!(f, "prev_value"),
-            Self::NextValue => write!(f, "next_value"),
+            Self::FirstXvalue => write!(f, "first_value"),
+            Self::LastXvalue => write!(f, "last_value"),
+            Self::NthXvalue => write!(f, "nth_value"),
+            Self::PrevXvalue => write!(f, "prev_value"),
+            Self::NextXvalue => write!(f, "next_value"),
             Self::Values => write!(f, "values"),
             Self::Count => write!(f, "count"),
-            Self::Count => write!(f, "__count__"),
+            Self::XXcountXx => write!(f, "__count__"),
             Self::Missing => write!(f, "missing"),
             Self::Valid => write!(f, "valid"),
             Self::Sum => write!(f, "sum"),
@@ -112953,22 +112953,22 @@ impl ::std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
-            "row_number" => Ok(Self::RowNumber),
+            "row_number" => Ok(Self::RowXnumber),
             "rank" => Ok(Self::Rank),
-            "dense_rank" => Ok(Self::DenseRank),
-            "percent_rank" => Ok(Self::PercentRank),
-            "cume_dist" => Ok(Self::CumeDist),
+            "dense_rank" => Ok(Self::DenseXrank),
+            "percent_rank" => Ok(Self::PercentXrank),
+            "cume_dist" => Ok(Self::CumeXdist),
             "ntile" => Ok(Self::Ntile),
             "lag" => Ok(Self::Lag),
             "lead" => Ok(Self::Lead),
-            "first_value" => Ok(Self::FirstValue),
-            "last_value" => Ok(Self::LastValue),
-            "nth_value" => Ok(Self::NthValue),
-            "prev_value" => Ok(Self::PrevValue),
-            "next_value" => Ok(Self::NextValue),
+            "first_value" => Ok(Self::FirstXvalue),
+            "last_value" => Ok(Self::LastXvalue),
+            "nth_value" => Ok(Self::NthXvalue),
+            "prev_value" => Ok(Self::PrevXvalue),
+            "next_value" => Ok(Self::NextXvalue),
             "values" => Ok(Self::Values),
             "count" => Ok(Self::Count),
-            "__count__" => Ok(Self::Count),
+            "__count__" => Ok(Self::XXcountXx),
             "missing" => Ok(Self::Missing),
             "valid" => Ok(Self::Valid),
             "sum" => Ok(Self::Sum),

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -281,9 +281,9 @@
     },
     "variants-differ-by-punct": {
       "enum": [
-        "2.5G",
-        "25G",
-        "2,5,g"
+        "2.5GBASE-T",
+        "25GBASE-T",
+        "2,5,GBASE,T"
       ]
     }
   }

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -278,6 +278,13 @@
           "description": "a pirate's favorite letter"
         }
       ]
+    },
+    "variants-differ-by-punct": {
+      "enum": [
+        "2.5G",
+        "25G",
+        "2,5,g"
+      ]
     }
   }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1310,6 +1310,87 @@ impl ::std::fmt::Display for StringVersion {
         self.0.fmt(f)
     }
 }
+#[doc = "VariantsDifferByPunct"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"2.5G\","]
+#[doc = "    \"25G\","]
+#[doc = "    \"2,5,G\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum VariantsDifferByPunct {
+    #[serde(rename = "2.5G")]
+    _25g,
+    #[serde(rename = "25G")]
+    _25g,
+    #[serde(rename = "2,5,G")]
+    _25G,
+}
+impl ::std::convert::From<&Self> for VariantsDifferByPunct {
+    fn from(value: &VariantsDifferByPunct) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for VariantsDifferByPunct {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::_25g => write!(f, "2.5G"),
+            Self::_25g => write!(f, "25G"),
+            Self::_25G => write!(f, "2,5,G"),
+        }
+    }
+}
+impl ::std::str::FromStr for VariantsDifferByPunct {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "2.5G" => Ok(Self::_25g),
+            "25G" => Ok(Self::_25g),
+            "2,5,G" => Ok(Self::_25G),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for VariantsDifferByPunct {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String> for VariantsDifferByPunct {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for VariantsDifferByPunct {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
 #[doc = r" Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1317,9 +1317,9 @@ impl ::std::fmt::Display for StringVersion {
 #[doc = r" ```json"]
 #[doc = "{"]
 #[doc = "  \"enum\": ["]
-#[doc = "    \"2.5G\","]
-#[doc = "    \"25G\","]
-#[doc = "    \"2,5,G\""]
+#[doc = "    \"2.5GBASE-T\","]
+#[doc = "    \"25GBASE-T\","]
+#[doc = "    \"2,5,GBASE,T\""]
 #[doc = "  ]"]
 #[doc = "}"]
 #[doc = r" ```"]
@@ -1337,12 +1337,12 @@ impl ::std::fmt::Display for StringVersion {
     PartialOrd,
 )]
 pub enum VariantsDifferByPunct {
-    #[serde(rename = "2.5G")]
-    _25g,
-    #[serde(rename = "25G")]
-    _25g,
-    #[serde(rename = "2,5,G")]
-    _25G,
+    #[serde(rename = "2.5GBASE-T")]
+    X2x5gbasext,
+    #[serde(rename = "25GBASE-T")]
+    X25gbasext,
+    #[serde(rename = "2,5,GBASE,T")]
+    X2x5xgbasext,
 }
 impl ::std::convert::From<&Self> for VariantsDifferByPunct {
     fn from(value: &VariantsDifferByPunct) -> Self {
@@ -1352,9 +1352,9 @@ impl ::std::convert::From<&Self> for VariantsDifferByPunct {
 impl ::std::fmt::Display for VariantsDifferByPunct {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::_25g => write!(f, "2.5G"),
-            Self::_25g => write!(f, "25G"),
-            Self::_25G => write!(f, "2,5,G"),
+            Self::X2x5gbasext => write!(f, "2.5GBASE-T"),
+            Self::X25gbasext => write!(f, "25GBASE-T"),
+            Self::X2x5xgbasext => write!(f, "2,5,GBASE,T"),
         }
     }
 }
@@ -1362,9 +1362,9 @@ impl ::std::str::FromStr for VariantsDifferByPunct {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
-            "2.5G" => Ok(Self::_25g),
-            "25G" => Ok(Self::_25g),
-            "2,5,G" => Ok(Self::_25G),
+            "2.5GBASE-T" => Ok(Self::X2x5gbasext),
+            "25GBASE-T" => Ok(Self::X25gbasext),
+            "2,5,GBASE,T" => Ok(Self::X2x5xgbasext),
             _ => Err("invalid value".into()),
         }
     }


### PR DESCRIPTION
Previously, conversion from the variant name derived from the schema and the Rust identifier was done for each variant as it was constructed. This change defers that conversion to when we construct the enum (i.e. when we have all variants in hand). This then allows us to check that each variant has a unique name, and try an alternative conversion. This also lets us fail rather than generating code that does not compile.

There's much more we could do to improve name generation, but this is a decent step forward both in terms of organization and resolving an immediate use case.