### PR TITLE
improve `null` recognition and identenifcation of mutually incompatible `anyOf` subschemas

### DIFF
--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Oxide Computer Company
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use log::debug;
 use schemars::schema::{
@@ -9,7 +9,7 @@ use schemars::schema::{
 };
 use unicode_ident::{is_xid_continue, is_xid_start};
 
-use crate::{Error, Name, RefKey, Result, TypeSpace};
+use crate::{validate::schema_value_validate, Error, Name, RefKey, Result, TypeSpace};
 
 pub(crate) fn metadata_description(metadata: &Option<Box<Metadata>>) -> Option<String> {
     metadata
@@ -44,7 +44,7 @@ pub(crate) fn metadata_title_and_description(metadata: &Option<Box<Metadata>>) -
 /// **could** be merged (i.e. if they're compatible).
 pub(crate) fn all_mutually_exclusive(
     subschemas: &[Schema],
-    definitions: &std::collections::BTreeMap<RefKey, Schema>,
+    definitions: &BTreeMap<RefKey, Schema>,
 ) -> bool {
     let len = subschemas.len();
     // Consider all pairs
@@ -53,13 +53,17 @@ pub(crate) fn all_mutually_exclusive(
         .all(|(ii, jj)| {
             let a = resolve(&subschemas[ii], definitions);
             let b = resolve(&subschemas[jj], definitions);
-            schemas_mutually_exclusive(a, b)
+            schemas_mutually_exclusive(a, b, definitions)
         })
 }
 
 /// This function needs to necessarily be conservative. We'd much prefer a
 /// false negative than a false positive.
-fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
+fn schemas_mutually_exclusive(
+    a: &Schema,
+    b: &Schema,
+    definitions: &BTreeMap<RefKey, Schema>,
+) -> bool {
     match (a, b) {
         // If either matches nothing then they are exclusive.
         (Schema::Bool(false), _) => true,
@@ -114,7 +118,9 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                 if_schema: None,
                 then_schema: None,
                 else_schema: None,
-            } => s.iter().any(|sub| schemas_mutually_exclusive(sub, other)),
+            } => s
+                .iter()
+                .any(|sub| schemas_mutually_exclusive(sub, other, definitions)),
 
             // For a oneOf or anyOf, *all* subschemas need to be incompatible.
             SubschemaValidation {
@@ -134,7 +140,9 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                 if_schema: None,
                 then_schema: None,
                 else_schema: None,
-            } => s.iter().all(|sub| schemas_mutually_exclusive(sub, other)),
+            } => s
+                .iter()
+                .all(|sub| schemas_mutually_exclusive(sub, other, definitions)),
 
             // For a not, they're mutually exclusive if they *do* match.
             SubschemaValidation {
@@ -145,21 +153,20 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                 if_schema: None,
                 then_schema: None,
                 else_schema: None,
-            } => !schemas_mutually_exclusive(sub, other),
+            } => !schemas_mutually_exclusive(sub, other, definitions),
 
             // Assume other subschemas are complex to understand and may
             // therefore be compatible.
             _ => false,
         },
 
-        // If one type has an explicit type and has enumerated value (but no
-        // type), we can check to see if every enumerated value is incompatible
-        // with the given type.
+        // If one schema has enumerated values, it's incompatible if all values
+        // fail to validate against the other schema. (Conversely, if all
+        // values *do* validate against the other schema, it simply seems
+        // redundant--the most interesting case is if *some* values validate
+        // and others do not.)
         (
-            Schema::Object(SchemaObject {
-                instance_type: Some(SingleOrVec::Single(marked_type)),
-                ..
-            }),
+            schema,
             Schema::Object(SchemaObject {
                 instance_type: None,
                 enum_values: Some(enum_values),
@@ -172,21 +179,27 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                 enum_values: Some(enum_values),
                 ..
             }),
-            Schema::Object(SchemaObject {
-                instance_type: Some(SingleOrVec::Single(marked_type)),
-                ..
-            }),
+            schema,
         ) => enum_values
             .iter()
