### PR TITLE
replace unnecessary use of `write!` with `Formatter::write_str`

### DIFF
--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -816,14 +816,16 @@ impl TypeEntry {
                     impl ::std::fmt::Display for #type_name {
                         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                             match *self {
-                                #(Self::#match_variants => write!(f, #match_strs),)*
+                                #(Self::#match_variants => f.write_str(#match_strs),)*
                             }
                         }
                     }
                     impl ::std::str::FromStr for #type_name {
                         type Err = self::error::ConversionError;
 
-                        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+                        fn from_str(value: &str) ->
+                            ::std::result::Result<Self, self::error::ConversionError>
+                        {
                             match value {
                                 #(#match_strs => Ok(Self::#match_variants),)*
                                 _ => Err("invalid value".into()),

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -196,9 +196,9 @@ mod types {
     impl ::std::fmt::Display for StringEnum {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
-                Self::One => write!(f, "One"),
-                Self::Two => write!(f, "Two"),
-                Self::BuckleMyShoe => write!(f, "BuckleMyShoe"),
+                Self::One => f.write_str("One"),
+                Self::Two => f.write_str("Two"),
+                Self::BuckleMyShoe => f.write_str("BuckleMyShoe"),
             }
         }
     }

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -267,9 +267,9 @@ impl ::std::convert::From<&Self> for AlertInstanceState {
 impl ::std::fmt::Display for AlertInstanceState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Dismissed => write!(f, "dismissed"),
-            Self::Fixed => write!(f, "fixed"),
+            Self::Open => f.write_str("open"),
+            Self::Dismissed => f.write_str("dismissed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -865,50 +865,50 @@ impl ::std::convert::From<&Self> for AppEventsItem {
 impl ::std::fmt::Display for AppEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => write!(f, "check_run"),
-            Self::CheckSuite => write!(f, "check_suite"),
-            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
-            Self::CommitComment => write!(f, "commit_comment"),
-            Self::ContentReference => write!(f, "content_reference"),
-            Self::Create => write!(f, "create"),
-            Self::Delete => write!(f, "delete"),
-            Self::Deployment => write!(f, "deployment"),
-            Self::DeploymentReview => write!(f, "deployment_review"),
-            Self::DeploymentStatus => write!(f, "deployment_status"),
-            Self::DeployKey => write!(f, "deploy_key"),
-            Self::Discussion => write!(f, "discussion"),
-            Self::DiscussionComment => write!(f, "discussion_comment"),
-            Self::Fork => write!(f, "fork"),
-            Self::Gollum => write!(f, "gollum"),
-            Self::Issues => write!(f, "issues"),
-            Self::IssueComment => write!(f, "issue_comment"),
-            Self::Label => write!(f, "label"),
-            Self::Member => write!(f, "member"),
-            Self::Membership => write!(f, "membership"),
-            Self::Milestone => write!(f, "milestone"),
-            Self::Organization => write!(f, "organization"),
-            Self::OrgBlock => write!(f, "org_block"),
-            Self::PageBuild => write!(f, "page_build"),
-            Self::Project => write!(f, "project"),
-            Self::ProjectCard => write!(f, "project_card"),
-            Self::ProjectColumn => write!(f, "project_column"),
-            Self::Public => write!(f, "public"),
-            Self::PullRequest => write!(f, "pull_request"),
-            Self::PullRequestReview => write!(f, "pull_request_review"),
-            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
-            Self::Push => write!(f, "push"),
-            Self::RegistryPackage => write!(f, "registry_package"),
-            Self::Release => write!(f, "release"),
-            Self::Repository => write!(f, "repository"),
-            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
-            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
-            Self::Star => write!(f, "star"),
-            Self::Status => write!(f, "status"),
-            Self::Team => write!(f, "team"),
-            Self::TeamAdd => write!(f, "team_add"),
-            Self::Watch => write!(f, "watch"),
-            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
-            Self::WorkflowRun => write!(f, "workflow_run"),
+            Self::CheckRun => f.write_str("check_run"),
+            Self::CheckSuite => f.write_str("check_suite"),
+            Self::CodeScanningAlert => f.write_str("code_scanning_alert"),
+            Self::CommitComment => f.write_str("commit_comment"),
+            Self::ContentReference => f.write_str("content_reference"),
+            Self::Create => f.write_str("create"),
+            Self::Delete => f.write_str("delete"),
+            Self::Deployment => f.write_str("deployment"),
+            Self::DeploymentReview => f.write_str("deployment_review"),
+            Self::DeploymentStatus => f.write_str("deployment_status"),
+            Self::DeployKey => f.write_str("deploy_key"),
+            Self::Discussion => f.write_str("discussion"),
+            Self::DiscussionComment => f.write_str("discussion_comment"),
+            Self::Fork => f.write_str("fork"),
+            Self::Gollum => f.write_str("gollum"),
+            Self::Issues => f.write_str("issues"),
+            Self::IssueComment => f.write_str("issue_comment"),
+            Self::Label => f.write_str("label"),
+            Self::Member => f.write_str("member"),
+            Self::Membership => f.write_str("membership"),
+            Self::Milestone => f.write_str("milestone"),
+            Self::Organization => f.write_str("organization"),
+            Self::OrgBlock => f.write_str("org_block"),
+            Self::PageBuild => f.write_str("page_build"),
+            Self::Project => f.write_str("project"),
+            Self::ProjectCard => f.write_str("project_card"),
+            Self::ProjectColumn => f.write_str("project_column"),
+            Self::Public => f.write_str("public"),
+            Self::PullRequest => f.write_str("pull_request"),
+            Self::PullRequestReview => f.write_str("pull_request_review"),
+            Self::PullRequestReviewComment => f.write_str("pull_request_review_comment"),
+            Self::Push => f.write_str("push"),
+            Self::RegistryPackage => f.write_str("registry_package"),
+            Self::Release => f.write_str("release"),
+            Self::Repository => f.write_str("repository"),
+            Self::RepositoryDispatch => f.write_str("repository_dispatch"),
+            Self::SecretScanningAlert => f.write_str("secret_scanning_alert"),
+            Self::Star => f.write_str("star"),
+            Self::Status => f.write_str("status"),
+            Self::Team => f.write_str("team"),
+            Self::TeamAdd => f.write_str("team_add"),
+            Self::Watch => f.write_str("watch"),
+            Self::WorkflowDispatch => f.write_str("workflow_dispatch"),
+            Self::WorkflowRun => f.write_str("workflow_run"),
         }
     }
 }
