### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -66,9 +66,9 @@ impl TypeSpace {
                 enum_values,
                 ..
             } if multiple.len() == 2 && multiple.contains(&InstanceType::Null) => {
-                let only_null = enum_values.as_ref().map_or(false, |values| {
-                    values.iter().all(serde_json::Value::is_null)
-                });
+                let only_null = enum_values
+                    .as_ref()
+                    .is_some_and(|values| values.iter().all(serde_json::Value::is_null));
 
                 if only_null {
                     // If there are enumerated values and they're all null,

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -691,7 +691,7 @@ mod tests {
 
         assert!(type_entry
             .validate_value(&type_space, &json!([null]))
-            .is_err(),);
+            .is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!([])),
             Ok(DefaultKind::Intrinsic),

--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -151,24 +151,24 @@ impl TypeEntry {
             }) => match tag_type {
                 EnumTagType::External => {
                     validate_default_for_external_enum(type_space, variants, default)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Internal { tag } => {
                     validate_default_for_internal_enum(type_space, variants, default, tag)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Adjacent { tag, content } => {
                     validate_default_for_adjacent_enum(type_space, variants, default, tag, content)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
                 EnumTagType::Untagged => {
                     validate_default_for_untagged_enum(type_space, variants, default)
-                        .ok_or_else(|| Error::invalid_value())
+                        .ok_or_else(Error::invalid_value)
                 }
             },
             TypeEntryDetails::Struct(TypeEntryStruct { properties, .. }) => {
                 validate_default_struct_props(properties, type_space, default)
-                    .ok_or_else(|| Error::invalid_value())
+                    .ok_or_else(Error::invalid_value)
             }
 
             TypeEntryDetails::Newtype(TypeEntryNewtype { type_id, .. }) => {
@@ -242,8 +242,9 @@ impl TypeEntry {
                     Err(Error::invalid_value())
                 }
             }
-            TypeEntryDetails::Tuple(ids) => validate_default_tuple(ids, type_space, default)
-                .ok_or_else(|| Error::invalid_value()),
+            TypeEntryDetails::Tuple(ids) => {
+                validate_default_tuple(ids, type_space, default).ok_or_else(Error::invalid_value)
+            }
 
             TypeEntryDetails::Array(type_id, length) => {
                 let Some(arr) = default.as_array() else {
@@ -648,10 +649,9 @@ mod tests {
         let (type_space, type_id) = get_type::<Option<u32>>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!("forty-two")),
-            Err(_)
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!("forty-two"))
+            .is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!(null)),
             Ok(DefaultKind::Intrinsic)
@@ -671,10 +671,9 @@ mod tests {
             extra_derives: Default::default(),
         };
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!("forty-two")),
-            Err(_)
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!("forty-two"))
+            .is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!(null)),
             Ok(DefaultKind::Intrinsic)
@@ -690,10 +689,9 @@ mod tests {
         let (type_space, type_id) = get_type::<Vec<u32>>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!([null])),
-            Err(_),
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!([null]))
+            .is_err(),);
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!([])),
             Ok(DefaultKind::Intrinsic),
@@ -709,10 +707,7 @@ mod tests {
         let (type_space, type_id) = get_type::<HashMap<String, u32>>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!([])),
-            Err(_),
-        ));
+        assert!(type_entry.validate_value(&type_space, &json!([])).is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!({})),
             Ok(DefaultKind::Intrinsic),
@@ -728,10 +723,9 @@ mod tests {
         let (type_space, type_id) = get_type::<(u32, u32, String)>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!([1, 2, "three", 4])),
-            Err(_),
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!([1, 2, "three", 4]))
+            .is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!([1, 2, "three"])),
             Ok(DefaultKind::Specific),
@@ -769,10 +763,9 @@ mod tests {
         let (type_space, type_id) = get_type::<u32>();
         let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
 
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!(true)),
-            Err(_),
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!(true))
+            .is_err());
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!(0)),
             Ok(DefaultKind::Intrinsic),
@@ -822,8 +815,8 @@ mod tests {
             ),
             Ok(DefaultKind::Specific),
         ));