-            .map(|v| match v {
-                serde_json::Value::Null => InstanceType::Null,
-                serde_json::Value::Bool(_) => InstanceType::Boolean,
-                serde_json::Value::Number(_) => InstanceType::Number,
-                serde_json::Value::String(_) => InstanceType::String,
-                serde_json::Value::Array(_) => InstanceType::Array,
-                serde_json::Value::Object(_) => InstanceType::Object,
-            })
-            .all(|value_type| value_type != **marked_type),
+            .all(|value| schema_value_validate(schema, value, definitions).is_err()),
+
+        // If one schema has a constant value, it's incompatible if that value
+        // fails to validate against the other schema.
+        (
+            schema,
+            Schema::Object(SchemaObject {
+                const_value: Some(value),
+                ..
+            }),
+        )
+        | (
+            Schema::Object(SchemaObject {
+                const_value: Some(value),
+                ..
+            }),
+            schema,
+        ) => schema_value_validate(schema, value, definitions).is_err(),
 
         // Neither is a Schema::Bool; we need to look at the instance types.
         (Schema::Object(a), Schema::Object(b)) => {
@@ -285,7 +298,7 @@ fn schemas_mutually_exclusive(a: &Schema, b: &Schema) -> bool {
                         },
                     ) = (a, b)
                     {
-                        array_schemas_mutually_exclusive(a_validation, b_validation)
+                        array_schemas_mutually_exclusive(a_validation, b_validation, definitions)
                     } else {
                         // Could check further, but we'll be conservative.
                         false
@@ -383,6 +396,7 @@ fn object_schemas_mutually_exclusive(
 fn array_schemas_mutually_exclusive(
     a_validation: &ArrayValidation,
     b_validation: &ArrayValidation,
+    definitions: &BTreeMap<RefKey, Schema>,
 ) -> bool {
     match (a_validation, b_validation) {
         // If one is an array with a single item type and the other is a tuple
@@ -421,7 +435,7 @@ fn array_schemas_mutually_exclusive(
             },
         ) if max_items == min_items && *max_items as usize == vec.len() => vec
             .iter()
-            .any(|schema| schemas_mutually_exclusive(schema, single)),
+            .any(|schema| schemas_mutually_exclusive(schema, single, definitions)),
 
         (aa, bb) => {
             // If min > max then these schemas are incompatible.
@@ -438,7 +452,7 @@ fn array_schemas_mutually_exclusive(
                 // If thee's a single item schema and it's mutually exclusive
                 // then we're done.
                 (Some(SingleOrVec::Single(a_items)), _, Some(SingleOrVec::Single(b_items)), _)
-                    if schemas_mutually_exclusive(a_items, b_items) =>
+                    if schemas_mutually_exclusive(a_items, b_items, definitions) =>
                 {
                     return true;
                 }
@@ -861,6 +875,8 @@ impl StringValidator {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use schemars::{
         gen::{SchemaGenerator, SchemaSettings},
         schema::StringValidation,
@@ -893,8 +909,8 @@ mod tests {
         let a = schema_for!(A).schema.into();
         let b = schema_for!(B).schema.into();
 
-        assert!(!schemas_mutually_exclusive(&a, &b));
-        assert!(!schemas_mutually_exclusive(&b, &a));
+        assert!(!schemas_mutually_exclusive(&a, &b, &BTreeMap::new()));
+        assert!(!schemas_mutually_exclusive(&b, &a, &BTreeMap::new()));
     }
 
     #[test]
@@ -913,7 +929,7 @@ mod tests {
 
         let a = gen.into_root_schema_for::<Vec<A>>().schema.into();
 
-        assert!(!schemas_mutually_exclusive(&a, &a));
+        assert!(!schemas_mutually_exclusive(&a, &a, &BTreeMap::new()));
     }
 
     #[test]
@@ -936,8 +952,8 @@ mod tests {
         let a = schema_for!(A).schema.into();
         let b = schema_for!(B).schema.into();
 
-        assert!(schemas_mutually_exclusive(&a, &b));
-        assert!(schemas_mutually_exclusive(&b, &a));
+        assert!(schemas_mutually_exclusive(&a, &b, &BTreeMap::new()));
+        assert!(schemas_mutually_exclusive(&b, &a, &BTreeMap::new()));
     }
 
     #[test]
@@ -961,8 +977,8 @@ mod tests {
         let a = schema_for!(A).schema.into();
         let b = schema_for!(B).schema.into();
 
-        assert!(schemas_mutually_exclusive(&a, &b));
-        assert!(schemas_mutually_exclusive(&b, &a));
+        assert!(schemas_mutually_exclusive(&a, &b, &BTreeMap::new()));
+        assert!(schemas_mutually_exclusive(&b, &a, &BTreeMap::new()));
     }
 
     #[test]
@@ -970,8 +986,8 @@ mod tests {
         let a = schema_for!(Vec<u32>).schema.into();
         let b = schema_for!(Vec<f32>).schema.into();
 
-        assert!(schemas_mutually_exclusive(&a, &b));
-        assert!(schemas_mutually_exclusive(&b, &a));
+        assert!(schemas_mutually_exclusive(&a, &b, &BTreeMap::new()));
+        assert!(schemas_mutually_exclusive(&b, &a, &BTreeMap::new()));
     }
 
     #[test]

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -285,6 +285,70 @@
         "25GBASE-T",
         "2,5,GBASE,T"
       ]
+    },
+    "option-oneof-enum": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            null
+          ]
+        }
+      ]
+    },
+    "option-oneof-const": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "const": null
+        }
+      ]
+    },
+    "option-oneof-null": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "option-anyof-enum": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            null
+          ]
+        }
+      ]
+    },
+    "option-anyof-const": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "const": null
+        }
+      ]
+    },
+    "option-anyof-null": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1020,6 +1020,256 @@ impl ::std::convert::From<i64> for OneOfTypes {
         Self::Bar(value)
     }
 }