@@ -1397,8 +1397,8 @@ impl ::std::convert::From<&Self> for AppPermissionsActions {
 impl ::std::fmt::Display for AppPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1474,8 +1474,8 @@ impl ::std::convert::From<&Self> for AppPermissionsAdministration {
 impl ::std::fmt::Display for AppPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1551,8 +1551,8 @@ impl ::std::convert::From<&Self> for AppPermissionsChecks {
 impl ::std::fmt::Display for AppPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1628,8 +1628,8 @@ impl ::std::convert::From<&Self> for AppPermissionsContentReferences {
 impl ::std::fmt::Display for AppPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1705,8 +1705,8 @@ impl ::std::convert::From<&Self> for AppPermissionsContents {
 impl ::std::fmt::Display for AppPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1782,8 +1782,8 @@ impl ::std::convert::From<&Self> for AppPermissionsDeployments {
 impl ::std::fmt::Display for AppPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1859,8 +1859,8 @@ impl ::std::convert::From<&Self> for AppPermissionsDiscussions {
 impl ::std::fmt::Display for AppPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -1936,8 +1936,8 @@ impl ::std::convert::From<&Self> for AppPermissionsEmails {
 impl ::std::fmt::Display for AppPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2013,8 +2013,8 @@ impl ::std::convert::From<&Self> for AppPermissionsEnvironments {
 impl ::std::fmt::Display for AppPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2090,8 +2090,8 @@ impl ::std::convert::From<&Self> for AppPermissionsIssues {
 impl ::std::fmt::Display for AppPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2167,8 +2167,8 @@ impl ::std::convert::From<&Self> for AppPermissionsMembers {
 impl ::std::fmt::Display for AppPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2244,8 +2244,8 @@ impl ::std::convert::From<&Self> for AppPermissionsMetadata {
 impl ::std::fmt::Display for AppPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2321,8 +2321,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationAdministration {
 impl ::std::fmt::Display for AppPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2398,8 +2398,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationHooks {
 impl ::std::fmt::Display for AppPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2475,8 +2475,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationPackages {
 impl ::std::fmt::Display for AppPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2552,8 +2552,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationPlan {
 impl ::std::fmt::Display for AppPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2629,8 +2629,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationProjects {
 impl ::std::fmt::Display for AppPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2706,8 +2706,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationSecrets {
 impl ::std::fmt::Display for AppPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2783,8 +2783,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationSelfHostedRunners
 impl ::std::fmt::Display for AppPermissionsOrganizationSelfHostedRunners {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2864,8 +2864,8 @@ impl ::std::convert::From<&Self> for AppPermissionsOrganizationUserBlocking {
 impl ::std::fmt::Display for AppPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -2941,8 +2941,8 @@ impl ::std::convert::From<&Self> for AppPermissionsPackages {
 impl ::std::fmt::Display for AppPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3018,8 +3018,8 @@ impl ::std::convert::From<&Self> for AppPermissionsPages {
 impl ::std::fmt::Display for AppPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3095,8 +3095,8 @@ impl ::std::convert::From<&Self> for AppPermissionsPullRequests {
 impl ::std::fmt::Display for AppPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3172,8 +3172,8 @@ impl ::std::convert::From<&Self> for AppPermissionsRepositoryHooks {
 impl ::std::fmt::Display for AppPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3249,8 +3249,8 @@ impl ::std::convert::From<&Self> for AppPermissionsRepositoryProjects {
 impl ::std::fmt::Display for AppPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3326,8 +3326,8 @@ impl ::std::convert::From<&Self> for AppPermissionsSecretScanningAlerts {
 impl ::std::fmt::Display for AppPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3403,8 +3403,8 @@ impl ::std::convert::From<&Self> for AppPermissionsSecrets {
 impl ::std::fmt::Display for AppPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3480,8 +3480,8 @@ impl ::std::convert::From<&Self> for AppPermissionsSecurityEvents {
 impl ::std::fmt::Display for AppPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3557,8 +3557,8 @@ impl ::std::convert::From<&Self> for AppPermissionsSecurityScanningAlert {
 impl ::std::fmt::Display for AppPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3634,8 +3634,8 @@ impl ::std::convert::From<&Self> for AppPermissionsSingleFile {
 impl ::std::fmt::Display for AppPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3711,8 +3711,8 @@ impl ::std::convert::From<&Self> for AppPermissionsStatuses {
 impl ::std::fmt::Display for AppPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3788,8 +3788,8 @@ impl ::std::convert::From<&Self> for AppPermissionsTeamDiscussions {
 impl ::std::fmt::Display for AppPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3865,8 +3865,8 @@ impl ::std::convert::From<&Self> for AppPermissionsVulnerabilityAlerts {
 impl ::std::fmt::Display for AppPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -3942,8 +3942,8 @@ impl ::std::convert::From<&Self> for AppPermissionsWorkflows {
 impl ::std::fmt::Display for AppPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -4040,14 +4040,14 @@ impl ::std::convert::From<&Self> for AuthorAssociation {
 impl ::std::fmt::Display for AuthorAssociation {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Collaborator => write!(f, "COLLABORATOR"),
-            Self::Contributor => write!(f, "CONTRIBUTOR"),
-            Self::FirstTimer => write!(f, "FIRST_TIMER"),
-            Self::FirstTimeContributor => write!(f, "FIRST_TIME_CONTRIBUTOR"),
-            Self::Mannequin => write!(f, "MANNEQUIN"),
-            Self::Member => write!(f, "MEMBER"),
-            Self::None => write!(f, "NONE"),
-            Self::Owner => write!(f, "OWNER"),
+            Self::Collaborator => f.write_str("COLLABORATOR"),
+            Self::Contributor => f.write_str("CONTRIBUTOR"),
+            Self::FirstTimer => f.write_str("FIRST_TIMER"),
+            Self::FirstTimeContributor => f.write_str("FIRST_TIME_CONTRIBUTOR"),
+            Self::Mannequin => f.write_str("MANNEQUIN"),
+            Self::Member => f.write_str("MEMBER"),
+            Self::None => f.write_str("NONE"),
+            Self::Owner => f.write_str("OWNER"),
         }
     }
 }
@@ -4338,9 +4338,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleAllowDeletionsEnforceme
 impl ::std::fmt::Display for BranchProtectionRuleAllowDeletionsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -4424,9 +4424,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleAllowForcePushesEnforce
 impl ::std::fmt::Display for BranchProtectionRuleAllowForcePushesEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -4564,7 +4564,7 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleCreatedAction {
 impl ::std::fmt::Display for BranchProtectionRuleCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -4696,7 +4696,7 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleDeletedAction {
 impl ::std::fmt::Display for BranchProtectionRuleDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -4864,7 +4864,7 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleEditedAction {
 impl ::std::fmt::Display for BranchProtectionRuleEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -5120,9 +5120,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleLinearHistoryRequiremen
 impl ::std::fmt::Display for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5208,9 +5208,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleMergeQueueEnforcementLe
 impl ::std::fmt::Display for BranchProtectionRuleMergeQueueEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5294,9 +5294,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRulePullRequestReviewsEnfor
 impl ::std::fmt::Display for BranchProtectionRulePullRequestReviewsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5380,9 +5380,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredConversationRes
 impl ::std::fmt::Display for BranchProtectionRuleRequiredConversationResolutionLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5466,9 +5466,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredDeploymentsEnfo
 impl ::std::fmt::Display for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5552,9 +5552,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredStatusChecksEnf
 impl ::std::fmt::Display for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -5638,9 +5638,9 @@ impl ::std::convert::From<&Self> for BranchProtectionRuleSignatureRequirementEnf
 impl ::std::fmt::Display for BranchProtectionRuleSignatureRequirementEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Off => write!(f, "off"),
-            Self::NonAdmins => write!(f, "non_admins"),
-            Self::Everyone => write!(f, "everyone"),
+            Self::Off => f.write_str("off"),
+            Self::NonAdmins => f.write_str("non_admins"),
+            Self::Everyone => f.write_str("everyone"),
         }
     }
 }
@@ -6021,7 +6021,7 @@ impl ::std::convert::From<&Self> for CheckRunCompletedAction {
 impl ::std::fmt::Display for CheckRunCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -6517,13 +6517,13 @@ impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunCheckSuiteConclusi
 impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -6611,9 +6611,9 @@ impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunCheckSuiteStatus {
 impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -6709,14 +6709,14 @@ impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunConclusion {
 impl ::std::fmt::Display for CheckRunCompletedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
-            Self::Skipped => write!(f, "skipped"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
+            Self::Skipped => f.write_str("skipped"),
         }
     }
 }
@@ -6855,7 +6855,7 @@ impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunStatus {
 impl ::std::fmt::Display for CheckRunCompletedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -7272,7 +7272,7 @@ impl ::std::convert::From<&Self> for CheckRunCreatedAction {
 impl ::std::fmt::Display for CheckRunCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -7773,13 +7773,13 @@ impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunCheckSuiteConclusion
 impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -7867,9 +7867,9 @@ impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunCheckSuiteStatus {
 impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -7965,14 +7965,14 @@ impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunConclusion {
 impl ::std::fmt::Display for CheckRunCreatedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
-            Self::Skipped => write!(f, "skipped"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
+            Self::Skipped => f.write_str("skipped"),
         }
     }
 }
@@ -8117,9 +8117,9 @@ impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunStatus {
 impl ::std::fmt::Display for CheckRunCreatedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -8846,7 +8846,7 @@ impl ::std::convert::From<&Self> for CheckRunRequestedActionAction {
 impl ::std::fmt::Display for CheckRunRequestedActionAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RequestedAction => write!(f, "requested_action"),
+            Self::RequestedAction => f.write_str("requested_action"),
         }
     }
 }
@@ -9347,13 +9347,13 @@ impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunCheckSuiteCo
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -9441,9 +9441,9 @@ impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunCheckSuiteSt
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -9543,14 +9543,14 @@ impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunConclusion {
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
-            Self::Skipped => write!(f, "skipped"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
+            Self::Skipped => f.write_str("skipped"),
         }
     }
 }
@@ -9697,9 +9697,9 @@ impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunStatus {
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -10109,7 +10109,7 @@ impl ::std::convert::From<&Self> for CheckRunRerequestedAction {
 impl ::std::fmt::Display for CheckRunRerequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Rerequested => write!(f, "rerequested"),
+            Self::Rerequested => f.write_str("rerequested"),
         }
     }
 }
@@ -10593,13 +10593,13 @@ impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunCheckSuiteConclu
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -10681,7 +10681,7 @@ impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunCheckSuiteStatus
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -10779,14 +10779,14 @@ impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunConclusion {
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
-            Self::Skipped => write!(f, "skipped"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
+            Self::Skipped => f.write_str("skipped"),
         }
     }
 }
@@ -10927,7 +10927,7 @@ impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunStatus {
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -11209,7 +11209,7 @@ impl ::std::convert::From<&Self> for CheckSuiteCompletedAction {
 impl ::std::fmt::Display for CheckSuiteCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -11453,13 +11453,13 @@ impl ::std::convert::From<&Self> for CheckSuiteCompletedCheckSuiteConclusion {
 impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -11547,10 +11547,10 @@ impl ::std::convert::From<&Self> for CheckSuiteCompletedCheckSuiteStatus {
 impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::Requested => f.write_str("requested"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -11843,7 +11843,7 @@ impl ::std::convert::From<&Self> for CheckSuiteRequestedAction {
 impl ::std::fmt::Display for CheckSuiteRequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
+            Self::Requested => f.write_str("requested"),
         }
     }
 }
@@ -12087,13 +12087,13 @@ impl ::std::convert::From<&Self> for CheckSuiteRequestedCheckSuiteConclusion {
 impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -12181,10 +12181,10 @@ impl ::std::convert::From<&Self> for CheckSuiteRequestedCheckSuiteStatus {
 impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::Requested => f.write_str("requested"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -12430,7 +12430,7 @@ impl ::std::convert::From<&Self> for CheckSuiteRerequestedAction {
 impl ::std::fmt::Display for CheckSuiteRerequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Rerequested => write!(f, "rerequested"),
+            Self::Rerequested => f.write_str("rerequested"),
         }
     }
 }
@@ -12674,13 +12674,13 @@ impl ::std::convert::From<&Self> for CheckSuiteRerequestedCheckSuiteConclusion {
 impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -12768,10 +12768,10 @@ impl ::std::convert::From<&Self> for CheckSuiteRerequestedCheckSuiteStatus {
 impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::Requested => f.write_str("requested"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -13060,7 +13060,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAction {
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AppearedInBranch => write!(f, "appeared_in_branch"),
+            Self::AppearedInBranch => f.write_str("appeared_in_branch"),
         }
     }
 }
@@ -13318,9 +13318,9 @@ impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertDismi
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => write!(f, "false positive"),
-            Self::WontFix => write!(f, "won't fix"),
-            Self::UsedInTests => write!(f, "used in tests"),
+            Self::FalsePositive => f.write_str("false positive"),
+            Self::WontFix => f.write_str("won't fix"),
+            Self::UsedInTests => f.write_str("used in tests"),
         }
     }
 }
@@ -13465,10 +13465,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertRuleS
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -13554,9 +13554,9 @@ impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertState
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Dismissed => write!(f, "dismissed"),
-            Self::Fixed => write!(f, "fixed"),
+            Self::Open => f.write_str("open"),
+            Self::Dismissed => f.write_str("dismissed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -13911,7 +13911,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAction {
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ClosedByUser => write!(f, "closed_by_user"),
+            Self::ClosedByUser => f.write_str("closed_by_user"),
         }
     }
 }
@@ -14191,9 +14191,9 @@ impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertDismissed
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => write!(f, "false positive"),
-            Self::WontFix => write!(f, "won't fix"),
-            Self::UsedInTests => write!(f, "used in tests"),
+            Self::FalsePositive => f.write_str("false positive"),
+            Self::WontFix => f.write_str("won't fix"),
+            Self::UsedInTests => f.write_str("used in tests"),
         }
     }
 }
@@ -14423,7 +14423,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertInstances
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -14586,10 +14586,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertRuleSever
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -14669,7 +14669,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertState {
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -15021,7 +15021,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAction {
 impl ::std::fmt::Display for CodeScanningAlertCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -15442,8 +15442,8 @@ impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertInstancesItemS
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Open => f.write_str("open"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -15607,10 +15607,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertRuleSeverity {
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -15689,8 +15689,8 @@ impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertState {
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Open => f.write_str("open"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -16139,7 +16139,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertFixedAction {
 impl ::std::fmt::Display for CodeScanningAlertFixedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => write!(f, "fixed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -16435,9 +16435,9 @@ impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertDismissedReason 
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => write!(f, "false positive"),
-            Self::WontFix => write!(f, "won't fix"),
-            Self::UsedInTests => write!(f, "used in tests"),
+            Self::FalsePositive => f.write_str("false positive"),
+            Self::WontFix => f.write_str("won't fix"),
+            Self::UsedInTests => f.write_str("used in tests"),
         }
     }
 }
@@ -16665,7 +16665,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertInstancesItemSta
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => write!(f, "fixed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -16826,10 +16826,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertRuleSeverity {
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -16905,7 +16905,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertState {
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fixed => write!(f, "fixed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -17255,7 +17255,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAction {
 impl ::std::fmt::Display for CodeScanningAlertReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => write!(f, "reopened"),
+            Self::Reopened => f.write_str("reopened"),
         }
     }
 }
@@ -17672,7 +17672,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertInstancesItem
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -17835,10 +17835,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertRuleSeverity 
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -17922,9 +17922,9 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertState {
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Dismissed => write!(f, "dismissed"),
-            Self::Fixed => write!(f, "fixed"),
+            Self::Open => f.write_str("open"),
+            Self::Dismissed => f.write_str("dismissed"),
+            Self::Fixed => f.write_str("fixed"),
         }
     }
 }
@@ -18258,7 +18258,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAction {
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReopenedByUser => write!(f, "reopened_by_user"),
+            Self::ReopenedByUser => f.write_str("reopened_by_user"),
         }
     }
 }
@@ -18657,7 +18657,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertInstanc
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -18800,10 +18800,10 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertRuleSev
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Note => write!(f, "note"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
+            Self::None => f.write_str("none"),
+            Self::Note => f.write_str("note"),
+            Self::Warning => f.write_str("warning"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -18883,7 +18883,7 @@ impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertState {
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -19242,7 +19242,7 @@ impl ::std::convert::From<&Self> for CommitCommentCreatedAction {
 impl ::std::fmt::Display for CommitCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -19660,7 +19660,7 @@ impl ::std::convert::From<&Self> for ContentReferenceCreatedAction {
 impl ::std::fmt::Display for ContentReferenceCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -19906,8 +19906,8 @@ impl ::std::convert::From<&Self> for CreateEventRefType {
 impl ::std::fmt::Display for CreateEventRefType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tag => write!(f, "tag"),
-            Self::Branch => write!(f, "branch"),
+            Self::Tag => f.write_str("tag"),
+            Self::Branch => f.write_str("branch"),
         }
     }
 }
@@ -20057,8 +20057,8 @@ impl ::std::convert::From<&Self> for DeleteEventRefType {
 impl ::std::fmt::Display for DeleteEventRefType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tag => write!(f, "tag"),
-            Self::Branch => write!(f, "branch"),
+            Self::Tag => f.write_str("tag"),
+            Self::Branch => f.write_str("branch"),
         }
     }
 }
@@ -20225,7 +20225,7 @@ impl ::std::convert::From<&Self> for DeployKeyCreatedAction {
 impl ::std::fmt::Display for DeployKeyCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -20452,7 +20452,7 @@ impl ::std::convert::From<&Self> for DeployKeyDeletedAction {
 impl ::std::fmt::Display for DeployKeyDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -20772,7 +20772,7 @@ impl ::std::convert::From<&Self> for DeploymentCreatedAction {
 impl ::std::fmt::Display for DeploymentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -21240,7 +21240,7 @@ impl ::std::convert::From<&Self> for DeploymentStatusCreatedAction {
 impl ::std::fmt::Display for DeploymentStatusCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -21950,7 +21950,7 @@ impl ::std::convert::From<&Self> for DiscussionAnsweredAction {
 impl ::std::fmt::Display for DiscussionAnsweredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Answered => write!(f, "answered"),
+            Self::Answered => f.write_str("answered"),
         }
     }
 }
@@ -22350,9 +22350,9 @@ impl ::std::convert::From<&Self> for DiscussionAnsweredDiscussionAnswerChosenByT
 impl ::std::fmt::Display for DiscussionAnsweredDiscussionAnswerChosenByType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -22511,9 +22511,9 @@ impl ::std::convert::From<&Self> for DiscussionAnsweredDiscussionState {
 impl ::std::fmt::Display for DiscussionAnsweredDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Locked => write!(f, "locked"),
-            Self::Converting => write!(f, "converting"),
+            Self::Open => f.write_str("open"),
+            Self::Locked => f.write_str("locked"),
+            Self::Converting => f.write_str("converting"),
         }
     }
 }
@@ -22781,7 +22781,7 @@ impl ::std::convert::From<&Self> for DiscussionCategoryChangedAction {
 impl ::std::fmt::Display for DiscussionCategoryChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CategoryChanged => write!(f, "category_changed"),
+            Self::CategoryChanged => f.write_str("category_changed"),
         }
     }
 }
@@ -23198,7 +23198,7 @@ impl ::std::convert::From<&Self> for DiscussionCommentCreatedAction {
 impl ::std::fmt::Display for DiscussionCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -23477,7 +23477,7 @@ impl ::std::convert::From<&Self> for DiscussionCommentDeletedAction {
 impl ::std::fmt::Display for DiscussionCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -23779,7 +23779,7 @@ impl ::std::convert::From<&Self> for DiscussionCommentEditedAction {
 impl ::std::fmt::Display for DiscussionCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -24152,7 +24152,7 @@ impl ::std::convert::From<&Self> for DiscussionCreatedAction {
 impl ::std::fmt::Display for DiscussionCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -24376,8 +24376,8 @@ impl ::std::convert::From<&Self> for DiscussionCreatedDiscussionState {
 impl ::std::fmt::Display for DiscussionCreatedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Converting => write!(f, "converting"),
+            Self::Open => f.write_str("open"),
+            Self::Converting => f.write_str("converting"),
         }
     }
 }
@@ -24509,7 +24509,7 @@ impl ::std::convert::From<&Self> for DiscussionDeletedAction {
 impl ::std::fmt::Display for DiscussionDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -24672,7 +24672,7 @@ impl ::std::convert::From<&Self> for DiscussionEditedAction {
 impl ::std::fmt::Display for DiscussionEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -25061,7 +25061,7 @@ impl ::std::convert::From<&Self> for DiscussionLabeledAction {
 impl ::std::fmt::Display for DiscussionLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => write!(f, "labeled"),
+            Self::Labeled => f.write_str("labeled"),
         }
     }
 }
@@ -25218,7 +25218,7 @@ impl ::std::convert::From<&Self> for DiscussionLockedAction {
 impl ::std::fmt::Display for DiscussionLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => write!(f, "locked"),
+            Self::Locked => f.write_str("locked"),
         }
     }
 }
@@ -25426,7 +25426,7 @@ impl ::std::convert::From<&Self> for DiscussionLockedDiscussionState {
 impl ::std::fmt::Display for DiscussionLockedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => write!(f, "locked"),
+            Self::Locked => f.write_str("locked"),
         }
     }
 }
@@ -25557,7 +25557,7 @@ impl ::std::convert::From<&Self> for DiscussionPinnedAction {
 impl ::std::fmt::Display for DiscussionPinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pinned => write!(f, "pinned"),
+            Self::Pinned => f.write_str("pinned"),
         }
     }
 }
@@ -25635,9 +25635,9 @@ impl ::std::convert::From<&Self> for DiscussionState {
 impl ::std::fmt::Display for DiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Locked => write!(f, "locked"),
-            Self::Converting => write!(f, "converting"),
+            Self::Open => f.write_str("open"),
+            Self::Locked => f.write_str("locked"),
+            Self::Converting => f.write_str("converting"),
         }
     }
 }
@@ -25788,7 +25788,7 @@ impl ::std::convert::From<&Self> for DiscussionTransferredAction {
 impl ::std::fmt::Display for DiscussionTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => write!(f, "transferred"),
+            Self::Transferred => f.write_str("transferred"),
         }
     }
 }
@@ -26053,7 +26053,7 @@ impl ::std::convert::From<&Self> for DiscussionUnansweredAction {
 impl ::std::fmt::Display for DiscussionUnansweredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unanswered => write!(f, "unanswered"),
+            Self::Unanswered => f.write_str("unanswered"),
         }
     }
 }
@@ -26284,9 +26284,9 @@ impl ::std::convert::From<&Self> for DiscussionUnansweredDiscussionState {
 impl ::std::fmt::Display for DiscussionUnansweredDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Locked => write!(f, "locked"),
-            Self::Converting => write!(f, "converting"),
+            Self::Open => f.write_str("open"),
+            Self::Locked => f.write_str("locked"),
+            Self::Converting => f.write_str("converting"),
         }
     }
 }
@@ -26510,7 +26510,7 @@ impl ::std::convert::From<&Self> for DiscussionUnlabeledAction {
 impl ::std::fmt::Display for DiscussionUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => write!(f, "unlabeled"),
+            Self::Unlabeled => f.write_str("unlabeled"),
         }
     }
 }
@@ -26667,7 +26667,7 @@ impl ::std::convert::From<&Self> for DiscussionUnlockedAction {
 impl ::std::fmt::Display for DiscussionUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => write!(f, "unlocked"),
+            Self::Unlocked => f.write_str("unlocked"),
         }
     }
 }
@@ -26875,7 +26875,7 @@ impl ::std::convert::From<&Self> for DiscussionUnlockedDiscussionState {
 impl ::std::fmt::Display for DiscussionUnlockedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -27006,7 +27006,7 @@ impl ::std::convert::From<&Self> for DiscussionUnpinnedAction {
 impl ::std::fmt::Display for DiscussionUnpinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpinned => write!(f, "unpinned"),
+            Self::Unpinned => f.write_str("unpinned"),
         }
     }
 }
@@ -28059,7 +28059,7 @@ impl ::std::convert::From<&Self> for GithubAppAuthorizationRevokedAction {
 impl ::std::fmt::Display for GithubAppAuthorizationRevokedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Revoked => write!(f, "revoked"),
+            Self::Revoked => f.write_str("revoked"),
         }
     }
 }
@@ -28458,8 +28458,8 @@ impl ::std::convert::From<&Self> for GollumEventPagesItemAction {
 impl ::std::fmt::Display for GollumEventPagesItemAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
-            Self::Edited => write!(f, "edited"),
+            Self::Created => f.write_str("created"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -29089,7 +29089,7 @@ impl ::std::convert::From<&Self> for InstallationCreatedAction {
 impl ::std::fmt::Display for InstallationCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -29386,7 +29386,7 @@ impl ::std::convert::From<&Self> for InstallationDeletedAction {
 impl ::std::fmt::Display for InstallationDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -29712,51 +29712,51 @@ impl ::std::convert::From<&Self> for InstallationEventsItem {
 impl ::std::fmt::Display for InstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => write!(f, "check_run"),
-            Self::CheckSuite => write!(f, "check_suite"),
-            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
-            Self::CommitComment => write!(f, "commit_comment"),
-            Self::ContentReference => write!(f, "content_reference"),
-            Self::Create => write!(f, "create"),
-            Self::Delete => write!(f, "delete"),
-            Self::Deployment => write!(f, "deployment"),
-            Self::DeploymentReview => write!(f, "deployment_review"),
-            Self::DeploymentStatus => write!(f, "deployment_status"),
-            Self::DeployKey => write!(f, "deploy_key"),
-            Self::Discussion => write!(f, "discussion"),
-            Self::DiscussionComment => write!(f, "discussion_comment"),
-            Self::Fork => write!(f, "fork"),
-            Self::Gollum => write!(f, "gollum"),
-            Self::Issues => write!(f, "issues"),
-            Self::IssueComment => write!(f, "issue_comment"),
-            Self::Label => write!(f, "label"),
-            Self::Member => write!(f, "member"),
-            Self::Membership => write!(f, "membership"),
-            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
-            Self::Milestone => write!(f, "milestone"),
-            Self::Organization => write!(f, "organization"),
-            Self::OrgBlock => write!(f, "org_block"),
-            Self::PageBuild => write!(f, "page_build"),
-            Self::Project => write!(f, "project"),
-            Self::ProjectCard => write!(f, "project_card"),
-            Self::ProjectColumn => write!(f, "project_column"),
-            Self::Public => write!(f, "public"),
-            Self::PullRequest => write!(f, "pull_request"),
-            Self::PullRequestReview => write!(f, "pull_request_review"),
-            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
-            Self::Push => write!(f, "push"),
-            Self::RegistryPackage => write!(f, "registry_package"),
-            Self::Release => write!(f, "release"),
-            Self::Repository => write!(f, "repository"),
-            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
-            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
-            Self::Star => write!(f, "star"),
-            Self::Status => write!(f, "status"),
-            Self::Team => write!(f, "team"),
-            Self::TeamAdd => write!(f, "team_add"),
-            Self::Watch => write!(f, "watch"),
-            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
-            Self::WorkflowRun => write!(f, "workflow_run"),
+            Self::CheckRun => f.write_str("check_run"),
+            Self::CheckSuite => f.write_str("check_suite"),
+            Self::CodeScanningAlert => f.write_str("code_scanning_alert"),
+            Self::CommitComment => f.write_str("commit_comment"),
+            Self::ContentReference => f.write_str("content_reference"),
+            Self::Create => f.write_str("create"),
+            Self::Delete => f.write_str("delete"),
+            Self::Deployment => f.write_str("deployment"),
+            Self::DeploymentReview => f.write_str("deployment_review"),
+            Self::DeploymentStatus => f.write_str("deployment_status"),
+            Self::DeployKey => f.write_str("deploy_key"),
+            Self::Discussion => f.write_str("discussion"),
+            Self::DiscussionComment => f.write_str("discussion_comment"),
+            Self::Fork => f.write_str("fork"),
+            Self::Gollum => f.write_str("gollum"),
+            Self::Issues => f.write_str("issues"),
+            Self::IssueComment => f.write_str("issue_comment"),
+            Self::Label => f.write_str("label"),
+            Self::Member => f.write_str("member"),
+            Self::Membership => f.write_str("membership"),
+            Self::MergeQueueEntry => f.write_str("merge_queue_entry"),
+            Self::Milestone => f.write_str("milestone"),
+            Self::Organization => f.write_str("organization"),
+            Self::OrgBlock => f.write_str("org_block"),
+            Self::PageBuild => f.write_str("page_build"),
+            Self::Project => f.write_str("project"),
+            Self::ProjectCard => f.write_str("project_card"),
+            Self::ProjectColumn => f.write_str("project_column"),
+            Self::Public => f.write_str("public"),
+            Self::PullRequest => f.write_str("pull_request"),
+            Self::PullRequestReview => f.write_str("pull_request_review"),
+            Self::PullRequestReviewComment => f.write_str("pull_request_review_comment"),
+            Self::Push => f.write_str("push"),
+            Self::RegistryPackage => f.write_str("registry_package"),
+            Self::Release => f.write_str("release"),
+            Self::Repository => f.write_str("repository"),
+            Self::RepositoryDispatch => f.write_str("repository_dispatch"),
+            Self::SecretScanningAlert => f.write_str("secret_scanning_alert"),
+            Self::Star => f.write_str("star"),
+            Self::Status => f.write_str("status"),
+            Self::Team => f.write_str("team"),
+            Self::TeamAdd => f.write_str("team_add"),
+            Self::Watch => f.write_str("watch"),
+            Self::WorkflowDispatch => f.write_str("workflow_dispatch"),
+            Self::WorkflowRun => f.write_str("workflow_run"),
         }
     }
 }
@@ -30000,7 +30000,7 @@ impl ::std::convert::From<&Self> for InstallationNewPermissionsAcceptedAction {
 impl ::std::fmt::Display for InstallationNewPermissionsAcceptedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::NewPermissionsAccepted => write!(f, "new_permissions_accepted"),
+            Self::NewPermissionsAccepted => f.write_str("new_permissions_accepted"),
         }
     }
 }
@@ -30514,8 +30514,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsActions {
 impl ::std::fmt::Display for InstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30591,8 +30591,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsAdministration {
 impl ::std::fmt::Display for InstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30668,8 +30668,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsChecks {
 impl ::std::fmt::Display for InstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30745,8 +30745,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsContentReferences {
 impl ::std::fmt::Display for InstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30822,8 +30822,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsContents {
 impl ::std::fmt::Display for InstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30899,8 +30899,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsDeployments {
 impl ::std::fmt::Display for InstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -30976,8 +30976,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsDiscussions {
 impl ::std::fmt::Display for InstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31053,8 +31053,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsEmails {
 impl ::std::fmt::Display for InstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31130,8 +31130,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsEnvironments {
 impl ::std::fmt::Display for InstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31207,8 +31207,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsIssues {
 impl ::std::fmt::Display for InstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31284,8 +31284,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsMembers {
 impl ::std::fmt::Display for InstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31361,8 +31361,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsMetadata {
 impl ::std::fmt::Display for InstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31438,8 +31438,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationAdminist
 impl ::std::fmt::Display for InstallationPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31519,8 +31519,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationEvents {
 impl ::std::fmt::Display for InstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31596,8 +31596,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationHooks {
 impl ::std::fmt::Display for InstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31673,8 +31673,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationPackages
 impl ::std::fmt::Display for InstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31754,8 +31754,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationPlan {
 impl ::std::fmt::Display for InstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31831,8 +31831,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationProjects
 impl ::std::fmt::Display for InstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31912,8 +31912,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationSecrets 
 impl ::std::fmt::Display for InstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -31991,8 +31991,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationSelfHost
 impl ::std::fmt::Display for InstallationPermissionsOrganizationSelfHostedRunners {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32072,8 +32072,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationUserBloc
 impl ::std::fmt::Display for InstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32153,8 +32153,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsPackages {
 impl ::std::fmt::Display for InstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32230,8 +32230,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsPages {
 impl ::std::fmt::Display for InstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32307,8 +32307,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsPullRequests {
 impl ::std::fmt::Display for InstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32384,8 +32384,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsRepositoryHooks {
 impl ::std::fmt::Display for InstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32461,8 +32461,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsRepositoryProjects {
 impl ::std::fmt::Display for InstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32538,8 +32538,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsSecretScanningAlerts
 impl ::std::fmt::Display for InstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32619,8 +32619,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsSecrets {
 impl ::std::fmt::Display for InstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32696,8 +32696,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsSecurityEvents {
 impl ::std::fmt::Display for InstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32773,8 +32773,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsSecurityScanningAler
 impl ::std::fmt::Display for InstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32854,8 +32854,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsSingleFile {
 impl ::std::fmt::Display for InstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -32931,8 +32931,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsStatuses {
 impl ::std::fmt::Display for InstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -33008,8 +33008,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsTeamDiscussions {
 impl ::std::fmt::Display for InstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -33085,8 +33085,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsVulnerabilityAlerts 
 impl ::std::fmt::Display for InstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -33164,8 +33164,8 @@ impl ::std::convert::From<&Self> for InstallationPermissionsWorkflows {
 impl ::std::fmt::Display for InstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -33375,7 +33375,7 @@ impl ::std::convert::From<&Self> for InstallationRepositoriesAddedAction {
 impl ::std::fmt::Display for InstallationRepositoriesAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => write!(f, "added"),
+            Self::Added => f.write_str("added"),
         }
     }
 }
@@ -33574,8 +33574,8 @@ impl ::std::convert::From<&Self> for InstallationRepositoriesAddedRepositorySele
 impl ::std::fmt::Display for InstallationRepositoriesAddedRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Selected => write!(f, "selected"),
+            Self::All => f.write_str("all"),
+            Self::Selected => f.write_str("selected"),
         }
     }
 }
@@ -33835,7 +33835,7 @@ impl ::std::convert::From<&Self> for InstallationRepositoriesRemovedAction {
 impl ::std::fmt::Display for InstallationRepositoriesRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => write!(f, "removed"),
+            Self::Removed => f.write_str("removed"),
         }
     }
 }
@@ -34025,8 +34025,8 @@ impl ::std::convert::From<&Self> for InstallationRepositoriesRemovedRepositorySe
 impl ::std::fmt::Display for InstallationRepositoriesRemovedRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Selected => write!(f, "selected"),
+            Self::All => f.write_str("all"),
+            Self::Selected => f.write_str("selected"),
         }
     }
 }
@@ -34107,8 +34107,8 @@ impl ::std::convert::From<&Self> for InstallationRepositorySelection {
 impl ::std::fmt::Display for InstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Selected => write!(f, "selected"),
+            Self::All => f.write_str("all"),
+            Self::Selected => f.write_str("selected"),
         }
     }
 }
@@ -34289,7 +34289,7 @@ impl ::std::convert::From<&Self> for InstallationSuspendAction {
 impl ::std::fmt::Display for InstallationSuspendAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Suspend => write!(f, "suspend"),
+            Self::Suspend => f.write_str("suspend"),
         }
     }
 }
@@ -34641,51 +34641,51 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationEventsItem {
 impl ::std::fmt::Display for InstallationSuspendInstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => write!(f, "check_run"),
-            Self::CheckSuite => write!(f, "check_suite"),
-            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
-            Self::CommitComment => write!(f, "commit_comment"),
-            Self::ContentReference => write!(f, "content_reference"),
-            Self::Create => write!(f, "create"),
-            Self::Delete => write!(f, "delete"),
-            Self::Deployment => write!(f, "deployment"),
-            Self::DeploymentReview => write!(f, "deployment_review"),
-            Self::DeploymentStatus => write!(f, "deployment_status"),
-            Self::DeployKey => write!(f, "deploy_key"),
-            Self::Discussion => write!(f, "discussion"),
-            Self::DiscussionComment => write!(f, "discussion_comment"),
-            Self::Fork => write!(f, "fork"),
-            Self::Gollum => write!(f, "gollum"),
-            Self::Issues => write!(f, "issues"),
-            Self::IssueComment => write!(f, "issue_comment"),
-            Self::Label => write!(f, "label"),
-            Self::Member => write!(f, "member"),
-            Self::Membership => write!(f, "membership"),
-            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
-            Self::Milestone => write!(f, "milestone"),
-            Self::Organization => write!(f, "organization"),
-            Self::OrgBlock => write!(f, "org_block"),
-            Self::PageBuild => write!(f, "page_build"),
-            Self::Project => write!(f, "project"),
-            Self::ProjectCard => write!(f, "project_card"),
-            Self::ProjectColumn => write!(f, "project_column"),
-            Self::Public => write!(f, "public"),
-            Self::PullRequest => write!(f, "pull_request"),
-            Self::PullRequestReview => write!(f, "pull_request_review"),
-            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
-            Self::Push => write!(f, "push"),
-            Self::RegistryPackage => write!(f, "registry_package"),
-            Self::Release => write!(f, "release"),
-            Self::Repository => write!(f, "repository"),
-            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
-            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
-            Self::Star => write!(f, "star"),
-            Self::Status => write!(f, "status"),
-            Self::Team => write!(f, "team"),
-            Self::TeamAdd => write!(f, "team_add"),
-            Self::Watch => write!(f, "watch"),
-            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
-            Self::WorkflowRun => write!(f, "workflow_run"),
+            Self::CheckRun => f.write_str("check_run"),
+            Self::CheckSuite => f.write_str("check_suite"),
+            Self::CodeScanningAlert => f.write_str("code_scanning_alert"),
+            Self::CommitComment => f.write_str("commit_comment"),
+            Self::ContentReference => f.write_str("content_reference"),
+            Self::Create => f.write_str("create"),
+            Self::Delete => f.write_str("delete"),
+            Self::Deployment => f.write_str("deployment"),
+            Self::DeploymentReview => f.write_str("deployment_review"),
+            Self::DeploymentStatus => f.write_str("deployment_status"),
+            Self::DeployKey => f.write_str("deploy_key"),
+            Self::Discussion => f.write_str("discussion"),
+            Self::DiscussionComment => f.write_str("discussion_comment"),
+            Self::Fork => f.write_str("fork"),
+            Self::Gollum => f.write_str("gollum"),
+            Self::Issues => f.write_str("issues"),
+            Self::IssueComment => f.write_str("issue_comment"),
+            Self::Label => f.write_str("label"),
+            Self::Member => f.write_str("member"),
+            Self::Membership => f.write_str("membership"),
+            Self::MergeQueueEntry => f.write_str("merge_queue_entry"),
+            Self::Milestone => f.write_str("milestone"),
+            Self::Organization => f.write_str("organization"),
+            Self::OrgBlock => f.write_str("org_block"),
+            Self::PageBuild => f.write_str("page_build"),
+            Self::Project => f.write_str("project"),
+            Self::ProjectCard => f.write_str("project_card"),
+            Self::ProjectColumn => f.write_str("project_column"),
+            Self::Public => f.write_str("public"),
+            Self::PullRequest => f.write_str("pull_request"),
+            Self::PullRequestReview => f.write_str("pull_request_review"),
+            Self::PullRequestReviewComment => f.write_str("pull_request_review_comment"),
+            Self::Push => f.write_str("push"),
+            Self::RegistryPackage => f.write_str("registry_package"),
+            Self::Release => f.write_str("release"),
+            Self::Repository => f.write_str("repository"),
+            Self::RepositoryDispatch => f.write_str("repository_dispatch"),
+            Self::SecretScanningAlert => f.write_str("secret_scanning_alert"),
+            Self::Star => f.write_str("star"),
+            Self::Status => f.write_str("status"),
+            Self::Team => f.write_str("team"),
+            Self::TeamAdd => f.write_str("team_add"),
+            Self::Watch => f.write_str("watch"),
+            Self::WorkflowDispatch => f.write_str("workflow_dispatch"),
+            Self::WorkflowRun => f.write_str("workflow_run"),
         }
     }
 }
@@ -35204,8 +35204,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsA
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35285,8 +35285,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsA
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35366,8 +35366,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsC
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35447,8 +35447,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsC
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35528,8 +35528,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsC
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35609,8 +35609,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsD
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35690,8 +35690,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsD
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35771,8 +35771,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsE
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35852,8 +35852,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsE
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -35933,8 +35933,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsI
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36014,8 +36014,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsM
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36095,8 +36095,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsM
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36178,8 +36178,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36261,8 +36261,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsO
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36344,8 +36344,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsO
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36427,8 +36427,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36510,8 +36510,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsO
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36593,8 +36593,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36676,8 +36676,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsO
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36765,8 +36765,8 @@ impl ::std::fmt::Display
 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36852,8 +36852,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -36935,8 +36935,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsP
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37016,8 +37016,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsP
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37097,8 +37097,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsP
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37178,8 +37178,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsR
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37259,8 +37259,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsR
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37344,8 +37344,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37427,8 +37427,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsS
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37508,8 +37508,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsS
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37591,8 +37591,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37674,8 +37674,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsS
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37755,8 +37755,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsS
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37836,8 +37836,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsT
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -37917,8 +37917,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsV
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -38000,8 +38000,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsW
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -38082,8 +38082,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationRepositorySe
 impl ::std::fmt::Display for InstallationSuspendInstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Selected => write!(f, "selected"),
+            Self::All => f.write_str("all"),
+            Self::Selected => f.write_str("selected"),
         }
     }
 }
@@ -38322,9 +38322,9 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationSuspendedByT
 impl ::std::fmt::Display for InstallationSuspendInstallationSuspendedByType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -38403,8 +38403,8 @@ impl ::std::convert::From<&Self> for InstallationSuspendInstallationTargetType {
 impl ::std::fmt::Display for InstallationSuspendInstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -38618,8 +38618,8 @@ impl ::std::convert::From<&Self> for InstallationTargetType {
 impl ::std::fmt::Display for InstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -38799,7 +38799,7 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendAction {
 impl ::std::fmt::Display for InstallationUnsuspendAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unsuspend => write!(f, "unsuspend"),
+            Self::Unsuspend => f.write_str("unsuspend"),
         }
     }
 }
@@ -39154,51 +39154,51 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationEventsItem
 impl ::std::fmt::Display for InstallationUnsuspendInstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => write!(f, "check_run"),
-            Self::CheckSuite => write!(f, "check_suite"),
-            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
-            Self::CommitComment => write!(f, "commit_comment"),
-            Self::ContentReference => write!(f, "content_reference"),
-            Self::Create => write!(f, "create"),
-            Self::Delete => write!(f, "delete"),
-            Self::Deployment => write!(f, "deployment"),
-            Self::DeploymentReview => write!(f, "deployment_review"),
-            Self::DeploymentStatus => write!(f, "deployment_status"),
-            Self::DeployKey => write!(f, "deploy_key"),
-            Self::Discussion => write!(f, "discussion"),
-            Self::DiscussionComment => write!(f, "discussion_comment"),
-            Self::Fork => write!(f, "fork"),
-            Self::Gollum => write!(f, "gollum"),
-            Self::Issues => write!(f, "issues"),
-            Self::IssueComment => write!(f, "issue_comment"),
-            Self::Label => write!(f, "label"),
-            Self::Member => write!(f, "member"),
-            Self::Membership => write!(f, "membership"),
-            Self::MergeQueueEntry => write!(f, "merge_queue_entry"),
-            Self::Milestone => write!(f, "milestone"),
-            Self::Organization => write!(f, "organization"),
-            Self::OrgBlock => write!(f, "org_block"),
-            Self::PageBuild => write!(f, "page_build"),
-            Self::Project => write!(f, "project"),
-            Self::ProjectCard => write!(f, "project_card"),
-            Self::ProjectColumn => write!(f, "project_column"),
-            Self::Public => write!(f, "public"),
-            Self::PullRequest => write!(f, "pull_request"),
-            Self::PullRequestReview => write!(f, "pull_request_review"),
-            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
-            Self::Push => write!(f, "push"),
-            Self::RegistryPackage => write!(f, "registry_package"),
-            Self::Release => write!(f, "release"),
-            Self::Repository => write!(f, "repository"),
-            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
-            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
-            Self::Star => write!(f, "star"),
-            Self::Status => write!(f, "status"),
-            Self::Team => write!(f, "team"),
-            Self::TeamAdd => write!(f, "team_add"),
-            Self::Watch => write!(f, "watch"),
-            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
-            Self::WorkflowRun => write!(f, "workflow_run"),
+            Self::CheckRun => f.write_str("check_run"),
+            Self::CheckSuite => f.write_str("check_suite"),
+            Self::CodeScanningAlert => f.write_str("code_scanning_alert"),
+            Self::CommitComment => f.write_str("commit_comment"),
+            Self::ContentReference => f.write_str("content_reference"),
+            Self::Create => f.write_str("create"),
+            Self::Delete => f.write_str("delete"),
+            Self::Deployment => f.write_str("deployment"),
+            Self::DeploymentReview => f.write_str("deployment_review"),
+            Self::DeploymentStatus => f.write_str("deployment_status"),
+            Self::DeployKey => f.write_str("deploy_key"),
+            Self::Discussion => f.write_str("discussion"),
+            Self::DiscussionComment => f.write_str("discussion_comment"),
+            Self::Fork => f.write_str("fork"),
+            Self::Gollum => f.write_str("gollum"),
+            Self::Issues => f.write_str("issues"),
+            Self::IssueComment => f.write_str("issue_comment"),
+            Self::Label => f.write_str("label"),
+            Self::Member => f.write_str("member"),
+            Self::Membership => f.write_str("membership"),
+            Self::MergeQueueEntry => f.write_str("merge_queue_entry"),
+            Self::Milestone => f.write_str("milestone"),
+            Self::Organization => f.write_str("organization"),
+            Self::OrgBlock => f.write_str("org_block"),
+            Self::PageBuild => f.write_str("page_build"),
+            Self::Project => f.write_str("project"),
+            Self::ProjectCard => f.write_str("project_card"),
+            Self::ProjectColumn => f.write_str("project_column"),
+            Self::Public => f.write_str("public"),
+            Self::PullRequest => f.write_str("pull_request"),
+            Self::PullRequestReview => f.write_str("pull_request_review"),
+            Self::PullRequestReviewComment => f.write_str("pull_request_review_comment"),
+            Self::Push => f.write_str("push"),
+            Self::RegistryPackage => f.write_str("registry_package"),
+            Self::Release => f.write_str("release"),
+            Self::Repository => f.write_str("repository"),
+            Self::RepositoryDispatch => f.write_str("repository_dispatch"),
+            Self::SecretScanningAlert => f.write_str("secret_scanning_alert"),
+            Self::Star => f.write_str("star"),
+            Self::Status => f.write_str("status"),
+            Self::Team => f.write_str("team"),
+            Self::TeamAdd => f.write_str("team_add"),
+            Self::Watch => f.write_str("watch"),
+            Self::WorkflowDispatch => f.write_str("workflow_dispatch"),
+            Self::WorkflowRun => f.write_str("workflow_run"),
         }
     }
 }
@@ -39723,8 +39723,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -39804,8 +39804,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -39885,8 +39885,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -39966,8 +39966,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40049,8 +40049,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40130,8 +40130,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40211,8 +40211,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40292,8 +40292,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40373,8 +40373,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40454,8 +40454,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40535,8 +40535,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40616,8 +40616,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40703,8 +40703,8 @@ impl ::std::fmt::Display
 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40790,8 +40790,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40873,8 +40873,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -40958,8 +40958,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41041,8 +41041,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41126,8 +41126,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41211,8 +41211,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41300,8 +41300,8 @@ impl ::std::fmt::Display
 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41387,8 +41387,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41470,8 +41470,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41551,8 +41551,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41632,8 +41632,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41713,8 +41713,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41796,8 +41796,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41881,8 +41881,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -41964,8 +41964,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42045,8 +42045,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42128,8 +42128,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42211,8 +42211,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42292,8 +42292,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42373,8 +42373,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42456,8 +42456,8 @@ impl ::std::convert::From<&Self>
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42539,8 +42539,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermission
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Read => write!(f, "read"),
-            Self::Write => write!(f, "write"),
+            Self::Read => f.write_str("read"),
+            Self::Write => f.write_str("write"),
         }
     }
 }
@@ -42621,8 +42621,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationRepository
 impl ::std::fmt::Display for InstallationUnsuspendInstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Selected => write!(f, "selected"),
+            Self::All => f.write_str("all"),
+            Self::Selected => f.write_str("selected"),
         }
     }
 }
@@ -42700,8 +42700,8 @@ impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationTargetType
 impl ::std::fmt::Display for InstallationUnsuspendInstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -43250,10 +43250,10 @@ impl ::std::convert::From<&Self> for IssueActiveLockReason {
 impl ::std::fmt::Display for IssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -43564,7 +43564,7 @@ impl ::std::convert::From<&Self> for IssueCommentCreatedAction {
 impl ::std::fmt::Display for IssueCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -43767,10 +43767,10 @@ impl ::std::convert::From<&Self> for IssueCommentCreatedIssueActiveLockReason {
 impl ::std::fmt::Display for IssueCommentCreatedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -43909,9 +43909,9 @@ impl ::std::convert::From<&Self> for IssueCommentCreatedIssueAssigneeType {
 impl ::std::fmt::Display for IssueCommentCreatedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -44038,8 +44038,8 @@ impl ::std::convert::From<&Self> for IssueCommentCreatedIssueState {
 impl ::std::fmt::Display for IssueCommentCreatedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -44248,7 +44248,7 @@ impl ::std::convert::From<&Self> for IssueCommentDeletedAction {
 impl ::std::fmt::Display for IssueCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -44451,10 +44451,10 @@ impl ::std::convert::From<&Self> for IssueCommentDeletedIssueActiveLockReason {
 impl ::std::fmt::Display for IssueCommentDeletedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -44593,9 +44593,9 @@ impl ::std::convert::From<&Self> for IssueCommentDeletedIssueAssigneeType {
 impl ::std::fmt::Display for IssueCommentDeletedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -44722,8 +44722,8 @@ impl ::std::convert::From<&Self> for IssueCommentDeletedIssueState {
 impl ::std::fmt::Display for IssueCommentDeletedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -44954,7 +44954,7 @@ impl ::std::convert::From<&Self> for IssueCommentEditedAction {
 impl ::std::fmt::Display for IssueCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -45233,10 +45233,10 @@ impl ::std::convert::From<&Self> for IssueCommentEditedIssueActiveLockReason {
 impl ::std::fmt::Display for IssueCommentEditedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -45375,9 +45375,9 @@ impl ::std::convert::From<&Self> for IssueCommentEditedIssueAssigneeType {
 impl ::std::fmt::Display for IssueCommentEditedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -45504,8 +45504,8 @@ impl ::std::convert::From<&Self> for IssueCommentEditedIssueState {
 impl ::std::fmt::Display for IssueCommentEditedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -45685,8 +45685,8 @@ impl ::std::convert::From<&Self> for IssueState {
 impl ::std::fmt::Display for IssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -45836,7 +45836,7 @@ impl ::std::convert::From<&Self> for IssuesAssignedAction {
 impl ::std::fmt::Display for IssuesAssignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Assigned => write!(f, "assigned"),
+            Self::Assigned => f.write_str("assigned"),
         }
     }
 }
@@ -45994,7 +45994,7 @@ impl ::std::convert::From<&Self> for IssuesClosedAction {
 impl ::std::fmt::Display for IssuesClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -46152,10 +46152,10 @@ impl ::std::convert::From<&Self> for IssuesClosedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesClosedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -46286,7 +46286,7 @@ impl ::std::convert::From<&Self> for IssuesClosedIssueState {
 impl ::std::fmt::Display for IssuesClosedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -46417,7 +46417,7 @@ impl ::std::convert::From<&Self> for IssuesDeletedAction {
 impl ::std::fmt::Display for IssuesDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -46569,7 +46569,7 @@ impl ::std::convert::From<&Self> for IssuesDemilestonedAction {
 impl ::std::fmt::Display for IssuesDemilestonedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Demilestoned => write!(f, "demilestoned"),
+            Self::Demilestoned => f.write_str("demilestoned"),
         }
     }
 }
@@ -46721,10 +46721,10 @@ impl ::std::convert::From<&Self> for IssuesDemilestonedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesDemilestonedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -46861,8 +46861,8 @@ impl ::std::convert::From<&Self> for IssuesDemilestonedIssueState {
 impl ::std::fmt::Display for IssuesDemilestonedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -47034,7 +47034,7 @@ impl ::std::convert::From<&Self> for IssuesEditedAction {
 impl ::std::fmt::Display for IssuesEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -47459,7 +47459,7 @@ impl ::std::convert::From<&Self> for IssuesLabeledAction {
 impl ::std::fmt::Display for IssuesLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => write!(f, "labeled"),
+            Self::Labeled => f.write_str("labeled"),
         }
     }
 }
@@ -47623,7 +47623,7 @@ impl ::std::convert::From<&Self> for IssuesLockedAction {
 impl ::std::fmt::Display for IssuesLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => write!(f, "locked"),
+            Self::Locked => f.write_str("locked"),
         }
     }
 }
@@ -47791,10 +47791,10 @@ impl ::std::convert::From<&Self> for IssuesLockedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesLockedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -47929,8 +47929,8 @@ impl ::std::convert::From<&Self> for IssuesLockedIssueState {
 impl ::std::fmt::Display for IssuesLockedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -48083,7 +48083,7 @@ impl ::std::convert::From<&Self> for IssuesMilestonedAction {
 impl ::std::fmt::Display for IssuesMilestonedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Milestoned => write!(f, "milestoned"),
+            Self::Milestoned => f.write_str("milestoned"),
         }
     }
 }
@@ -48235,10 +48235,10 @@ impl ::std::convert::From<&Self> for IssuesMilestonedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesMilestonedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -48455,8 +48455,8 @@ impl ::std::convert::From<&Self> for IssuesMilestonedIssueMilestoneState {
 impl ::std::fmt::Display for IssuesMilestonedIssueMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -48589,8 +48589,8 @@ impl ::std::convert::From<&Self> for IssuesMilestonedIssueState {
 impl ::std::fmt::Display for IssuesMilestonedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -48763,7 +48763,7 @@ impl ::std::convert::From<&Self> for IssuesOpenedAction {
 impl ::std::fmt::Display for IssuesOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => write!(f, "opened"),
+            Self::Opened => f.write_str("opened"),
         }
     }
 }
@@ -48954,10 +48954,10 @@ impl ::std::convert::From<&Self> for IssuesOpenedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesOpenedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -49088,7 +49088,7 @@ impl ::std::convert::From<&Self> for IssuesOpenedIssueState {
 impl ::std::fmt::Display for IssuesOpenedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -49219,7 +49219,7 @@ impl ::std::convert::From<&Self> for IssuesPinnedAction {
 impl ::std::fmt::Display for IssuesPinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pinned => write!(f, "pinned"),
+            Self::Pinned => f.write_str("pinned"),
         }
     }
 }
@@ -49369,7 +49369,7 @@ impl ::std::convert::From<&Self> for IssuesReopenedAction {
 impl ::std::fmt::Display for IssuesReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => write!(f, "reopened"),
+            Self::Reopened => f.write_str("reopened"),
         }
     }
 }
@@ -49522,10 +49522,10 @@ impl ::std::convert::From<&Self> for IssuesReopenedIssueActiveLockReason {
 impl ::std::fmt::Display for IssuesReopenedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -49656,7 +49656,7 @@ impl ::std::convert::From<&Self> for IssuesReopenedIssueState {
 impl ::std::fmt::Display for IssuesReopenedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -49805,7 +49805,7 @@ impl ::std::convert::From<&Self> for IssuesTransferredAction {
 impl ::std::fmt::Display for IssuesTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => write!(f, "transferred"),
+            Self::Transferred => f.write_str("transferred"),
         }
     }
 }
@@ -49987,7 +49987,7 @@ impl ::std::convert::From<&Self> for IssuesUnassignedAction {
 impl ::std::fmt::Display for IssuesUnassignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unassigned => write!(f, "unassigned"),
+            Self::Unassigned => f.write_str("unassigned"),
         }
     }
 }
@@ -50125,7 +50125,7 @@ impl ::std::convert::From<&Self> for IssuesUnlabeledAction {
 impl ::std::fmt::Display for IssuesUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => write!(f, "unlabeled"),
+            Self::Unlabeled => f.write_str("unlabeled"),
         }
     }
 }
@@ -50279,7 +50279,7 @@ impl ::std::convert::From<&Self> for IssuesUnlockedAction {
 impl ::std::fmt::Display for IssuesUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => write!(f, "unlocked"),
+            Self::Unlocked => f.write_str("unlocked"),
         }
     }
 }
@@ -50541,8 +50541,8 @@ impl ::std::convert::From<&Self> for IssuesUnlockedIssueState {
 impl ::std::fmt::Display for IssuesUnlockedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -50674,7 +50674,7 @@ impl ::std::convert::From<&Self> for IssuesUnpinnedAction {
 impl ::std::fmt::Display for IssuesUnpinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpinned => write!(f, "unpinned"),
+            Self::Unpinned => f.write_str("unpinned"),
         }
     }
 }
@@ -50878,7 +50878,7 @@ impl ::std::convert::From<&Self> for LabelCreatedAction {
 impl ::std::fmt::Display for LabelCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -51011,7 +51011,7 @@ impl ::std::convert::From<&Self> for LabelDeletedAction {
 impl ::std::fmt::Display for LabelDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -51192,7 +51192,7 @@ impl ::std::convert::From<&Self> for LabelEditedAction {
 impl ::std::fmt::Display for LabelEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -51910,7 +51910,7 @@ impl ::std::convert::From<&Self> for MarketplacePurchaseCancelledAction {
 impl ::std::fmt::Display for MarketplacePurchaseCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cancelled => write!(f, "cancelled"),
+            Self::Cancelled => f.write_str("cancelled"),
         }
     }
 }
@@ -52443,7 +52443,7 @@ impl ::std::convert::From<&Self> for MarketplacePurchaseChangedAction {
 impl ::std::fmt::Display for MarketplacePurchaseChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Changed => write!(f, "changed"),
+            Self::Changed => f.write_str("changed"),
         }
     }
 }
@@ -53039,7 +53039,7 @@ impl ::std::convert::From<&Self> for MarketplacePurchasePendingChangeAction {
 impl ::std::fmt::Display for MarketplacePurchasePendingChangeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingChange => write!(f, "pending_change"),
+            Self::PendingChange => f.write_str("pending_change"),
         }
     }
 }
@@ -53272,7 +53272,7 @@ impl ::std::convert::From<&Self> for MarketplacePurchasePendingChangeCancelledAc
 impl ::std::fmt::Display for MarketplacePurchasePendingChangeCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingChangeCancelled => write!(f, "pending_change_cancelled"),
+            Self::PendingChangeCancelled => f.write_str("pending_change_cancelled"),
         }
     }
 }
@@ -54186,7 +54186,7 @@ impl ::std::convert::From<&Self> for MarketplacePurchasePurchasedAction {
 impl ::std::fmt::Display for MarketplacePurchasePurchasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Purchased => write!(f, "purchased"),
+            Self::Purchased => f.write_str("purchased"),
         }
     }
 }
@@ -54641,7 +54641,7 @@ impl ::std::convert::From<&Self> for MemberAddedAction {
 impl ::std::fmt::Display for MemberAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => write!(f, "added"),
+            Self::Added => f.write_str("added"),
         }
     }
 }