-        assert!(matches!(
-            type_entry.validate_value(
+        assert!(type_entry
+            .validate_value(
                 &type_space,
                 &json!(
                     {
@@ -832,11 +825,10 @@ mod tests {
                         "d": 7
                     }
                 )
-            ),
-            Err(_),
-        ));
-        assert!(matches!(
-            type_entry.validate_value(
+            )
+            .is_err());
+        assert!(type_entry
+            .validate_value(
                 &type_space,
                 &json!(
                     {
@@ -845,9 +837,8 @@ mod tests {
                         "d": {}
                     }
                 )
-            ),
-            Err(_),
-        ));
+            )
+            .is_err());
     }
 
     #[test]
@@ -885,14 +876,10 @@ mod tests {
             ),
             Ok(DefaultKind::Specific),
         ));
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!({ "A": null })),
-            Err(_),
-        ));
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!("B")),
-            Err(_),
-        ));
+        assert!(type_entry
+            .validate_value(&type_space, &json!({ "A": null }))
+            .is_err());
+        assert!(type_entry.validate_value(&type_space, &json!("B")).is_err());
     }
 
     #[test]
@@ -928,25 +915,23 @@ mod tests {
             ),
             Ok(DefaultKind::Specific),
         ));
-        assert!(matches!(
-            type_entry.validate_value(
+        assert!(type_entry
+            .validate_value(
                 &type_space,
                 &json!({
                     "not-tag": "A"
                 })
-            ),
-            Err(_),
-        ));
-        assert!(matches!(
-            type_entry.validate_value(
+            )
+            .is_err());
+        assert!(type_entry
+            .validate_value(
                 &type_space,
                 &json!({
                     "tag": "B",
                     "cc": "where's D?"
                 })
-            ),
-            Err(_),
-        ));
+            )
+            .is_err());
     }
 
     #[test]
@@ -992,20 +977,16 @@ mod tests {
             ),
             Ok(DefaultKind::Specific),
         ));
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!("A")),
-            Err(_),
-        ));
-        assert!(matches!(
-            type_entry.validate_value(
+        assert!(type_entry.validate_value(&type_space, &json!("A")).is_err());
+        assert!(type_entry
+            .validate_value(
                 &type_space,
                 &json!({
                     "tag": "A",
                     "content": null,
                 })
-            ),
-            Err(_),
-        ));
+            )
+            .is_err());
     }
     #[test]
     fn test_enum_untagged() {
@@ -1033,9 +1014,6 @@ mod tests {
             type_entry.validate_value(&type_space, &json!( { "cc": "xx", "dd": "yy" })),
             Ok(DefaultKind::Specific),
         ));