+#[doc = "`OptionAnyofConst`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"anyOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"const\": null"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionAnyofConst(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionAnyofConst {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionAnyofConst> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionAnyofConst) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionAnyofConst> for OptionAnyofConst {
+    fn from(value: &OptionAnyofConst) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofConst {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`OptionAnyofEnum`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"anyOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"enum\": ["]
+#[doc = "        null"]
+#[doc = "      ]"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionAnyofEnum(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionAnyofEnum {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionAnyofEnum> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionAnyofEnum) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionAnyofEnum> for OptionAnyofEnum {
+    fn from(value: &OptionAnyofEnum) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofEnum {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`OptionAnyofNull`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"anyOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionAnyofNull(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionAnyofNull {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionAnyofNull> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionAnyofNull) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionAnyofNull> for OptionAnyofNull {
+    fn from(value: &OptionAnyofNull) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofNull {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`OptionOneofConst`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"const\": null"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionOneofConst(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionOneofConst {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionOneofConst> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionOneofConst) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionOneofConst> for OptionOneofConst {
+    fn from(value: &OptionOneofConst) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofConst {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`OptionOneofEnum`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"enum\": ["]
+#[doc = "        null"]
+#[doc = "      ]"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionOneofEnum(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionOneofEnum {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionOneofEnum> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionOneofEnum) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionOneofEnum> for OptionOneofEnum {
+    fn from(value: &OptionOneofEnum) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofEnum {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`OptionOneofNull`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct OptionOneofNull(pub ::std::option::Option<::std::string::String>);
+impl ::std::ops::Deref for OptionOneofNull {
+    type Target = ::std::option::Option<::std::string::String>;
+    fn deref(&self) -> &::std::option::Option<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<OptionOneofNull> for ::std::option::Option<::std::string::String> {
+    fn from(value: OptionOneofNull) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<&OptionOneofNull> for OptionOneofNull {
+    fn from(value: &OptionOneofNull) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofNull {
+    fn from(value: ::std::option::Option<::std::string::String>) -> Self {
+        Self(value)
+    }
+}
 #[doc = "`ReferenceDef`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]


### PR DESCRIPTION
Closes #816

This does a couple of things.

What's a null schema? Currently it's just schema with `type: null`. This PR expands that definition to include `enum: [null]` and `const: null`.

While our `anyOf` handling is essentially [broken](https://ahl.dtrace.org/2024/01/22/rust-and-json-schema/#anyof), we check to see if we we can treat it as a `oneOf` (which we do handle well) in the situation where each subschema is mutually exclusive (i.e. if `oneOf` and `anyOf` would be equivalent from the perspective of schema validation). That check for mutual exclusivity is intentionally conservative--it would be very bad to have a false positive whereas a false negative applies our `anyOf` handling (which, again, is fundamentally broken, but `c'est la vie`). This PR modifies that check to do a schema validation against enumerated values (`enum` or `const`).

The culmination of these two is that the following schema doesn't panic and produces an idiomatic type:

```json
{
  "anyOf": [
    {
      "type": "string"
    },
    {
      "const": null
    }
  ]
}
```

```rust
pub struct TypeName(Option<String>);
```