@@ -54796,8 +54796,8 @@ impl ::std::convert::From<&Self> for MemberAddedChangesPermissionTo {
 impl ::std::fmt::Display for MemberAddedChangesPermissionTo {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Write => write!(f, "write"),
-            Self::Admin => write!(f, "admin"),
+            Self::Write => f.write_str("write"),
+            Self::Admin => f.write_str("admin"),
         }
     }
 }
@@ -54951,7 +54951,7 @@ impl ::std::convert::From<&Self> for MemberEditedAction {
 impl ::std::fmt::Display for MemberEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -55197,7 +55197,7 @@ impl ::std::convert::From<&Self> for MemberRemovedAction {
 impl ::std::fmt::Display for MemberRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => write!(f, "removed"),
+            Self::Removed => f.write_str("removed"),
         }
     }
 }
@@ -55396,7 +55396,7 @@ impl ::std::convert::From<&Self> for MembershipAddedAction {
 impl ::std::fmt::Display for MembershipAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Added => write!(f, "added"),
+            Self::Added => f.write_str("added"),
         }
     }
 }
@@ -55469,7 +55469,7 @@ impl ::std::convert::From<&Self> for MembershipAddedScope {
 impl ::std::fmt::Display for MembershipAddedScope {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Team => write!(f, "team"),
+            Self::Team => f.write_str("team"),
         }
     }
 }
@@ -55676,7 +55676,7 @@ impl ::std::convert::From<&Self> for MembershipRemovedAction {
 impl ::std::fmt::Display for MembershipRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Removed => write!(f, "removed"),
+            Self::Removed => f.write_str("removed"),
         }
     }
 }
@@ -55752,8 +55752,8 @@ impl ::std::convert::From<&Self> for MembershipRemovedScope {
 impl ::std::fmt::Display for MembershipRemovedScope {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Team => write!(f, "team"),
-            Self::Organization => write!(f, "organization"),
+            Self::Team => f.write_str("team"),
+            Self::Organization => f.write_str("organization"),
         }
     }
 }
@@ -55997,7 +55997,7 @@ impl ::std::convert::From<&Self> for MetaDeletedAction {
 impl ::std::fmt::Display for MetaDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -56204,8 +56204,8 @@ impl ::std::convert::From<&Self> for MetaDeletedHookConfigContentType {
 impl ::std::fmt::Display for MetaDeletedHookConfigContentType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => write!(f, "json"),
-            Self::Form => write!(f, "form"),
+            Self::Json => f.write_str("json"),
+            Self::Form => f.write_str("form"),
         }
     }
 }
@@ -56531,7 +56531,7 @@ impl ::std::convert::From<&Self> for MilestoneClosedAction {
 impl ::std::fmt::Display for MilestoneClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -56663,7 +56663,7 @@ impl ::std::convert::From<&Self> for MilestoneClosedMilestoneState {
 impl ::std::fmt::Display for MilestoneClosedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -56817,7 +56817,7 @@ impl ::std::convert::From<&Self> for MilestoneCreatedAction {
 impl ::std::fmt::Display for MilestoneCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -56949,7 +56949,7 @@ impl ::std::convert::From<&Self> for MilestoneCreatedMilestoneState {
 impl ::std::fmt::Display for MilestoneCreatedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -57080,7 +57080,7 @@ impl ::std::convert::From<&Self> for MilestoneDeletedAction {
 impl ::std::fmt::Display for MilestoneDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -57259,7 +57259,7 @@ impl ::std::convert::From<&Self> for MilestoneEditedAction {
 impl ::std::fmt::Display for MilestoneEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -57650,7 +57650,7 @@ impl ::std::convert::From<&Self> for MilestoneOpenedAction {
 impl ::std::fmt::Display for MilestoneOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => write!(f, "opened"),
+            Self::Opened => f.write_str("opened"),
         }
     }
 }
@@ -57782,7 +57782,7 @@ impl ::std::convert::From<&Self> for MilestoneOpenedMilestoneState {
 impl ::std::fmt::Display for MilestoneOpenedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -57858,8 +57858,8 @@ impl ::std::convert::From<&Self> for MilestoneState {
 impl ::std::fmt::Display for MilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -57988,7 +57988,7 @@ impl ::std::convert::From<&Self> for OrgBlockBlockedAction {
 impl ::std::fmt::Display for OrgBlockBlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Blocked => write!(f, "blocked"),
+            Self::Blocked => f.write_str("blocked"),
         }
     }
 }
@@ -58154,7 +58154,7 @@ impl ::std::convert::From<&Self> for OrgBlockUnblockedAction {
 impl ::std::fmt::Display for OrgBlockUnblockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unblocked => write!(f, "unblocked"),
+            Self::Unblocked => f.write_str("unblocked"),
         }
     }
 }
@@ -58383,7 +58383,7 @@ impl ::std::convert::From<&Self> for OrganizationDeletedAction {
 impl ::std::fmt::Display for OrganizationDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -58574,7 +58574,7 @@ impl ::std::convert::From<&Self> for OrganizationMemberAddedAction {
 impl ::std::fmt::Display for OrganizationMemberAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberAdded => write!(f, "member_added"),
+            Self::MemberAdded => f.write_str("member_added"),
         }
     }
 }
@@ -58771,7 +58771,7 @@ impl ::std::convert::From<&Self> for OrganizationMemberInvitedAction {
 impl ::std::fmt::Display for OrganizationMemberInvitedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberInvited => write!(f, "member_invited"),
+            Self::MemberInvited => f.write_str("member_invited"),
         }
     }
 }
@@ -58995,7 +58995,7 @@ impl ::std::convert::From<&Self> for OrganizationMemberRemovedAction {
 impl ::std::fmt::Display for OrganizationMemberRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::MemberRemoved => write!(f, "member_removed"),
+            Self::MemberRemoved => f.write_str("member_removed"),
         }
     }
 }
@@ -59121,7 +59121,7 @@ impl ::std::convert::From<&Self> for OrganizationRenamedAction {
 impl ::std::fmt::Display for OrganizationRenamedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Renamed => write!(f, "renamed"),
+            Self::Renamed => f.write_str("renamed"),
         }
     }
 }
@@ -59574,7 +59574,7 @@ impl ::std::convert::From<&Self> for PackagePublishedAction {
 impl ::std::fmt::Display for PackagePublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => write!(f, "published"),
+            Self::Published => f.write_str("published"),
         }
     }
 }
@@ -60775,7 +60775,7 @@ impl ::std::convert::From<&Self> for PackageUpdatedAction {
 impl ::std::fmt::Display for PackageUpdatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Updated => write!(f, "updated"),
+            Self::Updated => f.write_str("updated"),
         }
     }
 }
@@ -62201,8 +62201,8 @@ impl ::std::convert::From<&Self> for PingEventHookConfigContentType {
 impl ::std::fmt::Display for PingEventHookConfigContentType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => write!(f, "json"),
-            Self::Form => write!(f, "form"),
+            Self::Json => f.write_str("json"),
+            Self::Form => f.write_str("form"),
         }
     }
 }
@@ -62610,7 +62610,7 @@ impl ::std::convert::From<&Self> for ProjectCardConvertedAction {
 impl ::std::fmt::Display for ProjectCardConvertedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Converted => write!(f, "converted"),
+            Self::Converted => f.write_str("converted"),
         }
     }
 }