-        assert!(matches!(
-            type_entry.validate_value(&type_space, &json!({})),
-            Err(_),
-        ));
+        assert!(type_entry.validate_value(&type_space, &json!({})).is_err());
     }
 }

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1050,7 +1050,7 @@ mod tests {
                 assert_eq!(variants.len(), 5);
 
                 assert!(matches!(
-                    variants.get(0).unwrap(),
+                    variants.first().unwrap(),
                     Variant {
                         details: VariantDetails::Simple,
                         ..

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -63,11 +63,7 @@ impl Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 fn show_type_name(type_name: Option<&str>) -> &str {
-    if let Some(type_name) = type_name {
-        type_name
-    } else {
-        "<unknown type>"
-    }
+    type_name.unwrap_or("<unknown type>")
 }
 
 /// Representation of a type which may have a definition or may be built-in.
@@ -987,7 +983,7 @@ impl ToTokens for TypeSpace {
     }
 }
 
-impl<'a> Type<'a> {
+impl Type<'_> {
     /// The name of the type as a String.
     pub fn name(&self) -> String {
         let Type {
@@ -1167,7 +1163,7 @@ impl<'a> TypeStruct<'a> {
     }
 }
 
-impl<'a> TypeNewtype<'a> {
+impl TypeNewtype<'_> {
     /// Get the inner type of the newtype struct.
     pub fn inner(&self) -> TypeId {
         self.details.type_id.clone()

--- a/typify-impl/src/merge.rs
+++ b/typify-impl/src/merge.rs
@@ -67,9 +67,7 @@ fn merge_additional_properties(
 ) -> Option<Schema> {
     match (a, b) {
         (None, other) | (other, None) => other.cloned(),
-        (Some(aa), Some(bb)) => {
-            Some(try_merge_schema(aa, bb, defs).unwrap_or_else(|_| Schema::Bool(false)))
-        }
+        (Some(aa), Some(bb)) => Some(try_merge_schema(aa, bb, defs).unwrap_or(Schema::Bool(false))),
     }
 }
 
@@ -893,12 +891,12 @@ fn merge_so_array(
                     let aa_items_iter = aa_items.iter().chain(repeat(
                         aa_additional_items
                             .as_deref()
-                            .unwrap_or_else(|| &Schema::Bool(true)),
+                            .unwrap_or(&Schema::Bool(true)),
                     ));
                     let bb_items_iter = bb_items.iter().chain(repeat(
                         bb_additional_items
                             .as_deref()
-                            .unwrap_or_else(|| &Schema::Bool(true)),
+                            .unwrap_or(&Schema::Bool(true)),
                     ));
                     let items_iter = aa_items_iter.zip(bb_items_iter).take(items_len);
                     let (items, allow_additional_items) =

--- a/typify-impl/src/output.rs
+++ b/typify-impl/src/output.rs
@@ -27,7 +27,7 @@ impl OutputSpace {
     ) {
         self.items
             .entry((location, order_hint.to_string()))
-            .or_insert_with(TokenStream::new)
+            .or_default()
             .extend(stream);
     }
 
@@ -36,12 +36,13 @@ impl OutputSpace {
             .items
             .into_iter()
             .map(|((location, _), item)| (location, item))
-            .fold(BTreeMap::new(), |mut map, (location, item)| {
-                map.entry(location)
-                    .or_insert_with(TokenStream::new)
-                    .extend(item);
-                map
-            });
+            .fold(
+                BTreeMap::<_, TokenStream>::new(),
+                |mut map, (location, item)| {
+                    map.entry(location).or_default().extend(item);
+                    map
+                },
+            );
 
         let mod_streams = mods.into_iter().map(|(location, items)| match location {
             OutputSpaceMod::Crate => quote! {

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1536,7 +1536,7 @@ impl TypeEntry {
                         static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(|| {
                             ::regress::Regex::new(#p).unwrap()
                         });
-                        if (&*PATTERN).find(value).is_none() {
+                        if PATTERN.find(value).is_none() {
                             return Err(#err.into());
                         }
                     }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -22329,7 +22329,7 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -22849,7 +22849,7 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -23428,7 +23428,7 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -24016,7 +24016,7 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -25219,7 +25219,7 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -25739,7 +25739,7 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -26318,7 +26318,7 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -26906,7 +26906,7 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Valu
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^(date|utc):.*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(date|utc):.*$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -31384,7 +31384,7 @@ impl ::std::str::FromStr for EncodeKey {
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^.+$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^.+$\"".into());
         }
         Ok(Self(value.to_string()))
@@ -107875,7 +107875,7 @@ impl ::std::str::FromStr for TitleVariant1EncodeSubtype0Key {
             ::std::sync::LazyLock::new(|| {
                 ::regress::Regex::new("^(?!interactive|name|style).+$").unwrap()
             });
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^(?!interactive|name|style).+$\"".into());
         }
         Ok(Self(value.to_string()))

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -326,7 +326,7 @@ impl ::std::str::FromStr for IdOrYoloYolo {
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new(".*").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \".*\"".into());
         }
         Ok(Self(value.to_string()))
@@ -410,7 +410,7 @@ impl ::std::str::FromStr for Name {
                 :: regress :: Regex :: new ("^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$") . unwrap ()
             },
         );
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err ("doesn't match pattern \"^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$\"" . into ()) ;
         }
         Ok(Self(value.to_string()))

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -104,7 +104,7 @@ impl ::std::str::FromStr for TestGrammarForPatternPropertiesRulesKey {
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("^[a-zA-Z_]\\w*$").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"^[a-zA-Z_]\\w*$\"".into());
         }
         Ok(Self(value.to_string()))

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -60,7 +60,7 @@ impl ::std::str::FromStr for PatternString {
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| ::regress::Regex::new("xx").unwrap());
-        if (&*PATTERN).find(value).is_none() {
+        if PATTERN.find(value).is_none() {
             return Err("doesn't match pattern \"xx\"".into());
         }
         Ok(Self(value.to_string()))


### PR DESCRIPTION
This PR fixes some (newer than 1.81) clippy warnings, some of which triggered on generated code.