### PR TITLE
restore public impls for MapType introduced in v0.3.0

### DIFF
--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -263,9 +263,31 @@ impl std::fmt::Display for MapType {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for MapType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(Self::new(s))
+    }
+}
+
+impl From<String> for MapType {
+    fn from(s: String) -> Self {
+        Self::new(&s)
+    }
+}
+
 impl From<&str> for MapType {
     fn from(s: &str) -> Self {
         Self::new(s)
+    }
+}
+
+impl From<syn::Type> for MapType {
+    fn from(t: syn::Type) -> Self {
+        Self(t)
     }
 }
 


### PR DESCRIPTION
#708 introduced some public impls for `MapType`; later--and for reasons that elude me--I removed some of those in #835. This is a breaking change, and--in fact--breaks progenitor! This PR restores those.