@@ -62808,7 +62808,7 @@ impl ::std::convert::From<&Self> for ProjectCardCreatedAction {
 impl ::std::fmt::Display for ProjectCardCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -62939,7 +62939,7 @@ impl ::std::convert::From<&Self> for ProjectCardDeletedAction {
 impl ::std::fmt::Display for ProjectCardDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -63093,7 +63093,7 @@ impl ::std::convert::From<&Self> for ProjectCardEditedAction {
 impl ::std::fmt::Display for ProjectCardEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -63398,7 +63398,7 @@ impl ::std::convert::From<&Self> for ProjectCardMovedAction {
 impl ::std::fmt::Display for ProjectCardMovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Moved => write!(f, "moved"),
+            Self::Moved => f.write_str("moved"),
         }
     }
 }
@@ -63650,7 +63650,7 @@ impl ::std::convert::From<&Self> for ProjectClosedAction {
 impl ::std::fmt::Display for ProjectClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -63856,7 +63856,7 @@ impl ::std::convert::From<&Self> for ProjectColumnCreatedAction {
 impl ::std::fmt::Display for ProjectColumnCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -63987,7 +63987,7 @@ impl ::std::convert::From<&Self> for ProjectColumnDeletedAction {
 impl ::std::fmt::Display for ProjectColumnDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -64138,7 +64138,7 @@ impl ::std::convert::From<&Self> for ProjectColumnEditedAction {
 impl ::std::fmt::Display for ProjectColumnEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -64397,7 +64397,7 @@ impl ::std::convert::From<&Self> for ProjectColumnMovedAction {
 impl ::std::fmt::Display for ProjectColumnMovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Moved => write!(f, "moved"),
+            Self::Moved => f.write_str("moved"),
         }
     }
 }
@@ -64528,7 +64528,7 @@ impl ::std::convert::From<&Self> for ProjectCreatedAction {
 impl ::std::fmt::Display for ProjectCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -64659,7 +64659,7 @@ impl ::std::convert::From<&Self> for ProjectDeletedAction {
 impl ::std::fmt::Display for ProjectDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -64825,7 +64825,7 @@ impl ::std::convert::From<&Self> for ProjectEditedAction {
 impl ::std::fmt::Display for ProjectEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -65144,7 +65144,7 @@ impl ::std::convert::From<&Self> for ProjectReopenedAction {
 impl ::std::fmt::Display for ProjectReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => write!(f, "reopened"),
+            Self::Reopened => f.write_str("reopened"),
         }
     }
 }
@@ -65220,8 +65220,8 @@ impl ::std::convert::From<&Self> for ProjectState {
 impl ::std::fmt::Display for ProjectState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -66148,10 +66148,10 @@ impl ::std::convert::From<&Self> for PullRequestActiveLockReason {
 impl ::std::fmt::Display for PullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -66297,7 +66297,7 @@ impl ::std::convert::From<&Self> for PullRequestAssignedAction {
 impl ::std::fmt::Display for PullRequestAssignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Assigned => write!(f, "assigned"),
+            Self::Assigned => f.write_str("assigned"),
         }
     }
 }
@@ -66433,7 +66433,7 @@ impl ::std::convert::From<&Self> for PullRequestAutoMergeDisabledAction {
 impl ::std::fmt::Display for PullRequestAutoMergeDisabledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AutoMergeDisabled => write!(f, "auto_merge_disabled"),
+            Self::AutoMergeDisabled => f.write_str("auto_merge_disabled"),
         }
     }
 }
@@ -66569,7 +66569,7 @@ impl ::std::convert::From<&Self> for PullRequestAutoMergeEnabledAction {
 impl ::std::fmt::Display for PullRequestAutoMergeEnabledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AutoMergeEnabled => write!(f, "auto_merge_enabled"),
+            Self::AutoMergeEnabled => f.write_str("auto_merge_enabled"),
         }
     }
 }
@@ -66786,7 +66786,7 @@ impl ::std::convert::From<&Self> for PullRequestClosedAction {
 impl ::std::fmt::Display for PullRequestClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -66968,10 +66968,10 @@ impl ::std::convert::From<&Self> for PullRequestClosedPullRequestActiveLockReaso
 impl ::std::fmt::Display for PullRequestClosedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -67255,7 +67255,7 @@ impl ::std::convert::From<&Self> for PullRequestClosedPullRequestState {
 impl ::std::fmt::Display for PullRequestClosedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Closed => write!(f, "closed"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -67432,7 +67432,7 @@ impl ::std::convert::From<&Self> for PullRequestConvertedToDraftAction {
 impl ::std::fmt::Display for PullRequestConvertedToDraftAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ConvertedToDraft => write!(f, "converted_to_draft"),
+            Self::ConvertedToDraft => f.write_str("converted_to_draft"),
         }
     }
 }
@@ -67628,10 +67628,10 @@ impl ::std::convert::From<&Self> for PullRequestConvertedToDraftPullRequestActiv
 impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -67923,8 +67923,8 @@ impl ::std::convert::From<&Self> for PullRequestConvertedToDraftPullRequestState
 impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -68102,7 +68102,7 @@ impl ::std::convert::From<&Self> for PullRequestEditedAction {
 impl ::std::fmt::Display for PullRequestEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -68591,7 +68591,7 @@ impl ::std::convert::From<&Self> for PullRequestLabeledAction {
 impl ::std::fmt::Display for PullRequestLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Labeled => write!(f, "labeled"),
+            Self::Labeled => f.write_str("labeled"),
         }
     }
 }
@@ -68794,7 +68794,7 @@ impl ::std::convert::From<&Self> for PullRequestLockedAction {
 impl ::std::fmt::Display for PullRequestLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Locked => write!(f, "locked"),
+            Self::Locked => f.write_str("locked"),
         }
     }
 }
@@ -68971,7 +68971,7 @@ impl ::std::convert::From<&Self> for PullRequestOpenedAction {
 impl ::std::fmt::Display for PullRequestOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Opened => write!(f, "opened"),
+            Self::Opened => f.write_str("opened"),
         }
     }
 }
@@ -69412,7 +69412,7 @@ impl ::std::convert::From<&Self> for PullRequestOpenedPullRequestState {
 impl ::std::fmt::Display for PullRequestOpenedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -69593,7 +69593,7 @@ impl ::std::convert::From<&Self> for PullRequestReadyForReviewAction {
 impl ::std::fmt::Display for PullRequestReadyForReviewAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReadyForReview => write!(f, "ready_for_review"),
+            Self::ReadyForReview => f.write_str("ready_for_review"),
         }
     }
 }
@@ -69792,10 +69792,10 @@ impl ::std::convert::From<&Self> for PullRequestReadyForReviewPullRequestActiveL
 impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -70083,7 +70083,7 @@ impl ::std::convert::From<&Self> for PullRequestReadyForReviewPullRequestState {
 impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -70260,7 +70260,7 @@ impl ::std::convert::From<&Self> for PullRequestReopenedAction {
 impl ::std::fmt::Display for PullRequestReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => write!(f, "reopened"),
+            Self::Reopened => f.write_str("reopened"),
         }
     }
 }
@@ -70452,10 +70452,10 @@ impl ::std::convert::From<&Self> for PullRequestReopenedPullRequestActiveLockRea
 impl ::std::fmt::Display for PullRequestReopenedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -70743,7 +70743,7 @@ impl ::std::convert::From<&Self> for PullRequestReopenedPullRequestState {
 impl ::std::fmt::Display for PullRequestReopenedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
+            Self::Open => f.write_str("open"),
         }
     }
 }
@@ -71457,7 +71457,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedAction {
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -71900,10 +71900,10 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedPullRequestA
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -72200,8 +72200,8 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedPullRequestS
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -72642,7 +72642,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedAction {
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -73085,10 +73085,10 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedPullRequestA
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -73385,8 +73385,8 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedPullRequestS
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -73849,7 +73849,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedAction {
 impl ::std::fmt::Display for PullRequestReviewCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -74372,10 +74372,10 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedPullRequestAc
 impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -74672,8 +74672,8 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedPullRequestSt
 impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -74841,8 +74841,8 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentSide {
 impl ::std::fmt::Display for PullRequestReviewCommentSide {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "LEFT"),
-            Self::Right => write!(f, "RIGHT"),
+            Self::Left => f.write_str("LEFT"),
+            Self::Right => f.write_str("RIGHT"),
         }
     }
 }
@@ -74920,8 +74920,8 @@ impl ::std::convert::From<&Self> for PullRequestReviewCommentStartSide {
 impl ::std::fmt::Display for PullRequestReviewCommentStartSide {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "LEFT"),
-            Self::Right => write!(f, "RIGHT"),
+            Self::Left => f.write_str("LEFT"),
+            Self::Right => f.write_str("RIGHT"),
         }
     }
 }
@@ -75133,7 +75133,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewDismissedAction {
 impl ::std::fmt::Display for PullRequestReviewDismissedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -75350,7 +75350,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewDismissedReviewState {
 impl ::std::fmt::Display for PullRequestReviewDismissedReviewState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismissed => write!(f, "dismissed"),
+            Self::Dismissed => f.write_str("dismissed"),
         }
     }
 }
@@ -75579,7 +75579,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewEditedAction {
 impl ::std::fmt::Display for PullRequestReviewEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -76049,7 +76049,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestRemovedVariant0Acti
 impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant0Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequestRemoved => write!(f, "review_request_removed"),
+            Self::ReviewRequestRemoved => f.write_str("review_request_removed"),
         }
     }
 }
@@ -76125,7 +76125,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestRemovedVariant1Acti
 impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant1Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequestRemoved => write!(f, "review_request_removed"),
+            Self::ReviewRequestRemoved => f.write_str("review_request_removed"),
         }
     }
 }
@@ -76333,7 +76333,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestedVariant0Action {
 impl ::std::fmt::Display for PullRequestReviewRequestedVariant0Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequested => write!(f, "review_requested"),
+            Self::ReviewRequested => f.write_str("review_requested"),
         }
     }
 }
@@ -76405,7 +76405,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestedVariant1Action {
 impl ::std::fmt::Display for PullRequestReviewRequestedVariant1Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ReviewRequested => write!(f, "review_requested"),
+            Self::ReviewRequested => f.write_str("review_requested"),
         }
     }
 }
@@ -76613,7 +76613,7 @@ impl ::std::convert::From<&Self> for PullRequestReviewSubmittedAction {
 impl ::std::fmt::Display for PullRequestReviewSubmittedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Submitted => write!(f, "submitted"),
+            Self::Submitted => f.write_str("submitted"),
         }
     }
 }
@@ -76831,8 +76831,8 @@ impl ::std::convert::From<&Self> for PullRequestState {
 impl ::std::fmt::Display for PullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -76981,7 +76981,7 @@ impl ::std::convert::From<&Self> for PullRequestSynchronizeAction {
 impl ::std::fmt::Display for PullRequestSynchronizeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Synchronize => write!(f, "synchronize"),
+            Self::Synchronize => f.write_str("synchronize"),
         }
     }
 }
@@ -77124,7 +77124,7 @@ impl ::std::convert::From<&Self> for PullRequestUnassignedAction {
 impl ::std::fmt::Display for PullRequestUnassignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unassigned => write!(f, "unassigned"),
+            Self::Unassigned => f.write_str("unassigned"),
         }
     }
 }
@@ -77267,7 +77267,7 @@ impl ::std::convert::From<&Self> for PullRequestUnlabeledAction {
 impl ::std::fmt::Display for PullRequestUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlabeled => write!(f, "unlabeled"),
+            Self::Unlabeled => f.write_str("unlabeled"),
         }
     }
 }
@@ -77405,7 +77405,7 @@ impl ::std::convert::From<&Self> for PullRequestUnlockedAction {
 impl ::std::fmt::Display for PullRequestUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unlocked => write!(f, "unlocked"),
+            Self::Unlocked => f.write_str("unlocked"),
         }
     }
 }
@@ -77855,7 +77855,7 @@ impl ::std::convert::From<&Self> for ReleaseAssetState {
 impl ::std::fmt::Display for ReleaseAssetState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Uploaded => write!(f, "uploaded"),
+            Self::Uploaded => f.write_str("uploaded"),
         }
     }
 }
@@ -77986,7 +77986,7 @@ impl ::std::convert::From<&Self> for ReleaseCreatedAction {
 impl ::std::fmt::Display for ReleaseCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -78117,7 +78117,7 @@ impl ::std::convert::From<&Self> for ReleaseDeletedAction {
 impl ::std::fmt::Display for ReleaseDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -78282,7 +78282,7 @@ impl ::std::convert::From<&Self> for ReleaseEditedAction {
 impl ::std::fmt::Display for ReleaseEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -78638,7 +78638,7 @@ impl ::std::convert::From<&Self> for ReleasePrereleasedAction {
 impl ::std::fmt::Display for ReleasePrereleasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Prereleased => write!(f, "prereleased"),
+            Self::Prereleased => f.write_str("prereleased"),
         }
     }
 }
@@ -78846,7 +78846,7 @@ impl ::std::convert::From<&Self> for ReleasePublishedAction {
 impl ::std::fmt::Display for ReleasePublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => write!(f, "published"),
+            Self::Published => f.write_str("published"),
         }
     }
 }
@@ -79035,7 +79035,7 @@ impl ::std::convert::From<&Self> for ReleaseReleasedAction {
 impl ::std::fmt::Display for ReleaseReleasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Released => write!(f, "released"),
+            Self::Released => f.write_str("released"),
         }
     }
 }
@@ -79182,7 +79182,7 @@ impl ::std::convert::From<&Self> for ReleaseUnpublishedAction {
 impl ::std::fmt::Display for ReleaseUnpublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unpublished => write!(f, "unpublished"),
+            Self::Unpublished => f.write_str("unpublished"),
         }
     }
 }
@@ -80021,7 +80021,7 @@ impl ::std::convert::From<&Self> for RepositoryArchivedAction {
 impl ::std::fmt::Display for RepositoryArchivedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Archived => write!(f, "archived"),
+            Self::Archived => f.write_str("archived"),
         }
     }
 }
@@ -80477,7 +80477,7 @@ impl ::std::convert::From<&Self> for RepositoryCreatedAction {
 impl ::std::fmt::Display for RepositoryCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -80684,7 +80684,7 @@ impl ::std::convert::From<&Self> for RepositoryDeletedAction {
 impl ::std::fmt::Display for RepositoryDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -80859,7 +80859,7 @@ impl ::std::convert::From<&Self> for RepositoryDispatchOnDemandTestAction {
 impl ::std::fmt::Display for RepositoryDispatchOnDemandTestAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::OnDemandTest => write!(f, "on-demand-test"),
+            Self::OnDemandTest => f.write_str("on-demand-test"),
         }
     }
 }
@@ -81035,7 +81035,7 @@ impl ::std::convert::From<&Self> for RepositoryEditedAction {
 impl ::std::fmt::Display for RepositoryEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -81446,9 +81446,9 @@ impl ::std::convert::From<&Self> for RepositoryImportEventStatus {
 impl ::std::fmt::Display for RepositoryImportEventStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::Failure => write!(f, "failure"),
+            Self::Success => f.write_str("success"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::Failure => f.write_str("failure"),
         }
     }
 }
@@ -81948,7 +81948,7 @@ impl ::std::convert::From<&Self> for RepositoryPrivatizedAction {
 impl ::std::fmt::Display for RepositoryPrivatizedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Privatized => write!(f, "privatized"),
+            Self::Privatized => f.write_str("privatized"),
         }
     }
 }
@@ -82423,7 +82423,7 @@ impl ::std::convert::From<&Self> for RepositoryPublicizedAction {
 impl ::std::fmt::Display for RepositoryPublicizedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Publicized => write!(f, "publicized"),
+            Self::Publicized => f.write_str("publicized"),
         }
     }
 }
@@ -82953,7 +82953,7 @@ impl ::std::convert::From<&Self> for RepositoryRenamedAction {
 impl ::std::fmt::Display for RepositoryRenamedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Renamed => write!(f, "renamed"),
+            Self::Renamed => f.write_str("renamed"),
         }
     }
 }
@@ -83226,7 +83226,7 @@ impl ::std::convert::From<&Self> for RepositoryTransferredAction {
 impl ::std::fmt::Display for RepositoryTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Transferred => write!(f, "transferred"),
+            Self::Transferred => f.write_str("transferred"),
         }
     }
 }
@@ -83490,7 +83490,7 @@ impl ::std::convert::From<&Self> for RepositoryUnarchivedAction {
 impl ::std::fmt::Display for RepositoryUnarchivedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Unarchived => write!(f, "unarchived"),
+            Self::Unarchived => f.write_str("unarchived"),
         }
     }
 }
@@ -83997,7 +83997,7 @@ impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertCreateAction {
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertCreateAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Create => write!(f, "create"),
+            Self::Create => f.write_str("create"),
         }
     }
 }
@@ -84265,7 +84265,7 @@ impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertDismissAction {
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertDismissAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dismiss => write!(f, "dismiss"),
+            Self::Dismiss => f.write_str("dismiss"),
         }
     }
 }
@@ -84583,7 +84583,7 @@ impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertResolveAction {
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertResolveAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolve => write!(f, "resolve"),
+            Self::Resolve => f.write_str("resolve"),
         }
     }
 }
@@ -84823,7 +84823,7 @@ impl ::std::convert::From<&Self> for SecretScanningAlertCreatedAction {
 impl ::std::fmt::Display for SecretScanningAlertCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -85077,7 +85077,7 @@ impl ::std::convert::From<&Self> for SecretScanningAlertReopenedAction {
 impl ::std::fmt::Display for SecretScanningAlertReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Reopened => write!(f, "reopened"),
+            Self::Reopened => f.write_str("reopened"),
         }
     }
 }
@@ -85290,7 +85290,7 @@ impl ::std::convert::From<&Self> for SecretScanningAlertResolvedAction {
 impl ::std::fmt::Display for SecretScanningAlertResolvedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
+            Self::Resolved => f.write_str("resolved"),
         }
     }
 }
@@ -85427,10 +85427,10 @@ impl ::std::convert::From<&Self> for SecretScanningAlertResolvedAlertResolution 
 impl ::std::fmt::Display for SecretScanningAlertResolvedAlertResolution {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::FalsePositive => write!(f, "false_positive"),
-            Self::Wontfix => write!(f, "wontfix"),
-            Self::Revoked => write!(f, "revoked"),
-            Self::UsedInTests => write!(f, "used_in_tests"),
+            Self::FalsePositive => f.write_str("false_positive"),
+            Self::Wontfix => f.write_str("wontfix"),
+            Self::Revoked => f.write_str("revoked"),
+            Self::UsedInTests => f.write_str("used_in_tests"),
         }
     }
 }
@@ -85769,7 +85769,7 @@ impl ::std::convert::From<&Self> for SecurityAdvisoryPerformedAction {
 impl ::std::fmt::Display for SecurityAdvisoryPerformedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Performed => write!(f, "performed"),
+            Self::Performed => f.write_str("performed"),
         }
     }
 }
@@ -86536,7 +86536,7 @@ impl ::std::convert::From<&Self> for SecurityAdvisoryPublishedAction {
 impl ::std::fmt::Display for SecurityAdvisoryPublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Published => write!(f, "published"),
+            Self::Published => f.write_str("published"),
         }
     }
 }
@@ -87303,7 +87303,7 @@ impl ::std::convert::From<&Self> for SecurityAdvisoryUpdatedAction {
 impl ::std::fmt::Display for SecurityAdvisoryUpdatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Updated => write!(f, "updated"),
+            Self::Updated => f.write_str("updated"),
         }
     }
 }
@@ -88067,7 +88067,7 @@ impl ::std::convert::From<&Self> for SecurityAdvisoryWithdrawnAction {
 impl ::std::fmt::Display for SecurityAdvisoryWithdrawnAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Withdrawn => write!(f, "withdrawn"),
+            Self::Withdrawn => f.write_str("withdrawn"),
         }
     }
 }
@@ -88994,10 +88994,10 @@ impl ::std::convert::From<&Self> for SimplePullRequestActiveLockReason {
 impl ::std::fmt::Display for SimplePullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolved => write!(f, "resolved"),
-            Self::OffTopic => write!(f, "off-topic"),
-            Self::TooHeated => write!(f, "too heated"),
-            Self::Spam => write!(f, "spam"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::OffTopic => f.write_str("off-topic"),
+            Self::TooHeated => f.write_str("too heated"),
+            Self::Spam => f.write_str("spam"),
         }
     }
 }
@@ -89278,8 +89278,8 @@ impl ::std::convert::From<&Self> for SimplePullRequestState {
 impl ::std::fmt::Display for SimplePullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
         }
     }
 }
@@ -89425,7 +89425,7 @@ impl ::std::convert::From<&Self> for SponsorshipCancelledAction {
 impl ::std::fmt::Display for SponsorshipCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cancelled => write!(f, "cancelled"),
+            Self::Cancelled => f.write_str("cancelled"),
         }
     }
 }
@@ -89624,7 +89624,7 @@ impl ::std::convert::From<&Self> for SponsorshipCreatedAction {
 impl ::std::fmt::Display for SponsorshipCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -89844,7 +89844,7 @@ impl ::std::convert::From<&Self> for SponsorshipEditedAction {
 impl ::std::fmt::Display for SponsorshipEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -90201,7 +90201,7 @@ impl ::std::convert::From<&Self> for SponsorshipPendingCancellationAction {
 impl ::std::fmt::Display for SponsorshipPendingCancellationAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingCancellation => write!(f, "pending_cancellation"),
+            Self::PendingCancellation => f.write_str("pending_cancellation"),
         }
     }
 }
@@ -90432,7 +90432,7 @@ impl ::std::convert::From<&Self> for SponsorshipPendingTierChangeAction {
 impl ::std::fmt::Display for SponsorshipPendingTierChangeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::PendingTierChange => write!(f, "pending_tier_change"),
+            Self::PendingTierChange => f.write_str("pending_tier_change"),
         }
     }
 }
@@ -90794,7 +90794,7 @@ impl ::std::convert::From<&Self> for SponsorshipTierChangedAction {
 impl ::std::fmt::Display for SponsorshipTierChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::TierChanged => write!(f, "tier_changed"),
+            Self::TierChanged => f.write_str("tier_changed"),
         }
     }
 }
@@ -91052,7 +91052,7 @@ impl ::std::convert::From<&Self> for StarCreatedAction {
 impl ::std::fmt::Display for StarCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -91185,7 +91185,7 @@ impl ::std::convert::From<&Self> for StarDeletedAction {
 impl ::std::fmt::Display for StarDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -92353,19 +92353,19 @@ impl ::std::convert::From<&Self> for StatusEventCommitCommitVerificationReason {
 impl ::std::fmt::Display for StatusEventCommitCommitVerificationReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::ExpiredKey => write!(f, "expired_key"),
-            Self::NotSigningKey => write!(f, "not_signing_key"),
-            Self::GpgverifyError => write!(f, "gpgverify_error"),
-            Self::GpgverifyUnavailable => write!(f, "gpgverify_unavailable"),
-            Self::Unsigned => write!(f, "unsigned"),
-            Self::UnknownSignatureType => write!(f, "unknown_signature_type"),
-            Self::NoUser => write!(f, "no_user"),
-            Self::UnverifiedEmail => write!(f, "unverified_email"),
-            Self::BadEmail => write!(f, "bad_email"),
-            Self::UnknownKey => write!(f, "unknown_key"),
-            Self::MalformedSignature => write!(f, "malformed_signature"),
-            Self::Invalid => write!(f, "invalid"),
-            Self::Valid => write!(f, "valid"),
+            Self::ExpiredKey => f.write_str("expired_key"),
+            Self::NotSigningKey => f.write_str("not_signing_key"),
+            Self::GpgverifyError => f.write_str("gpgverify_error"),
+            Self::GpgverifyUnavailable => f.write_str("gpgverify_unavailable"),
+            Self::Unsigned => f.write_str("unsigned"),
+            Self::UnknownSignatureType => f.write_str("unknown_signature_type"),
+            Self::NoUser => f.write_str("no_user"),
+            Self::UnverifiedEmail => f.write_str("unverified_email"),
+            Self::BadEmail => f.write_str("bad_email"),
+            Self::UnknownKey => f.write_str("unknown_key"),
+            Self::MalformedSignature => f.write_str("malformed_signature"),
+            Self::Invalid => f.write_str("invalid"),
+            Self::Valid => f.write_str("valid"),
         }
     }
 }
@@ -92500,10 +92500,10 @@ impl ::std::convert::From<&Self> for StatusEventState {
 impl ::std::fmt::Display for StatusEventState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pending => write!(f, "pending"),
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Error => write!(f, "error"),
+            Self::Pending => f.write_str("pending"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Error => f.write_str("error"),
         }
     }
 }
@@ -92866,7 +92866,7 @@ impl ::std::convert::From<&Self> for TeamAddedToRepositoryAction {
 impl ::std::fmt::Display for TeamAddedToRepositoryAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AddedToRepository => write!(f, "added_to_repository"),
+            Self::AddedToRepository => f.write_str("added_to_repository"),
         }
     }
 }
@@ -92997,7 +92997,7 @@ impl ::std::convert::From<&Self> for TeamCreatedAction {
 impl ::std::fmt::Display for TeamCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Created => write!(f, "created"),
+            Self::Created => f.write_str("created"),
         }
     }
 }
@@ -93128,7 +93128,7 @@ impl ::std::convert::From<&Self> for TeamDeletedAction {
 impl ::std::fmt::Display for TeamDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Deleted => write!(f, "deleted"),
+            Self::Deleted => f.write_str("deleted"),
         }
     }
 }
@@ -93343,7 +93343,7 @@ impl ::std::convert::From<&Self> for TeamEditedAction {
 impl ::std::fmt::Display for TeamEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Edited => write!(f, "edited"),
+            Self::Edited => f.write_str("edited"),
         }
     }
 }
@@ -93949,9 +93949,9 @@ impl ::std::convert::From<&Self> for TeamParentPrivacy {
 impl ::std::fmt::Display for TeamParentPrivacy {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
-            Self::Secret => write!(f, "secret"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
+            Self::Secret => f.write_str("secret"),
         }
     }
 }
@@ -94031,9 +94031,9 @@ impl ::std::convert::From<&Self> for TeamPrivacy {
 impl ::std::fmt::Display for TeamPrivacy {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Open => write!(f, "open"),
-            Self::Closed => write!(f, "closed"),
-            Self::Secret => write!(f, "secret"),
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
+            Self::Secret => f.write_str("secret"),
         }
     }
 }
@@ -94166,7 +94166,7 @@ impl ::std::convert::From<&Self> for TeamRemovedFromRepositoryAction {
 impl ::std::fmt::Display for TeamRemovedFromRepositoryAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RemovedFromRepository => write!(f, "removed_from_repository"),
+            Self::RemovedFromRepository => f.write_str("removed_from_repository"),
         }
     }
 }
@@ -94388,9 +94388,9 @@ impl ::std::convert::From<&Self> for UserType {
 impl ::std::fmt::Display for UserType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bot => write!(f, "Bot"),
-            Self::User => write!(f, "User"),
-            Self::Organization => write!(f, "Organization"),
+            Self::Bot => f.write_str("Bot"),
+            Self::User => f.write_str("User"),
+            Self::Organization => f.write_str("Organization"),
         }
     }
 }
@@ -94556,7 +94556,7 @@ impl ::std::convert::From<&Self> for WatchStartedAction {
 impl ::std::fmt::Display for WatchStartedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Started => write!(f, "started"),
+            Self::Started => f.write_str("started"),
         }
     }
 }
@@ -94864,53 +94864,53 @@ impl ::std::convert::From<&Self> for WebhookEventsVariant0Item {
 impl ::std::fmt::Display for WebhookEventsVariant0Item {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::CheckRun => write!(f, "check_run"),
-            Self::CheckSuite => write!(f, "check_suite"),
-            Self::CodeScanningAlert => write!(f, "code_scanning_alert"),
-            Self::CommitComment => write!(f, "commit_comment"),
-            Self::ContentReference => write!(f, "content_reference"),
-            Self::Create => write!(f, "create"),
-            Self::Delete => write!(f, "delete"),
-            Self::Deployment => write!(f, "deployment"),
-            Self::DeploymentReview => write!(f, "deployment_review"),
-            Self::DeploymentStatus => write!(f, "deployment_status"),
-            Self::DeployKey => write!(f, "deploy_key"),
-            Self::Discussion => write!(f, "discussion"),
-            Self::DiscussionComment => write!(f, "discussion_comment"),
-            Self::Fork => write!(f, "fork"),
-            Self::Gollum => write!(f, "gollum"),
-            Self::Issues => write!(f, "issues"),
-            Self::IssueComment => write!(f, "issue_comment"),
-            Self::Label => write!(f, "label"),
-            Self::Member => write!(f, "member"),
-            Self::Membership => write!(f, "membership"),
-            Self::Meta => write!(f, "meta"),
-            Self::Milestone => write!(f, "milestone"),
-            Self::Organization => write!(f, "organization"),
-            Self::OrgBlock => write!(f, "org_block"),
-            Self::PageBuild => write!(f, "page_build"),
-            Self::Project => write!(f, "project"),
-            Self::ProjectCard => write!(f, "project_card"),
-            Self::ProjectColumn => write!(f, "project_column"),
-            Self::Public => write!(f, "public"),
-            Self::PullRequest => write!(f, "pull_request"),
-            Self::PullRequestReview => write!(f, "pull_request_review"),
-            Self::PullRequestReviewComment => write!(f, "pull_request_review_comment"),
-            Self::Push => write!(f, "push"),
-            Self::RegistryPackage => write!(f, "registry_package"),
-            Self::Release => write!(f, "release"),
-            Self::Repository => write!(f, "repository"),
-            Self::RepositoryDispatch => write!(f, "repository_dispatch"),
-            Self::RepositoryImport => write!(f, "repository_import"),
-            Self::RepositoryVulnerabilityAlert => write!(f, "repository_vulnerability_alert"),
-            Self::SecretScanningAlert => write!(f, "secret_scanning_alert"),
-            Self::Star => write!(f, "star"),
-            Self::Status => write!(f, "status"),
-            Self::Team => write!(f, "team"),
-            Self::TeamAdd => write!(f, "team_add"),
-            Self::Watch => write!(f, "watch"),
-            Self::WorkflowDispatch => write!(f, "workflow_dispatch"),
-            Self::WorkflowRun => write!(f, "workflow_run"),
+            Self::CheckRun => f.write_str("check_run"),
+            Self::CheckSuite => f.write_str("check_suite"),
+            Self::CodeScanningAlert => f.write_str("code_scanning_alert"),
+            Self::CommitComment => f.write_str("commit_comment"),
+            Self::ContentReference => f.write_str("content_reference"),
+            Self::Create => f.write_str("create"),
+            Self::Delete => f.write_str("delete"),
+            Self::Deployment => f.write_str("deployment"),
+            Self::DeploymentReview => f.write_str("deployment_review"),
+            Self::DeploymentStatus => f.write_str("deployment_status"),
+            Self::DeployKey => f.write_str("deploy_key"),
+            Self::Discussion => f.write_str("discussion"),
+            Self::DiscussionComment => f.write_str("discussion_comment"),
+            Self::Fork => f.write_str("fork"),
+            Self::Gollum => f.write_str("gollum"),
+            Self::Issues => f.write_str("issues"),
+            Self::IssueComment => f.write_str("issue_comment"),
+            Self::Label => f.write_str("label"),
+            Self::Member => f.write_str("member"),
+            Self::Membership => f.write_str("membership"),
+            Self::Meta => f.write_str("meta"),
+            Self::Milestone => f.write_str("milestone"),
+            Self::Organization => f.write_str("organization"),
+            Self::OrgBlock => f.write_str("org_block"),
+            Self::PageBuild => f.write_str("page_build"),
+            Self::Project => f.write_str("project"),
+            Self::ProjectCard => f.write_str("project_card"),
+            Self::ProjectColumn => f.write_str("project_column"),
+            Self::Public => f.write_str("public"),
+            Self::PullRequest => f.write_str("pull_request"),
+            Self::PullRequestReview => f.write_str("pull_request_review"),
+            Self::PullRequestReviewComment => f.write_str("pull_request_review_comment"),
+            Self::Push => f.write_str("push"),
+            Self::RegistryPackage => f.write_str("registry_package"),
+            Self::Release => f.write_str("release"),
+            Self::Repository => f.write_str("repository"),
+            Self::RepositoryDispatch => f.write_str("repository_dispatch"),
+            Self::RepositoryImport => f.write_str("repository_import"),
+            Self::RepositoryVulnerabilityAlert => f.write_str("repository_vulnerability_alert"),
+            Self::SecretScanningAlert => f.write_str("secret_scanning_alert"),
+            Self::Star => f.write_str("star"),
+            Self::Status => f.write_str("status"),
+            Self::Team => f.write_str("team"),
+            Self::TeamAdd => f.write_str("team_add"),
+            Self::Watch => f.write_str("watch"),
+            Self::WorkflowDispatch => f.write_str("workflow_dispatch"),
+            Self::WorkflowRun => f.write_str("workflow_run"),
         }
     }
 }
@@ -95385,7 +95385,7 @@ impl ::std::convert::From<&Self> for WorkflowJobCompletedAction {
 impl ::std::fmt::Display for WorkflowJobCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -95514,8 +95514,8 @@ impl ::std::convert::From<&Self> for WorkflowJobCompletedWorkflowJobConclusion {
 impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
         }
     }
 }
@@ -95594,9 +95594,9 @@ impl ::std::convert::From<&Self> for WorkflowJobCompletedWorkflowJobStatus {
 impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -95673,8 +95673,8 @@ impl ::std::convert::From<&Self> for WorkflowJobConclusion {
 impl ::std::fmt::Display for WorkflowJobConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
         }
     }
 }
@@ -95932,7 +95932,7 @@ impl ::std::convert::From<&Self> for WorkflowJobQueuedAction {
 impl ::std::fmt::Display for WorkflowJobQueuedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -96117,7 +96117,7 @@ impl ::std::convert::From<&Self> for WorkflowJobQueuedWorkflowJobStatus {
 impl ::std::fmt::Display for WorkflowJobQueuedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -96277,7 +96277,7 @@ impl ::std::convert::From<&Self> for WorkflowJobStartedAction {
 impl ::std::fmt::Display for WorkflowJobStartedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Started => write!(f, "started"),
+            Self::Started => f.write_str("started"),
         }
     }
 }
@@ -96471,9 +96471,9 @@ impl ::std::convert::From<&Self> for WorkflowJobStartedWorkflowJobStatus {
 impl ::std::fmt::Display for WorkflowJobStartedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -96553,9 +96553,9 @@ impl ::std::convert::From<&Self> for WorkflowJobStatus {
 impl ::std::fmt::Display for WorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Queued => write!(f, "queued"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
+            Self::Queued => f.write_str("queued"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -96972,7 +96972,7 @@ impl ::std::convert::From<&Self> for WorkflowRunCompletedAction {
 impl ::std::fmt::Display for WorkflowRunCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -97133,13 +97133,13 @@ impl ::std::convert::From<&Self> for WorkflowRunCompletedWorkflowRunConclusion {
 impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -97396,10 +97396,10 @@ impl ::std::convert::From<&Self> for WorkflowRunCompletedWorkflowRunStatus {
 impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::Requested => f.write_str("requested"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -97492,13 +97492,13 @@ impl ::std::convert::From<&Self> for WorkflowRunConclusion {
 impl ::std::fmt::Display for WorkflowRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
-            Self::Failure => write!(f, "failure"),
-            Self::Neutral => write!(f, "neutral"),
-            Self::Cancelled => write!(f, "cancelled"),
-            Self::TimedOut => write!(f, "timed_out"),
-            Self::ActionRequired => write!(f, "action_required"),
-            Self::Stale => write!(f, "stale"),
+            Self::Success => f.write_str("success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Neutral => f.write_str("neutral"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed_out"),
+            Self::ActionRequired => f.write_str("action_required"),
+            Self::Stale => f.write_str("stale"),
         }
     }
 }
@@ -97842,7 +97842,7 @@ impl ::std::convert::From<&Self> for WorkflowRunRequestedAction {
 impl ::std::fmt::Display for WorkflowRunRequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
+            Self::Requested => f.write_str("requested"),
         }
     }
 }
@@ -97923,10 +97923,10 @@ impl ::std::convert::From<&Self> for WorkflowRunStatus {
 impl ::std::fmt::Display for WorkflowRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Requested => write!(f, "requested"),
-            Self::InProgress => write!(f, "in_progress"),
-            Self::Completed => write!(f, "completed"),
-            Self::Queued => write!(f, "queued"),
+            Self::Requested => f.write_str("requested"),
+            Self::InProgress => f.write_str("in_progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Queued => f.write_str("queued"),
         }
     }
 }
@@ -98112,9 +98112,9 @@ impl ::std::convert::From<&Self> for WorkflowStepCompletedConclusion {
 impl ::std::fmt::Display for WorkflowStepCompletedConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Failure => write!(f, "failure"),
-            Self::Skipped => write!(f, "skipped"),
-            Self::Success => write!(f, "success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Skipped => f.write_str("skipped"),
+            Self::Success => f.write_str("success"),
         }
     }
 }
@@ -98188,7 +98188,7 @@ impl ::std::convert::From<&Self> for WorkflowStepCompletedStatus {
 impl ::std::fmt::Display for WorkflowStepCompletedStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Completed => write!(f, "completed"),
+            Self::Completed => f.write_str("completed"),
         }
     }
 }
@@ -98319,7 +98319,7 @@ impl ::std::convert::From<&Self> for WorkflowStepInProgressStatus {
 impl ::std::fmt::Display for WorkflowStepInProgressStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::InProgress => write!(f, "in_progress"),
+            Self::InProgress => f.write_str("in_progress"),
         }
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -901,30 +901,30 @@ impl ::std::convert::From<&Self> for AggregateTransformOpsVariant0ItemVariant0 {
 impl ::std::fmt::Display for AggregateTransformOpsVariant0ItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => write!(f, "values"),
-            Self::Count => write!(f, "count"),
-            Self::XXcountXx => write!(f, "__count__"),
-            Self::Missing => write!(f, "missing"),
-            Self::Valid => write!(f, "valid"),
-            Self::Sum => write!(f, "sum"),
-            Self::Product => write!(f, "product"),
-            Self::Mean => write!(f, "mean"),
-            Self::Average => write!(f, "average"),
-            Self::Variance => write!(f, "variance"),
-            Self::Variancep => write!(f, "variancep"),
-            Self::Stdev => write!(f, "stdev"),
-            Self::Stdevp => write!(f, "stdevp"),
-            Self::Stderr => write!(f, "stderr"),
-            Self::Distinct => write!(f, "distinct"),
-            Self::Ci0 => write!(f, "ci0"),
-            Self::Ci1 => write!(f, "ci1"),
-            Self::Median => write!(f, "median"),
-            Self::Q1 => write!(f, "q1"),
-            Self::Q3 => write!(f, "q3"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
-            Self::Argmin => write!(f, "argmin"),
-            Self::Argmax => write!(f, "argmax"),
+            Self::Values => f.write_str("values"),
+            Self::Count => f.write_str("count"),
+            Self::XXcountXx => f.write_str("__count__"),
+            Self::Missing => f.write_str("missing"),
+            Self::Valid => f.write_str("valid"),
+            Self::Sum => f.write_str("sum"),
+            Self::Product => f.write_str("product"),
+            Self::Mean => f.write_str("mean"),
+            Self::Average => f.write_str("average"),
+            Self::Variance => f.write_str("variance"),
+            Self::Variancep => f.write_str("variancep"),
+            Self::Stdev => f.write_str("stdev"),
+            Self::Stdevp => f.write_str("stdevp"),
+            Self::Stderr => f.write_str("stderr"),
+            Self::Distinct => f.write_str("distinct"),
+            Self::Ci0 => f.write_str("ci0"),
+            Self::Ci1 => f.write_str("ci1"),
+            Self::Median => f.write_str("median"),
+            Self::Q1 => f.write_str("q1"),
+            Self::Q3 => f.write_str("q3"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::Argmin => f.write_str("argmin"),
+            Self::Argmax => f.write_str("argmax"),
         }
     }
 }
@@ -1018,7 +1018,7 @@ impl ::std::convert::From<&Self> for AggregateTransformType {
 impl ::std::fmt::Display for AggregateTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Aggregate => write!(f, "aggregate"),
+            Self::Aggregate => f.write_str("aggregate"),
         }
     }
 }
@@ -1565,9 +1565,9 @@ impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0Variant1Value
 impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -2212,9 +2212,9 @@ impl ::std::convert::From<&Self> for AlignValueVariant1Variant0Variant1Value {
 impl ::std::fmt::Display for AlignValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -3073,9 +3073,9 @@ impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0Variant1Valu
 impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -3720,9 +3720,9 @@ impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0Variant1Value {
 impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -6817,11 +6817,11 @@ impl ::std::convert::From<&Self> for AutosizeVariant0 {
 impl ::std::fmt::Display for AutosizeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pad => write!(f, "pad"),
-            Self::Fit => write!(f, "fit"),
-            Self::FitX => write!(f, "fit-x"),
-            Self::FitY => write!(f, "fit-y"),
-            Self::None => write!(f, "none"),
+            Self::Pad => f.write_str("pad"),
+            Self::Fit => f.write_str("fit"),
+            Self::FitX => f.write_str("fit-x"),
+            Self::FitY => f.write_str("fit-y"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -6899,8 +6899,8 @@ impl ::std::convert::From<&Self> for AutosizeVariant1Contains {
 impl ::std::fmt::Display for AutosizeVariant1Contains {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Content => write!(f, "content"),
-            Self::Padding => write!(f, "padding"),
+            Self::Content => f.write_str("content"),
+            Self::Padding => f.write_str("padding"),
         }
     }
 }
@@ -6985,11 +6985,11 @@ impl ::std::convert::From<&Self> for AutosizeVariant1Type {
 impl ::std::fmt::Display for AutosizeVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pad => write!(f, "pad"),
-            Self::Fit => write!(f, "fit"),
-            Self::FitX => write!(f, "fit-x"),
-            Self::FitY => write!(f, "fit-y"),
-            Self::None => write!(f, "none"),
+            Self::Pad => f.write_str("pad"),
+            Self::Fit => f.write_str("fit"),
+            Self::FitX => f.write_str("fit-x"),
+            Self::FitY => f.write_str("fit-y"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -8797,9 +8797,9 @@ impl ::std::convert::From<&Self> for AxisFormatTypeVariant0 {
 impl ::std::fmt::Display for AxisFormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -9145,9 +9145,9 @@ impl ::std::convert::From<&Self> for AxisLabelAlignVariant0 {
 impl ::std::fmt::Display for AxisLabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -9318,12 +9318,12 @@ impl ::std::convert::From<&Self> for AxisLabelBaselineVariant0 {
 impl ::std::fmt::Display for AxisLabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -10052,10 +10052,10 @@ impl ::std::convert::From<&Self> for AxisOrientVariant0 {
 impl ::std::fmt::Display for AxisOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
         }
     }
 }
@@ -10554,9 +10554,9 @@ impl ::std::convert::From<&Self> for AxisTitleAlignVariant0 {
 impl ::std::fmt::Display for AxisTitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -10679,9 +10679,9 @@ impl ::std::convert::From<&Self> for AxisTitleAnchorVariant0 {
 impl ::std::fmt::Display for AxisTitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -10852,12 +10852,12 @@ impl ::std::convert::From<&Self> for AxisTitleBaselineVariant0 {
 impl ::std::fmt::Display for AxisTitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -12752,10 +12752,10 @@ impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0Variant1Va
 impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
         }
     }
 }
@@ -13408,10 +13408,10 @@ impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0Variant1Value 
 impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
         }
     }
 }
@@ -14840,7 +14840,7 @@ impl ::std::convert::From<&Self> for BinTransformType {
 impl ::std::fmt::Display for BinTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bin => write!(f, "bin"),
+            Self::Bin => f.write_str("bin"),
         }
     }
 }
@@ -15118,7 +15118,7 @@ impl ::std::convert::From<&Self> for BindVariant0Input {
 impl ::std::fmt::Display for BindVariant0Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Checkbox => write!(f, "checkbox"),
+            Self::Checkbox => f.write_str("checkbox"),
         }
     }
 }
@@ -15192,8 +15192,8 @@ impl ::std::convert::From<&Self> for BindVariant1Input {
 impl ::std::fmt::Display for BindVariant1Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Radio => write!(f, "radio"),
-            Self::Select => write!(f, "select"),
+            Self::Radio => f.write_str("radio"),
+            Self::Select => f.write_str("select"),
         }
     }
 }
@@ -15265,7 +15265,7 @@ impl ::std::convert::From<&Self> for BindVariant2Input {
 impl ::std::fmt::Display for BindVariant2Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Range => write!(f, "range"),
+            Self::Range => f.write_str("range"),
         }
     }
 }
@@ -15965,21 +15965,21 @@ impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0Variant1Value
 impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Multiply => write!(f, "multiply"),
-            Self::Screen => write!(f, "screen"),
-            Self::Overlay => write!(f, "overlay"),
-            Self::Darken => write!(f, "darken"),
-            Self::Lighten => write!(f, "lighten"),
-            Self::ColorDodge => write!(f, "color-dodge"),
-            Self::ColorBurn => write!(f, "color-burn"),
-            Self::HardLight => write!(f, "hard-light"),
-            Self::SoftLight => write!(f, "soft-light"),
-            Self::Difference => write!(f, "difference"),
-            Self::Exclusion => write!(f, "exclusion"),
-            Self::Hue => write!(f, "hue"),
-            Self::Saturation => write!(f, "saturation"),
-            Self::Color => write!(f, "color"),
-            Self::Luminosity => write!(f, "luminosity"),
+            Self::Multiply => f.write_str("multiply"),
+            Self::Screen => f.write_str("screen"),
+            Self::Overlay => f.write_str("overlay"),
+            Self::Darken => f.write_str("darken"),
+            Self::Lighten => f.write_str("lighten"),
+            Self::ColorDodge => f.write_str("color-dodge"),
+            Self::ColorBurn => f.write_str("color-burn"),
+            Self::HardLight => f.write_str("hard-light"),
+            Self::SoftLight => f.write_str("soft-light"),
+            Self::Difference => f.write_str("difference"),
+            Self::Exclusion => f.write_str("exclusion"),
+            Self::Hue => f.write_str("hue"),
+            Self::Saturation => f.write_str("saturation"),
+            Self::Color => f.write_str("color"),
+            Self::Luminosity => f.write_str("luminosity"),
         }
     }
 }
@@ -16725,21 +16725,21 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant0Variant1Value {
 impl ::std::fmt::Display for BlendValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Multiply => write!(f, "multiply"),
-            Self::Screen => write!(f, "screen"),
-            Self::Overlay => write!(f, "overlay"),
-            Self::Darken => write!(f, "darken"),
-            Self::Lighten => write!(f, "lighten"),
-            Self::ColorDodge => write!(f, "color-dodge"),
-            Self::ColorBurn => write!(f, "color-burn"),
-            Self::HardLight => write!(f, "hard-light"),
-            Self::SoftLight => write!(f, "soft-light"),
-            Self::Difference => write!(f, "difference"),
-            Self::Exclusion => write!(f, "exclusion"),
-            Self::Hue => write!(f, "hue"),
-            Self::Saturation => write!(f, "saturation"),
-            Self::Color => write!(f, "color"),
-            Self::Luminosity => write!(f, "luminosity"),
+            Self::Multiply => f.write_str("multiply"),
+            Self::Screen => f.write_str("screen"),
+            Self::Overlay => f.write_str("overlay"),
+            Self::Darken => f.write_str("darken"),
+            Self::Lighten => f.write_str("lighten"),
+            Self::ColorDodge => f.write_str("color-dodge"),
+            Self::ColorBurn => f.write_str("color-burn"),
+            Self::HardLight => f.write_str("hard-light"),
+            Self::SoftLight => f.write_str("soft-light"),
+            Self::Difference => f.write_str("difference"),
+            Self::Exclusion => f.write_str("exclusion"),
+            Self::Hue => f.write_str("hue"),
+            Self::Saturation => f.write_str("saturation"),
+            Self::Color => f.write_str("color"),
+            Self::Luminosity => f.write_str("luminosity"),
         }
     }
 }
@@ -18542,7 +18542,7 @@ impl ::std::convert::From<&Self> for CollectTransformType {
 impl ::std::fmt::Display for CollectTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Collect => write!(f, "collect"),
+            Self::Collect => f.write_str("collect"),
         }
     }
 }
@@ -19500,7 +19500,7 @@ impl ::std::convert::From<&Self> for ContourTransformType {
 impl ::std::fmt::Display for ContourTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Contour => write!(f, "contour"),
+            Self::Contour => f.write_str("contour"),
         }
     }
 }
@@ -20073,9 +20073,9 @@ impl ::std::convert::From<&Self> for CountpatternTransformCaseVariant0 {
 impl ::std::fmt::Display for CountpatternTransformCaseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Upper => write!(f, "upper"),
-            Self::Lower => write!(f, "lower"),
-            Self::Mixed => write!(f, "mixed"),
+            Self::Upper => f.write_str("upper"),
+            Self::Lower => f.write_str("lower"),
+            Self::Mixed => f.write_str("mixed"),
         }
     }
 }
@@ -20267,7 +20267,7 @@ impl ::std::convert::From<&Self> for CountpatternTransformType {
 impl ::std::fmt::Display for CountpatternTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Countpattern => write!(f, "countpattern"),
+            Self::Countpattern => f.write_str("countpattern"),
         }
     }
 }
@@ -20503,7 +20503,7 @@ impl ::std::convert::From<&Self> for CrossTransformType {
 impl ::std::fmt::Display for CrossTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Cross => write!(f, "cross"),
+            Self::Cross => f.write_str("cross"),
         }
     }
 }
@@ -20788,7 +20788,7 @@ impl ::std::convert::From<&Self> for CrossfilterTransformType {
 impl ::std::fmt::Display for CrossfilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Crossfilter => write!(f, "crossfilter"),
+            Self::Crossfilter => f.write_str("crossfilter"),
         }
     }
 }
@@ -22065,7 +22065,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -22243,10 +22243,10 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -22585,7 +22585,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -22763,10 +22763,10 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -22933,7 +22933,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1Type {
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => write!(f, "json"),
+            Self::Json => f.write_str("json"),
         }
     }
 }
@@ -23164,7 +23164,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -23342,10 +23342,10 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -23515,8 +23515,8 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2Type {
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Csv => write!(f, "csv"),
-            Self::Tsv => write!(f, "tsv"),
+            Self::Csv => f.write_str("csv"),
+            Self::Tsv => f.write_str("tsv"),
         }
     }
 }
@@ -23752,7 +23752,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -23930,10 +23930,10 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3ParseVari
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -24100,7 +24100,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3Type {
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dsv => write!(f, "dsv"),
+            Self::Dsv => f.write_str("dsv"),
         }
     }
 }
@@ -24256,7 +24256,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant0T
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => write!(f, "topojson"),
+            Self::Topojson => f.write_str("topojson"),
         }
     }
 }
@@ -24335,8 +24335,8 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant1F
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Filter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Interior => write!(f, "interior"),
-            Self::Exterior => write!(f, "exterior"),
+            Self::Interior => f.write_str("interior"),
+            Self::Exterior => f.write_str("exterior"),
         }
     }
 }
@@ -24412,7 +24412,7 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant1T
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => write!(f, "topojson"),
+            Self::Topojson => f.write_str("topojson"),
         }
     }
 }
@@ -24955,7 +24955,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -25133,10 +25133,10 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -25475,7 +25475,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -25653,10 +25653,10 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -25823,7 +25823,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1Type {
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Json => write!(f, "json"),
+            Self::Json => f.write_str("json"),
         }
     }
 }
@@ -26054,7 +26054,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -26232,10 +26232,10 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -26405,8 +26405,8 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2Type {
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Csv => write!(f, "csv"),
-            Self::Tsv => write!(f, "tsv"),
+            Self::Csv => f.write_str("csv"),
+            Self::Tsv => f.write_str("tsv"),
         }
     }
 }
@@ -26642,7 +26642,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Auto => write!(f, "auto"),
+            Self::Auto => f.write_str("auto"),
         }
     }
 }
@@ -26820,10 +26820,10 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3ParseVari
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Boolean => write!(f, "boolean"),
-            Self::Number => write!(f, "number"),
-            Self::Date => write!(f, "date"),
-            Self::String => write!(f, "string"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Number => f.write_str("number"),
+            Self::Date => f.write_str("date"),
+            Self::String => f.write_str("string"),
         }
     }
 }
@@ -26990,7 +26990,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3Type {
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dsv => write!(f, "dsv"),
+            Self::Dsv => f.write_str("dsv"),
         }
     }
 }
@@ -27146,7 +27146,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant0T
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => write!(f, "topojson"),
+            Self::Topojson => f.write_str("topojson"),
         }
     }
 }
@@ -27225,8 +27225,8 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant1F
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Filter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Interior => write!(f, "interior"),
-            Self::Exterior => write!(f, "exterior"),
+            Self::Interior => f.write_str("interior"),
+            Self::Exterior => f.write_str("exterior"),
         }
     }
 }
@@ -27302,7 +27302,7 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant1T
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Topojson => write!(f, "topojson"),
+            Self::Topojson => f.write_str("topojson"),
         }
     }
 }
@@ -28719,7 +28719,7 @@ impl ::std::convert::From<&Self> for DensityTransformType {
 impl ::std::fmt::Display for DensityTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Density => write!(f, "density"),
+            Self::Density => f.write_str("density"),
         }
     }
 }
@@ -29259,8 +29259,8 @@ impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0Variant1V
 impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => write!(f, "horizontal"),
-            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
+            Self::Vertical => f.write_str("vertical"),
         }
     }
 }
@@ -29897,8 +29897,8 @@ impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0Variant1Value
 impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => write!(f, "horizontal"),
-            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
+            Self::Vertical => f.write_str("vertical"),
         }
     }
 }
@@ -30662,7 +30662,7 @@ impl ::std::convert::From<&Self> for DotbinTransformType {
 impl ::std::fmt::Display for DotbinTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Dotbin => write!(f, "dotbin"),
+            Self::Dotbin => f.write_str("dotbin"),
         }
     }
 }
@@ -31814,7 +31814,7 @@ impl ::std::convert::From<&Self> for ExtentTransformType {
 impl ::std::fmt::Display for ExtentTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Extent => write!(f, "extent"),
+            Self::Extent => f.write_str("extent"),
         }
     }
 }
@@ -32337,7 +32337,7 @@ impl ::std::convert::From<&Self> for FilterTransformType {
 impl ::std::fmt::Display for FilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Filter => write!(f, "filter"),
+            Self::Filter => f.write_str("filter"),
         }
     }
 }
@@ -32722,7 +32722,7 @@ impl ::std::convert::From<&Self> for FlattenTransformType {
 impl ::std::fmt::Display for FlattenTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Flatten => write!(f, "flatten"),
+            Self::Flatten => f.write_str("flatten"),
         }
     }
 }
@@ -33078,7 +33078,7 @@ impl ::std::convert::From<&Self> for FoldTransformType {
 impl ::std::fmt::Display for FoldTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Fold => write!(f, "fold"),
+            Self::Fold => f.write_str("fold"),
         }
     }
 }
@@ -36333,7 +36333,7 @@ impl ::std::convert::From<&Self> for ForceTransformType {
 impl ::std::fmt::Display for ForceTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Force => write!(f, "force"),
+            Self::Force => f.write_str("force"),
         }
     }
 }
@@ -36586,7 +36586,7 @@ impl ::std::convert::From<&Self> for FormulaTransformType {
 impl ::std::fmt::Display for FormulaTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Formula => write!(f, "formula"),
+            Self::Formula => f.write_str("formula"),
         }
     }
 }
@@ -36917,7 +36917,7 @@ impl ::std::convert::From<&Self> for GeojsonTransformType {
 impl ::std::fmt::Display for GeojsonTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geojson => write!(f, "geojson"),
+            Self::Geojson => f.write_str("geojson"),
         }
     }
 }
@@ -37222,7 +37222,7 @@ impl ::std::convert::From<&Self> for GeopathTransformType {
 impl ::std::fmt::Display for GeopathTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geopath => write!(f, "geopath"),
+            Self::Geopath => f.write_str("geopath"),
         }
     }
 }
@@ -37587,7 +37587,7 @@ impl ::std::convert::From<&Self> for GeopointTransformType {
 impl ::std::fmt::Display for GeopointTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geopoint => write!(f, "geopoint"),
+            Self::Geopoint => f.write_str("geopoint"),
         }
     }
 }
@@ -37901,7 +37901,7 @@ impl ::std::convert::From<&Self> for GeoshapeTransformType {
 impl ::std::fmt::Display for GeoshapeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Geoshape => write!(f, "geoshape"),
+            Self::Geoshape => f.write_str("geoshape"),
         }
     }
 }
@@ -38704,7 +38704,7 @@ impl ::std::convert::From<&Self> for GraticuleTransformType {
 impl ::std::fmt::Display for GraticuleTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Graticule => write!(f, "graticule"),
+            Self::Graticule => f.write_str("graticule"),
         }
     }
 }
@@ -39187,8 +39187,8 @@ impl ::std::convert::From<&Self> for HeatmapTransformResolveVariant0 {
 impl ::std::fmt::Display for HeatmapTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => write!(f, "shared"),
-            Self::Independent => write!(f, "independent"),
+            Self::Shared => f.write_str("shared"),
+            Self::Independent => f.write_str("independent"),
         }
     }
 }
@@ -39260,7 +39260,7 @@ impl ::std::convert::From<&Self> for HeatmapTransformType {
 impl ::std::fmt::Display for HeatmapTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -39414,7 +39414,7 @@ impl ::std::convert::From<&Self> for IdentifierTransformType {
 impl ::std::fmt::Display for IdentifierTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Identifier => write!(f, "identifier"),
+            Self::Identifier => f.write_str("identifier"),
         }
     }
 }
@@ -39907,11 +39907,11 @@ impl ::std::convert::From<&Self> for ImputeTransformMethodVariant0 {
 impl ::std::fmt::Display for ImputeTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Value => write!(f, "value"),
-            Self::Mean => write!(f, "mean"),
-            Self::Median => write!(f, "median"),
-            Self::Max => write!(f, "max"),
-            Self::Min => write!(f, "min"),
+            Self::Value => f.write_str("value"),
+            Self::Mean => f.write_str("mean"),
+            Self::Median => f.write_str("median"),
+            Self::Max => f.write_str("max"),
+            Self::Min => f.write_str("min"),
         }
     }
 }
@@ -39986,7 +39986,7 @@ impl ::std::convert::From<&Self> for ImputeTransformType {
 impl ::std::fmt::Display for ImputeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Impute => write!(f, "impute"),
+            Self::Impute => f.write_str("impute"),
         }
     }
 }
@@ -40475,8 +40475,8 @@ impl ::std::convert::From<&Self> for IsocontourTransformResolveVariant0 {
 impl ::std::fmt::Display for IsocontourTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => write!(f, "shared"),
-            Self::Independent => write!(f, "independent"),
+            Self::Shared => f.write_str("shared"),
+            Self::Independent => f.write_str("independent"),
         }
     }
 }
@@ -40848,7 +40848,7 @@ impl ::std::convert::From<&Self> for IsocontourTransformType {
 impl ::std::fmt::Display for IsocontourTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Isocontour => write!(f, "isocontour"),
+            Self::Isocontour => f.write_str("isocontour"),
         }
     }
 }
@@ -41697,30 +41697,30 @@ impl ::std::convert::From<&Self> for JoinaggregateTransformOpsVariant0ItemVarian
 impl ::std::fmt::Display for JoinaggregateTransformOpsVariant0ItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => write!(f, "values"),
-            Self::Count => write!(f, "count"),
-            Self::XXcountXx => write!(f, "__count__"),
-            Self::Missing => write!(f, "missing"),
-            Self::Valid => write!(f, "valid"),
-            Self::Sum => write!(f, "sum"),
-            Self::Product => write!(f, "product"),
-            Self::Mean => write!(f, "mean"),
-            Self::Average => write!(f, "average"),
-            Self::Variance => write!(f, "variance"),
-            Self::Variancep => write!(f, "variancep"),
-            Self::Stdev => write!(f, "stdev"),
-            Self::Stdevp => write!(f, "stdevp"),
-            Self::Stderr => write!(f, "stderr"),
-            Self::Distinct => write!(f, "distinct"),
-            Self::Ci0 => write!(f, "ci0"),
-            Self::Ci1 => write!(f, "ci1"),
-            Self::Median => write!(f, "median"),
-            Self::Q1 => write!(f, "q1"),
-            Self::Q3 => write!(f, "q3"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
-            Self::Argmin => write!(f, "argmin"),
-            Self::Argmax => write!(f, "argmax"),
+            Self::Values => f.write_str("values"),
+            Self::Count => f.write_str("count"),
+            Self::XXcountXx => f.write_str("__count__"),
+            Self::Missing => f.write_str("missing"),
+            Self::Valid => f.write_str("valid"),
+            Self::Sum => f.write_str("sum"),
+            Self::Product => f.write_str("product"),
+            Self::Mean => f.write_str("mean"),
+            Self::Average => f.write_str("average"),
+            Self::Variance => f.write_str("variance"),
+            Self::Variancep => f.write_str("variancep"),
+            Self::Stdev => f.write_str("stdev"),
+            Self::Stdevp => f.write_str("stdevp"),
+            Self::Stderr => f.write_str("stderr"),
+            Self::Distinct => f.write_str("distinct"),
+            Self::Ci0 => f.write_str("ci0"),
+            Self::Ci1 => f.write_str("ci1"),
+            Self::Median => f.write_str("median"),
+            Self::Q1 => f.write_str("q1"),
+            Self::Q3 => f.write_str("q3"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::Argmin => f.write_str("argmin"),
+            Self::Argmax => f.write_str("argmax"),
         }
     }
 }
@@ -41818,7 +41818,7 @@ impl ::std::convert::From<&Self> for JoinaggregateTransformType {
 impl ::std::fmt::Display for JoinaggregateTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Joinaggregate => write!(f, "joinaggregate"),
+            Self::Joinaggregate => f.write_str("joinaggregate"),
         }
     }
 }
@@ -42478,7 +42478,7 @@ impl ::std::convert::From<&Self> for Kde2dTransformType {
 impl ::std::fmt::Display for Kde2dTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Kde2d => write!(f, "kde2d"),
+            Self::Kde2d => f.write_str("kde2d"),
         }
     }
 }
@@ -43487,8 +43487,8 @@ impl ::std::convert::From<&Self> for KdeTransformResolveVariant0 {
 impl ::std::fmt::Display for KdeTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Shared => write!(f, "shared"),
-            Self::Independent => write!(f, "independent"),
+            Self::Shared => f.write_str("shared"),
+            Self::Independent => f.write_str("independent"),
         }
     }
 }
@@ -43598,7 +43598,7 @@ impl ::std::convert::From<&Self> for KdeTransformType {
 impl ::std::fmt::Display for KdeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Kde => write!(f, "kde"),
+            Self::Kde => f.write_str("kde"),
         }
     }
 }
@@ -43722,8 +43722,8 @@ impl ::std::convert::From<&Self> for LabelOverlapVariant1 {
 impl ::std::fmt::Display for LabelOverlapVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Parity => write!(f, "parity"),
-            Self::Greedy => write!(f, "greedy"),
+            Self::Parity => f.write_str("parity"),
+            Self::Greedy => f.write_str("greedy"),
         }
     }
 }
@@ -44679,7 +44679,7 @@ impl ::std::convert::From<&Self> for LabelTransformType {
 impl ::std::fmt::Display for LabelTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Label => write!(f, "label"),
+            Self::Label => f.write_str("label"),
         }
     }
 }
@@ -45212,9 +45212,9 @@ impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant0Variant0 {
 impl ::std::fmt::Display for LayoutVariant0AlignVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -45337,9 +45337,9 @@ impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1ColumnVariant0 {
 impl ::std::fmt::Display for LayoutVariant0AlignVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -45462,9 +45462,9 @@ impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1RowVariant0 {
 impl ::std::fmt::Display for LayoutVariant0AlignVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -45581,8 +45581,8 @@ impl ::std::convert::From<&Self> for LayoutVariant0BoundsVariant0 {
 impl ::std::fmt::Display for LayoutVariant0BoundsVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Full => write!(f, "full"),
-            Self::Flush => write!(f, "flush"),
+            Self::Full => f.write_str("full"),
+            Self::Flush => f.write_str("flush"),
         }
     }
 }
@@ -46091,8 +46091,8 @@ impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant0Variant0 {
 impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -46210,8 +46210,8 @@ impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1ColumnVari
 impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -46333,8 +46333,8 @@ impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1RowVariant
 impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -49715,8 +49715,8 @@ impl ::std::convert::From<&Self> for LegendVariant0Direction {
 impl ::std::fmt::Display for LegendVariant0Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -50028,9 +50028,9 @@ impl ::std::convert::From<&Self> for LegendVariant0FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant0FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -50264,9 +50264,9 @@ impl ::std::convert::From<&Self> for LegendVariant0GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant0GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -50387,9 +50387,9 @@ impl ::std::convert::From<&Self> for LegendVariant0LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant0LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -50522,12 +50522,12 @@ impl ::std::convert::From<&Self> for LegendVariant0LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant0LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -51108,15 +51108,15 @@ impl ::std::convert::From<&Self> for LegendVariant0OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant0OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -51656,9 +51656,9 @@ impl ::std::convert::From<&Self> for LegendVariant0TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant0TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -51783,9 +51783,9 @@ impl ::std::convert::From<&Self> for LegendVariant0TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant0TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -51918,12 +51918,12 @@ impl ::std::convert::From<&Self> for LegendVariant0TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant0TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -52368,10 +52368,10 @@ impl ::std::convert::From<&Self> for LegendVariant0TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant0TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -52486,8 +52486,8 @@ impl ::std::convert::From<&Self> for LegendVariant0Type {
 impl ::std::fmt::Display for LegendVariant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -52600,8 +52600,8 @@ impl ::std::convert::From<&Self> for LegendVariant1Direction {
 impl ::std::fmt::Display for LegendVariant1Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -52913,9 +52913,9 @@ impl ::std::convert::From<&Self> for LegendVariant1FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant1FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -53149,9 +53149,9 @@ impl ::std::convert::From<&Self> for LegendVariant1GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant1GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -53272,9 +53272,9 @@ impl ::std::convert::From<&Self> for LegendVariant1LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant1LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -53407,12 +53407,12 @@ impl ::std::convert::From<&Self> for LegendVariant1LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant1LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -53993,15 +53993,15 @@ impl ::std::convert::From<&Self> for LegendVariant1OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant1OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -54541,9 +54541,9 @@ impl ::std::convert::From<&Self> for LegendVariant1TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant1TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -54668,9 +54668,9 @@ impl ::std::convert::From<&Self> for LegendVariant1TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant1TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -54803,12 +54803,12 @@ impl ::std::convert::From<&Self> for LegendVariant1TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant1TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -55253,10 +55253,10 @@ impl ::std::convert::From<&Self> for LegendVariant1TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant1TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -55371,8 +55371,8 @@ impl ::std::convert::From<&Self> for LegendVariant1Type {
 impl ::std::fmt::Display for LegendVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -55485,8 +55485,8 @@ impl ::std::convert::From<&Self> for LegendVariant2Direction {
 impl ::std::fmt::Display for LegendVariant2Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -55798,9 +55798,9 @@ impl ::std::convert::From<&Self> for LegendVariant2FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant2FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -56034,9 +56034,9 @@ impl ::std::convert::From<&Self> for LegendVariant2GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant2GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -56157,9 +56157,9 @@ impl ::std::convert::From<&Self> for LegendVariant2LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant2LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -56292,12 +56292,12 @@ impl ::std::convert::From<&Self> for LegendVariant2LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant2LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -56878,15 +56878,15 @@ impl ::std::convert::From<&Self> for LegendVariant2OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant2OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -57426,9 +57426,9 @@ impl ::std::convert::From<&Self> for LegendVariant2TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant2TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -57553,9 +57553,9 @@ impl ::std::convert::From<&Self> for LegendVariant2TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant2TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -57688,12 +57688,12 @@ impl ::std::convert::From<&Self> for LegendVariant2TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant2TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -58138,10 +58138,10 @@ impl ::std::convert::From<&Self> for LegendVariant2TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant2TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -58256,8 +58256,8 @@ impl ::std::convert::From<&Self> for LegendVariant2Type {
 impl ::std::fmt::Display for LegendVariant2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -58370,8 +58370,8 @@ impl ::std::convert::From<&Self> for LegendVariant3Direction {
 impl ::std::fmt::Display for LegendVariant3Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -58683,9 +58683,9 @@ impl ::std::convert::From<&Self> for LegendVariant3FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant3FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -58919,9 +58919,9 @@ impl ::std::convert::From<&Self> for LegendVariant3GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant3GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -59042,9 +59042,9 @@ impl ::std::convert::From<&Self> for LegendVariant3LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant3LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -59177,12 +59177,12 @@ impl ::std::convert::From<&Self> for LegendVariant3LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant3LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -59763,15 +59763,15 @@ impl ::std::convert::From<&Self> for LegendVariant3OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant3OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -60311,9 +60311,9 @@ impl ::std::convert::From<&Self> for LegendVariant3TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant3TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -60438,9 +60438,9 @@ impl ::std::convert::From<&Self> for LegendVariant3TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant3TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -60573,12 +60573,12 @@ impl ::std::convert::From<&Self> for LegendVariant3TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant3TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -61023,10 +61023,10 @@ impl ::std::convert::From<&Self> for LegendVariant3TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant3TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -61141,8 +61141,8 @@ impl ::std::convert::From<&Self> for LegendVariant3Type {
 impl ::std::fmt::Display for LegendVariant3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -61255,8 +61255,8 @@ impl ::std::convert::From<&Self> for LegendVariant4Direction {
 impl ::std::fmt::Display for LegendVariant4Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -61568,9 +61568,9 @@ impl ::std::convert::From<&Self> for LegendVariant4FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant4FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -61804,9 +61804,9 @@ impl ::std::convert::From<&Self> for LegendVariant4GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant4GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -61927,9 +61927,9 @@ impl ::std::convert::From<&Self> for LegendVariant4LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant4LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -62062,12 +62062,12 @@ impl ::std::convert::From<&Self> for LegendVariant4LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant4LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -62648,15 +62648,15 @@ impl ::std::convert::From<&Self> for LegendVariant4OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant4OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -63196,9 +63196,9 @@ impl ::std::convert::From<&Self> for LegendVariant4TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant4TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -63323,9 +63323,9 @@ impl ::std::convert::From<&Self> for LegendVariant4TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant4TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -63458,12 +63458,12 @@ impl ::std::convert::From<&Self> for LegendVariant4TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant4TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -63908,10 +63908,10 @@ impl ::std::convert::From<&Self> for LegendVariant4TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant4TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -64026,8 +64026,8 @@ impl ::std::convert::From<&Self> for LegendVariant4Type {
 impl ::std::fmt::Display for LegendVariant4Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -64140,8 +64140,8 @@ impl ::std::convert::From<&Self> for LegendVariant5Direction {
 impl ::std::fmt::Display for LegendVariant5Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -64453,9 +64453,9 @@ impl ::std::convert::From<&Self> for LegendVariant5FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant5FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -64689,9 +64689,9 @@ impl ::std::convert::From<&Self> for LegendVariant5GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant5GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -64812,9 +64812,9 @@ impl ::std::convert::From<&Self> for LegendVariant5LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant5LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -64947,12 +64947,12 @@ impl ::std::convert::From<&Self> for LegendVariant5LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant5LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -65533,15 +65533,15 @@ impl ::std::convert::From<&Self> for LegendVariant5OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant5OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -66081,9 +66081,9 @@ impl ::std::convert::From<&Self> for LegendVariant5TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant5TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -66208,9 +66208,9 @@ impl ::std::convert::From<&Self> for LegendVariant5TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant5TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -66343,12 +66343,12 @@ impl ::std::convert::From<&Self> for LegendVariant5TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant5TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -66793,10 +66793,10 @@ impl ::std::convert::From<&Self> for LegendVariant5TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant5TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -66911,8 +66911,8 @@ impl ::std::convert::From<&Self> for LegendVariant5Type {
 impl ::std::fmt::Display for LegendVariant5Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -67025,8 +67025,8 @@ impl ::std::convert::From<&Self> for LegendVariant6Direction {
 impl ::std::fmt::Display for LegendVariant6Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Vertical => write!(f, "vertical"),
-            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
         }
     }
 }
@@ -67338,9 +67338,9 @@ impl ::std::convert::From<&Self> for LegendVariant6FormatTypeVariant0 {
 impl ::std::fmt::Display for LegendVariant6FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Number => write!(f, "number"),
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Number => f.write_str("number"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -67574,9 +67574,9 @@ impl ::std::convert::From<&Self> for LegendVariant6GridAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant6GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::All => write!(f, "all"),
-            Self::Each => write!(f, "each"),
-            Self::None => write!(f, "none"),
+            Self::All => f.write_str("all"),
+            Self::Each => f.write_str("each"),
+            Self::None => f.write_str("none"),
         }
     }
 }
@@ -67697,9 +67697,9 @@ impl ::std::convert::From<&Self> for LegendVariant6LabelAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant6LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -67832,12 +67832,12 @@ impl ::std::convert::From<&Self> for LegendVariant6LabelBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant6LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -68418,15 +68418,15 @@ impl ::std::convert::From<&Self> for LegendVariant6OrientVariant0 {
 impl ::std::fmt::Display for LegendVariant6OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::TopLeft => write!(f, "top-left"),
-            Self::TopRight => write!(f, "top-right"),
-            Self::BottomLeft => write!(f, "bottom-left"),
-            Self::BottomRight => write!(f, "bottom-right"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::TopLeft => f.write_str("top-left"),
+            Self::TopRight => f.write_str("top-right"),
+            Self::BottomLeft => f.write_str("bottom-left"),
+            Self::BottomRight => f.write_str("bottom-right"),
         }
     }
 }
@@ -68966,9 +68966,9 @@ impl ::std::convert::From<&Self> for LegendVariant6TitleAlignVariant0 {
 impl ::std::fmt::Display for LegendVariant6TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -69093,9 +69093,9 @@ impl ::std::convert::From<&Self> for LegendVariant6TitleAnchorVariant0 {
 impl ::std::fmt::Display for LegendVariant6TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -69228,12 +69228,12 @@ impl ::std::convert::From<&Self> for LegendVariant6TitleBaselineVariant0 {
 impl ::std::fmt::Display for LegendVariant6TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -69678,10 +69678,10 @@ impl ::std::convert::From<&Self> for LegendVariant6TitleOrientVariant0 {
 impl ::std::fmt::Display for LegendVariant6TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -69796,8 +69796,8 @@ impl ::std::convert::From<&Self> for LegendVariant6Type {
 impl ::std::fmt::Display for LegendVariant6Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Gradient => write!(f, "gradient"),
-            Self::Symbol => write!(f, "symbol"),
+            Self::Gradient => f.write_str("gradient"),
+            Self::Symbol => f.write_str("symbol"),
         }
     }
 }
@@ -69930,7 +69930,7 @@ impl ::std::convert::From<&Self> for LinearGradientGradient {
 impl ::std::fmt::Display for LinearGradientGradient {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linear => write!(f, "linear"),
+            Self::Linear => f.write_str("linear"),
         }
     }
 }
@@ -70249,9 +70249,9 @@ impl ::std::convert::From<&Self> for LinkpathTransformOrientVariant0 {
 impl ::std::fmt::Display for LinkpathTransformOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Horizontal => write!(f, "horizontal"),
-            Self::Vertical => write!(f, "vertical"),
-            Self::Radial => write!(f, "radial"),
+            Self::Horizontal => f.write_str("horizontal"),
+            Self::Vertical => f.write_str("vertical"),
+            Self::Radial => f.write_str("radial"),
         }
     }
 }
@@ -70386,11 +70386,11 @@ impl ::std::convert::From<&Self> for LinkpathTransformShapeVariant0 {
 impl ::std::fmt::Display for LinkpathTransformShapeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Line => write!(f, "line"),
-            Self::Arc => write!(f, "arc"),
-            Self::Curve => write!(f, "curve"),
-            Self::Diagonal => write!(f, "diagonal"),
-            Self::Orthogonal => write!(f, "orthogonal"),
+            Self::Line => f.write_str("line"),
+            Self::Arc => f.write_str("arc"),
+            Self::Curve => f.write_str("curve"),
+            Self::Diagonal => f.write_str("diagonal"),
+            Self::Orthogonal => f.write_str("orthogonal"),
         }
     }
 }
@@ -70685,7 +70685,7 @@ impl ::std::convert::From<&Self> for LinkpathTransformType {
 impl ::std::fmt::Display for LinkpathTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linkpath => write!(f, "linkpath"),
+            Self::Linkpath => f.write_str("linkpath"),
         }
     }
 }
@@ -71162,7 +71162,7 @@ impl ::std::convert::From<&Self> for LoessTransformType {
 impl ::std::fmt::Display for LoessTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Loess => write!(f, "loess"),
+            Self::Loess => f.write_str("loess"),
         }
     }
 }
@@ -71691,7 +71691,7 @@ impl ::std::convert::From<&Self> for LookupTransformType {
 impl ::std::fmt::Display for LookupTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Lookup => write!(f, "lookup"),
+            Self::Lookup => f.write_str("lookup"),
         }
     }
 }
@@ -72126,7 +72126,7 @@ impl ::std::convert::From<&Self> for MarkGroupType {
 impl ::std::fmt::Display for MarkGroupType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Group => write!(f, "group"),
+            Self::Group => f.write_str("group"),
         }
     }
 }
@@ -72582,7 +72582,7 @@ impl ::std::convert::From<&Self> for NestTransformType {
 impl ::std::fmt::Display for NestTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Nest => write!(f, "nest"),
+            Self::Nest => f.write_str("nest"),
         }
     }
 }
@@ -77658,10 +77658,10 @@ impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0Variant1Valu
 impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -78314,10 +78314,10 @@ impl ::std::convert::From<&Self> for OrientValueVariant1Variant0Variant1Value {
 impl ::std::fmt::Display for OrientValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -79163,7 +79163,7 @@ impl ::std::convert::From<&Self> for PackTransformType {
 impl ::std::fmt::Display for PackTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pack => write!(f, "pack"),
+            Self::Pack => f.write_str("pack"),
         }
     }
 }
@@ -79789,7 +79789,7 @@ impl ::std::convert::From<&Self> for PartitionTransformType {
 impl ::std::fmt::Display for PartitionTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Partition => write!(f, "partition"),
+            Self::Partition => f.write_str("partition"),
         }
     }
 }
@@ -80243,7 +80243,7 @@ impl ::std::convert::From<&Self> for PieTransformType {
 impl ::std::fmt::Display for PieTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pie => write!(f, "pie"),
+            Self::Pie => f.write_str("pie"),
         }
     }
 }
@@ -80841,30 +80841,30 @@ impl ::std::convert::From<&Self> for PivotTransformOpVariant0 {
 impl ::std::fmt::Display for PivotTransformOpVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Values => write!(f, "values"),
-            Self::Count => write!(f, "count"),
-            Self::XXcountXx => write!(f, "__count__"),
-            Self::Missing => write!(f, "missing"),
-            Self::Valid => write!(f, "valid"),
-            Self::Sum => write!(f, "sum"),
-            Self::Product => write!(f, "product"),
-            Self::Mean => write!(f, "mean"),
-            Self::Average => write!(f, "average"),
-            Self::Variance => write!(f, "variance"),
-            Self::Variancep => write!(f, "variancep"),
-            Self::Stdev => write!(f, "stdev"),
-            Self::Stdevp => write!(f, "stdevp"),
-            Self::Stderr => write!(f, "stderr"),
-            Self::Distinct => write!(f, "distinct"),
-            Self::Ci0 => write!(f, "ci0"),
-            Self::Ci1 => write!(f, "ci1"),
-            Self::Median => write!(f, "median"),
-            Self::Q1 => write!(f, "q1"),
-            Self::Q3 => write!(f, "q3"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
-            Self::Argmin => write!(f, "argmin"),
-            Self::Argmax => write!(f, "argmax"),
+            Self::Values => f.write_str("values"),
+            Self::Count => f.write_str("count"),
+            Self::XXcountXx => f.write_str("__count__"),
+            Self::Missing => f.write_str("missing"),
+            Self::Valid => f.write_str("valid"),
+            Self::Sum => f.write_str("sum"),
+            Self::Product => f.write_str("product"),
+            Self::Mean => f.write_str("mean"),
+            Self::Average => f.write_str("average"),
+            Self::Variance => f.write_str("variance"),
+            Self::Variancep => f.write_str("variancep"),
+            Self::Stdev => f.write_str("stdev"),
+            Self::Stdevp => f.write_str("stdevp"),
+            Self::Stderr => f.write_str("stderr"),
+            Self::Distinct => f.write_str("distinct"),
+            Self::Ci0 => f.write_str("ci0"),
+            Self::Ci1 => f.write_str("ci1"),
+            Self::Median => f.write_str("median"),
+            Self::Q1 => f.write_str("q1"),
+            Self::Q3 => f.write_str("q3"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::Argmin => f.write_str("argmin"),
+            Self::Argmax => f.write_str("argmax"),
         }
     }
 }
@@ -80958,7 +80958,7 @@ impl ::std::convert::From<&Self> for PivotTransformType {
 impl ::std::fmt::Display for PivotTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pivot => write!(f, "pivot"),
+            Self::Pivot => f.write_str("pivot"),
         }
     }
 }
@@ -81355,7 +81355,7 @@ impl ::std::convert::From<&Self> for ProjectTransformType {
 impl ::std::fmt::Display for ProjectTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Project => write!(f, "project"),
+            Self::Project => f.write_str("project"),
         }
     }
 }
@@ -82613,7 +82613,7 @@ impl ::std::convert::From<&Self> for QuantileTransformType {
 impl ::std::fmt::Display for QuantileTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantile => write!(f, "quantile"),
+            Self::Quantile => f.write_str("quantile"),
         }
     }
 }
@@ -82755,7 +82755,7 @@ impl ::std::convert::From<&Self> for RadialGradientGradient {
 impl ::std::fmt::Display for RadialGradientGradient {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Radial => write!(f, "radial"),
+            Self::Radial => f.write_str("radial"),
         }
     }
 }
@@ -83400,7 +83400,7 @@ impl ::std::convert::From<&Self> for RegressionTransformType {
 impl ::std::fmt::Display for RegressionTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Regression => write!(f, "regression"),
+            Self::Regression => f.write_str("regression"),
         }
     }
 }
@@ -83655,7 +83655,7 @@ impl ::std::convert::From<&Self> for ResolvefilterTransformType {
 impl ::std::fmt::Display for ResolvefilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Resolvefilter => write!(f, "resolvefilter"),
+            Self::Resolvefilter => f.write_str("resolvefilter"),
         }
     }
 }
@@ -83852,7 +83852,7 @@ impl ::std::convert::From<&Self> for SampleTransformType {
 impl ::std::fmt::Display for SampleTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Sample => write!(f, "sample"),
+            Self::Sample => f.write_str("sample"),
         }
     }
 }
@@ -87377,7 +87377,7 @@ impl ::std::convert::From<&Self> for ScaleDataVariant1SortVariant1Op {
 impl ::std::fmt::Display for ScaleDataVariant1SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
+            Self::Count => f.write_str("count"),
         }
     }
 }
@@ -87454,9 +87454,9 @@ impl ::std::convert::From<&Self> for ScaleDataVariant1SortVariant2Op {
 impl ::std::fmt::Display for ScaleDataVariant1SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
+            Self::Count => f.write_str("count"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
         }
     }
 }
@@ -87767,7 +87767,7 @@ impl ::std::convert::From<&Self> for ScaleDataVariant2SortVariant1Op {
 impl ::std::fmt::Display for ScaleDataVariant2SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
+            Self::Count => f.write_str("count"),
         }
     }
 }
@@ -87844,9 +87844,9 @@ impl ::std::convert::From<&Self> for ScaleDataVariant2SortVariant2Op {
 impl ::std::fmt::Display for ScaleDataVariant2SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
+            Self::Count => f.write_str("count"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
         }
     }
 }
@@ -88190,7 +88190,7 @@ impl ::std::convert::From<&Self> for ScaleVariant0Type {
 impl ::std::fmt::Display for ScaleVariant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Identity => write!(f, "identity"),
+            Self::Identity => f.write_str("identity"),
         }
     }
 }
@@ -88652,14 +88652,14 @@ impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant10RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -88934,7 +88934,7 @@ impl ::std::convert::From<&Self> for ScaleVariant10Type {
 impl ::std::fmt::Display for ScaleVariant10Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Pow => write!(f, "pow"),
+            Self::Pow => f.write_str("pow"),
         }
     }
 }
@@ -89396,14 +89396,14 @@ impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant11RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -89678,7 +89678,7 @@ impl ::std::convert::From<&Self> for ScaleVariant11Type {
 impl ::std::fmt::Display for ScaleVariant11Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Symlog => write!(f, "symlog"),
+            Self::Symlog => f.write_str("symlog"),
         }
     }
 }
@@ -90299,14 +90299,14 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant1RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -90946,7 +90946,7 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant1SortVaria
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
+            Self::Count => f.write_str("count"),
         }
     }
 }
@@ -91027,9 +91027,9 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant1SortVaria
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
+            Self::Count => f.write_str("count"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
         }
     }
 }
@@ -91350,7 +91350,7 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2SortVaria
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
+            Self::Count => f.write_str("count"),
         }
     }
 }
@@ -91431,9 +91431,9 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2SortVaria
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Count => write!(f, "count"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
+            Self::Count => f.write_str("count"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
         }
     }
 }
@@ -91510,7 +91510,7 @@ impl ::std::convert::From<&Self> for ScaleVariant1Type {
 impl ::std::fmt::Display for ScaleVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Ordinal => write!(f, "ordinal"),
+            Self::Ordinal => f.write_str("ordinal"),
         }
     }
 }
@@ -91879,14 +91879,14 @@ impl ::std::convert::From<&Self> for ScaleVariant2RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant2RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -92031,7 +92031,7 @@ impl ::std::convert::From<&Self> for ScaleVariant2Type {
 impl ::std::fmt::Display for ScaleVariant2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Band => write!(f, "band"),
+            Self::Band => f.write_str("band"),
         }
     }
 }
@@ -92400,14 +92400,14 @@ impl ::std::convert::From<&Self> for ScaleVariant3RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant3RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -92552,7 +92552,7 @@ impl ::std::convert::From<&Self> for ScaleVariant3Type {
 impl ::std::fmt::Display for ScaleVariant3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Point => write!(f, "point"),
+            Self::Point => f.write_str("point"),
         }
     }
 }
@@ -93012,14 +93012,14 @@ impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant4RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -93297,8 +93297,8 @@ impl ::std::convert::From<&Self> for ScaleVariant4Type {
 impl ::std::fmt::Display for ScaleVariant4Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantize => write!(f, "quantize"),
-            Self::Threshold => write!(f, "threshold"),
+            Self::Quantize => f.write_str("quantize"),
+            Self::Threshold => f.write_str("threshold"),
         }
     }
 }
@@ -93712,14 +93712,14 @@ impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant5RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -93994,7 +93994,7 @@ impl ::std::convert::From<&Self> for ScaleVariant5Type {
 impl ::std::fmt::Display for ScaleVariant5Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Quantile => write!(f, "quantile"),
+            Self::Quantile => f.write_str("quantile"),
         }
     }
 }
@@ -94407,14 +94407,14 @@ impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant6RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -94689,7 +94689,7 @@ impl ::std::convert::From<&Self> for ScaleVariant6Type {
 impl ::std::fmt::Display for ScaleVariant6Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::BinOrdinal => write!(f, "bin-ordinal"),
+            Self::BinOrdinal => f.write_str("bin-ordinal"),
         }
     }
 }
@@ -95047,14 +95047,14 @@ impl ::std::convert::From<&Self> for ScaleVariant7NiceVariant1 {
 impl ::std::fmt::Display for ScaleVariant7NiceVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => write!(f, "millisecond"),
-            Self::Second => write!(f, "second"),
-            Self::Minute => write!(f, "minute"),
-            Self::Hour => write!(f, "hour"),
-            Self::Day => write!(f, "day"),
-            Self::Week => write!(f, "week"),
-            Self::Month => write!(f, "month"),
-            Self::Year => write!(f, "year"),
+            Self::Millisecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
+            Self::Month => f.write_str("month"),
+            Self::Year => f.write_str("year"),
         }
     }
 }
@@ -95202,14 +95202,14 @@ impl ::std::convert::From<&Self> for ScaleVariant7NiceVariant2IntervalVariant0 {
 impl ::std::fmt::Display for ScaleVariant7NiceVariant2IntervalVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => write!(f, "millisecond"),
-            Self::Second => write!(f, "second"),
-            Self::Minute => write!(f, "minute"),
-            Self::Hour => write!(f, "hour"),
-            Self::Day => write!(f, "day"),
-            Self::Week => write!(f, "week"),
-            Self::Month => write!(f, "month"),
-            Self::Year => write!(f, "year"),
+            Self::Millisecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
+            Self::Month => f.write_str("month"),
+            Self::Year => f.write_str("year"),
         }
     }
 }
@@ -95446,14 +95446,14 @@ impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant7RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -95731,8 +95731,8 @@ impl ::std::convert::From<&Self> for ScaleVariant7Type {
 impl ::std::fmt::Display for ScaleVariant7Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Time => write!(f, "time"),
-            Self::Utc => write!(f, "utc"),
+            Self::Time => f.write_str("time"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -96193,14 +96193,14 @@ impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant8RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -96481,9 +96481,9 @@ impl ::std::convert::From<&Self> for ScaleVariant8Type {
 impl ::std::fmt::Display for ScaleVariant8Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Linear => write!(f, "linear"),
-            Self::Sqrt => write!(f, "sqrt"),
-            Self::Sequential => write!(f, "sequential"),
+            Self::Linear => f.write_str("linear"),
+            Self::Sqrt => f.write_str("sqrt"),
+            Self::Sequential => f.write_str("sequential"),
         }
     }
 }
@@ -96945,14 +96945,14 @@ impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant0 {
 impl ::std::fmt::Display for ScaleVariant9RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Width => write!(f, "width"),
-            Self::Height => write!(f, "height"),
-            Self::Symbol => write!(f, "symbol"),
-            Self::Category => write!(f, "category"),
-            Self::Ordinal => write!(f, "ordinal"),
-            Self::Ramp => write!(f, "ramp"),
-            Self::Diverging => write!(f, "diverging"),
-            Self::Heatmap => write!(f, "heatmap"),
+            Self::Width => f.write_str("width"),
+            Self::Height => f.write_str("height"),
+            Self::Symbol => f.write_str("symbol"),
+            Self::Category => f.write_str("category"),
+            Self::Ordinal => f.write_str("ordinal"),
+            Self::Ramp => f.write_str("ramp"),
+            Self::Diverging => f.write_str("diverging"),
+            Self::Heatmap => f.write_str("heatmap"),
         }
     }
 }
@@ -97227,7 +97227,7 @@ impl ::std::convert::From<&Self> for ScaleVariant9Type {
 impl ::std::fmt::Display for ScaleVariant9Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Log => write!(f, "log"),
+            Self::Log => f.write_str("log"),
         }
     }
 }
@@ -97757,7 +97757,7 @@ impl ::std::convert::From<&Self> for SequenceTransformType {
 impl ::std::fmt::Display for SequenceTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Sequence => write!(f, "sequence"),
+            Self::Sequence => f.write_str("sequence"),
         }
     }
 }
@@ -98054,7 +98054,7 @@ impl ::std::convert::From<&Self> for SignalVariant0Push {
 impl ::std::fmt::Display for SignalVariant0Push {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Outer => write!(f, "outer"),
+            Self::Outer => f.write_str("outer"),
         }
     }
 }
@@ -98169,8 +98169,8 @@ impl ::std::convert::From<&Self> for SortOrderVariant0 {
 impl ::std::fmt::Display for SortOrderVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Ascending => write!(f, "ascending"),
-            Self::Descending => write!(f, "descending"),
+            Self::Ascending => f.write_str("ascending"),
+            Self::Descending => f.write_str("descending"),
         }
     }
 }
@@ -98665,9 +98665,9 @@ impl ::std::convert::From<&Self> for StackTransformOffsetVariant0 {
 impl ::std::fmt::Display for StackTransformOffsetVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Zero => write!(f, "zero"),
-            Self::Center => write!(f, "center"),
-            Self::Normalize => write!(f, "normalize"),
+            Self::Zero => f.write_str("zero"),
+            Self::Center => f.write_str("center"),
+            Self::Normalize => f.write_str("normalize"),
         }
     }
 }
@@ -98740,7 +98740,7 @@ impl ::std::convert::From<&Self> for StackTransformType {
 impl ::std::fmt::Display for StackTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Stack => write!(f, "stack"),
+            Self::Stack => f.write_str("stack"),
         }
     }
 }
@@ -98973,7 +98973,7 @@ impl ::std::convert::From<&Self> for StratifyTransformType {
 impl ::std::fmt::Display for StratifyTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Stratify => write!(f, "stratify"),
+            Self::Stratify => f.write_str("stratify"),
         }
     }
 }
@@ -101173,9 +101173,9 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0Variant1V
 impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Butt => write!(f, "butt"),
-            Self::Round => write!(f, "round"),
-            Self::Square => write!(f, "square"),
+            Self::Butt => f.write_str("butt"),
+            Self::Round => f.write_str("round"),
+            Self::Square => f.write_str("square"),
         }
     }
 }
@@ -101820,9 +101820,9 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0Variant1Value
 impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Butt => write!(f, "butt"),
-            Self::Round => write!(f, "round"),
-            Self::Square => write!(f, "square"),
+            Self::Butt => f.write_str("butt"),
+            Self::Round => f.write_str("round"),
+            Self::Square => f.write_str("square"),
         }
     }
 }
@@ -102689,9 +102689,9 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0Variant1
 impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Miter => write!(f, "miter"),
-            Self::Round => write!(f, "round"),
-            Self::Bevel => write!(f, "bevel"),
+            Self::Miter => f.write_str("miter"),
+            Self::Round => f.write_str("round"),
+            Self::Bevel => f.write_str("bevel"),
         }
     }
 }
@@ -103336,9 +103336,9 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0Variant1Valu
 impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Miter => write!(f, "miter"),
-            Self::Round => write!(f, "round"),
-            Self::Bevel => write!(f, "bevel"),
+            Self::Miter => f.write_str("miter"),
+            Self::Round => f.write_str("round"),
+            Self::Bevel => f.write_str("bevel"),
         }
     }
 }
@@ -105369,8 +105369,8 @@ impl ::std::convert::From<&Self> for TickBandVariant0 {
 impl ::std::fmt::Display for TickBandVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Center => write!(f, "center"),
-            Self::Extent => write!(f, "extent"),
+            Self::Center => f.write_str("center"),
+            Self::Extent => f.write_str("extent"),
         }
     }
 }
@@ -105555,14 +105555,14 @@ impl ::std::convert::From<&Self> for TickCountVariant1 {
 impl ::std::fmt::Display for TickCountVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => write!(f, "millisecond"),
-            Self::Second => write!(f, "second"),
-            Self::Minute => write!(f, "minute"),
-            Self::Hour => write!(f, "hour"),
-            Self::Day => write!(f, "day"),
-            Self::Week => write!(f, "week"),
-            Self::Month => write!(f, "month"),
-            Self::Year => write!(f, "year"),
+            Self::Millisecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
+            Self::Month => f.write_str("month"),
+            Self::Year => f.write_str("year"),
         }
     }
 }
@@ -105708,14 +105708,14 @@ impl ::std::convert::From<&Self> for TickCountVariant2IntervalVariant0 {
 impl ::std::fmt::Display for TickCountVariant2IntervalVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Millisecond => write!(f, "millisecond"),
-            Self::Second => write!(f, "second"),
-            Self::Minute => write!(f, "minute"),
-            Self::Hour => write!(f, "hour"),
-            Self::Day => write!(f, "day"),
-            Self::Week => write!(f, "week"),
-            Self::Month => write!(f, "month"),
-            Self::Year => write!(f, "year"),
+            Self::Millisecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
+            Self::Month => f.write_str("month"),
+            Self::Year => f.write_str("year"),
         }
     }
 }
@@ -106396,8 +106396,8 @@ impl ::std::convert::From<&Self> for TimeunitTransformTimezoneVariant0 {
 impl ::std::fmt::Display for TimeunitTransformTimezoneVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Local => write!(f, "local"),
-            Self::Utc => write!(f, "utc"),
+            Self::Local => f.write_str("local"),
+            Self::Utc => f.write_str("utc"),
         }
     }
 }
@@ -106469,7 +106469,7 @@ impl ::std::convert::From<&Self> for TimeunitTransformType {
 impl ::std::fmt::Display for TimeunitTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Timeunit => write!(f, "timeunit"),
+            Self::Timeunit => f.write_str("timeunit"),
         }
     }
 }
@@ -106684,17 +106684,17 @@ impl ::std::convert::From<&Self> for TimeunitTransformUnitsVariant0ItemVariant0 
 impl ::std::fmt::Display for TimeunitTransformUnitsVariant0ItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Year => write!(f, "year"),
-            Self::Quarter => write!(f, "quarter"),
-            Self::Month => write!(f, "month"),
-            Self::Week => write!(f, "week"),
-            Self::Date => write!(f, "date"),
-            Self::Day => write!(f, "day"),
-            Self::Dayofyear => write!(f, "dayofyear"),
-            Self::Hours => write!(f, "hours"),
-            Self::Minutes => write!(f, "minutes"),
-            Self::Seconds => write!(f, "seconds"),
-            Self::Milliseconds => write!(f, "milliseconds"),
+            Self::Year => f.write_str("year"),
+            Self::Quarter => f.write_str("quarter"),
+            Self::Month => f.write_str("month"),
+            Self::Week => f.write_str("week"),
+            Self::Date => f.write_str("date"),
+            Self::Day => f.write_str("day"),
+            Self::Dayofyear => f.write_str("dayofyear"),
+            Self::Hours => f.write_str("hours"),
+            Self::Minutes => f.write_str("minutes"),
+            Self::Seconds => f.write_str("seconds"),
+            Self::Milliseconds => f.write_str("milliseconds"),
         }
     }
 }
@@ -107315,9 +107315,9 @@ impl ::std::convert::From<&Self> for TitleVariant1AlignVariant0 {
 impl ::std::fmt::Display for TitleVariant1AlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Center => write!(f, "center"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Center => f.write_str("center"),
         }
     }
 }
@@ -107442,9 +107442,9 @@ impl ::std::convert::From<&Self> for TitleVariant1AnchorVariant0 {
 impl ::std::fmt::Display for TitleVariant1AnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }
@@ -107615,12 +107615,12 @@ impl ::std::convert::From<&Self> for TitleVariant1BaselineVariant0 {
 impl ::std::fmt::Display for TitleVariant1BaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Top => write!(f, "top"),
-            Self::Middle => write!(f, "middle"),
-            Self::Bottom => write!(f, "bottom"),
-            Self::Alphabetic => write!(f, "alphabetic"),
-            Self::LineTop => write!(f, "line-top"),
-            Self::LineBottom => write!(f, "line-bottom"),
+            Self::Top => f.write_str("top"),
+            Self::Middle => f.write_str("middle"),
+            Self::Bottom => f.write_str("bottom"),
+            Self::Alphabetic => f.write_str("alphabetic"),
+            Self::LineTop => f.write_str("line-top"),
+            Self::LineBottom => f.write_str("line-bottom"),
         }
     }
 }
@@ -108207,8 +108207,8 @@ impl ::std::convert::From<&Self> for TitleVariant1FrameVariant0 {
 impl ::std::fmt::Display for TitleVariant1FrameVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Group => write!(f, "group"),
-            Self::Bounds => write!(f, "bounds"),
+            Self::Group => f.write_str("group"),
+            Self::Bounds => f.write_str("bounds"),
         }
     }
 }
@@ -108452,11 +108452,11 @@ impl ::std::convert::From<&Self> for TitleVariant1OrientVariant0 {
 impl ::std::fmt::Display for TitleVariant1OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::None => write!(f, "none"),
-            Self::Left => write!(f, "left"),
-            Self::Right => write!(f, "right"),
-            Self::Top => write!(f, "top"),
-            Self::Bottom => write!(f, "bottom"),
+            Self::None => f.write_str("none"),
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Top => f.write_str("top"),
+            Self::Bottom => f.write_str("bottom"),
         }
     }
 }
@@ -109905,8 +109905,8 @@ impl ::std::convert::From<&Self> for TreeTransformMethodVariant0 {
 impl ::std::fmt::Display for TreeTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tidy => write!(f, "tidy"),
-            Self::Cluster => write!(f, "cluster"),
+            Self::Tidy => f.write_str("tidy"),
+            Self::Cluster => f.write_str("cluster"),
         }
     }
 }
@@ -110198,7 +110198,7 @@ impl ::std::convert::From<&Self> for TreeTransformType {
 impl ::std::fmt::Display for TreeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Tree => write!(f, "tree"),
+            Self::Tree => f.write_str("tree"),
         }
     }
 }
@@ -110306,7 +110306,7 @@ impl ::std::convert::From<&Self> for TreelinksTransformType {
 impl ::std::fmt::Display for TreelinksTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Treelinks => write!(f, "treelinks"),
+            Self::Treelinks => f.write_str("treelinks"),
         }
     }
 }
@@ -110859,12 +110859,12 @@ impl ::std::convert::From<&Self> for TreemapTransformMethodVariant0 {
 impl ::std::fmt::Display for TreemapTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Squarify => write!(f, "squarify"),
-            Self::Resquarify => write!(f, "resquarify"),
-            Self::Binary => write!(f, "binary"),
-            Self::Dice => write!(f, "dice"),
-            Self::Slice => write!(f, "slice"),
-            Self::Slicedice => write!(f, "slicedice"),
+            Self::Squarify => f.write_str("squarify"),
+            Self::Resquarify => f.write_str("resquarify"),
+            Self::Binary => f.write_str("binary"),
+            Self::Dice => f.write_str("dice"),
+            Self::Slice => f.write_str("slice"),
+            Self::Slicedice => f.write_str("slicedice"),
         }
     }
 }
@@ -111376,7 +111376,7 @@ impl ::std::convert::From<&Self> for TreemapTransformType {
 impl ::std::fmt::Display for TreemapTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Treemap => write!(f, "treemap"),
+            Self::Treemap => f.write_str("treemap"),
         }
     }
 }
@@ -111762,7 +111762,7 @@ impl ::std::convert::From<&Self> for VoronoiTransformType {
 impl ::std::fmt::Display for VoronoiTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Voronoi => write!(f, "voronoi"),
+            Self::Voronoi => f.write_str("voronoi"),
         }
     }
 }
@@ -112895,43 +112895,43 @@ impl ::std::convert::From<&Self> for WindowTransformOpsVariant0ItemVariant0 {
 impl ::std::fmt::Display for WindowTransformOpsVariant0ItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::RowXnumber => write!(f, "row_number"),
-            Self::Rank => write!(f, "rank"),
-            Self::DenseXrank => write!(f, "dense_rank"),
-            Self::PercentXrank => write!(f, "percent_rank"),
-            Self::CumeXdist => write!(f, "cume_dist"),
-            Self::Ntile => write!(f, "ntile"),
-            Self::Lag => write!(f, "lag"),
-            Self::Lead => write!(f, "lead"),
-            Self::FirstXvalue => write!(f, "first_value"),
-            Self::LastXvalue => write!(f, "last_value"),
-            Self::NthXvalue => write!(f, "nth_value"),
-            Self::PrevXvalue => write!(f, "prev_value"),
-            Self::NextXvalue => write!(f, "next_value"),
-            Self::Values => write!(f, "values"),
-            Self::Count => write!(f, "count"),
-            Self::XXcountXx => write!(f, "__count__"),
-            Self::Missing => write!(f, "missing"),
-            Self::Valid => write!(f, "valid"),
-            Self::Sum => write!(f, "sum"),
-            Self::Product => write!(f, "product"),
-            Self::Mean => write!(f, "mean"),
-            Self::Average => write!(f, "average"),
-            Self::Variance => write!(f, "variance"),
-            Self::Variancep => write!(f, "variancep"),
-            Self::Stdev => write!(f, "stdev"),
-            Self::Stdevp => write!(f, "stdevp"),
-            Self::Stderr => write!(f, "stderr"),
-            Self::Distinct => write!(f, "distinct"),
-            Self::Ci0 => write!(f, "ci0"),
-            Self::Ci1 => write!(f, "ci1"),
-            Self::Median => write!(f, "median"),
-            Self::Q1 => write!(f, "q1"),
-            Self::Q3 => write!(f, "q3"),
-            Self::Min => write!(f, "min"),
-            Self::Max => write!(f, "max"),
-            Self::Argmin => write!(f, "argmin"),
-            Self::Argmax => write!(f, "argmax"),
+            Self::RowXnumber => f.write_str("row_number"),
+            Self::Rank => f.write_str("rank"),
+            Self::DenseXrank => f.write_str("dense_rank"),
+            Self::PercentXrank => f.write_str("percent_rank"),
+            Self::CumeXdist => f.write_str("cume_dist"),
+            Self::Ntile => f.write_str("ntile"),
+            Self::Lag => f.write_str("lag"),
+            Self::Lead => f.write_str("lead"),
+            Self::FirstXvalue => f.write_str("first_value"),
+            Self::LastXvalue => f.write_str("last_value"),
+            Self::NthXvalue => f.write_str("nth_value"),
+            Self::PrevXvalue => f.write_str("prev_value"),
+            Self::NextXvalue => f.write_str("next_value"),
+            Self::Values => f.write_str("values"),
+            Self::Count => f.write_str("count"),
+            Self::XXcountXx => f.write_str("__count__"),
+            Self::Missing => f.write_str("missing"),
+            Self::Valid => f.write_str("valid"),
+            Self::Sum => f.write_str("sum"),
+            Self::Product => f.write_str("product"),
+            Self::Mean => f.write_str("mean"),
+            Self::Average => f.write_str("average"),
+            Self::Variance => f.write_str("variance"),
+            Self::Variancep => f.write_str("variancep"),
+            Self::Stdev => f.write_str("stdev"),
+            Self::Stdevp => f.write_str("stdevp"),
+            Self::Stderr => f.write_str("stderr"),
+            Self::Distinct => f.write_str("distinct"),
+            Self::Ci0 => f.write_str("ci0"),
+            Self::Ci1 => f.write_str("ci1"),
+            Self::Median => f.write_str("median"),
+            Self::Q1 => f.write_str("q1"),
+            Self::Q3 => f.write_str("q3"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::Argmin => f.write_str("argmin"),
+            Self::Argmax => f.write_str("argmax"),
         }
     }
 }
@@ -113133,7 +113133,7 @@ impl ::std::convert::From<&Self> for WindowTransformType {
 impl ::std::fmt::Display for WindowTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Window => write!(f, "window"),
+            Self::Window => f.write_str("window"),
         }
     }
 }
@@ -114200,7 +114200,7 @@ impl ::std::convert::From<&Self> for WordcloudTransformType {
 impl ::std::fmt::Display for WordcloudTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Wordcloud => write!(f, "wordcloud"),
+            Self::Wordcloud => f.write_str("wordcloud"),
         }
     }
 }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -111,8 +111,8 @@ impl ::std::convert::From<&Self> for LetterBoxLetter {
 impl ::std::fmt::Display for LetterBoxLetter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => write!(f, "a"),
-            Self::B => write!(f, "b"),
+            Self::A => f.write_str("a"),
+            Self::B => f.write_str("b"),
         }
     }
 }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -364,7 +364,7 @@ impl ::std::convert::From<&Self> for JsonSuccessBaseResult {
 impl ::std::fmt::Display for JsonSuccessBaseResult {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
+            Self::Success => f.write_str("success"),
         }
     }
 }
@@ -436,7 +436,7 @@ impl ::std::convert::From<&Self> for JsonSuccessResult {
 impl ::std::fmt::Display for JsonSuccessResult {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Success => write!(f, "success"),
+            Self::Success => f.write_str("success"),
         }
     }
 }
@@ -952,7 +952,7 @@ impl ::std::convert::From<&Self> for UnchangedByMergeTag {
 impl ::std::fmt::Display for UnchangedByMergeTag {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Something => write!(f, "something"),
+            Self::Something => f.write_str("something"),
         }
     }
 }
@@ -1278,7 +1278,7 @@ impl ::std::convert::From<&Self> for Unsatisfiable3B {
 impl ::std::fmt::Display for Unsatisfiable3B {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Bar => write!(f, "bar"),
+            Self::Bar => f.write_str("bar"),
         }
     }
 }
@@ -1350,7 +1350,7 @@ impl ::std::convert::From<&Self> for Unsatisfiable3C {
 impl ::std::fmt::Display for Unsatisfiable3C {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Foo => write!(f, "foo"),
+            Self::Foo => f.write_str("foo"),
         }
     }
 }

--- a/typify/tests/schemas/rust-collisions.json
+++ b/typify/tests/schemas/rust-collisions.json
@@ -12,7 +12,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "convert": {
           "type": "object",
@@ -21,7 +23,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "fmt": {
           "type": "object",
@@ -30,7 +34,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "str": {
           "type": "object",
@@ -39,7 +45,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "string": {
           "type": "object",
@@ -48,7 +56,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "option": {
           "type": "object",
@@ -57,7 +67,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         },
         "boxed": {
           "type": "object",
@@ -66,7 +78,9 @@
               "type": "string"
             }
           },
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         }
       },
       "required": [
@@ -86,7 +100,9 @@
           "type": "string"
         }
       },
-      "required": ["data"]
+      "required": [
+        "data"
+      ]
     },
     "Option": {
       "type": "object",
@@ -95,7 +111,9 @@
           "type": "string"
         }
       },
-      "required": ["maybe"]
+      "required": [
+        "maybe"
+      ]
     },
     "Vec": {
       "type": "object",
@@ -107,7 +125,9 @@
           }
         }
       },
-      "required": ["items"]
+      "required": [
+        "items"
+      ]
     },
     "String": {
       "type": "object",
@@ -116,7 +136,9 @@
           "type": "string"
         }
       },
-      "required": ["text"]
+      "required": [
+        "text"
+      ]
     },
     "Copy": {
       "type": "object",
@@ -125,7 +147,9 @@
           "type": "integer"
         }
       },
-      "required": ["value"]
+      "required": [
+        "value"
+      ]
     },
     "Sync": {
       "type": "object",
@@ -134,7 +158,9 @@
           "type": "string"
         }
       },
-      "required": ["data"]
+      "required": [
+        "data"
+      ]
     },
     "Send": {
       "type": "object",
@@ -143,7 +169,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "Pin": {
       "type": "object",
@@ -152,7 +180,9 @@
           "type": "string"
         }
       },
-      "required": ["pointer"]
+      "required": [
+        "pointer"
+      ]
     },
     "Drop": {
       "type": "object",
@@ -161,19 +191,26 @@
           "type": "boolean"
         }
       },
-      "required": ["cleanup"]
+      "required": [
+        "cleanup"
+      ]
     },
     "TypeWithOptionField": {
       "type": "object",
       "properties": {
         "optional_field": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "boxed_field": {
           "$ref": "#/definitions/Box"
         }
       },
-      "required": ["boxed_field"]
+      "required": [
+        "boxed_field"
+      ]
     },
     "StringNewtype": {
       "type": "string",
@@ -182,7 +219,11 @@
     },
     "StringEnum": {
       "type": "string",
-      "enum": ["one", "two", "three"]
+      "enum": [
+        "one",
+        "two",
+        "three"
+      ]
     },
     "RustKeywordMonster": {
       "type": "object",
@@ -417,7 +458,9 @@
           }
         }
       },
-      "required": ["keyword_map"]
+      "required": [
+        "keyword_map"
+      ]
     },
     "NestedTypeCollisions": {
       "type": "object",
@@ -432,60 +475,99 @@
           }
         },
         "option_type": {
-          "type": ["null", "object"],
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
-            "type": { "type": "string" }
+            "type": {
+              "type": "string"
+            }
           }
         }
       },
-      "required": ["type", "types"]
+      "required": [
+        "type",
+        "types"
+      ]
     },
-
     "KeywordFieldsEnum": {
       "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "type": { "type": "string" },
-            "match": { "type": "integer" },
-            "ref": { "type": "boolean" },
-            "impl": { "type": "string" }
+            "type": {
+              "type": "string"
+            },
+            "match": {
+              "type": "integer"
+            },
+            "ref": {
+              "type": "boolean"
+            },
+            "impl": {
+              "type": "string"
+            }
           },
-          "required": ["type", "match", "ref", "impl"]
+          "required": [
+            "type",
+            "match",
+            "ref",
+            "impl"
+          ]
         },
         {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "minItems": 2,
           "maxItems": 2
         }
       ]
     },
-
     "FlattenedKeywords": {
       "type": "object",
       "properties": {
-        "normal": { "type": "string" }
+        "normal": {
+          "type": "string"
+        }
       },
-      "required": ["normal"],
+      "required": [
+        "normal"
+      ],
       "additionalProperties": {
         "type": "string"
       }
     },
-
     "DoubleOptionCollision": {
       "type": "object",
       "properties": {
         "option": {
-          "type": ["null", "object"],
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
             "option": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         }
       }
+    },
+    "format-collision": {
+      "enum": [
+        "{abc}def",
+        "{http://example.com/Foo}Thing",
+        "{self}",
+        "quote\"unquote",
+        "xyz"
+      ]
     }
   }
 }

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -246,6 +246,97 @@ impl FlattenedKeywords {
         Default::default()
     }
 }
+#[doc = "`FormatCollision`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"{abc}def\","]
+#[doc = "    \"{http://example.com/Foo}Thing\","]
+#[doc = "    \"{self}\","]
+#[doc = "    \"quote\\\"unquote\","]
+#[doc = "    \"xyz\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum FormatCollision {
+    #[serde(rename = "{abc}def")]
+    AbcDef,
+    #[serde(rename = "{http://example.com/Foo}Thing")]
+    HttpExampleComFooThing,
+    #[serde(rename = "{self}")]
+    Self_,
+    #[serde(rename = "quote\"unquote")]
+    QuoteUnquote,
+    #[serde(rename = "xyz")]
+    Xyz,
+}
+impl ::std::convert::From<&Self> for FormatCollision {
+    fn from(value: &FormatCollision) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for FormatCollision {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::AbcDef => write!(f, "{abc}def"),
+            Self::HttpExampleComFooThing => write!(f, "{http://example.com/Foo}Thing"),
+            Self::Self_ => write!(f, "{self}"),
+            Self::QuoteUnquote => write!(f, "quote\"unquote"),
+            Self::Xyz => write!(f, "xyz"),
+        }
+    }
+}
+impl ::std::str::FromStr for FormatCollision {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "{abc}def" => Ok(Self::AbcDef),
+            "{http://example.com/Foo}Thing" => Ok(Self::HttpExampleComFooThing),
+            "{self}" => Ok(Self::Self_),
+            "quote\"unquote" => Ok(Self::QuoteUnquote),
+            "xyz" => Ok(Self::Xyz),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for FormatCollision {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String> for FormatCollision {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for FormatCollision {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
 #[doc = "`KeywordFieldsEnum`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -294,11 +294,11 @@ impl ::std::convert::From<&Self> for FormatCollision {
 impl ::std::fmt::Display for FormatCollision {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::AbcDef => write!(f, "{abc}def"),
-            Self::HttpExampleComFooThing => write!(f, "{http://example.com/Foo}Thing"),
-            Self::Self_ => write!(f, "{self}"),
-            Self::QuoteUnquote => write!(f, "quote\"unquote"),
-            Self::Xyz => write!(f, "xyz"),
+            Self::AbcDef => f.write_str("{abc}def"),
+            Self::HttpExampleComFooThing => f.write_str("{http://example.com/Foo}Thing"),
+            Self::Self_ => f.write_str("{self}"),
+            Self::QuoteUnquote => f.write_str("quote\"unquote"),
+            Self::Xyz => f.write_str("xyz"),
         }
     }
 }
@@ -533,20 +533,20 @@ impl ::std::convert::From<&Self> for MapOfKeywordsKeywordMapValue {
 impl ::std::fmt::Display for MapOfKeywordsKeywordMapValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Type => write!(f, "type"),
-            Self::Impl => write!(f, "impl"),
-            Self::Fn => write!(f, "fn"),
-            Self::Let => write!(f, "let"),
-            Self::Match => write!(f, "match"),
-            Self::Mod => write!(f, "mod"),
-            Self::Move => write!(f, "move"),
-            Self::Pub => write!(f, "pub"),
-            Self::Ref => write!(f, "ref"),
-            Self::Self_ => write!(f, "self"),
-            Self::Super => write!(f, "super"),
-            Self::Trait => write!(f, "trait"),
-            Self::Use => write!(f, "use"),
-            Self::Where => write!(f, "where"),
+            Self::Type => f.write_str("type"),
+            Self::Impl => f.write_str("impl"),
+            Self::Fn => f.write_str("fn"),
+            Self::Let => f.write_str("let"),
+            Self::Match => f.write_str("match"),
+            Self::Mod => f.write_str("mod"),
+            Self::Move => f.write_str("move"),
+            Self::Pub => f.write_str("pub"),
+            Self::Ref => f.write_str("ref"),
+            Self::Self_ => f.write_str("self"),
+            Self::Super => f.write_str("super"),
+            Self::Trait => f.write_str("trait"),
+            Self::Use => f.write_str("use"),
+            Self::Where => f.write_str("where"),
         }
     }
 }
@@ -1529,9 +1529,9 @@ impl ::std::convert::From<&Self> for StringEnum {
 impl ::std::fmt::Display for StringEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::One => write!(f, "one"),
-            Self::Two => write!(f, "two"),
-            Self::Three => write!(f, "three"),
+            Self::One => f.write_str("one"),
+            Self::Two => f.write_str("two"),
+            Self::Three => f.write_str("three"),
         }
     }
 }

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -69,9 +69,9 @@ impl ::std::convert::From<&Self> for TestEnum {
 impl ::std::fmt::Display for TestEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Failure => write!(f, "failure"),
-            Self::Skipped => write!(f, "skipped"),
-            Self::Success => write!(f, "success"),
+            Self::Failure => f.write_str("failure"),
+            Self::Skipped => f.write_str("skipped"),
+            Self::Success => f.write_str("success"),
         }
     }
 }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -107,9 +107,9 @@ impl ::std::convert::From<&Self> for TestTypeValue {
 impl ::std::fmt::Display for TestTypeValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Start => write!(f, "start"),
-            Self::Middle => write!(f, "middle"),
-            Self::End => write!(f, "end"),
+            Self::Start => f.write_str("start"),
+            Self::Middle => f.write_str("middle"),
+            Self::End => f.write_str("end"),
         }
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -66,9 +66,9 @@ impl ::std::convert::From<&Self> for AlternativeEnum {
 impl ::std::fmt::Display for AlternativeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Choice1 => write!(f, "Choice1"),
-            Self::Choice2 => write!(f, "Choice2"),
-            Self::Choice3 => write!(f, "Choice3"),
+            Self::Choice1 => f.write_str("Choice1"),
+            Self::Choice2 => f.write_str("Choice2"),
+            Self::Choice3 => f.write_str("Choice3"),
         }
     }
 }
@@ -165,9 +165,9 @@ impl ::std::convert::From<&Self> for CommentedVariants {
 impl ::std::fmt::Display for CommentedVariants {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => write!(f, "A"),
-            Self::B => write!(f, "B"),
-            Self::C => write!(f, "C"),
+            Self::A => f.write_str("A"),
+            Self::B => f.write_str("B"),
+            Self::C => f.write_str("C"),
         }
     }
 }
@@ -288,9 +288,9 @@ impl ::std::convert::From<&Self> for DiskAttachmentState {
 impl ::std::fmt::Display for DiskAttachmentState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Detached => write!(f, "Detached"),
-            Self::Destroyed => write!(f, "Destroyed"),
-            Self::Faulted => write!(f, "Faulted"),
+            Self::Detached => f.write_str("Detached"),
+            Self::Destroyed => f.write_str("Destroyed"),
+            Self::Faulted => f.write_str("Faulted"),
         }
     }
 }
@@ -932,9 +932,9 @@ impl ::std::convert::From<&Self> for NullStringEnumWithUnknownFormatInner {
 impl ::std::fmt::Display for NullStringEnumWithUnknownFormatInner {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::A => write!(f, "a"),
-            Self::B => write!(f, "b"),
-            Self::C => write!(f, "c"),
+            Self::A => f.write_str("a"),
+            Self::B => f.write_str("b"),
+            Self::C => f.write_str("c"),
         }
     }
 }
@@ -1602,9 +1602,9 @@ impl ::std::convert::From<&Self> for VariantsDifferByPunct {
 impl ::std::fmt::Display for VariantsDifferByPunct {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::X2x5gbasext => write!(f, "2.5GBASE-T"),
-            Self::X25gbasext => write!(f, "25GBASE-T"),
-            Self::X2x5xgbasext => write!(f, "2,5,GBASE,T"),
+            Self::X2x5gbasext => f.write_str("2.5GBASE-T"),
+            Self::X25gbasext => f.write_str("25GBASE-T"),
+            Self::X2x5xgbasext => f.write_str("2,5,GBASE,T"),
         }
     }
 }


### PR DESCRIPTION
Closes #839 

This is a dumb one... and an old one! We're writing out static strings using `write!` which takes a format parameter. We really just want to use `Formatter::write_str` which takes a static string. (EDIT: not that old; introduced by #663)

Adds a new test case that fails to build without this fix.